### PR TITLE
Make CPU-time monitoring optional

### DIFF
--- a/include/proxysql_glovars.hpp
+++ b/include/proxysql_glovars.hpp
@@ -66,6 +66,7 @@ class ProxySQL_GlobalVariables {
 #endif /* IDLE_THREADS */
 		pthread_mutex_t start_mutex;
 		bool foreground;
+		bool cputiming;
 #ifdef DEBUG
 		int gdb;
 		debug_level *gdbg_lvl;

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -56,6 +56,7 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 	global.gdbg=false;
 	global.nostart=false;
 	global.foreground=false;
+	global.cputiming=false;
 	global.monitor=true;
 #ifdef IDLE_THREADS
 	global.idle_threads=false;
@@ -93,6 +94,7 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 	opt->add((const char *)"",0,0,0,(const char *)"Starts only the admin service",(const char *)"-n",(const char *)"--no-start");
 	opt->add((const char *)"",0,0,0,(const char *)"Do not start Monitor Module",(const char *)"-M",(const char *)"--no-monitor");
 	opt->add((const char *)"",0,0,0,(const char *)"Run in foreground",(const char *)"-f",(const char *)"--foreground");
+	opt->add((const char *)"",0,0,0,(const char *)"Measure CPU time",(const char *)"-p",(const char *)"--cpu-time");
 #ifdef SO_REUSEPORT
 	opt->add((const char *)"",0,0,0,(const char *)"Use SO_REUSEPORT",(const char *)"-r",(const char *)"--reuseport");
 #endif /* SO_REUSEPORT */
@@ -222,6 +224,10 @@ void ProxySQL_GlobalVariables::process_opts_post() {
 		proxy_warning("ProxySQL does not support daemonize in Darwin: running in foreground\n");
 		global.foreground=true;
 #endif
+	}
+
+	if (opt->isSet("-p")) {
+		global.cputiming=true;
 	}
 
 	if (opt->isSet("-M")) {


### PR DESCRIPTION
In deploying ProxySQL we see very high levels of system CPU time -- a lot of what it's doing is `recv`ing from one socket and `send`ing to another, so this make sense, and a great deal of time is spent in `poll` -- but checking production nodes with `strace -fp $pid -cc -e trace=!poll,nanosleep` shows that up to a third of our system calls are to `clock_gettime`, specifically the `CLOCK_THREAD_CPUTIME_ID` variant.

This is a [reasonably expensive variant](https://stackoverflow.com/a/13096917) of `clock_gettime`, because it's so accurate, but I'm not doing anything with the statistics being collected into `query_processor_time` and `backend_query_time` and I'd like to be able to turn them off.

This patch turns collecting these statistics off by default, and adds a `-p` param to enable collecting them. You may prefer to make this tuneable via the admin SQL interface but this seemed to be the smallest change to the code, so I went this route.

---

I tested on a 4 socket, 32 core, 64bit Ubuntu 14.04 machine with `sysbench` 1.0.2 and Linux kernel 3.19. I used this ProxySQL fork both collecting the time stats and not with this sysbench config:

```bash
sysbench --time=60 --mysql-port=6033 --mysql-host=127.0.0.1 \
--oltp-table-size=214748364800 --oltp-test-mode=complex \
--mysql-db=sysbench --mysql-user=root --mysql-password=root \
--oltp-read-only=off --threads=32 --report-interval=5 \
--events=10000000 --rate=1000 \
/usr/share/sysbench/tests/include/oltp_legacy/select.lua run
```

While this was running I collected stats using strace again, with this command line:

```bash
strace -fp $PID -cc -e trace'!=poll,nanosleep' & (sleep 10 && killall -INT strace)
```

The ProxySQL config was the default proxysql.cfg that ships with the source code.

The top six syscalls while collecting query stats:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 42.75    0.006170           0     40972           sendto
 35.95    0.005188           0    119854           clock_gettime
 21.31    0.003075           0     59991     19051 recvfrom
  0.00    0.000000           0        32           ioctl
  0.00    0.000000           0         7           madvise
  0.00    0.000000           0        32           accept
```

The top six syscalls while not collecting query stats:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 76.69    0.006001           0     42400           sendto
 23.18    0.001814           0     61542     19155 recvfrom
  0.13    0.000010           0       385       123 futex
  0.00    0.000000           0         6           read
  0.00    0.000000           0        21        16 open
  0.00    0.000000           0         7           close
```

While in normal operation each thread is spending a lot of time in `nanosleep` and `poll`, I think that this is enough of a saving that other people would want the option to disable stats in production.

If you're happy with the concept I'm happy to work on changes to the code to fit your design principles or coding standards.