### PR TITLE
Do not `assert()` on `COM_SLEEP`

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1741,6 +1741,10 @@ __get_pkts_from_client:
 							case _MYSQL_COM_FIELD_LIST:
 								handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_FIELD_LIST(&pkt);
 								break;
+                                                        case _MYSQL_COM_SLEEP:
+                                                                proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 5, "Dummy handling for COM_SLEEP\n");
+                                                                return -1;
+                                                                break;
 							default:
 								assert(0);
 								break;


### PR DESCRIPTION
Do not `assert()` on `COM_SLEEP`.

```
(gdb) bt
#0  0x00007f3601ee75f7 in raise () from /lib64/libc.so.6
#1  0x00007f3601ee8ce8 in abort () from /lib64/libc.so.6
#2  0x00007f3601ee0566 in __assert_fail_base () from /lib64/libc.so.6
#3  0x00007f3601ee0612 in __assert_fail () from /lib64/libc.so.6
#4  0x0000000000466242 in MySQL_Session::handler (this=this@entry=0x7f35f8631000) at MySQL_Session.cpp:1745
#5  0x0000000000454dc4 in MySQL_Thread::process_all_sessions (this=this@entry=0x7f35f860d000) at MySQL_Thread.cpp:2678
#6  0x000000000045cfd1 in MySQL_Thread::run (this=this@entry=0x7f35f860d000) at MySQL_Thread.cpp:2518
#7  0x0000000000438f24 in mysql_worker_thread_func (arg=0x7f360043c9b0) at main.cpp:165
#8  0x00007f3603712dc5 in start_thread () from /lib64/libpthread.so.0
#9  0x00007f3601fa8ced in clone () from /lib64/libc.so.6

(gdb) p (enum_mysql_command)c
$2 = _MYSQL_COM_SLEEP

(gdb) p pkt
$2 = {ptr = 0x7f35f8617940, size = 28}

(gdb) x/28b pkt->ptr
0x7f35f8617940:    24    0    0    0    24    1    0    0
0x7f35f8617948:    0    0    0    97    58    49    58    123
0x7f35f8617950:    105    58    48    59    115    58    48    58
0x7f35f8617958:    34    34    59    125
```

Quick workaround around to do not crash ProxySQL instance..

@renecannao 