### PR TITLE
Assign hostgroup_id to Monitor_State_Data, fixes laggy backends not being shunned.

### DIFF
--- a/include/MySQL_Monitor.hpp
+++ b/include/MySQL_Monitor.hpp
@@ -50,7 +50,7 @@ class MySQL_Monitor_State_Data {
   MYSQL_ROW *row;
   unsigned int repl_lag;
   unsigned int hostgroup_id;
-	MySQL_Monitor_State_Data(char *h, int p, struct event_base *b, bool _use_ssl=0);
+	MySQL_Monitor_State_Data(char *h, int p, struct event_base *b, bool _use_ssl=0, int g=0);
 	~MySQL_Monitor_State_Data();
 	SQLite3DB *mondb;
 	bool create_new_connection();

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -232,7 +232,7 @@ void MySQL_Monitor_Connection_Pool::put_connection(char *hostname, int port, MYS
 	pthread_mutex_unlock(&mutex);
 }
 
-MySQL_Monitor_State_Data::MySQL_Monitor_State_Data(char *h, int p, struct event_base *b, bool _use_ssl) {
+MySQL_Monitor_State_Data::MySQL_Monitor_State_Data(char *h, int p, struct event_base *b, bool _use_ssl, int g) {
 		task_id=MON_CONNECT;
 		mysql=NULL;
 		result=NULL;
@@ -245,6 +245,7 @@ MySQL_Monitor_State_Data::MySQL_Monitor_State_Data(char *h, int p, struct event_
 		use_ssl=_use_ssl;
 		ST=0;
 		//ev_mysql=NULL;
+		hostgroup_id=g;
 	};
 
 MySQL_Monitor_State_Data::~MySQL_Monitor_State_Data() {
@@ -1352,7 +1353,7 @@ void * MySQL_Monitor::monitor_replication_lag() {
 			}
 			for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 				SQLite3_row *r=*it;
-				MySQL_Monitor_State_Data *mmsd = new MySQL_Monitor_State_Data(r->fields[1],atoi(r->fields[2]), NULL, atoi(r->fields[4]));
+				MySQL_Monitor_State_Data *mmsd = new MySQL_Monitor_State_Data(r->fields[1], atoi(r->fields[2]), NULL, atoi(r->fields[4]), atoi(r->fields[0]));
 				mmsd->mondb=monitordb;
 				WorkItem* item;
 				item=new WorkItem(mmsd,monitor_replication_lag_thread);


### PR DESCRIPTION
```MySQL_HostGroups_Manager::replication_lag_action``` expects a hostgroup_id in _hid but ```MySQL_Monitor::monitor_replication_lag``` doesn't set the field in ```MySQL_Monitor_State_Data```, so this check ```if (_hid >= 0 && _hid!=(int)myhgc->hid) continue``` always fails.