### PR TITLE
Add build/support for CentOS 5

### DIFF
--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -1,0 +1,73 @@
+# Don't try fancy stuff like debuginfo, which is useless on binary-only
+# packages. Don't strip binary too
+# Be sure buildpolicy set to do nothing
+%define        __spec_install_post %{nil}
+%define          debug_package %{nil}
+%define        __os_install_post %{_dbpath}/brp-compress
+
+Summary: A high-performance MySQL proxy
+Name: proxysql
+Version: 1.3.0h
+Release: 1
+License: GPL+
+Group: Development/Tools
+SOURCE0 : %{name}-%{version}.tar.gz
+URL: http://www.proxysql.com/
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%build
+# Empty section.
+
+%install
+rm -rf %{buildroot}
+mkdir -p  %{buildroot}
+
+# in builddir
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%post
+mkdir /var/run/%{name}
+chkconfig --add %{name}
+
+%postun
+rm -rf /var/run/%{name}
+chkconfig --del %{name}
+
+%files
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/%{name}.cnf
+%{_bindir}/*
+%{_sysconfdir}/init.d/%{name}
+/usr/share/proxysql/tools/proxysql_galera_checker.sh
+/usr/share/proxysql/tools/proxysql_galera_writer.pl
+
+%changelog
+* Wed Oct 19 2016  Rene Cannao <rene.cannao@gmail.com> 1.3.0
+- experimental support for Prepared Statements
+- enhanced scalability
+* Thu Sep 29 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.4
+- Forth stable release of 1.2
+* Tue Sep 20 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.3
+- Third stable release of 1.2
+* Fri Sep 2 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.2
+- Second stable release of 1.2
+* Tue Aug 2 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.1
+- First stable release of 1.2
+* Mon Mar 14 2016 Rene Cannao <rene.cannao@gmail.com> 1.2.0
+- First testing release of 1.2
+* Sat Mar 11 2016 Rene Cannao <rene.cannao@gmail.com> 1.1.2
+- Upgraded to release 1.1.2
+* Sat Oct 31 2015 Rene Cannao <rene.cannao@gmail.com> 1.0.1
+- Compiles 1.0.1
+* Wed Sep 9 2015  Andrei Ismail <iandrei@gmail.com> 0.2
+- Added support for automatic packaging on Ubuntu 14.04 and CentOS 7.

--- a/docker/images/proxysql/centos5-build/rpmmacros
+++ b/docker/images/proxysql/centos5-build/rpmmacros
@@ -1,0 +1,2 @@
+%_topdir   %(echo $HOME)/rpmbuild
+%_tmppath  %{_topdir}/tmp

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -8,6 +8,12 @@
 MySQL_Session *sess_stopat;
 #endif
 
+#ifdef epoll_create1
+	#define EPOLL_CREATE epoll_create1(0)
+#else
+	#define EPOLL_CREATE epoll_create(1)
+#endif
+
 #define PROXYSQL_LISTEN_LEN 1024
 #define MIN_THREADS_FOR_MAINTENANCE 8
 
@@ -1930,7 +1936,7 @@ void MySQL_Thread::run() {
 	if (idle_maintenance_thread) {
 		// we check if it is the first time we are called
 		if (efd==-1) {
-			efd = epoll_create1(0);
+			efd = EPOLL_CREATE;
 			int fd=pipefd[0];
 			struct epoll_event event;
 			memset(&event,0,sizeof(event)); // let's make valgrind happy


### PR DESCRIPTION
CentOS 5 doesn't have support for `epoll_create1()`, so I've defined a macro to fall back on `epoll_create()` in that case.

Note that the `1` argument to epoll_create() is actually ignored, and is only there to conform to the requirement that it be larger than 0.

Note that the docker image used to build this is:

```
FROM centos:5

RUN yum -y install epel-release
RUN yum install -y automake bzip2 make openssl openssl-devel patch tar wget git
RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++ openssl-devel patch
RUN ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /usr/bin/cc
RUN ln -s /opt/rh/devtoolset-2/root/usr/bin/g++ /usr/bin/g++
RUN echo "export CC=/opt/rh/devtoolset-2/root/usr/bin/gcc" >> /root/.bashrc
RUN echo "export CPP=/opt/rh/devtoolset-2/root/usr/bin/cpp" >> /root/.bashrc
RUN echo "export CXX=/opt/rh/devtoolset-2/root/usr/bin/c++" >> /root/.bashrc
RUN yum install -y rpm-build
RUN cd /usr/local/src && \
  wget --no-check-certificate http://www.cmake.org/files/v2.8/cmake-2.8.10.2.tar.gz && \
  tar -xzvf cmake-2.8.10.2.tar.gz && \
  cd cmake-2.8.10.2 && \
  ./bootstrap && make && make install

```