### PR TITLE
Don't exit with non-zero code if proxysql was stopped

### DIFF
--- a/etc/init.d/proxysql
+++ b/etc/init.d/proxysql
@@ -92,7 +92,6 @@ stop() {
   if [ "X$pid" = "X" ]
 	then
 		echo "ProxySQL was not running."
-		exit 1
 	else
 		# Note: we send a kill to all the processes, not just to the child
 		for i in `pgrep proxysql` ; do


### PR DESCRIPTION
If proxysql is stopped, function `stop()` should return exit code `0` instead of a non-zero code. This also fixes `restart` action cannot start (a already stopped) proxysql service.