### PR TITLE
Added systemd support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,18 +168,27 @@ cleanall:
 	rm binaries/*deb || true
 	rm binaries/*rpm || true
 
+
 install: src/proxysql
 	install -m 0755 src/proxysql /usr/local/bin
 	install -m 0600 etc/proxysql.cnf /etc
-	install -m 0755 etc/init.d/proxysql /etc/init.d
 	if [ ! -d /var/lib/proxysql ]; then mkdir /var/lib/proxysql ; fi
-	update-rc.d proxysql defaults
+	if [ -d /usr/lib/systemd/system ]; then \
+		install -m 0755 usr/lib/systemd/system/proxysql.service /usr/lib/systemd/system ; \
+	else \
+  	install -m 0755 etc/init.d/proxysql /etc/init.d ; \
+  	update-rc.d proxysql defaults ; \
+	fi
 .PHONY: install
 
 uninstall:
-	rm /etc/init.d/proxysql
 	rm /etc/proxysql.cnf
 	rm /usr/local/bin/proxysql
 	rmdir /var/lib/proxysql 2>/dev/null || true
-	update-rc.d proxysql remove
+	if [ -d /usr/lib/systemd/system ]; then \
+		rm /usr/lib/systemd/system/proxysql.service ;\
+	else \
+  	rm etc/init.d/proxysql ;\
+		update-rc.d proxysql remove ;\
+	fi
 .PHONY: uninstall

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -148,7 +148,6 @@ void ProxySQL_GlobalVariables::process_opts_pre() {
 		__cmd_proxysql_reload=true;
 	}
 
-
 	config_file=GloVars.__cmd_proxysql_config_file;
 
 	if (config_file==NULL) {

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -75,9 +75,9 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 	opt->add((const char *)"",0,0,0,(const char *)"Starts only the admin service",(const char *)"-n",(const char *)"--no-start");
 	opt->add((const char *)"",0,0,0,(const char *)"Run in foreground",(const char *)"-f",(const char *)"--foreground");
 	opt->add((const char *)"",0,0,0,(const char *)"Do not restart ProxySQL if crashes",(const char *)"-e",(const char *)"--exit-on-error");
-	opt->add((const char *)"~/proxysql.cnf",0,1,0,(const char *)"Configuraton file",(const char *)"-c",(const char *)"--config");
+	opt->add((const char *)"/etc/proxysql.cnf",0,1,0,(const char *)"Configuraton file",(const char *)"-c",(const char *)"--config");
 	//opt->add((const char *)"",0,0,0,(const char *)"Enable custom memory allocator",(const char *)"-m",(const char *)"--custom-memory");
-	opt->add((const char *)"",0,1,0,(const char *)"Datadir",(const char *)"-D",(const char *)"--datadir");
+	opt->add((const char *)"/var/lib/proxysql",0,1,0,(const char *)"Datadir",(const char *)"-D",(const char *)"--datadir");
 	opt->add((const char *)"",0,0,0,(const char *)"Rename/empty database file",(const char *)"--initial");
 	opt->add((const char *)"",0,0,0,(const char *)"Merge config file into database file",(const char *)"--reload");
 	opt->add((const char *)"",0,1,0,(const char *)"Administration Unix Socket",(const char *)"-S",(const char *)"--admin-socket");
@@ -112,7 +112,7 @@ void ProxySQL_GlobalVariables::process_opts_pre() {
 	}
 
 	if (opt->isSet("-d")) {
-		opt->get("-d")->getInt(GloVars.__cmd_proxysql_gdbg);	
+		opt->get("-d")->getInt(GloVars.__cmd_proxysql_gdbg);
 		global.gdbg=true;
 	}
 
@@ -148,7 +148,7 @@ void ProxySQL_GlobalVariables::process_opts_pre() {
 		__cmd_proxysql_reload=true;
 	}
 
-	
+
 	config_file=GloVars.__cmd_proxysql_config_file;
 
 	if (config_file==NULL) {

--- a/usr/lib/systemd/system/proxysql.service
+++ b/usr/lib/systemd/system/proxysql.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=High Performance Advanced Proxy for MySQL
+
+[Service]
+Type=forking
+PIDFile=/var/lib/proxysql/proxysql.pid
+ExecStart=/usr/local/bin/proxysql
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hello Rene, 

I was testing ProxySQL and when I ran "make install" in a CentOS 7 vm I was getting errors because of systemd so I decided to modify the make file.

Also I have added the default parameters in the options (configfile and datadir) based on ezOptionParser configuration.

As you can see this is not a big help for the project but it can help other that use systemd.

Regards, 

Martin.
