### PR TITLE
Changes in DONOR/DESYNC logic

### DIFF
--- a/tools/proxysql_galera_checker.sh
+++ b/tools/proxysql_galera_checker.sh
@@ -277,7 +277,7 @@ cnt=0
 if [  ${HOSTGROUP_READER_ID} -ne -1 -a ${NUMBER_READERS_ONLINE} -eq 0 ]; then
   echo "`date` ###### TRYING TO FIX MISSING READERS ######"
   echo "`date` --> No readers found, Trying to enable last available node of the cluster (in Donor/Desync state) or pick the master" >> ${ERR_FILE}
-  $PROXYSQL_CMDLINE "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD'" | while read hostgroup server port stat
+  $PROXYSQL_CMDLINE "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status <> 'OFFLINE_HARD'" | while read hostgroup server port stat
   do
     safety_cnt=0
       while [ ${cnt} -eq 0 -a ${safety_cnt} -lt 5 ]

--- a/tools/proxysql_galera_checker.sh
+++ b/tools/proxysql_galera_checker.sh
@@ -155,9 +155,9 @@ do
   fi
 
   # WSREP status is not ok, but the node is marked online, we should put it offline
-  if [ "${WSREP_STATUS}" != "4" -a "${WSREP_STATUS}" != "2" -a "$stat" = "ONLINE" ]; then
+  if [ "${WSREP_STATUS}" != "4" -a "$stat" = "ONLINE" ]; then
     change_server_status $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "WSREP status is ${WSREP_STATUS} which is not ok"
-  elif [ "${WSREP_STATUS}" != "4" -a "${WSREP_STATUS}" != "2" -a "$stat" = "OFFLINE_SOFT" ]; then
+  elif [ "${WSREP_STATUS}" != "4" -a "$stat" = "OFFLINE_SOFT" ]; then
     echo "`date` server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok" >> ${ERR_FILE}
   fi
 
@@ -286,7 +286,7 @@ if [  ${HOSTGROUP_READER_ID} -ne -1 -a ${NUMBER_READERS_ONLINE} -eq 0 ]; then
         echo "`date` Check server $hostgroup:$server:$port for only available node in DONOR state, status $stat , wsrep_local_state $WSREP_STATUS" >> ${ERR_FILE}
         if [ "${WSREP_STATUS}" = "2" -a "$stat" != "ONLINE" ]
         then
-          change_server_status $HOSTGROUP_WRITER_ID "$server" $port "ONLINE" "WSREP status is DESYNC/DONOR, as this is the only node we will put this one online"
+          change_server_status $HOSTGROUP_READER_ID "$server" $port "ONLINE" "WSREP status is DESYNC/DONOR, as this is the only node we will put this one online"
           cnt=$(( $cnt + 1 ))
         fi
         safety_cnt=$(( $safety_cnt + 1 ))


### PR DESCRIPTION
s/HOSTGROUP_WRITER_ID/HOSTGROUP_READER_ID/ for "TRYING TO FIX MISSING READERS".
Use only Synced nodes while building list of writers, pick one DONOR/DESYNC node later if no SYNCED hosts.