### PR TITLE
Fix RPM errors on upgrade

### DIFF
--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -36,7 +36,7 @@ cp -a * %{buildroot}
 rm -rf %{buildroot}
 
 %post
-mkdir /var/run/%{name}
+mkdir -p /var/run/%{name}
 chkconfig --add %{name}
 
 %preun

--- a/docker/images/proxysql/centos67-build/proxysql.spec
+++ b/docker/images/proxysql/centos67-build/proxysql.spec
@@ -36,7 +36,7 @@ cp -a * %{buildroot}
 rm -rf %{buildroot}
 
 %post
-mkdir /var/run/%{name}
+mkdir -p /var/run/%{name}
 chkconfig --add %{name}
 
 %preun

--- a/docker/images/proxysql/centos7-build/proxysql.spec
+++ b/docker/images/proxysql/centos7-build/proxysql.spec
@@ -36,7 +36,7 @@ cp -a * %{buildroot}
 rm -rf %{buildroot}
 
 %post
-mkdir /var/run/%{name}
+mkdir -p /var/run/%{name}
 chkconfig --add %{name}
 
 %preun

--- a/docker/images/proxysql/fedora24-build/proxysql.spec
+++ b/docker/images/proxysql/fedora24-build/proxysql.spec
@@ -36,7 +36,7 @@ cp -a * %{buildroot}
 rm -rf %{buildroot}
 
 %post
-mkdir /var/run/%{name}
+mkdir -p /var/run/%{name}
 chkconfig --add %{name}
 
 %preun


### PR DESCRIPTION
If the `/var/run/proxysql` directory already exists -- as it does for upgrades -- the rpm installation errors out. Using `mkdir -p` ensures that the directory gets created if it doesn't exist, but no-ops if it already does.