### PR TITLE
V1.3.0 exp2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEBUG=${ALL_DEBUG}
 #export DEBUG
 #export OPTZ
 #export EXTRALINK
-CURVER=1.3.0
+CURVER=1.3.0-exp2
 DISTRO := $(shell gawk -F= '/^NAME/{print $$2}' /etc/os-release)
 ifeq ($(wildcard /usr/lib/systemd/systemd), /usr/lib/systemd/systemd)
 	SYSTEMD=1

--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -109,6 +109,8 @@ class MySQL_Session
 	unsigned long long start_time;
 	unsigned long long pause_until;
 
+	unsigned long long idle_since;
+
 	// pointers
 	MySQL_Thread *thread;
 	Query_Processor_Output *qpo;

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -165,6 +165,8 @@ class MySQL_Thread
 	int pipefd[2];
 	int shutdown;
 
+	bool epoll_thread;
+
 	// status variables are per thread only
 	// in this way, there is no need for atomic operation and there is no cache miss
 	// when it is needed a total, all threads are checked
@@ -344,6 +346,7 @@ class MySQL_Threads_Handler
 	public:
 	unsigned int num_threads;
 	proxysql_mysql_thread_t *mysql_threads;
+	proxysql_mysql_thread_t *mysql_threads_idles;
 	rwlock_t rwlock_idles;
 	rwlock_t rwlock_resumes;
 	PtrArray *idle_mysql_sessions;

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -147,6 +147,7 @@ class MySQL_Thread
 
 	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];
 	int efd;
+	std::map<unsigned int, unsigned int> sessmap;
 
 	protected:
 	int nfds;

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -147,6 +147,7 @@ class MySQL_Thread
 
 	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];
 	int efd;
+	int mysess_idx;
 	std::map<unsigned int, unsigned int> sessmap;
 
 	protected:

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -241,7 +241,7 @@ class MySQL_Listeners_Manager {
 	public:
   MySQL_Listeners_Manager();
 	~MySQL_Listeners_Manager();
-	int add(const char *iface, unsigned int num_threads, int *perthrsocks);
+	int add(const char *iface, unsigned int num_threads, int **perthrsocks);
 	//int add(const char *address, int port);
 	int find_idx(const char *iface);
 	int find_idx(const char *address, int port);

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -147,7 +147,7 @@ class MySQL_Thread
 
 	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];
 	int efd;
-	int mysess_idx;
+	unsigned int mysess_idx;
 	std::map<unsigned int, unsigned int> sessmap;
 
 	protected:
@@ -295,6 +295,7 @@ class MySQL_Threads_Handler
 		int connect_timeout_server;
 		int connect_timeout_server_max;
 		int free_connections_pct;
+		int session_idle_ms;
 		bool sessions_sort;
 		char *default_schema;
 		char *interfaces;

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -241,8 +241,8 @@ class MySQL_Listeners_Manager {
 	public:
   MySQL_Listeners_Manager();
 	~MySQL_Listeners_Manager();
-	int add(const char *iface);
-	int add(const char *address, int port);
+	int add(const char *iface, unsigned int num_threads, int *perthrsocks);
+	//int add(const char *address, int port);
 	int find_idx(const char *iface);
 	int find_idx(const char *address, int port);
 	iface_info * find_iface_from_fd(int fd);

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -3,11 +3,11 @@
 #define ____CLASS_STANDARD_MYSQL_THREAD_H
 #include "proxysql.h"
 #include "cpp.h"
-
+#include <sys/epoll.h>
 
 #define MIN_POLL_LEN 8
 #define MIN_POLL_DELETE_RATIO  8
-
+#define MY_EPOLL_THREAD_MAXEVENTS 128
 
 #define ADMIN_HOSTGROUP	-2
 #define STATS_HOSTGROUP	-3
@@ -145,7 +145,7 @@ class MySQL_Thread
 
 	PtrArray *cached_connections;
 
-	struct epoll_event *events;
+	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];
 	int efd;
 
 	protected:

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -19,6 +19,13 @@ static unsigned int near_pow_2 (unsigned int n) {
   return i ? i : n;
 }
 
+typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) _conn_exchange_t {
+	pthread_mutex_t mutex_idles;
+	PtrArray *idle_mysql_sessions;
+	pthread_mutex_t mutex_resumes;
+	PtrArray *resume_mysql_sessions;
+} conn_exchange_t;
+
 class ProxySQL_Poll {
 
   private:
@@ -162,6 +169,9 @@ class MySQL_Thread
 	PtrArray *mysql_sessions;
 	PtrArray *idle_mysql_sessions;
 	PtrArray *resume_mysql_sessions;
+
+	conn_exchange_t myexchange;
+
 	int pipefd[2];
 	int shutdown;
 
@@ -347,10 +357,10 @@ class MySQL_Threads_Handler
 	unsigned int num_threads;
 	proxysql_mysql_thread_t *mysql_threads;
 	proxysql_mysql_thread_t *mysql_threads_idles;
-	rwlock_t rwlock_idles;
-	rwlock_t rwlock_resumes;
-	PtrArray *idle_mysql_sessions;
-	PtrArray *resume_mysql_sessions;
+	//rwlock_t rwlock_idles;
+	//rwlock_t rwlock_resumes;
+	//PtrArray *idle_mysql_sessions;
+	//PtrArray *resume_mysql_sessions;
 	//virtual const char *version() {return NULL;};
 	unsigned int get_global_version();
 	void wrlock();

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -155,6 +155,8 @@ class MySQL_Thread
 	unsigned long long curtime;
 	unsigned long long last_maintenance_time;
 	PtrArray *mysql_sessions;
+	PtrArray *idle_mysql_sessions;
+	PtrArray *resume_mysql_sessions;
 	int pipefd[2];
 	int shutdown;
 
@@ -189,10 +191,10 @@ class MySQL_Thread
   void run();
   void poll_listener_add(int sock);
   void poll_listener_del(int sock);
-  void register_session(MySQL_Session*);
+  void register_session(MySQL_Session*, bool up_start=true);
   void unregister_session(int);
   struct pollfd * get_pollfd(unsigned int i);
-  void process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned int n);
+  bool process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned int n);
   void process_all_sessions();
   void refresh_variables();
   void register_session_connection_handler(MySQL_Session *_sess, bool _new=false);
@@ -336,6 +338,10 @@ class MySQL_Threads_Handler
 	public:
 	unsigned int num_threads;
 	proxysql_mysql_thread_t *mysql_threads;
+	rwlock_t rwlock_idles;
+	rwlock_t rwlock_resumes;
+	PtrArray *idle_mysql_sessions;
+	PtrArray *resume_mysql_sessions;
 	//virtual const char *version() {return NULL;};
 	unsigned int get_global_version();
 	void wrlock();

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -145,6 +145,9 @@ class MySQL_Thread
 
 	PtrArray *cached_connections;
 
+	struct epoll_event *events;
+	int efd;
+
 	protected:
 	int nfds;
 

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -401,6 +401,7 @@ class MySQL_Threads_Handler
 	unsigned long long get_queries_backends_bytes_recv();
 	unsigned long long get_queries_backends_bytes_sent();
 	unsigned int get_active_transations();
+	unsigned int get_non_idle_client_connections();
 	unsigned long long get_query_processor_time();
 	unsigned long long get_backend_query_time();
 	unsigned long long get_mysql_backend_buffers_bytes();

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -308,6 +308,7 @@ class MySQL_Threads_Handler
 		int connect_timeout_server_max;
 		int free_connections_pct;
 		int session_idle_ms;
+		bool session_idle_show_processlist;
 		bool sessions_sort;
 		char *default_schema;
 		char *interfaces;

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -370,7 +370,7 @@ class MySQL_Threads_Handler
 	int get_variable_int(char *name);
 	void print_version();
 	void init(unsigned int num=0, size_t stack=0);
-	proxysql_mysql_thread_t *create_thread(unsigned int tn, void *(*start_routine) (void *));
+	proxysql_mysql_thread_t *create_thread(unsigned int tn, void *(*start_routine) (void *), bool);
 	void shutdown_threads();
 	int listener_add(const char *iface);
 	int listener_add(const char *address, int port);

--- a/include/proxysql.h
+++ b/include/proxysql.h
@@ -111,7 +111,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 //mysql_data_stream_t * mysql_data_stream_New(mysql_session_t *, int, mysql_backend_t *);
-int listen_on_port(char *, uint16_t, int);
+int listen_on_port(char *ip, uint16_t port, int backlog, bool reuseport=false);
 int listen_on_unix(char *, int);
 int connect_socket(char *, int);
 //void process_global_variables_from_file(GKeyFile *, int );

--- a/include/proxysql_glovars.hpp
+++ b/include/proxysql_glovars.hpp
@@ -36,6 +36,9 @@ class ProxySQL_GlobalVariables {
 		bool gdbg;
 		bool nostart;
 		bool monitor;
+#ifdef SO_REUSEPORT
+		bool reuseport;
+#endif /* SO_REUSEPORT */
 //		bool use_proxysql_mem;
 		pthread_mutex_t start_mutex;
 		bool foreground;

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -819,6 +819,7 @@ __thread bool mysql_thread___commands_stats;
 __thread bool mysql_thread___query_digests;
 __thread bool mysql_thread___default_reconnect;
 __thread bool mysql_thread___sessions_sort;
+__thread bool mysql_thread___session_idle_ms;
 
 /* variables used for Query Cache */
 __thread int mysql_thread___query_cache_size_MB;
@@ -905,6 +906,7 @@ extern __thread bool mysql_thread___commands_stats;
 extern __thread bool mysql_thread___query_digests;
 extern __thread bool mysql_thread___default_reconnect;
 extern __thread bool mysql_thread___sessions_sort;
+extern __thread bool mysql_thread___session_idle_ms;
 
 /* variables used for Query Cache */
 extern __thread int mysql_thread___query_cache_size_MB;

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -818,6 +818,7 @@ __thread bool mysql_thread___servers_stats;
 __thread bool mysql_thread___commands_stats;
 __thread bool mysql_thread___query_digests;
 __thread bool mysql_thread___default_reconnect;
+__thread bool mysql_thread___session_idle_show_processlist;
 __thread bool mysql_thread___sessions_sort;
 __thread bool mysql_thread___session_idle_ms;
 
@@ -905,6 +906,7 @@ extern __thread bool mysql_thread___servers_stats;
 extern __thread bool mysql_thread___commands_stats;
 extern __thread bool mysql_thread___query_digests;
 extern __thread bool mysql_thread___default_reconnect;
+extern __thread bool mysql_thread___session_idle_show_processlist;
 extern __thread bool mysql_thread___sessions_sort;
 extern __thread bool mysql_thread___session_idle_ms;
 

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -298,6 +298,9 @@ MySQL_Monitor::MySQL_Monitor() {
 			num_threads=GloMTH->num_threads*2;
 		}
 	}
+	if (num_threads>16) {
+		num_threads=16;	// limit to 16
+	}
 };
 
 MySQL_Monitor::~MySQL_Monitor() {

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -1004,7 +1004,7 @@ bool MySQL_Protocol::generate_pkt_initial_handshake(bool send, void **ptr, unsig
   //srand(pthread_self());
   //uint32_t thread_id=rand()%100000;
   uint32_t thread_id=__sync_fetch_and_add(&glovars.thread_id,1);
-	if (_thread_id==0) {
+	if (thread_id==0) {
 		thread_id=__sync_fetch_and_add(&glovars.thread_id,1); // again!
 	}
 	*_thread_id=thread_id;

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -1004,8 +1004,10 @@ bool MySQL_Protocol::generate_pkt_initial_handshake(bool send, void **ptr, unsig
   //srand(pthread_self());
   //uint32_t thread_id=rand()%100000;
   uint32_t thread_id=__sync_fetch_and_add(&glovars.thread_id,1);
-	if (_thread_id)
-		*_thread_id=thread_id;
+	if (_thread_id==0) {
+		thread_id=__sync_fetch_and_add(&glovars.thread_id,1); // again!
+	}
+	*_thread_id=thread_id;
   //uint32_t thread_id=pthread_self();
 
   rand_struct rand_st;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -653,6 +653,9 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 		newsess->client_myds->myds_type=MYDS_FRONTEND;
 		newsess->client_myds->PSarrayOUT= new PtrSizeArray();
 		newsess->thread_session_id=__sync_fetch_and_add(&glovars.thread_id,1);
+		if (newsess->thread_session_id==0) {
+			newsess->thread_session_id=__sync_fetch_and_add(&glovars.thread_id,1);
+		}
 		thread->register_session(newsess);
 		newsess->status=WAITING_CLIENT_DATA;
 		MySQL_Connection *myconn=new MySQL_Connection;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2106,9 +2106,11 @@ __run_skip_1a:
 			refresh_variables();
 		}
 
-		for (n=0; n<mysql_sessions->len; n++) {
-			MySQL_Session *_sess=(MySQL_Session *)mysql_sessions->index(n);
-			_sess->to_process=0;
+		if (GloMTH->num_threads >= MIN_THREADS_FOR_MAINTENANCE && idle_maintenance_thread==false) {
+			for (n=0; n<mysql_sessions->len; n++) {
+				MySQL_Session *_sess=(MySQL_Session *)mysql_sessions->index(n);
+				_sess->to_process=0;
+			}
 		}
 
 		// here we handle epoll_wait()

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2319,13 +2319,15 @@ __run_skip_1a:
 					mysess_idx=0;
 				}
 				unsigned int i;
+				unsigned long long min_idle = curtime - (unsigned long long)mysql_thread___wait_timeout*1000;
 				for (i=0;i<SESS_TO_SCAN && mysess_idx < mysql_sessions->len; i++) {
 					uint32_t sess_pos=mysess_idx;
 					MySQL_Session *mysess=(MySQL_Session *)mysql_sessions->index(sess_pos);
 
 					//unsigned long long sess_time = mysess->IdleTime();
-					unsigned long long sess_time = curtime - mysess->idle_since;
-					if ( (sess_time/1000 > (unsigned long long)mysql_thread___wait_timeout) ) {
+					//unsigned long long sess_time = curtime - mysess->idle_since;
+					//if ( (sess_time/1000 > (unsigned long long)mysql_thread___wait_timeout) ) {
+					if (mysess->idle_since < min_idle) {
 						mysess->killed=true;
 						//uint32_t sess_thr_id=mysess->thread_session_id;
 						MySQL_Data_Stream *tmp_myds=mysess->client_myds;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1916,7 +1916,7 @@ __run_skip_1:
 			myds=mypolls.myds[n];
 			mypolls.fds[n].revents=0;
 			if (myds) {
-				if (GloMTH->num_threads >= MIN_THREADS_FOR_MAINTENANCE && idle_maintenance_thread==false) {
+				//if (GloMTH->num_threads >= MIN_THREADS_FOR_MAINTENANCE && idle_maintenance_thread==false) {
 					// here we try to move it to the maintenance thread
 					if (mypolls.last_recv[n] < curtime - 1000000) {
 						if (myds->myds_type==MYDS_FRONTEND && myds->sess) {
@@ -1954,7 +1954,7 @@ __run_skip_1:
 							}
 						}
 					}
-				}
+				//}
 				if (myds->wait_until) {
 					if (myds->wait_until > curtime) {
 						if (mypolls.poll_timeout==0 || (myds->wait_until - curtime < mypolls.poll_timeout) ) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1934,7 +1934,7 @@ __run_skip_1:
 			if (myds) {
 				//if (GloMTH->num_threads >= MIN_THREADS_FOR_MAINTENANCE && idle_maintenance_thread==false) {
 					// here we try to move it to the maintenance thread
-					if (mypolls.last_recv[n] < curtime - 1000000) {
+					if (mypolls.last_recv[n] < curtime - mysql_thread___session_idle_ms) {
 						if (myds->myds_type==MYDS_FRONTEND && myds->sess) {
 							if (myds->sess->client_myds == myds) { // extra check
 								if (myds->DSS==STATE_SLEEP && myds->sess->status==WAITING_CLIENT_DATA) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2306,7 +2306,13 @@ void MySQL_Thread::listener_handle_new_connection(MySQL_Data_Stream *myds, unsig
 	memset(addr, 0, sizeof(struct sockaddr));
 	if (GloMTH->num_threads > 1) {
 		// there are more than 1 thread . We pause for a little bit to avoid all connections to be handled by the same thread
+#ifdef SO_REUSEPORT
+		if (GloVars.global.reuseport==false) { // only if reuseport is not enabled
+			usleep(10+rand()%50);
+		}
+#else
 		usleep(10+rand()%50);
+#endif /* SO_REUSEPORT */
 	}
 	c=accept(myds->fd, addr, &addrlen);
 	if (c>-1) { // accept() succeeded

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1904,7 +1904,7 @@ __run_skip_1:
 				event.data.u32=mysess->thread_session_id;
 				event.events = EPOLLIN;
 				epoll_ctl (efd, EPOLL_CTL_ADD, myds->fd, &event);
-				fprintf(stderr,"Adding session %p idx, DS %p idx %d\n",mysess,myds,myds->poll_fds_idx);
+				//fprintf(stderr,"Adding session %p idx, DS %p idx %d\n",mysess,myds,myds->poll_fds_idx);
 			}
 			spin_wrunlock(&GloMTH->rwlock_idles);
 			goto __run_skip_1a;
@@ -2120,10 +2120,10 @@ __run_skip_1a:
 					for (i=0; i<rc; i++) {
 						uint32_t sess_thr_id=events[i].data.u32;
 						//memcpy(&mysess2,&events[epi].data.ptr,sizeof(MySQL_Session *));
-						if (mysess->thread_session_id==sess_thr_id) { // found it!
+						if (events[i].events == EPOLLIN && mysess->thread_session_id==sess_thr_id) { // found it!
 							MySQL_Data_Stream *tmp_myds=mysess->client_myds;
 							int dsidx=tmp_myds->poll_fds_idx;
-							fprintf(stderr,"Removing session %p, DS %p idx %d\n",mysess,tmp_myds,dsidx);
+							//fprintf(stderr,"Removing session %p, DS %p idx %d\n",mysess,tmp_myds,dsidx);
 							mypolls.remove_index_fast(dsidx);
 							tmp_myds->mypolls=NULL;
 							mysess->thread=NULL;
@@ -2135,7 +2135,7 @@ __run_skip_1a:
 					}
 				}
 				for (i=0; i<rc; i++) {
-					if (events[i].data.u32==0) {
+					if (events[i].events == EPOLLIN && events[i].data.u32==0) {
 						unsigned char c;
 						int fd=pipefd[0];
 						if (read(fd, &c, 1)==-1) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2256,8 +2256,10 @@ __run_skip_1a:
 						spin_wrunlock(&thread_mutex);
 						usleep(c*1000);
 						spin_wrlock(&thread_mutex);
+						// we enter in maintenance loop only if c is set
+						// when threads are signaling each other, there is no need to set maintenance_loop
+						maintenance_loop=true;
 					}
-					maintenance_loop=true;
 				}
 			continue;
 			}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2120,7 +2120,9 @@ __run_skip_1a:
 					for (i=0; i<rc; i++) {
 						uint32_t sess_thr_id=events[i].data.u32;
 						//memcpy(&mysess2,&events[epi].data.ptr,sizeof(MySQL_Session *));
-						if (events[i].events == EPOLLIN && mysess->thread_session_id==sess_thr_id) { // found it!
+						//if (events[i].events == EPOLLIN && mysess->thread_session_id==sess_thr_id) { // found it!
+						// NOTE: not sure why, sometime events returns odd values. If set, we take it out as normal worker threads know how to handle it
+						if (events[i].events && mysess->thread_session_id==sess_thr_id) { // found it!
 							MySQL_Data_Stream *tmp_myds=mysess->client_myds;
 							int dsidx=tmp_myds->poll_fds_idx;
 							//fprintf(stderr,"Removing session %p, DS %p idx %d\n",mysess,tmp_myds,dsidx);

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2014,6 +2014,7 @@ __run_skip_1:
 												mysess->thread=NULL;
 												unregister_session(i);
 												exit_cond=true;
+												mysess->idle_since = curtime - mysess->IdleTime();
 												idle_mysql_sessions->add(mysess);
 												break;
 											}
@@ -2321,7 +2322,8 @@ __run_skip_1a:
 					uint32_t sess_pos=mysess_idx;
 					MySQL_Session *mysess=(MySQL_Session *)mysql_sessions->index(sess_pos);
 
-					unsigned long long sess_time = mysess->IdleTime();
+					//unsigned long long sess_time = mysess->IdleTime();
+					unsigned long long sess_time = curtime - mysess->idle_since;
 					if ( (sess_time/1000 > (unsigned long long)mysql_thread___wait_timeout) ) {
 						mysess->killed=true;
 						//uint32_t sess_thr_id=mysess->thread_session_id;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2121,7 +2121,7 @@ __run_skip_1a:
 					epi--;
 					MySQL_Session *mysess=(MySQL_Session *)mysql_sessions->index(epi);
 					for (i=0; i<rc; i++) {
-						uint32_t sess_thr_id=events[epi].data.u32;
+						uint32_t sess_thr_id=events[i].data.u32;
 						//memcpy(&mysess2,&events[epi].data.ptr,sizeof(MySQL_Session *));
 						if (mysess->thread_session_id==sess_thr_id) { // found it!
 							MySQL_Data_Stream *tmp_myds=mysess->client_myds;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1909,7 +1909,7 @@ __run_skip_1:
 										}
 									}
 									if (exit_cond) {
-										break;
+										continue;
 									}
 								}
 							}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1884,7 +1884,7 @@ __run_skip_1:
 			myds=mypolls.myds[n];
 			mypolls.fds[n].revents=0;
 			if (myds) {
-				if (idle_maintenance_thread==false) {
+				if (GloMTH->num_threads >= MIN_THREADS_FOR_MAINTENANCE && idle_maintenance_thread==false) {
 					// here we try to move it to the maintenance thread
 					if (mypolls.last_recv[n] < curtime - 1000000) {
 						if (myds->myds_type==MYDS_FRONTEND && myds->sess) {
@@ -1959,7 +1959,7 @@ __run_skip_1:
 			proxy_debug(PROXY_DEBUG_NET,1,"Poll for DataStream=%p will be called with FD=%d and events=%d\n", mypolls.myds[n], mypolls.fds[n].fd, mypolls.fds[n].events);
 		}
 
-		if (idle_maintenance_thread==false) {
+		if (GloMTH->num_threads >= MIN_THREADS_FOR_MAINTENANCE && idle_maintenance_thread==false) {
 			if (idle_mysql_sessions->len) {
 				unsigned int ims=0;
 				spin_wrlock(&GloMTH->rwlock_idles);

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1906,6 +1906,7 @@ __run_skip_1:
 				epoll_ctl (efd, EPOLL_CTL_ADD, myds->fd, &event);
 			}
 			spin_wrunlock(&GloMTH->rwlock_idles);
+			goto __run_skip_1a;
 		}
 		for (n = 0; n < mypolls.len; n++) {
 			MySQL_Data_Stream *myds=NULL;
@@ -2025,7 +2026,7 @@ __run_skip_1:
 			}
 			spin_wrunlock(&GloMTH->rwlock_resumes);
 		}
-
+__run_skip_1a:
 		spin_wrunlock(&thread_mutex);
 
 		while ((n=__sync_add_and_fetch(&mypolls.pending_listener_add,0))) {	// spin here

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2138,7 +2138,7 @@ __run_skip_1a:
 					}
 				}
 				for (i=0; i<rc; i++) {
-					if (events[epi].data.u32==0) {
+					if (events[i].data.u32==0) {
 						unsigned char c;
 						int fd=pipefd[0];
 						if (read(fd, &c, 1)==-1) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2003,6 +2003,7 @@ __run_skip_1:
 											conns++;
 										}
 									}
+									unsigned long long idle_since = curtime - myds->sess->IdleTime();
 									bool exit_cond=false;
 									if (conns==0) {
 										mypolls.remove_index_fast(n);
@@ -2014,7 +2015,7 @@ __run_skip_1:
 												mysess->thread=NULL;
 												unregister_session(i);
 												exit_cond=true;
-												mysess->idle_since = curtime - mysess->IdleTime();
+												mysess->idle_since = idle_since;
 												idle_mysql_sessions->add(mysess);
 												break;
 											}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1887,7 +1887,8 @@ __run_skip_1:
 									unsigned int j;
 									int conns=0;
 									for (j=0;j<myds->sess->mybes->len;j++) {
-										MySQL_Data_Stream *__myds=(MySQL_Data_Stream *)myds->sess->mybes->index(j);
+										MySQL_Backend *tmp_mybe=(MySQL_Backend *)myds->sess->mybes->index(j);
+										MySQL_Data_Stream *__myds=tmp_mybe->server_myds;
 										if (__myds->myconn) {
 											conns++;
 										}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1606,9 +1606,12 @@ void MySQL_Threads_Handler::init(unsigned int num, size_t stack) {
 	mysql_threads_idles=(proxysql_mysql_thread_t *)malloc(sizeof(proxysql_mysql_thread_t)*num_threads);
 }
 
-proxysql_mysql_thread_t * MySQL_Threads_Handler::create_thread(unsigned int tn, void *(*start_routine) (void *)) {
-	pthread_create(&mysql_threads[tn].thread_id, &attr, start_routine , &mysql_threads[tn]);
-	pthread_create(&mysql_threads_idles[tn].thread_id, &attr, start_routine , &mysql_threads_idles[tn]);
+proxysql_mysql_thread_t * MySQL_Threads_Handler::create_thread(unsigned int tn, void *(*start_routine) (void *), bool idles) {
+	if (idles==false) {
+		pthread_create(&mysql_threads[tn].thread_id, &attr, start_routine , &mysql_threads[tn]);
+	} else {
+		pthread_create(&mysql_threads_idles[tn].thread_id, &attr, start_routine , &mysql_threads_idles[tn]);
+	}
 	return NULL;
 }
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2130,7 +2130,7 @@ __run_skip_1a:
 							mypolls.remove_index_fast(dsidx);
 							tmp_myds->mypolls=NULL;
 							mysess->thread=NULL;
-							unregister_session(i);
+							unregister_session(epi);
 							resume_mysql_sessions->add(mysess);
 							epoll_ctl(efd, EPOLL_CTL_DEL, tmp_myds->fd, NULL);
 							i=rc;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2263,12 +2263,12 @@ __run_skip_2:
 				}
 				spin_wrunlock(&GloMTH->rwlock_resumes);
 			}
+		} else {
+			// iterate through all sessions and process the session logic
+			process_all_sessions();
+
+			return_local_connections();
 		}
-		// iterate through all sessions and process the session logic
-		process_all_sessions();
-
-		return_local_connections();
-
 	}
 }
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2053,6 +2053,7 @@ __run_skip_1a:
 
 
 		if (idle_maintenance_thread) {
+			memset(events,0,sizeof(struct epoll_event)*MY_EPOLL_THREAD_MAXEVENTS); // let's make valgrind happy. It also seems that needs to be zeroed anyway
 			// we call epoll()
 			rc = epoll_wait (efd, events, MY_EPOLL_THREAD_MAXEVENTS, mysql_thread___poll_timeout);
 		} else {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2114,7 +2114,7 @@ __run_skip_1a:
 				int epi;
 				int sessindexes[MAXEVENTS];
 				for (epi=0; epi<rc; epi++) {
-					sessindexes[epi]=events->data.fd; // is not really a fd! But an integer pointer of mysql_sessions
+					sessindexes[epi]=events[epi].data.fd; // is not really a fd! But an integer pointer of mysql_sessions
 				}
 				qsort(sessindexes, rc, sizeof(int), int_cmp);
 				epi=rc-1;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3085,7 +3085,7 @@ void MySQL_Threads_Handler::Get_Memory_Stats() {
 		if (i<num_threads) {
 			thr=(MySQL_Thread *)mysql_threads[i].worker;
 		} else {
-			thr=(MySQL_Thread *)mysql_threads_idles[i].worker;
+			thr=(MySQL_Thread *)mysql_threads_idles[i-num_threads].worker;
 		}
 		spin_wrlock(&thr->thread_mutex);
 	}
@@ -3093,7 +3093,7 @@ void MySQL_Threads_Handler::Get_Memory_Stats() {
 		if (i<num_threads) {
 			thr=(MySQL_Thread *)mysql_threads[i].worker;
 		} else {
-			thr=(MySQL_Thread *)mysql_threads_idles[i].worker;
+			thr=(MySQL_Thread *)mysql_threads_idles[i-num_threads].worker;
 		}
 		thr->Get_Memory_Stats();
 	}
@@ -3101,7 +3101,7 @@ void MySQL_Threads_Handler::Get_Memory_Stats() {
 		if (i<num_threads) {
 			thr=(MySQL_Thread *)mysql_threads[i].worker;
 		} else {
-			thr=(MySQL_Thread *)mysql_threads_idles[i].worker;
+			thr=(MySQL_Thread *)mysql_threads_idles[i-num_threads].worker;
 		}
 		spin_wrunlock(&thr->thread_mutex);
 	}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3089,7 +3089,7 @@ void MySQL_Threads_Handler::Get_Memory_Stats() {
 		}
 		spin_wrlock(&thr->thread_mutex);
 	}
-	for (i=0;i<num_threads;i++) {
+	for (i=0;i<num_threads*2;i++) {
 		if (i<num_threads) {
 			thr=(MySQL_Thread *)mysql_threads[i].worker;
 		} else {
@@ -3097,7 +3097,7 @@ void MySQL_Threads_Handler::Get_Memory_Stats() {
 		}
 		thr->Get_Memory_Stats();
 	}
-	for (i=0;i<num_threads;i++) {
+	for (i=0;i<num_threads*2;i++) {
 		if (i<num_threads) {
 			thr=(MySQL_Thread *)mysql_threads[i].worker;
 		} else {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2175,6 +2175,13 @@ bool MySQL_Thread::process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned
 						// timeout
 						myds->sess->to_process=1;
 						assert(myds->sess->status!=NONE);
+					} else {
+						if (myds->pause_until && curtime > myds->pause_until) {
+							// timeout
+							myds->sess->to_process=1;
+						} else {
+							to_process=0;
+						}
 					}
 				}
 				if (myds->myds_type==MYDS_BACKEND && myds->sess->status!=FAST_FORWARD) {
@@ -2262,6 +2269,7 @@ void MySQL_Thread::process_all_sessions() {
 		if (maintenance_loop) {
 			unsigned int numTrx=0;
 			unsigned long long sess_time = sess->IdleTime();
+			sess->to_process=1;
 			if ( (sess_time/1000 > (unsigned long long)mysql_thread___max_transaction_time) || (sess_time/1000 > (unsigned long long)mysql_thread___wait_timeout) ) {
 				numTrx = sess->NumActiveTransactions();
 				if (numTrx) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2050,6 +2050,10 @@ __run_skip_1:
 			refresh_variables();
 		}
 
+		for (n=0; n<mysql_sessions->len; n++) {
+			MySQL_Session *_sess=(MySQL_Session *)mysql_sessions->index(n);
+			_sess->to_process=0;
+		}
 
 		for (n = 0; n < mypolls.len; n++) {
 			proxy_debug(PROXY_DEBUG_NET,3, "poll for fd %d events %d revents %d\n", mypolls.fds[n].fd , mypolls.fds[n].events, mypolls.fds[n].revents);
@@ -2072,6 +2076,7 @@ __run_skip_1:
 						usleep(c*1000);
 						spin_wrlock(&thread_mutex);
 					}
+					maintenance_loop=true;
 				}
 			continue;
 			}
@@ -2176,11 +2181,9 @@ bool MySQL_Thread::process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned
 						myds->sess->to_process=1;
 						assert(myds->sess->status!=NONE);
 					} else {
-						if (myds->pause_until && curtime > myds->pause_until) {
+						if (myds->sess->pause_until && curtime > myds->sess->pause_until) {
 							// timeout
 							myds->sess->to_process=1;
-						} else {
-							to_process=0;
 						}
 					}
 				}

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -59,7 +59,7 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 	global.foreground=false;
 	global.monitor=true;
 #ifdef SO_REUSEPORT
-	global.reuseport=true;
+	global.reuseport=false;
 #endif /* SO_REUSEPORT */
 //	global.use_proxysql_mem=false;
 	pthread_mutex_init(&global.start_mutex,NULL);

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -58,6 +58,9 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 	global.nostart=false;
 	global.foreground=false;
 	global.monitor=true;
+#ifdef SO_REUSEPORT
+	global.reuseport=true;
+#endif /* SO_REUSEPORT */
 //	global.use_proxysql_mem=false;
 	pthread_mutex_init(&global.start_mutex,NULL);
 #ifdef DEBUG
@@ -78,6 +81,9 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 	opt->add((const char *)"",0,0,0,(const char *)"Starts only the admin service",(const char *)"-n",(const char *)"--no-start");
 	opt->add((const char *)"",0,0,0,(const char *)"Do not start Monitor Module",(const char *)"-M",(const char *)"--no-monitor");
 	opt->add((const char *)"",0,0,0,(const char *)"Run in foreground",(const char *)"-f",(const char *)"--foreground");
+#ifdef SO_REUSEPORT
+	opt->add((const char *)"",0,0,0,(const char *)"Use SO_REUSEPORT",(const char *)"-r",(const char *)"--reuseport");
+#endif /* SO_REUSEPORT */
 	opt->add((const char *)"",0,0,0,(const char *)"Do not restart ProxySQL if crashes",(const char *)"-e",(const char *)"--exit-on-error");
 	opt->add((const char *)"~/proxysql.cnf",0,1,0,(const char *)"Configuraton file",(const char *)"-c",(const char *)"--config");
 	//opt->add((const char *)"",0,0,0,(const char *)"Enable custom memory allocator",(const char *)"-m",(const char *)"--custom-memory");
@@ -188,6 +194,12 @@ void ProxySQL_GlobalVariables::process_opts_post() {
 	if (opt->isSet("-M")) {
 		global.monitor=false;
 	}
+
+#ifdef SO_REUSEPORT
+	if (opt->isSet("-r")) {
+		global.reuseport=true;
+	}
+#endif /* SO_REUSEPORT */
 
 	if (opt->isSet("-S")) {
 		std::string admin_socket;

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -16,8 +16,14 @@ int listen_on_port(char *ip, uint16_t port, int backlog) {
 		return -1;
 	}
 
+#ifdef SO_REUSEPORT
+	// set SO_REUSEADDR and SO_REUSEPORT
+	rc = setsockopt(sd, SOL_SOCKET,  SO_REUSEADDR | SO_REUSEPORT, (char *)&arg_on, sizeof(arg_on));
+#else
 	// set SO_REUSEADDR
 	rc = setsockopt(sd, SOL_SOCKET,  SO_REUSEADDR, (char *)&arg_on, sizeof(arg_on));
+#endif /* SO_REUSEPORT */
+
 	if (rc < 0) {
 		proxy_error("setsockopt() failed\n");
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,7 +270,7 @@ void ProxySQL_Main_init_Query_module() {
 void ProxySQL_Main_init_MySQL_Threads_Handler_module() {
 	unsigned int i;
 	GloMTH->init();
-	load_ = GloMTH->num_threads + 1;
+	load_ = GloMTH->num_threads * 2 + 1;
 	for (i=0; i<GloMTH->num_threads; i++) {
 		GloMTH->create_thread(i,mysql_worker_thread_func);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,7 +290,7 @@ void ProxySQL_Main_init_Query_module() {
 void ProxySQL_Main_init_MySQL_Threads_Handler_module() {
 	unsigned int i;
 	GloMTH->init();
-	load_ = GloMTH->num_threads + 1;
+	load_ = GloMTH->num_threads * 2 + 1;
 	for (i=0; i<GloMTH->num_threads; i++) {
 		GloMTH->create_thread(i,mysql_worker_thread_func, false);
 		GloMTH->create_thread(i,mysql_worker_thread_func_idles, true);


### PR DESCRIPTION
Merging the experimental v1.3.0-exp2 into v1.3.0.

ProxySQL in this branch can easily accept one million connections.
It is also able to handle workloads with hundreds thousands client connections, but only few connections are active.
For example, 100k total connections, but only 100 active connections.

This merge includes:
* support for `SO_REUSEPORT` , that can be only enabled on the command line with `-r` or `--reuseport` 
* at startup, limit the number of Monitor thread to 16
* each MySQL_Thread now has a pair thread: therefore the number of threads executed are `mysql-threads x 2`
* the second set of MySQL_Threads are responsible to only handle idle connections
* two new variables:
  * `mysql-session_idle_ms` (default `1000`) : when a session is idle for that long, it is moved to a thread responsible to handle idle connections
  * `mysql-session_idle_show_processlist` (default `false`) : specifies if idle connections are displayed on `SHOW PROCESSLIST` or on any query against `stats_mysql_processlist`
* one new status variable:
  `Client_Connections_non_idle` : returns the number of client connections that are not idle, therefore handled by the main MySQL_Threads and not moved to the second set of MySQL_Threads responsible to only handle idle connections