### PR TITLE
Enable custom version numbers for custom-built versions of ProxySQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEBUG=${ALL_DEBUG}
 #export DEBUG
 #export OPTZ
 #export EXTRALINK
-CURVER=1.3.0g
+CURVER?=1.3.0g
 MAKEOPT="-j 8"
 DISTRO := $(shell gawk -F= '/^NAME/{print $$2}' /etc/os-release)
 ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)


### PR DESCRIPTION
`CURVER` is always set to the value specified in the Makefile, as a result, the version number of a custom RPM, might not be accurate.

The change adds support for using an environment variable if it exists, otherwise, we default to the value specified in the Makefile.