### PR TITLE
Clean mongoose too with make cleanall

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -81,5 +81,6 @@ cleanall:
 	cd libinjection && ${MAKE} clean
 	cd libevent && rm -rf libevent-2.0.22-stable
 	cd sqlite3/sqlite3 && rm -rf *.o
+	cd mongoose/mongoose && rm -rf *.o
 .PHONY: cleanall
 


### PR DESCRIPTION
## Why
mongoose.o is a dependency and we want it cleaned when cleaning all dependencies.
## What
Delete deps/mongoose/mongoose/*.o on `make cleanall`.