### PR TITLE
Compiling improvements : Linux/FreeBSD , gcc/clang

### DIFF
--- a/compile_examples.txt
+++ b/compile_examples.txt
@@ -1,8 +1,22 @@
-## On Linux
-## compile using gcc 4.8
-time CXX=g++-4.8 CC=gcc-4.8 make -j 5 build_deps
+## EXAMPLES of how to compiles on Linux and FreeBSD
 
 ## On Linux
+
+## compile using gcc 4.8
+time CXX=g++-4.8 CC=gcc-4.8 make
+
 ## compile using clang 3.6 and stdc++4.8
-CXX=clang++-3.6 CC=clang-3.6 CPPFLAGS="-I/usr/include/c++/4.8/ -I/usr/include/x86_64-linux-gnu/c++/4.8" LDFLAGS="-L/usr/lib/x86_64-linux-gnu/ -L/usr/lib/gcc/x86_64-linux-gnu/4.8" make -j 5 build_deps
-CXX=clang++-3.6 CC=clang-3.6 CPPFLAGS="-I/usr/include/c++/4.8/ -I/usr/include/x86_64-linux-gnu/c++/4.8" LDFLAGS="-L/usr/lib/x86_64-linux-gnu/ -L/usr/lib/gcc/x86_64-linux-gnu/4.8" make -j 5
+CXX=clang++-3.6 CC=clang-3.6 CPPFLAGS="-I/usr/include/c++/4.8/ -I/usr/include/x86_64-linux-gnu/c++/4.8" LDFLAGS="-L/usr/lib/x86_64-linux-gnu/ -L/usr/lib/gcc/x86_64-linux-gnu/4.8" make
+
+====
+
+## On FreeBSD
+
+## compile using gcc 4.9
+CC=gcc49 CXX=g++49 LIBS="-Wl,-rpath=/usr/local/lib/gcc49 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
+
+## compile using gcc 4.9
+CC=gcc48 CXX=g++48 LIBS="-Wl,-rpath=/usr/local/lib/gcc48 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
+
+## compile using clang 3.7
+CC=clang37 CXX=clang++37 gmake

--- a/compile_examples.txt
+++ b/compile_examples.txt
@@ -1,0 +1,8 @@
+## On Linux
+## compile using gcc 4.8
+time CXX=g++-4.8 CC=gcc-4.8 make -j 5 build_deps
+
+## On Linux
+## compile using clang 3.6 and stdc++4.8
+CXX=clang++-3.6 CC=clang-3.6 CPPFLAGS="-I/usr/include/c++/4.8/ -I/usr/include/x86_64-linux-gnu/c++/4.8" LDFLAGS="-L/usr/lib/x86_64-linux-gnu/ -L/usr/lib/gcc/x86_64-linux-gnu/4.8" make -j 5 build_deps
+CXX=clang++-3.6 CC=clang-3.6 CPPFLAGS="-I/usr/include/c++/4.8/ -I/usr/include/x86_64-linux-gnu/c++/4.8" LDFLAGS="-L/usr/lib/x86_64-linux-gnu/ -L/usr/lib/gcc/x86_64-linux-gnu/4.8" make -j 5

--- a/include/cpp.h
+++ b/include/cpp.h
@@ -18,4 +18,19 @@
 #include "proxysql_admin.h"
 #include "MySQL_HostGroups_Manager.h"
 #include "MySQL_Logger.hpp"
+#undef swap
+#undef min
+#undef max
+#include <memory>
+#include <stdio.h>
+#include <algorithm>
+#include <functional>
+#include <type_traits>
+#include <iosfwd>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 //#endif /* __cplusplus */

--- a/include/proxysql_atomic.h
+++ b/include/proxysql_atomic.h
@@ -22,7 +22,7 @@ struct _rwlock_t {
 
 static inline unsigned xchg_32(void *ptr, unsigned x) {
     __asm__ __volatile__("xchgl %0,%1"
-                :"=r" ((unsigned) x)
+                :"=r" (x)
                 :"m" (*(volatile unsigned *)ptr), "0" (x)
                 :"memory");
     return x;

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -32,16 +32,19 @@ IDIRS=-I$(IDIR) -I$(JEMALLOC_IDIR) -I$(MARIADB_IDIR) $(LIBCONFIG_IDIR) -I$(RE2_I
 
 LDIRS=-L$(JEMALLOC_PATH)/lib -L$(RE2_PATH)/obj -L$(INJECTION_PATH)
 
-LIBS=-rdynamic -Wl,-Bstatic -ljemalloc_pic -lre2 -Wl,-Bdynamic -ldl -lpthread -lm -lz -lrt $(EXTRALINK)
+#LIBS=-rdynamic -Wl,-Bstatic -ljemalloc_pic -lre2 -Wl,-Bdynamic -ldl -lpthread -lm -lz -lrt $(EXTRALINK)
+#LIBS=-Wl,--export-dynamic -Wl,-Bstatic -ljemalloc_pic -lre2 -Wl,-Bdynamic -ldl -lpthread -lm -lz -lrt $(EXTRALINK)
 
 ODIR= obj
 
-CC=gcc
-CPP=g++
+#CC=gcc
+#CPP=g++
 #CC=clang
 
-CFLAGS=$(IDIRS) $(OPTZ) $(DEBUG) -Wall #-lcrypto
-CPPFLAGS=-std=c++0x $(CFLAGS) $(LDIRS) $(LIBS)
+#CFLAGS=$(IDIRS) $(OPTZ) $(DEBUG) -Wall #-lcrypto
+#CPPFLAGS=-std=c++11 $(CFLAGS) $(LDIRS) $(LIBS)
+MYCFLAGS=$(IDIRS) $(OPTZ) $(DEBUG) -Wall
+MYCPPFLAGS=-std=c++11 $(MYCFLAGS)
 
 default: libproxysql.a
 .PHONY: default
@@ -52,13 +55,13 @@ _OBJ_CPP = ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo 
 OBJ_CPP = $(patsubst %,$(ODIR)/%,$(_OBJ_CPP))
 
 %.ko: %.cpp
-	$(CPP) -fPIC -c -o $@ $< $(CPPFLAGS)
+	$(CXX) -fPIC -c -o $@ $< $(MYCPPFLAGS) $(CPPFLAGS)
 
 $(ODIR)/%.o: %.c
-	$(CC) -fPIC -c -o $@ $< $(CFLAGS)
+	$(CC) -fPIC -c -o $@ $< $(MYCFLAGS) $(CFLAGS)
 
 $(ODIR)/%.oo: %.cpp
-	$(CPP) -fPIC -c -o $@ $< $(CPPFLAGS)
+	$(CXX) -fPIC -c -o $@ $< $(MYCPPFLAGS) $(CPPFLAGS)
 
 libproxysql.a: $(ODIR) $(OBJ) $(OBJ_CPP) $(INJECTION_PATH)/libinjection.a $(RE2_PATH)/obj/libre2.a $(LIBEVENT_PATH)/.libs/libevent.a $(PROTOBUF_IDIR)/.libs/libprotobuf.a
 	ar rcs $@ $(OBJ) $(OBJ_CPP) $(INJECTION_PATH)/libinjection.a $(RE2_PATH)/obj/libre2.a $(LIBEVENT_PATH)/.libs/libevent.a $(PROTOBUF_IDIR)/.libs/libprotobuf.a

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -62,7 +62,7 @@ static int total_read_only__num_active_connections=0;
 
 
 struct cmp_str {
-	bool operator()(char const *a, char const *b)
+	bool operator()(char const *a, char const *b) const
 	{
 		return strcmp(a, b) < 0;
 	}
@@ -88,7 +88,7 @@ MySQL_Monitor_Connection_Pool::~MySQL_Monitor_Connection_Pool() {
 }
 
 MYSQL * MySQL_Monitor_Connection_Pool::get_connection(char *hostname, int port) {
-	std::map<char *, std::list<MYSQL *>* >::iterator it;
+	std::map<char *, std::list<MYSQL *>* , cmp_str >::iterator it;
 	//it = my_connections.find(std::make_pair(hostname,port));
 	char *buf=(char *)malloc(16+strlen(hostname));
 	sprintf(buf,"%s:%d",hostname,port);
@@ -108,7 +108,7 @@ MYSQL * MySQL_Monitor_Connection_Pool::get_connection(char *hostname, int port) 
 
 void MySQL_Monitor_Connection_Pool::put_connection(char *hostname, int port, MYSQL *my) {
 	size++;
-	std::map<char *, std::list<MYSQL *>* >::iterator it;
+	std::map<char *, std::list<MYSQL *>* , cmp_str >::iterator it;
 	char * buf=(char *)malloc(16+strlen(hostname));
 	sprintf(buf,"%s:%d",hostname,port);
 	it = my_connections.find(buf);

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,8 +54,10 @@ LDIRS=-L$(LDIR) -L$(JEMALLOC_LDIR) $(LIBCONFIG_LDIR) -L$(RE2_PATH)/obj -L$(INJEC
 #LDIRS=-L$(LDIR) -L$(JEMALLOC_LDIR) -L$(MARIADB_LDIR) $(GLIB_LDIRS) $(LIBCONFIG_LDIR)
 
 
-CFLAGS=-std=c++0x $(IDIRS) $(OPTZ) $(DEBUG)
-LIBS=-rdynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -linjection -levent -lmariadbclient -lprotobuf -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl -lcrypto -lssl $(EXTRALINK)
+MYCPPFLAGS=-std=c++11 $(IDIRS) $(OPTZ) $(DEBUG)
+LDFLAGS+=
+#LIBS=-rdynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -linjection -levent -lmariadbclient -lprotobuf -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl -lcrypto -lssl $(EXTRALINK)
+MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -linjection -levent -lmariadbclient -lprotobuf -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl -lcrypto -lssl $(EXTRALINK)
 #LIBS=-rdynamic -Wl,-Bstatic -lproxysql -ljemalloc -levent $(GLIB_LIB) -Wl,-Bdynamic -ldl -lpthread -lm -lz -lrt
 
 LIBPROXYSQLAR=$(LDIR)/libproxysql.a
@@ -63,7 +65,7 @@ LIBPROXYSQLAR=$(LDIR)/libproxysql.a
 ODIR= obj
 
 #CC=gcc
-CC=g++
+#CC=g++
 #CC=clang
 
 
@@ -73,12 +75,12 @@ _OBJ = main.o proxysql_global.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
 $(ODIR)/%.o: %.cpp
-	$(CXX) -c -o $@ $< $(CFLAGS) -Wall
+	$(CXX) -c -o $@ $< $(MYCPPFLAGS) $(CPPFLAGS) -Wall
 
 
 
 proxysql: $(ODIR) $(OBJ) $(LIBPROXYSQLAR)
-	$(CXX) -o $@ $(OBJ) $(LIBPROXYSQLAR) $(CFLAGS) $(LDIRS) $(LIBS)
+	$(CXX) -o $@ $(OBJ) $(LIBPROXYSQLAR) $(MYCPPFLAGS) $(CPPFLAGS) $(LDIRS) $(LIBS) $(LDFLAGS) $(MYLIBS)
 
 $(ODIR):
 	mkdir $(ODIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,8 +57,16 @@ LDIRS=-L$(LDIR) -L$(JEMALLOC_LDIR) $(LIBCONFIG_LDIR) -L$(RE2_PATH)/obj -L$(INJEC
 MYCPPFLAGS=-std=c++11 $(IDIRS) $(OPTZ) $(DEBUG)
 LDFLAGS+=
 #LIBS=-rdynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -linjection -levent -lmariadbclient -lprotobuf -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl -lcrypto -lssl $(EXTRALINK)
-MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -linjection -levent -lmariadbclient -lprotobuf -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl -lcrypto -lssl $(EXTRALINK)
+MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -linjection -levent -lmariadbclient -lprotobuf -Wl,-Bdynamic -lpthread -lm -lz -lrt -lcrypto -lssl $(EXTRALINK)
 #LIBS=-rdynamic -Wl,-Bstatic -lproxysql -ljemalloc -levent $(GLIB_LIB) -Wl,-Bdynamic -ldl -lpthread -lm -lz -lrt
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	MYLIBS+= -ldl
+endif
+ifeq ($(UNAME_S),FreeBSD)
+	MYLIBS+= -lexecinfo
+endif
 
 LIBPROXYSQLAR=$(LDIR)/libproxysql.a
 


### PR DESCRIPTION
This branch improves the compiling process.
ProxySQL now compiles on both Linux and FreeBSD , with either gcc or clang .

Not all versions version of gcc and clang were tested , but the minimum requirement should be:
* gcc 4.8
* clang 3.6

Through environment variables it is possible to define the compiler , linker options, and more.
Here some examples:

## On Linux

## compile using gcc 4.8
```
CXX=g++-4.8 CC=gcc-4.8 make
```

## compile using clang 3.6 and stdc++4.8
```
CXX=clang++-3.6 CC=clang-3.6 CPPFLAGS="-I/usr/include/c++/4.8/ -I/usr/include/x86_64-linux-gnu/c++/4.8" LDFLAGS="-L/usr/lib/x86_64-linux-gnu/ -L/usr/lib/gcc/x86_64-linux-gnu/4.8" make
```

====

## On FreeBSD

## compile using gcc 4.9
```
CC=gcc49 CXX=g++49 LIBS="-Wl,-rpath=/usr/local/lib/gcc49 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
```

## compile using gcc 4.8
```
CC=gcc48 CXX=g++48 LIBS="-Wl,-rpath=/usr/local/lib/gcc48 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
```

## compile using clang 3.7
```
CC=clang37 CXX=clang++37 gmake
```