### PR TITLE
improved pgrep usage

### DIFF
--- a/etc/init.d/proxysql
+++ b/etc/init.d/proxysql
@@ -104,7 +104,7 @@ stop() {
 		exit 0
 	else
 		# Note: we send a kill to all the processes, not just to the child
-		for i in `pgrep proxysql` ; do
+		for i in `pgrep -x proxysql` ; do
 			if [ "$i" != "$$" ]; then
 				kill $i
 			fi


### PR DESCRIPTION
When the init.d script searches for process to kill using pgrep, it can incorrectly also choose other processes which have `proxysql` in their name. For example, if I run a test script in one terminal
```
$ cat proxysql_do 
#!/bin/bash
echo "my pid is $$"
sleep 120;
```

`pgrep proxysql` will return the pid of `proxysql_do` and also all other proxysql processes running on the host:
```
$ ./proxysql_do 
my pid is 15998
```
while in another terminal:
```
$ pgrep proxysql
6565
6566
15998
$ pgrep  -x proxysql
6565
6566
```