### PR TITLE
Do not shunt the server if max_user_connections is reached for user

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -140,6 +140,7 @@ void MySrvC::connect_error(int err_num) {
 		case 1044: // access denied
 		case 1045: // access denied
 		case 1049: //Unknown databas
+               case 1226: // do not increase counter to avoid Shunning if user has max_user_connections restriction
 			return;
 			break;
 		default:


### PR DESCRIPTION
Do not shunt the server if max_user_connections is reached for user.

I see the situation when we have limits for every user like:
```
Oct 15 17:25:45 us-imm-proxysql1.xxx.io proxysql[924]: 2016-10-15 17:25:45 mysql_connection.cpp:495:handler(): [ERROR] Failed to mysql_real_connect() on v6.us-imm-sql1.xxx.io:3306 , FD (Conn:38 , MyDS:38) , 1226: User 'id37680_wp_94591388bdb77a428ed7ffaa2c63f641' has exceeded the 'max_user_connections' resource (current value: 3).
```
This is the problem, because this always calls `NEXT_IMMEDIATE(ASYNC_CONNECT_FAILED);`, which in turn increases `connect_ERR_at_time_last_detected_error` and sets `status=MYSQL_SERVER_STATUS_SHUNNED;`. This means, that we have this ERROR almost all the time:
```
Oct 15 17:26:51 us-imm-proxysql1.000webhost.io proxysql[924]: 2016-10-15 17:26:51 MySQL_HostGroups_Manager.cpp:166:connect_error(): [ERROR] Shunning server v6.us-imm-sql1.xxx.io:3306 with 5 errors/sec. Shunning for 10 seconds
```

@renecannao 