### PR TITLE
T113 Detect when daemon is restarted an push alert

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -62,6 +62,7 @@ ProxySQL supports integration with [OpsGenie](www.opsgenie.com) so it can send a
 
 So far ProxySQL sends alerts for the following events:
 * when a backend server gets shunned
+* when the angel process restarts the daemon process
 
 ###Configure integration with OpsGenie
 1. Create an OpsGenie account.

--- a/include/AlertRouter.h
+++ b/include/AlertRouter.h
@@ -18,6 +18,7 @@ private:
     void pushAlertInDetachedThread(void *(*pushMethod)(void *), char *message);
 public:
     AlertRouter();
+    AlertRouter(time_t lastPushTime);
     void pushAlert(char *message);
 };
 

--- a/lib/AlertRouter.cpp
+++ b/lib/AlertRouter.cpp
@@ -14,6 +14,11 @@ AlertRouter::AlertRouter() {
 }
 
 
+AlertRouter::AlertRouter(time_t lastPushTime) {
+    this->lastPushTime = lastPushTime;
+}
+
+
 // Forwards the given message to OpsGenieConnector so it can be pushed to OpsGenie.
 //
 // It assumes that it can be run in a different thread than the one that allocated message so it will free message


### PR DESCRIPTION
Set flags in the angel process that the daemon can read so the daemon
can learn that it was restarted because of a failure. Pus an alert in
case the daemon detects it has been restarted.