### PR TITLE
Checksum

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -65,7 +65,6 @@ class ProxySQL_Admin {
 	void flush_mysql_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty);
 	void flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace);
 
-
 	char **get_variables_list();
 	char *get_variable(char *name);
 	bool set_variable(char *name, char *value);
@@ -120,7 +119,9 @@ class ProxySQL_Admin {
 	void load_mysql_variables_to_runtime() { flush_mysql_variables___database_to_runtime(admindb, true); }
 	void save_mysql_variables_from_runtime() { flush_mysql_variables___runtime_to_database(admindb, true, true, false); }
 
-
+	
+	char *table_checksum(char *tablename, char *source, char **err);
+	
 	void stats___mysql_query_rules();
 	void stats___mysql_query_digests();
 	void stats___mysql_query_digests_reset();

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -119,6 +119,7 @@ class ProxySQL_Admin {
 
 	void load_mysql_variables_to_runtime() { flush_mysql_variables___database_to_runtime(admindb, true); }
 	void save_mysql_variables_from_runtime() { flush_mysql_variables___runtime_to_database(admindb, true, true, false); }
+
 	
 	void stats___mysql_query_rules();
 	void stats___mysql_query_digests();

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -120,8 +120,6 @@ class ProxySQL_Admin {
 	void load_mysql_variables_to_runtime() { flush_mysql_variables___database_to_runtime(admindb, true); }
 	void save_mysql_variables_from_runtime() { flush_mysql_variables___runtime_to_database(admindb, true, true, false); }
 	
-	char *table_checksum(char *tablename, char *source, char **err);
-	
 	void stats___mysql_query_rules();
 	void stats___mysql_query_digests();
 	void stats___mysql_query_digests_reset();

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -65,6 +65,7 @@ class ProxySQL_Admin {
 	void flush_mysql_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty);
 	void flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace);
 
+
 	char **get_variables_list();
 	char *get_variable(char *name);
 	bool set_variable(char *name, char *value);
@@ -118,7 +119,6 @@ class ProxySQL_Admin {
 
 	void load_mysql_variables_to_runtime() { flush_mysql_variables___database_to_runtime(admindb, true); }
 	void save_mysql_variables_from_runtime() { flush_mysql_variables___runtime_to_database(admindb, true, true, false); }
-
 	
 	char *table_checksum(char *tablename, char *source, char **err);
 	

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -120,7 +120,7 @@ class ProxySQL_Admin {
 	void load_mysql_variables_to_runtime() { flush_mysql_variables___database_to_runtime(admindb, true); }
 	void save_mysql_variables_from_runtime() { flush_mysql_variables___runtime_to_database(admindb, true, true, false); }
 
-	
+
 	void stats___mysql_query_rules();
 	void stats___mysql_query_digests();
 	void stats___mysql_query_digests_reset();

--- a/include/sqlite3db.h
+++ b/include/sqlite3db.h
@@ -3,6 +3,8 @@
 #include "proxysql.h"
 #include "cpp.h"
 
+
+
 //struct _sqlite3row_t {
 //};
 
@@ -91,7 +93,6 @@ class SQLite3_result {
 	SQLite3_result() {
 		columns=0;
 	};
-
 	void add_column_definition(int a, const char *b) {
 		SQLite3_column *cf=new SQLite3_column(a,b);
 		column_definition.push_back(cf);
@@ -113,7 +114,6 @@ class SQLite3_result {
 		rows_count++;
 		return SQLITE_ROW;
 	};
-
 	SQLite3_result(sqlite3_stmt *stmt) {
 		rows_count=0;
 		columns=sqlite3_column_count(stmt);

--- a/include/sqlite3db.h
+++ b/include/sqlite3db.h
@@ -3,8 +3,6 @@
 #include "proxysql.h"
 #include "cpp.h"
 
-
-
 //struct _sqlite3row_t {
 //};
 
@@ -85,11 +83,15 @@ class SQLite3_result {
 	public:
 	int columns;
 	int rows_count;
+	char *checksum();
+	int64_t raw_checksum();
+
 	std::vector<SQLite3_column *> column_definition;
 	std::vector<SQLite3_row *> rows;
 	SQLite3_result() {
 		columns=0;
 	};
+
 	void add_column_definition(int a, const char *b) {
 		SQLite3_column *cf=new SQLite3_column(a,b);
 		column_definition.push_back(cf);
@@ -111,6 +113,7 @@ class SQLite3_result {
 		rows_count++;
 		return SQLITE_ROW;
 	};
+
 	SQLite3_result(sqlite3_stmt *stmt) {
 		rows_count=0;
 		columns=sqlite3_column_count(stmt);

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1116,7 +1116,6 @@ SQLite3_result * ProxySQL_Admin::generate_show_table_status(const char *tablenam
 		*err=strdup(error);
 		free(error);
 		if (resultset) delete resultset;
-
 		free(tn);
 		return NULL;
 	}
@@ -1366,11 +1365,18 @@ void admin_session_handler(MySQL_Session *sess, ProxySQL_Admin *pa, PtrSize_t *p
 		}
 
 		if (strlen(query_no_space)==strlen("CHECKSUM DISK MYSQL VARIABLES") && !strncasecmp("CHECKSUM DISK MYSQL VARIABLES", query_no_space, strlen(query_no_space))){
-			char *q=(char *)"SELECT * FROM global_variables ORDER BY variable_name";
+			char *q=(char *)"SELECT * FROM global_variables WHERE variable_name LIKE 'mysql-%' ORDER BY variable_name";
 			tablename=(char *)"MYSQL VARIABLES";
 			SPA->configdb->execute_statement(q, &error, &cols, &affected_rows, &resultset);
 
 		}
+
+		if (strlen(query_no_space)==strlen("CHECKSUM DISK MYSQL REPLICATION HOSTGROUPS") && !strncasecmp("CHECKSUM DISK MYSQL REPLICATION HOSTGROUPS", query_no_space, strlen(query_no_space))){
+                        char *q=(char *)"SELECT * FROM mysql_replication_hostgroups ORDER BY writer_hostgroup";
+                        tablename=(char *)"MYSQL REPLICATION HOSTGROUPS";
+                        SPA->configdb->execute_statement(q, &error, &cols, &affected_rows, &resultset);
+
+                }
 
 		if ((strlen(query_no_space)==strlen("CHECKSUM MEMORY MYSQL SERVERS") && !strncasecmp("CHECKSUM MEMORY MYSQL SERVERS", query_no_space, strlen(query_no_space)))
 		||
@@ -1407,10 +1413,20 @@ void admin_session_handler(MySQL_Session *sess, ProxySQL_Admin *pa, PtrSize_t *p
 		(strlen(query_no_space)==strlen("CHECKSUM MEM MYSQL VARIABLES") && !strncasecmp("CHECKSUM MEM MYSQL VARIABLES", query_no_space, strlen(query_no_space)))
 		||
 		(strlen(query_no_space)==strlen("CHECKSUM MYSQL VARIABLES") && !strncasecmp("CHECKSUM MYSQL VARIABLES", query_no_space, strlen(query_no_space)))){
-			char *q=(char *)"SELECT * FROM global_variables ORDER BY variable_name";
+			char *q=(char *)"SELECT * FROM global_variables WHERE variable_name LIKE 'mysql-%' ORDER BY variable_name";
 			tablename=(char *)"MYSQL VARIABLES";
 			SPA->admindb->execute_statement(q, &error, &cols, &affected_rows, &resultset);
 		}
+
+		if ((strlen(query_no_space)==strlen("CHECKSUM MEMORY MYSQL REPLICATION HOSTGROUPS") && !strncasecmp("CHECKSUM MEMORY MYSQL REPLICATION HOSTGROUPS", query_no_space, strlen(query_no_space)))
+                ||
+                (strlen(query_no_space)==strlen("CHECKSUM MEM MYSQL REPLICATION HOSTGROUPS") && !strncasecmp("CHECKSUM MEM MYSQL REPLICATION HOSTGROUPS", query_no_space, strlen(query_no_space)))
+                ||
+                (strlen(query_no_space)==strlen("CHECKSUM MYSQL REPLICATION HOSTGROUPS") && !strncasecmp("CHECKSUM MYSQL REPLICATION HOSTGROUPS", query_no_space, strlen(query_no_space)))){
+                        char *q=(char *)"SELECT * FROM mysql_replication_hostgroups ORDER BY writer_hostgroup";
+                        tablename=(char *)"MYSQL REPLICATION HOSTGROUPS";
+                        SPA->admindb->execute_statement(q, &error, &cols, &affected_rows, &resultset);
+                }
 
 		if (error) {
 			proxy_error("Error: %s\n", error);

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1173,6 +1173,7 @@ SQLite3_result * ProxySQL_Admin::generate_show_table_status(const char *tablenam
 	return result;
 }
 
+
 void admin_session_handler(MySQL_Session *sess, ProxySQL_Admin *pa, PtrSize_t *pkt) {
 
 	char *error=NULL;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1440,6 +1440,7 @@ void admin_session_handler(MySQL_Session *sess, ProxySQL_Admin *pa, PtrSize_t *p
 			char *checksum=(char *)resultset->checksum();
 			query=(char *)malloc(strlen(q)+strlen(tablename)+strlen(checksum)+1);
 			sprintf(query,q,tablename,checksum);
+			free(checksum);
 		}
 		goto __run_query;
         }

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1587,7 +1587,6 @@ __run_query:
 			SPA->statsdb->execute_statement(query, &error , &cols , &affected_rows , &resultset);
 			SPA->statsdb->execute("PRAGMA query_only = OFF");
 		}
-		proxy_info("%s", query);
 		sess->SQLite3_to_MySQL(resultset, error, affected_rows, &sess->client_myds->myprot);
 		delete resultset;
 	}
@@ -2111,10 +2110,6 @@ bool ProxySQL_Admin::is_command(std::string s) {
 	}
 	return true;
 };
-
-
-
-
 
 void ProxySQL_Admin::dump_mysql_collations() {
 	const CHARSET_INFO * c = compiled_charsets;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2111,6 +2111,7 @@ bool ProxySQL_Admin::is_command(std::string s) {
 	return true;
 };
 
+
 void ProxySQL_Admin::dump_mysql_collations() {
 	const CHARSET_INFO * c = compiled_charsets;
 	char buf[1024];

--- a/lib/sqlite3db.cpp
+++ b/lib/sqlite3db.cpp
@@ -63,6 +63,7 @@ bool SQLite3DB::execute_statement(const char *str, char **error, int *cols, int 
 	sqlite3_stmt *statement;
 	*error=NULL;
 	bool ret=false;
+	proxy_info("executing: %s\n", str);
 	if(sqlite3_prepare_v2(db, str, -1, &statement, 0) != SQLITE_OK) {
 		*error=strdup(sqlite3_errmsg(db));
 		goto __exit_execute_statement;

--- a/lib/sqlite3db.cpp
+++ b/lib/sqlite3db.cpp
@@ -63,7 +63,6 @@ bool SQLite3DB::execute_statement(const char *str, char **error, int *cols, int 
 	sqlite3_stmt *statement;
 	*error=NULL;
 	bool ret=false;
-	proxy_info("executing: %s\n", str);
 	if(sqlite3_prepare_v2(db, str, -1, &statement, 0) != SQLITE_OK) {
 		*error=strdup(sqlite3_errmsg(db));
 		goto __exit_execute_statement;


### PR DESCRIPTION
This patch adds `CHECKSUM disk|memory <table>` command for `mysql_servers`, `mysql_replication_hostgroups`, `global_variables`, `mysql_users`, and `mysql_query_rules`.

One minor detail is that a checksum of an empty table returns `0xFF` whereas MySQL's checksum of an empty table return `NULL`(https://dev.mysql.com/doc/refman/5.7/en/checksum-table.html). I'd be happy to change that please let me know.