### PR TITLE
Define version outside the `spec` file for RPM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ binaries/proxysql-${CURVER}-1-centos5.x86_64.rpm:
 	docker cp docker/images/proxysql/centos5-build/proxysql.spec centos5_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -146,7 +146,7 @@ binaries/proxysql-${CURVER}-1-dbg-centos5.x86_64.rpm:
 	docker cp docker/images/proxysql/centos5-build/proxysql.spec centos5_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -167,7 +167,7 @@ binaries/proxysql-${CURVER}-1-centos67.x86_64.rpm:
 	docker cp docker/images/proxysql/centos67-build/proxysql.spec centos67_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -188,7 +188,7 @@ binaries/proxysql-${CURVER}-1-dbg-centos67.x86_64.rpm:
 	docker cp docker/images/proxysql/centos67-build/proxysql.spec centos67_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -209,7 +209,7 @@ binaries/proxysql-${CURVER}-1-centos7.x86_64.rpm:
 	docker cp docker/images/proxysql/centos7-build/proxysql.spec centos7_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -230,7 +230,7 @@ binaries/proxysql-${CURVER}-1-dbg-centos7.x86_64.rpm:
 	docker cp docker/images/proxysql/centos7-build/proxysql.spec centos7_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -252,7 +252,7 @@ binaries/proxysql-${CURVER}-1-fedora24.x86_64.rpm:
 	docker cp docker/images/proxysql/fedora24-build/proxysql.spec fedora24_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -273,7 +273,7 @@ binaries/proxysql-${CURVER}-1-dbg-fedora24.x86_64.rpm:
 	docker cp docker/images/proxysql/fedora24-build/proxysql.spec fedora24_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2

--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.0h
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools

--- a/docker/images/proxysql/centos67-build/proxysql.spec
+++ b/docker/images/proxysql/centos67-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.0h
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools

--- a/docker/images/proxysql/centos7-build/proxysql.spec
+++ b/docker/images/proxysql/centos7-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.0h
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools

--- a/docker/images/proxysql/fedora24-build/proxysql.spec
+++ b/docker/images/proxysql/fedora24-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.0h
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools


### PR DESCRIPTION
Instead of hardcoding the version number in the RPM spec file, we can pass the version in as part of the `rpmbuild` process, using the same version as is defined in the Makefile.