### PR TITLE
apt-get cleanup for smaller docker image

### DIFF
--- a/docker/images/proxysql/proxysql/Dockerfile
+++ b/docker/images/proxysql/proxysql/Dockerfile
@@ -8,18 +8,21 @@ LABEL vendor=proxysql\
       com.proxysql.config=simple\
       com.proxysql.purpose=testing
 
-RUN apt-get update && apt-get install -y\
-	automake\
-	cmake\
-	make\
-	g++\
-	gcc\
-	gdb\
-	gdbserver\
-	git\
-	libmysqlclient-dev\
-	libssl-dev\
-	libtool
+RUN apt-get update && apt-get install -y \
+	automake \
+	cmake \
+	make \
+	g++ \
+	gcc \
+	gdb \
+	gdbserver \
+	git \
+	libmysqlclient-dev \
+	libssl-dev \
+	libtool \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
 
 RUN cd /opt; git clone https://github.com/akopytov/sysbench.git
 RUN cd /opt/sysbench; ./autogen.sh; ./configure --bindir=/usr/bin; make; make install


### PR DESCRIPTION
apt-get layer cleanup results in 21MB savings. Not huge for a test image, but every little bit helps.