### PR TITLE
Renamed CPP to CXX in Makefiles

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -36,11 +36,11 @@ LDIRS=-L$(JEMALLOC_PATH)/lib -L$(RE2_PATH)/obj -L$(INJECTION_PATH)
 ODIR= obj
 
 #CC=gcc
-#CPP=g++
+#CXX=g++
 #CC=clang
 
 #CFLAGS=$(IDIRS) $(OPTZ) $(DEBUG) -Wall #-lcrypto
-#CPPFLAGS=-std=c++11 $(CFLAGS) $(LDIRS) $(LIBS)
+#CXXFLAGS=-std=c++11 $(CFLAGS) $(LDIRS) $(LIBS)
 NOJEMALLOC := $(shell echo $(NOJEMALLOC))
 ifeq ($(NOJEMALLOC),1)
 NOJEM=-DNOJEM
@@ -48,27 +48,27 @@ else
 NOJEM=
 endif
 MYCFLAGS=$(IDIRS) $(OPTZ) $(DEBUG) -Wall -DGITVERSION=\"$(GIT_VERSION)\" $(NOJEM)
-MYCPPFLAGS=-std=c++11 $(MYCFLAGS)
+MYCXXFLAGS=-std=c++11 $(MYCFLAGS)
 
 default: libproxysql.a
 .PHONY: default
 
 _OBJ = c_tokenizer.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
-_OBJ_CPP = ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo SpookyV2.oo MySQL_Authentication.oo gen_utils.oo sqlite3db.oo global_variables.oo mysql_connection.oo MySQL_HostGroups_Manager.oo mysql_data_stream.oo MySQL_Thread.oo MySQL_Session.oo MySQL_Protocol.oo mysql_backend.oo Query_Processor.oo ProxySQL_Admin.oo MySQL_Monitor.oo MySQL_Logger.oo thread.oo MySQL_PreparedStatement.oo
-OBJ_CPP = $(patsubst %,$(ODIR)/%,$(_OBJ_CPP))
+_OBJ_CXX = ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo SpookyV2.oo MySQL_Authentication.oo gen_utils.oo sqlite3db.oo global_variables.oo mysql_connection.oo MySQL_HostGroups_Manager.oo mysql_data_stream.oo MySQL_Thread.oo MySQL_Session.oo MySQL_Protocol.oo mysql_backend.oo Query_Processor.oo ProxySQL_Admin.oo MySQL_Monitor.oo MySQL_Logger.oo thread.oo MySQL_PreparedStatement.oo
+OBJ_CXX = $(patsubst %,$(ODIR)/%,$(_OBJ_CXX))
 
 %.ko: %.cpp
-	$(CXX) -fPIC -c -o $@ $< $(MYCPPFLAGS) $(CPPFLAGS)
+	$(CXX) -fPIC -c -o $@ $< $(MYCXXFLAGS) $(CXXFLAGS)
 
 $(ODIR)/%.o: %.c
 	$(CC) -fPIC -c -o $@ $< $(MYCFLAGS) $(CFLAGS)
 
 $(ODIR)/%.oo: %.cpp
-	$(CXX) -fPIC -c -o $@ $< $(MYCPPFLAGS) $(CPPFLAGS)
+	$(CXX) -fPIC -c -o $@ $< $(MYCXXFLAGS) $(CXXFLAGS)
 
-libproxysql.a: $(ODIR) $(OBJ) $(OBJ_CPP) $(RE2_PATH)/obj/libre2.a $(SQLITE3_DIR)/sqlite3.o 
-	ar rcs $@ $(OBJ) $(OBJ_CPP) $(RE2_PATH)/obj/libre2.a $(SQLITE3_DIR)/sqlite3.o
+libproxysql.a: $(ODIR) $(OBJ) $(OBJ_CXX) $(RE2_PATH)/obj/libre2.a $(SQLITE3_DIR)/sqlite3.o
+	ar rcs $@ $(OBJ) $(OBJ_CXX) $(RE2_PATH)/obj/libre2.a $(SQLITE3_DIR)/sqlite3.o
 
 $(ODIR):
 	mkdir $(ODIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ IDIRS=-I$(IDIR) -I$(JEMALLOC_IDIR) -I$(MARIADB_IDIR) $(LIBCONFIG_IDIR) -I$(DAEMO
 LDIRS=-L$(LDIR) -L$(JEMALLOC_LDIR) $(LIBCONFIG_LDIR) -L$(RE2_PATH)/obj -L$(MARIADB_LDIR) -L$(DAEMONPATH_LDIR) -L$(PCRE_LDIR)
 
 
-MYCPPFLAGS=-std=c++11 $(IDIRS) $(OPTZ) $(DEBUG)
+MYCXXFLAGS=-std=c++11 $(IDIRS) $(OPTZ) $(DEBUG)
 LDFLAGS+=
 NOJEMALLOC := $(shell echo $(NOJEMALLOC))
 ifeq ($(NOJEMALLOC),1)
@@ -62,10 +62,10 @@ _OBJ = main.o proxysql_global.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
 $(ODIR)/%.o: %.cpp
-	$(CXX) -c -o $@ $< $(MYCPPFLAGS) $(CPPFLAGS) -Wall
+	$(CXX) -c -o $@ $< $(MYCXXFLAGS) $(CXXFLAGS) -Wall
 
 proxysql: $(ODIR) $(OBJ) $(LIBPROXYSQLAR)
-	$(CXX) -o $@ $(OBJ) $(LIBPROXYSQLAR) $(MYCPPFLAGS) $(CPPFLAGS) $(LDIRS) $(LIBS) $(LDFLAGS) $(MYLIBS)
+	$(CXX) -o $@ $(OBJ) $(LIBPROXYSQLAR) $(MYCXXFLAGS) $(CXXFLAGS) $(LDIRS) $(LIBS) $(LDFLAGS) $(MYLIBS)
 
 $(ODIR):
 	mkdir $(ODIR)


### PR DESCRIPTION
Renamed all variables in Makefiles that have 'CPP' in the name to 'CXX':

"CFLAGS enables the addition of switches for the C compiler, while
CXXFLAGS is meant to be used when invoking a C++ compiler. Similarly, a
variable CPPFLAGS exists with switches to be passed to the C or C++
preprocessor." (https://en.wikipedia.org/wiki/CFLAGS)

This change facilitates the building with customized CXXFLAGS (rpmbuild
exports a customized CXXFLAGS with hardening flags).

More 2 links:
https://stackoverflow.com/questions/495598/difference-between-cppflags-and-cxxflags-in-gnu-make
https://stackoverflow.com/questions/5541946/cflags-ccflags-cxxflags-what-exactly-do-these-variables-control