### PR TITLE
initialize the filler byte to 0

### DIFF
--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -704,6 +704,7 @@ bool MySQL_Protocol::generate_STMT_PREPARE_RESPONSE(uint8_t sequence_id, MySQL_S
 	hdr.pkt_length=12;
 	memcpy(okpack,&hdr,sizeof(mysql_hdr)); // copy header
 	okpack[4]=0;
+	okpack[13]=0;
 	okpack[15]=0;
 	if (_stmt_id) {
 		memcpy(okpack+5,&_stmt_id,sizeof(uint32_t));


### PR DESCRIPTION
```
COM_STMT_PREPARE OK
  OK response to a COM_STMT_PREPARE packet

  direction: server -> client

  payload:
    1              [00] OK
    4              statement-id
    2              num-columns
    2              num-params
    1              [00] filler
    2              warning count
```

According to the protocol 10th byte (filler) of the response should be
0. introduced by 02432b2b2734473654e5fe8055d6b623a42be4f2.

We recently upgraded from 1.3.5 to 1.4.1 and started to get errors randomly. I was able to reduce it to the prepare statement query.

```elixir
Application.ensure_all_started(:mariaex)
{:ok, conn} = Mariaex.start_link(username: "root", password: "sqlsecret", database: "pato_dev", port: "6033")
for i <- 1..100 do
  Mariaex.prepare(conn, "by_kind", "select id FROM sidekiq_jobs WHERE kind='$1'")
end
IO.puts "OK"
```

```
timestamp=2017-09-08T10:43:21.112Z level=error  message= GenServer #PID<0.747.0> terminating
** (DBConnection.ConnectionError) client #PID<0.73.0> stopped: ** (MatchError) no match of right hand side value: <<0, 1, 0, 0, 0, 1, 0, 0, 0, 7, 0, 0>>
    (mariaex) lib/mariaex/messages.ex:149: Mariaex.Messages.decode_stmt_prepare_ok/1
    (mariaex) lib/mariaex/messages.ex:219: Mariaex.Messages.decode/2
```

The client library we use make assertion on the structure of response from mysql. Because the filler byte is not always zero, the assertion fails randomly. Initializing it to zero fixes the problem.