### PR TITLE
T98 consul multi table config

### DIFF
--- a/integrations/consul/consul_data_format.md
+++ b/integrations/consul/consul_data_format.md
@@ -1,4 +1,4 @@
-proxysql-consul writes table contents read from ProxySQL's admin interface to Consul's key/value store. proxysql-consul uses one key for each table and each key is prefixed with 'proxysql' so that all ProxySQL keys live in their own namespace.
+proxysql-consul writes table contents corresponding to a configuration read from ProxySQL's admin interface to Consul's key/value store. proxysql-consul uses one key for each configuration type and each key is prefixed with 'proxysql' so that all ProxySQL keys live in their own namespace.
 
 Example:
 ```
@@ -6,41 +6,45 @@ key: proxysql/mysql_servers
 ```
 
 The value written is a JSON with multiple fields:
-- table - the name of the table.
+- config_name - the name of the configuration.
 - uuid - unique identifier of the proxysql-consul instance.
-- rows - content of the table as an array of rows. Each row is an array of string values.
+- tables - one key/value pair for each of the tables that comprise the configuration. The key is the table name and the value is an array of rows. Each row is an array of string values.
 
 Example:
 ```
 {  
-   "table":"mysql_servers",
-   "rows":[  
-      [  
-         "0",
-         "127.0.0.1",
-         "3306",
-         "ONLINE",
-         "1",
-         "0",
-         "1000",
-         "10"
+   "tables":{  
+      "mysql_replication_hostgroups":[  
+
       ],
-      [  
-         "0",
-         "/var/lib/mysql/mysql.sock",
-         "0",
-         "ONLINE",
-         "1",
-         "0",
-         "1000",
-         "0"
-      ]
-   ],
+      "mysql_servers":[  
+         [  
+            "0",
+            "127.0.0.1",
+            "3306",
+            "ONLINE",
+            "1",
+            "0",
+            "1000",
+            "10"
+         ],
+         [  
+            "0",
+            "/var/lib/mysql/mysql.sock",
+            "0",
+            "ONLINE",
+            "1",
+            "0",
+            "1000",
+            "0"
+         ]
+   },
+   "config_name":"mysql_servers",
    "uuid":"aae13abd-2a76-4882-afd3-0b2369e02b07"
 }
 ```
 
-The value corresponds to the following mysql_servers dump:
+The example corresponds to the following mysql_servers dump (mysql_replication_hostgroups is empty):
 ```
 +--------------+---------------------------+------+--------+--------+-------------+-----------------+---------------------+
 | hostgroup_id | hostname                  | port | status | weight | compression | max_connections | max_replication_lag |

--- a/integrations/consul/proxysql-consul
+++ b/integrations/consul/proxysql-consul
@@ -43,7 +43,13 @@ CONFIG_NAME_TO_KEY = {
 
 RUNTIME_TABLE_BY_TABLE = {
         'mysql_servers': 'runtime_mysql_servers',
+        'mysql_replication_hostgroups': 'runtime_mysql_replication_hostgroups',
         'mysql_query_rules': 'runtime_mysql_query_rules'
+        }
+
+TABLE_LIST_BY_CONFIG_NAME = {
+        'mysql_servers': ['mysql_servers', 'mysql_replication_hostgroups'],
+        'mysql_query_rules': ['mysql_query_rules']
         }
 
 SAVE_QUERY_BY_CONFIG_NAME = {
@@ -86,20 +92,32 @@ def read_uuid_from_file():
             _uuid = uuid_file.read()
     config[CFG_UUID] = _uuid
 
-def read_proxysql_runtime_config(table):
+
+def read_proxysql_runtime_config(config_name):
+    """
+    Reads the content of the tables that represent the named config and returns
+    it as a dictionary where keys are table names and values lists of rows.
+
+    Each row is a list of the values in the row.
+
+    Will throw an exception if the config_name is not known.
+    """
     admin_connection = MySQLdb.connect(config[CFG_PROXY_IFACE],
             config[CFG_PROXY_USERNAME],
             config[CFG_PROXY_PASSWORD],
             port=config[CFG_PROXY_PORT],
             db='main')
 
-    # read runtime config directly from runtime tables
-    cursor = admin_connection.cursor()
-    cursor.execute('SELECT * FROM %s' % RUNTIME_TABLE_BY_TABLE[table])
-    rows = cursor.fetchall()
-    cursor.close()
+    rows_by_table = {}
+    for table_name in TABLE_LIST_BY_CONFIG_NAME[config_name]:
+        cursor = admin_connection.cursor()
+        cursor.execute('SELECT * FROM %s' % RUNTIME_TABLE_BY_TABLE[table_name])
+        rows = cursor.fetchall()
+        rows_by_table[table_name] = rows
+        cursor.close()
+
     admin_connection.close()
-    return rows 
+    return rows_by_table 
 
 
 def put_config_to_consul(config_name):
@@ -107,11 +125,13 @@ def put_config_to_consul(config_name):
         print 'Unknown config name. Exiting.'
         exit(1)
 
-    rows = read_proxysql_runtime_config(config_name)
+    # read table contents for given config name
+    rows_by_table = read_proxysql_runtime_config(config_name)
+
     consul_data = {}
     # TODO(iprunache) update JSON structure to support multi table configs
     consul_data['config_name'] = config_name
-    consul_data['rows'] = rows
+    consul_data['tables'] = rows_by_table
     consul_data['uuid'] = config[CFG_UUID]
     consul_data_json = json.dumps(consul_data)
 

--- a/integrations/consul/proxysql-consul
+++ b/integrations/consul/proxysql-consul
@@ -153,26 +153,31 @@ def build_multivalue_insert(table, rows):
     query = 'INSERT INTO %s VALUES(%s)' % (table, '),('.join(row_join))
     return query
 
-def update_proxysql_runtime_config(table, rows):
+def update_proxysql_runtime_config(config_name, rows_by_table):
     admin_connection = MySQLdb.connect(config[CFG_PROXY_IFACE],
             config[CFG_PROXY_USERNAME],
             config[CFG_PROXY_PASSWORD],
             port=config[CFG_PROXY_PORT],
             db='main')
-    
-    # clear table
-    cursor = admin_connection.cursor()
-    cursor.execute('DELETE FROM %s' % table)
-    cursor.close()
-    
-    # insert values from Consul
-    insert_query = build_multivalue_insert(table, rows)
-    cursor = admin_connection.cursor()
-    cursor.execute(insert_query)
-    cursor.close()
+
+    for table_name in rows_by_table.keys():
+        rows = rows_by_table[table_name]
+        if not rows:
+            continue
+
+        # clear table
+        cursor = admin_connection.cursor()
+        cursor.execute('DELETE FROM %s' % table_name)
+        cursor.close()
+        
+        # insert values from Consul
+        insert_query = build_multivalue_insert(table_name, rows)
+        cursor = admin_connection.cursor()
+        cursor.execute(insert_query)
+        cursor.close()
 
     # commit changes to runtine
-    load_query = LOAD_QUERY_BY_CONFIG_NAME[table]
+    load_query = LOAD_QUERY_BY_CONFIG_NAME[config_name]
     cursor = admin_connection.cursor()
     cursor.execute(load_query)
     cursor.close()
@@ -189,18 +194,15 @@ def update_config():
     updated_config = json.loads(updated_config_json)
 
     # TODO(iprunache) update JSON structure to support multi table configs
-    config_name = udpated_config['config_name']
-    rows = updated_config['rows']
+    config_name = updated_config['config_name']
+    rows_by_table = updated_config['tables']
     _uuid = updated_config['uuid']
     
-    if not rows:
-        print 'Empty config set for table: %s.' % table
-        return
     if _uuid == config[CFG_UUID]:
         print 'Ignoring self update.'
         return
     
-    update_proxysql_runtime_config(config_name, rows)
+    update_proxysql_runtime_config(config_name, rows_by_table)
     print 'Configs updated successfully.'
 
 # TODO(iprunache) rename to read_consul_data and extract data processing to
@@ -247,5 +249,5 @@ if __name__ == '__main__':
     if arguments['put']:
         put_config_to_consul(arguments['<config-name>'])
     elif arguments['update']:
-        read_consul_data()
+        update_config()
 

--- a/integrations/consul/proxysql-consul
+++ b/integrations/consul/proxysql-consul
@@ -159,9 +159,33 @@ def update_proxysql_runtime_config(table, rows):
 
     admin_connection.close()
 
+def update_config():
+    """
+    Processes the updated config from Consul and if valid pushes it to
+    the local ProxySQL instance runtime.
+    """
+
+    updated_config_json = read_consul_data()
+    updated_config = json.loads(updated_config_json)
+
+    # TODO(iprunache) update JSON structure to support multi table configs
+    config_name = udpated_config['config_name']
+    rows = updated_config['rows']
+    _uuid = updated_config['uuid']
+    
+    if not rows:
+        print 'Empty config set for table: %s.' % table
+        return
+    if _uuid == config[CFG_UUID]:
+        print 'Ignoring self update.'
+        return
+    
+    update_proxysql_runtime_config(config_name, rows)
+    print 'Configs updated successfully.'
+
 # TODO(iprunache) rename to read_consul_data and extract data processing to
 # separate method.
-def update_config():
+def read_consul_data():
     """
     Reads all input from stdin that is passed by Consul and extracts the config
     that was modified.
@@ -173,6 +197,9 @@ def update_config():
 
     Values are returned as a JSON array. The actual value content is stored in
     the 'Value' field, base64 encoded.
+
+    Returns the decoded JSON that was the latest to be updated or None if it
+    failed to determine which key was last updated.
     """
     if 'CONSUL_INDEX' not in os.environ:
         print 'Missing consul index on update request'
@@ -187,25 +214,10 @@ def update_config():
            updated_value = value
            break
     if not updated_value:
-        print 'Failed to determine updated config from Consul data'
+        print 'Failed to determine updated key from Consul.'
         exit(1)
 
-    proxysql_config_json = base64.b64decode(updated_value['Value'])
-    proxysql_config = json.loads(proxysql_config_json)
-    # TODO(iprunache) update JSON structure to support multi table configs
-    config_name = proxysql_config['config_name']
-    rows = proxysql_config['rows']
-    _uuid = proxysql_config['uuid']
-    
-    if not rows:
-        print 'Empty config set for table: %s.' % table
-        return
-    if _uuid == config[CFG_UUID]:
-        print 'Ignoring self update.'
-        return
-    
-    update_proxysql_runtime_config(config_name, rows)
-    print 'Configs updated successfully.'
+    return base64.b64decode(updated_value['Value'])
 
 if __name__ == '__main__':
     arguments = docopt(__doc__, version='proxysql-consul 1.0')
@@ -215,5 +227,5 @@ if __name__ == '__main__':
     if arguments['put']:
         put_config_to_consul(arguments['<config-name>'])
     elif arguments['update']:
-        update_config()
+        read_consul_data()
 

--- a/integrations/consul/proxysql-consul
+++ b/integrations/consul/proxysql-consul
@@ -2,7 +2,7 @@
 
 """
 Usage:
-  proxysql-consul put <table> [--config-file=<config-file>]
+  proxysql-consul put <config-name> [--config-file=<config-file>]
   proxysql-consul update [--config-file=<config-file>]
   proxysql-consul (-h | --help)
 
@@ -36,7 +36,7 @@ CFG_PROXY_USERNAME = 'proxysql_admin_username'
 CFG_PROXY_PASSWORD = 'proxysql_admin_password'
 
 # Proxysql config types to Consul key mapping
-TABLE_TO_KEY = {
+CONFIG_NAME_TO_KEY = {
         'mysql_servers': 'proxysql/mysql_servers',
         'mysql_query_rules': 'proxysql/mysql_query_rules'
         }
@@ -46,12 +46,12 @@ RUNTIME_TABLE_BY_TABLE = {
         'mysql_query_rules': 'runtime_mysql_query_rules'
         }
 
-SAVE_QUERY_BY_TABLE = {
+SAVE_QUERY_BY_CONFIG_NAME = {
         'mysql_servers': 'SAVE MYSQL SERVERS TO MEMORY',
         'mysql_query_rules': 'SAVE MYSQL QUERY RULES TO MEMORY'
         }
 
-LOAD_QUERY_BY_TABLE = {
+LOAD_QUERY_BY_CONFIG_NAME = {
         'mysql_servers': 'LOAD MYSQL SERVERS FROM MEMORY',
         'mysql_query_rules': 'LOAD MYSQL QUERY RULES FROM MEMORY'
         }
@@ -102,19 +102,20 @@ def read_proxysql_runtime_config(table):
     return rows 
 
 
-def put_config_to_consul(table):
-    if table not in TABLE_TO_KEY:
-        print 'Unknown config table. Exiting.'
+def put_config_to_consul(config_name):
+    if config_name not in CONFIG_NAME_TO_KEY:
+        print 'Unknown config name. Exiting.'
         exit(1)
 
-    rows = read_proxysql_runtime_config(table)
+    rows = read_proxysql_runtime_config(config_name)
     consul_data = {}
-    consul_data['table'] = table
+    # TODO(iprunache) update JSON structure to support multi table configs
+    consul_data['config_name'] = config_name
     consul_data['rows'] = rows
     consul_data['uuid'] = config[CFG_UUID]
     consul_data_json = json.dumps(consul_data)
 
-    key = TABLE_TO_KEY[table]
+    key = CONFIG_NAME_TO_KEY[config_name]
     consul_iface = config[CFG_CONSUL_IFACE]
     consul_port = config[CFG_CONSUL_PORT]
 
@@ -151,14 +152,15 @@ def update_proxysql_runtime_config(table, rows):
     cursor.close()
 
     # commit changes to runtine
-    load_query = LOAD_QUERY_BY_TABLE[table]
+    load_query = LOAD_QUERY_BY_CONFIG_NAME[table]
     cursor = admin_connection.cursor()
     cursor.execute(load_query)
     cursor.close()
 
     admin_connection.close()
 
-
+# TODO(iprunache) rename to read_consul_data and extract data processing to
+# separate method.
 def update_config():
     """
     Reads all input from stdin that is passed by Consul and extracts the config
@@ -190,7 +192,8 @@ def update_config():
 
     proxysql_config_json = base64.b64decode(updated_value['Value'])
     proxysql_config = json.loads(proxysql_config_json)
-    table = proxysql_config['table']
+    # TODO(iprunache) update JSON structure to support multi table configs
+    config_name = proxysql_config['config_name']
     rows = proxysql_config['rows']
     _uuid = proxysql_config['uuid']
     
@@ -201,7 +204,7 @@ def update_config():
         print 'Ignoring self update.'
         return
     
-    update_proxysql_runtime_config(table, rows)
+    update_proxysql_runtime_config(config_name, rows)
     print 'Configs updated successfully.'
 
 if __name__ == '__main__':
@@ -210,7 +213,7 @@ if __name__ == '__main__':
     read_uuid_from_file()
 
     if arguments['put']:
-        put_config_to_consul(arguments['<table>'])
+        put_config_to_consul(arguments['<config-name>'])
     elif arguments['update']:
         update_config()
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -3480,31 +3480,31 @@ void ProxySQL_Admin::load_mysql_servers_to_runtime() {
 }
 
 
-// Gets a copy of the runtime mysql servers config and passes is to an external script for distribution
-// to other ProxySQL instances. Returns true in case of success and false in case of failure.
+// Triggers configuration propagation to all ProxySQL servers in a cluster for mysql servers. Returns
+// true in case of success.
 bool ProxySQL_Admin::save_mysql_servers_to_cluster() {
-	char *tablename = (char *)"mysql_servers";
-	int status_code = save_config_to_cluster(tablename);
+	char *config_name = (char *)"mysql_servers";
+	int status_code = save_config_to_cluster(config_name);
 	return status_code == 0;
 }
 
-// Gets a copy of the runtime mysql query rules config and passes is to an external script for distribution
-// to other ProxySQL instances. Returns true in case of success and false in case of failure.
+// Triggers configuration propagation to all ProxySQL servers in a cluster for mysql query rules. Returns
+// true in case of success.
 bool ProxySQL_Admin::save_mysql_query_rules_to_cluster() {
-	char *tablename = (char *)"mysql_query_rules";
-	int status_code = save_config_to_cluster(tablename);
+	char *config_name = (char *)"mysql_query_rules";
+	int status_code = save_config_to_cluster(config_name);
 	return status_code == 0;
 }
 
-// Runs external config distribution script passing it the given table name. The script will use the admin
-// interface to read the contents of the table.
-int ProxySQL_Admin::save_config_to_cluster(char *tablename) {
+// Runs external config distribution script passing it the given configuration name. The script will use the
+// admin interface to read the configuration.
+int ProxySQL_Admin::save_config_to_cluster(char *config_name) {
 	pid_t pid = fork();
 	if (pid == 0) {
 		// child
 		errno = 0;
 		char *proxysql_consul_script_path = get_variable((char *)"proxysql_consul_script_path");
-		int exec_status = execlp(proxysql_consul_script_path, proxysql_consul_script_path, "put", tablename, (char *) 0);
+		int exec_status = execlp(proxysql_consul_script_path, proxysql_consul_script_path, "put", config_name, (char *) 0);
 		if (exec_status == -1) {
 			proxy_error("Exec failed for config save script with errno: %d.\n", errno);
 		}


### PR DESCRIPTION
Some LOAD/SAVE commands like `LOAD MYSQL SERVERS` affect multiple tables - mysql_servers and mysql_replication_hostgroups for this example - which was not supported by the consul integration script. Added support for configurations comprising of multiple tables.