### PR TITLE
Disable libssh2 support in curl to fix building on Fedora 27

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -20,7 +20,7 @@ endif
 curl/curl/lib/.libs/libcurl.a:
 	cd curl && rm -rf curl-7.57.0 || true
 	cd curl && tar -zxf curl-7.57.0.tar.gz
-	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 && CC=${CC} CXX=${CXX} ${MAKE}
+	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 && CC=${CC} CXX=${CXX} ${MAKE}
 curl: curl/curl/lib/.libs/libcurl.a
 
 libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:


### PR DESCRIPTION
Without this building failed with undefined references to libssh2:
```
g++ -o proxysql obj/main.o obj/proxysql_global.o ../lib/libproxysql.a -std=c++11 -I../include -I../deps/jemalloc/jemalloc/include/jemalloc -I../deps/mariadb-client-library/mariadb_client/include -I../deps/libconfig/libconfig-1.4.9/lib -I../deps/libdaemon/libdaemon -I../deps/sqlite3/sqlite3 -I../deps/clickhouse-cpp/clickhouse-cpp -I../deps/libmicrohttpd/libmicrohttpd/src/include -I../deps/curl/curl//include -O2 -ggdb    -L../lib -L../deps/jemalloc/jemalloc/lib -L../deps/libconfig/libconfig-1.4.9/lib/.libs -L../deps/re2/re2/obj -L../deps/mariadb-client-library/mariadb_client/libmariadb -L../deps/libdaemon/libdaemon/libdaemon/.libs -L../deps/pcre/pcre/.libs -L../deps/libmicrohttpd/libmicrohttpd/src/microhttpd/.libs -L../deps/curl/curl//lib/.libs   -Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lmicrohttpd -lcurl -Wl,-Bdynamic -lpthread -lm -lz -lrt -lcrypto -lssl  -ldl
../deps/curl/curl//lib/.libs/libcurl.a(libcurl_la-easy.o): In function `global_init':
easy.c:(.text+0x7d): undefined reference to `libssh2_init'
../deps/curl/curl//lib/.libs/libcurl.a(libcurl_la-easy.o): In function `curl_global_cleanup':
easy.c:(.text+0x2c8): undefined reference to `libssh2_exit'
```

I don't think libssh2 support is needed and this fixes the build.
The other option would be to add `-lssh2`.