### PR TITLE
Invoke sub-makes as ${MAKE}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,34 +12,34 @@ DEBUG=${ALL_DEBUG}
 export EXTRALINK
 
 all:
-	OPTZ="${O2}" make default
+	OPTZ="${O2}" ${MAKE} default
 
 .PHONY: default
 default:
-	make deps
-	make lib
-	make src
+	${MAKE} deps
+	${MAKE} lib
+	${MAKE} src
 
 .PHONY: debug
 debug:
-	OPTZ="${O0}" DEBUG="${ALL_DEBUG}" make default
+	OPTZ="${O0}" DEBUG="${ALL_DEBUG}" ${MAKE} default
 
 .PHONY: deps
 deps:
-	cd deps && make -j 5
+	cd deps && ${MAKE}
 
 .PHONY: lib
 lib:
-	cd lib && make -j 5
+	cd lib && ${MAKE}
 
 .PHONY: src
 src:
-	cd src && make
+	cd src && ${MAKE}
 
 .PHONY: clean
 clean:
-	cd lib && make clean
-	cd src && make clean
+	cd lib && ${MAKE} clean
+	cd src && ${MAKE} clean
 
 packages: centos7 ubuntu12 ubuntu14
 .PHONY: packages
@@ -76,7 +76,7 @@ binaries/proxysql_1.0.1-ubuntu14_amd64.deb:
 	docker create --name ubuntu14_build renecannao/proxysql:build-ubuntu14 bash -c "while : ; do sleep 10 ; done"
 	docker start ubuntu14_build
 	docker exec ubuntu14_build bash -c "cd /opt; git clone https://github.com/sysown/proxysql.git proxysql"
-	docker exec ubuntu14_build bash -c "cd /opt/proxysql; make clean && make -j"
+	docker exec ubuntu14_build bash -c "cd /opt/proxysql; ${MAKE} clean && ${MAKE} -j"
 	docker cp docker/images/proxysql/ubuntu-14.04-build/proxysql.ctl ubuntu14_build:/opt/proxysql/
 	docker exec ubuntu14_build bash -c "cd /opt/proxysql; cp src/proxysql . ; equivs-build proxysql.ctl"
 	docker cp ubuntu14_build:/opt/proxysql/proxysql_1.0.1_amd64.deb ./binaries/proxysql_1.0.1-ubuntu14_amd64.deb
@@ -86,9 +86,9 @@ binaries/proxysql_1.0.1-ubuntu14_amd64.deb:
 
 .PHONY: cleanall
 cleanall:
-	cd deps && make cleanall
-	cd lib && make clean
-	cd src && make clean
+	cd deps && ${MAKE} cleanall
+	cd lib && ${MAKE} clean
+	cd src && ${MAKE} clean
 	rm binaries/*deb || true
 	rm binaries/*rpm || true
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -8,7 +8,7 @@ libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
 	cd libdaemon && rm -rf libdaemon-0.14
 	cd libdaemon && tar -zxf libdaemon-0.14.tar.gz
 	cd libdaemon/libdaemon && ./configure
-	cd libdaemon/libdaemon && make
+	cd libdaemon/libdaemon && ${MAKE}
 
 libdaemon: libdaemon/libdaemon/libdaemon/.libs/libdaemon.a
 
@@ -16,12 +16,12 @@ libevent/libevent/.libs/libevent.a:
 	cd libevent && rm -rf libevent-2.0.22-stable
 	cd libevent && tar -zxf libevent-2.0.22-stable.tar.gz
 	cd libevent/libevent && ./configure
-	cd libevent/libevent && make
+	cd libevent/libevent && ${MAKE}
 
 libevent: libevent/libevent/.libs/libevent.a
 
 libinjection/libinjection.a:
-	cd libinjection && make
+	cd libinjection && ${MAKE}
 
 libinjection: libinjection/libinjection.a
 
@@ -30,7 +30,7 @@ jemalloc/jemalloc/lib/libjemalloc.a:
 	cd jemalloc && rm -rf jemalloc-3.6.0
 	cd jemalloc && tar -jxf jemalloc-3.6.0.tar.bz2
 	cd jemalloc/jemalloc && ./configure --enable-xmalloc
-	cd jemalloc/jemalloc && make
+	cd jemalloc/jemalloc && ${MAKE}
 
 jemalloc: jemalloc/jemalloc/lib/libjemalloc.a
 
@@ -42,7 +42,7 @@ mariadb-client-library/mariadb_client/include/my_config.h:
 	cd mariadb-client-library/mariadb_client && cmake .
 	cd mariadb-client-library/mariadb_client && patch libmariadb/libmariadb.c < ../libmariadb.c.patch
 	cd mariadb-client-library/mariadb_client && patch include/mysql.h < ../mysql.h.patch
-	cd mariadb-client-library/mariadb_client && make
+	cd mariadb-client-library/mariadb_client && ${MAKE}
 # cd mariadb-client-library/mariadb_client/include && make my_config.h
 
 mariadb_client: mariadb-client-library/mariadb_client/include/my_config.h
@@ -59,7 +59,7 @@ libconfig/libconfig/lib/.libs/libconfig++.a:
 	cd libconfig && rm -rf libconfig-1.4.9
 	cd libconfig && tar -zxf libconfig-1.4.9.tar.gz
 	cd libconfig/libconfig && ./configure
-	cd libconfig/libconfig && make
+	cd libconfig/libconfig && ${MAKE}
 
 libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
 
@@ -69,7 +69,7 @@ re2/re2/obj/libre2.a:
 	cd re2 && tar -zxf re2-20140304.tgz
 	cd re2/re2 && sed -i -e 's/-O3 -g /-O3 -fPIC /' Makefile
 	cd re2 && patch re2/util/mutex.h < mutex.h.patch
-	cd re2/re2 && make
+	cd re2/re2 && ${MAKE}
 
 re2: re2/re2/obj/libre2.a
 
@@ -79,7 +79,7 @@ cleanall:
 	cd mariadb-client-library && rm -rf mariadb_client-2.0.0-src
 	cd libconfig && rm -rf libconfig-1.4.9
 	cd re2 && rm -rf re2
-	cd libinjection && make clean
+	cd libinjection && ${MAKE} clean
 	cd libevent && rm -rf libevent-2.0.22-stable
 #	cd sqlite3 && rm -rf sqlite-amalgamation-3080403
 .PHONY: cleanall

--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ $(ODIR):
 	mkdir $(ODIR)
 
 $(LIBPROXYSQLAR):
-	cd $(LDIR) && make
+	cd $(LDIR) && ${MAKE}
 
 default: $(EXECUTABLE)
 


### PR DESCRIPTION
- This fixes the case where make is not named make, e.g. gmake
- This handles jobs correctly