### PR TITLE
Fix FreeBSD Compilation error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,9 @@
 #include <thread>
 #include "btree_map.h"
 #include "proxysql.h"
+#ifdef __FreeBSD__
+#include <fcntl.h>
+#endif
 
 //#define PROXYSQL_EXTERN
 #include "cpp.h"


### PR DESCRIPTION
Fix these errors

`main.cpp:26:32: error: use of undeclared identifier 'O_WRONLY'
                outfd=open(GloVars.errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
                                             ^
main.cpp:26:43: error: use of undeclared identifier 'O_APPEND'
                outfd=open(GloVars.errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
                                                        ^
main.cpp:26:54: error: use of undeclared identifier 'O_CREAT'
                outfd=open(GloVars.errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
                                                                   ^
main.cpp:33:32: error: use of undeclared identifier 'O_WRONLY'
                errfd=open(GloVars.errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
                                             ^
main.cpp:33:43: error: use of undeclared identifier 'O_APPEND'
                errfd=open(GloVars.errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
                                                        ^
main.cpp:33:54: error: use of undeclared identifier 'O_CREAT'
                errfd=open(GloVars.errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);`