### PR TITLE
Make sure we're not hitting uninitialized memory that happens to match prefix

### DIFF
--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -123,7 +123,7 @@ bool MySQL_Connection_userinfo::set_schemaname(char *_new, int l) {
 	if (schemaname) {
 		_l=strlen(schemaname); // bug fix for #609
 	}
-	if ((schemaname==NULL) || (strncmp(_new,schemaname, (l > _l ? l : _l) ))) {
+	if ((schemaname==NULL) || (l != _l) || (strncmp(_new,schemaname, l ))) {
 		if (schemaname) {
 			free(schemaname);
 			schemaname=NULL;


### PR DESCRIPTION
Fixes #1016 on `master`