### PR TITLE
Add custom union for handling both sockaddr_in/sockaddr_in6 structures

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -10,8 +10,6 @@
 
 #define EXPMARIA
 
-#define BUFLEN 256
-
 extern const CHARSET_INFO * proxysql_find_charset_name(const char * const name);
 
 extern MySQL_Authentication *GloMyAuth;
@@ -1778,16 +1776,16 @@ __get_pkts_from_client:
 					default:
 						proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 5, "Statuses: WAITING_CLIENT_DATA - STATE_UNKNOWN\n");
 						{
-							char buf[BUFLEN];
+                                                        char buf[INET6_ADDRSTRLEN];
                                                         switch (client_myds->client_addr->sa_family) {
                                                         case AF_INET: {
                                                                 struct sockaddr_in *ipv4 = (struct sockaddr_in *)client_myds->client_addr;
-                                                                inet_ntop(client_myds->client_addr->sa_family, &ipv4->sin_addr, buf, BUFLEN);
+                                                                inet_ntop(client_myds->client_addr->sa_family, &ipv4->sin_addr, buf, INET_ADDRSTRLEN);
                                                                 break;
                                                                 }
                                                         case AF_INET6: {
                                                                 struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)client_myds->client_addr;
-                                                                inet_ntop(client_myds->client_addr->sa_family, &ipv6->sin6_addr, buf, BUFLEN);
+                                                                inet_ntop(client_myds->client_addr->sa_family, &ipv6->sin6_addr, buf, INET6_ADDRSTRLEN);
                                                                 break;
                                                         }
                                                         default:

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -10,7 +10,6 @@ MySQL_Session *sess_stopat;
 
 #define PROXYSQL_LISTEN_LEN 1024
 #define MIN_THREADS_FOR_MAINTENANCE 8
-#define BUFLEN 256
 
 extern Query_Processor *GloQPro;
 extern MySQL_Authentication *GloMyAuth;
@@ -2885,9 +2884,13 @@ void MySQL_Thread::unregister_session_connection_handler(int idx, bool _new) {
 
 void MySQL_Thread::listener_handle_new_connection(MySQL_Data_Stream *myds, unsigned int n) {
 	int c;
-	struct sockaddr *addr=(struct sockaddr *)malloc(sizeof(struct sockaddr));
-	socklen_t addrlen=sizeof(struct sockaddr);
-	memset(addr, 0, sizeof(struct sockaddr));
+	union {
+        	struct sockaddr_in in;
+                struct sockaddr_in6 in6;
+        } custom_sockaddr;
+	struct sockaddr *addr=(struct sockaddr *)malloc(sizeof(custom_sockaddr));
+	socklen_t addrlen=sizeof(custom_sockaddr);
+	memset(addr, 0, sizeof(custom_sockaddr));
 	if (GloMTH->num_threads > 1) {
 		// there are more than 1 thread . We pause for a little bit to avoid all connections to be handled by the same thread
 #ifdef SO_REUSEPORT
@@ -2915,18 +2918,18 @@ void MySQL_Thread::listener_handle_new_connection(MySQL_Data_Stream *myds, unsig
                 switch (sess->client_myds->client_addr->sa_family) {
                         case AF_INET: {
                                 struct sockaddr_in *ipv4 = (struct sockaddr_in *)sess->client_myds->client_addr;
-                                char buf[BUFLEN];
-                                inet_ntop(sess->client_myds->client_addr->sa_family, &ipv4->sin_addr, buf, BUFLEN);
-                                sess->client_myds->addr.addr = strdup(buf);
-                                sess->client_myds->addr.port = htons(ipv4->sin_port);
+                                char buf[INET_ADDRSTRLEN];
+	                        inet_ntop(sess->client_myds->client_addr->sa_family, &ipv4->sin_addr, buf, INET_ADDRSTRLEN);
+		                sess->client_myds->addr.addr = strdup(buf);
+			        sess->client_myds->addr.port = htons(ipv4->sin_port);
                                 break;
                                 }
                         case AF_INET6: {
                                 struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)sess->client_myds->client_addr;
-                                char buf[BUFLEN];
-                                inet_ntop(sess->client_myds->client_addr->sa_family, &ipv6->sin6_addr, buf, BUFLEN);
-                                sess->client_myds->addr.addr = strdup(buf);
-                                sess->client_myds->addr.port = htons(ipv6->sin6_port);
+                                char buf[INET6_ADDRSTRLEN];
+	                        inet_ntop(sess->client_myds->client_addr->sa_family, &ipv6->sin6_addr, buf, INET6_ADDRSTRLEN);
+		                sess->client_myds->addr.addr = strdup(buf);
+			        sess->client_myds->addr.port = htons(ipv6->sin6_port);
                                 break;
                         }
                         default:
@@ -3260,7 +3263,7 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
                                         switch (sess->client_myds->client_addr->sa_family) {
                                         case AF_INET: {
                                                 struct sockaddr_in *ipv4 = (struct sockaddr_in *)sess->client_myds->client_addr;
-                                                inet_ntop(sess->client_myds->client_addr->sa_family, &ipv4->sin_addr, buf, BUFLEN);
+                                                inet_ntop(sess->client_myds->client_addr->sa_family, &ipv4->sin_addr, buf, INET_ADDRSTRLEN);
                                                 pta[4] = strdup(buf);
                                                 sprintf(port, "%d", ntohs(ipv4->sin_port));
                                                 pta[5] = strdup(port);
@@ -3268,7 +3271,7 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
                                                 }
                                         case AF_INET6: {
                                                 struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)sess->client_myds->client_addr;
-                                                inet_ntop(sess->client_myds->client_addr->sa_family, &ipv6->sin6_addr, buf, BUFLEN);
+                                                inet_ntop(sess->client_myds->client_addr->sa_family, &ipv6->sin6_addr, buf, INET6_ADDRSTRLEN);
                                                 pta[4] = strdup(buf);
                                                 sprintf(port, "%d", ntohs(ipv6->sin6_port));
                                                 pta[5] = strdup(port);
@@ -3295,7 +3298,7 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
                                         switch (addr.sa_family) { 
                                                 case AF_INET: {
                                                         struct sockaddr_in *ipv4 = (struct sockaddr_in *)&addr;
-                                                        inet_ntop(addr.sa_family, &ipv4->sin_addr, buf, BUFLEN);
+                                                        inet_ntop(addr.sa_family, &ipv4->sin_addr, buf, INET_ADDRSTRLEN);
                                                         pta[7] = strdup(buf);
                                                         sprintf(port, "%d", ntohs(ipv4->sin_port));
                                                         pta[8] = strdup(port);
@@ -3303,7 +3306,7 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
                                                         }
                                                 case AF_INET6: {
                                                         struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)&addr;
-                                                        inet_ntop(addr.sa_family, &ipv6->sin6_addr, buf, BUFLEN);
+                                                        inet_ntop(addr.sa_family, &ipv6->sin6_addr, buf, INET6_ADDRSTRLEN);
                                                         pta[7] = strdup(buf);
                                                         sprintf(port, "%d", ntohs(ipv6->sin6_port));
                                                         pta[8] = strdup(port);


### PR DESCRIPTION
In addition use two MACROs for allocating buffers to store IP addresses, thus saving some space.

```
(gdb) bt
#0  0x00007f6b1a22cfb3 in inet_ntop () from /lib64/libc.so.6
#1  0x0000000000456189 in MySQL_Thread::listener_handle_new_connection (this=0x7f6b1100d000, myds=0x7f6b1101a200, n=<optimized out>) at MySQL_Thread.cpp:2910
#2  0x000000000045d16e in MySQL_Thread::run (this=this@entry=0x7f6b1100d000) at MySQL_Thread.cpp:2452
#3  0x00000000004390d4 in mysql_worker_thread_func (arg=0x7f6b1863c990) at main.cpp:165
#4  0x00007f6b1b988dc5 in start_thread () from /lib64/libpthread.so.0
#5  0x00007f6b1a21eced in clone () from /lib64/libc.so.6

(gdb) x/16b &(*(struct sockaddr_in6 *)sess->client_myds->client_addr)->sin6_addr
0x7f6b021ffff8:	0x2a	0x02	0x47	0x80	0x0b	0xad	0xf0	0x0d
0x7f6b02200000:	Cannot access memory at address 0x7f6b02200000
```