### PR TITLE
Post Uninstall hooks for fedora based OS's

### DIFF
--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -39,9 +39,12 @@ rm -rf %{buildroot}
 mkdir /var/run/%{name}
 chkconfig --add %{name}
 
+%preun
+/etc/init.d/%{name} stop
+chkconfig --del %{name}
+
 %postun
 rm -rf /var/run/%{name}
-chkconfig --del %{name}
 
 %files
 %defattr(-,root,root,-)

--- a/docker/images/proxysql/centos67-build/proxysql.spec
+++ b/docker/images/proxysql/centos67-build/proxysql.spec
@@ -39,9 +39,12 @@ rm -rf %{buildroot}
 mkdir /var/run/%{name}
 chkconfig --add %{name}
 
+%preun
+/etc/init.d/%{name} stop
+chkconfig --del %{name}
+
 %postun
 rm -rf /var/run/%{name}
-chkconfig --del %{name}
 
 %files
 %defattr(-,root,root,-)

--- a/docker/images/proxysql/centos7-build/proxysql.spec
+++ b/docker/images/proxysql/centos7-build/proxysql.spec
@@ -39,9 +39,12 @@ rm -rf %{buildroot}
 mkdir /var/run/%{name}
 chkconfig --add %{name}
 
+%preun
+/etc/init.d/%{name} stop
+chkconfig --del %{name}
+
 %postun
 rm -rf /var/run/%{name}
-chkconfig --del %{name}
 
 %files
 %defattr(-,root,root,-)

--- a/docker/images/proxysql/fedora24-build/proxysql.spec
+++ b/docker/images/proxysql/fedora24-build/proxysql.spec
@@ -39,9 +39,12 @@ rm -rf %{buildroot}
 mkdir /var/run/%{name}
 chkconfig --add %{name}
 
+%preun
+/etc/init.d/%{name} stop
+chkconfig --del %{name}
+
 %postun
 rm -rf /var/run/%{name}
-chkconfig --del %{name}
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
Previously the `postun` hook would try and remove ProxySQL from chkconfig, but that would fail because the package was already uninstalled.

Instead, we can do this in the `preun` hook, and ensure that ProxySQL is properly shutdown before doing cleanup tasks.

Fixes #756