### PR TITLE
Ensure that users num_connections_used doesn't get incremented if connection rejected

### DIFF
--- a/lib/MySQL_Authentication.cpp
+++ b/lib/MySQL_Authentication.cpp
@@ -270,8 +270,10 @@ int MySQL_Authentication::increase_frontend_user_connections(char *username, int
 	it = cg.bt_map.find(hash1);
 	if (it != cg.bt_map.end()) {
 		account_details_t *ad=it->second;
-		ad->num_connections_used++;
-		ret=ad->max_connections-ad->num_connections_used;
+		if (ad->max_connections > ad->num_connections_used) {
+			ret=ad->max_connections-ad->num_connections_used;
+			ad->num_connections_used++;
+		}
 		if (mc) {
 			*mc=ad->max_connections;
 		}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2572,7 +2572,7 @@ void MySQL_Session::handler___status_CONNECTING_CLIENT___STATE_SERVER_HANDSHAKE(
 				client_authenticated=true;
 				free_users=GloMyAuth->increase_frontend_user_connections(client_myds->myconn->userinfo->username, &used_users);
 			}
-			if (max_connections_reached==true || free_users<0) {
+			if (max_connections_reached==true || free_users<=0) {
 				*wrong_pass=true;
 				client_myds->setDSS_STATE_QUERY_SENT_NET();
 				if (max_connections_reached==true) {


### PR DESCRIPTION
If the users connection is rejected we shouldn't be incrementing `num_connections_used` on the account_details object. This leads to `free_users` dropping below zero and _all_ subsequent requests getting rejected for that user.

Refs #940