### PR TITLE
Applying 1.4.8 fixes to 2.0-lab

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -34,7 +34,7 @@ coredumper: google-coredumper/google-coredumper/.libs/libcoredumper.a
 curl/curl/lib/.libs/libcurl.a:
 	cd curl && rm -rf curl-7.57.0 || true
 	cd curl && tar -zxf curl-7.57.0.tar.gz
-	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 && CC=${CC} CXX=${CXX} ${MAKE}
+	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli && CC=${CC} CXX=${CXX} ${MAKE}
 curl: curl/curl/lib/.libs/libcurl.a
 
 libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -34,7 +34,7 @@ coredumper: google-coredumper/google-coredumper/.libs/libcoredumper.a
 curl/curl/lib/.libs/libcurl.a:
 	cd curl && rm -rf curl-7.57.0 || true
 	cd curl && tar -zxf curl-7.57.0.tar.gz
-	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 && CC=${CC} CXX=${CXX} ${MAKE}
+	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 && CC=${CC} CXX=${CXX} ${MAKE}
 curl: curl/curl/lib/.libs/libcurl.a
 
 libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:

--- a/include/mysql_connection.h
+++ b/include/mysql_connection.h
@@ -92,6 +92,8 @@ class MySQL_Connection {
 	bool processing_prepared_statement_execute;
 	bool processing_multi_statement;
 	bool multiplex_delayed;
+	bool unknown_transaction_status;
+	void compute_unknown_transaction_status();
 	MySQL_Connection();
 	~MySQL_Connection();
 	bool set_autocommit(bool);

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -14,6 +14,7 @@ struct _Query_Processor_rule_t {
 	char *schemaname;
 	int flagIN;
 	char *client_addr;
+	int client_addr_wildcard_position;
 	char *proxy_addr;
 	int proxy_port;
 	uint64_t digest;

--- a/lib/ClickHouse_Server.cpp
+++ b/lib/ClickHouse_Server.cpp
@@ -495,7 +495,7 @@ void ClickHouse_Server_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t
 
 
 	if (sess->session_type == PROXYSQL_SESSION_CLICKHOUSE) {
-		if (!strncmp("SET ", query_no_space, 4)) {
+		if (!strncasecmp("SET ", query_no_space, 4)) {
 			if (
 				!strncasecmp("SET AUTOCOMMIT", query_no_space, 14) ||
 				!strncasecmp("SET NAMES ", query_no_space, 10) ||
@@ -503,7 +503,8 @@ void ClickHouse_Server_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t
 				!strncasecmp("SET COLLATION", query_no_space, 13) ||
 				!strncasecmp("SET SQL_AUTO_", query_no_space, 13) ||
 				!strncasecmp("SET SQL_SAFE_", query_no_space, 13) ||
-				!strncasecmp("SET SESSION TRANSACTION", query_no_space, 23)
+				!strncasecmp("SET SESSION TRANSACTION", query_no_space, 23) ||
+				!strncasecmp("SET WAIT_TIMEOUT", query_no_space, 16)
 			) {
 				GloClickHouseServer->send_MySQL_OK(&sess->client_myds->myprot, NULL);
 				run_query=false;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -400,7 +400,11 @@ void * monitor_connect_thread(void *arg) {
 	rc=sqlite3_reset(statement); assert(rc==SQLITE_OK);
 	sqlite3_finalize(statement);
 	if (mmsd->mysql_error_msg) {
-		if (strncmp(mmsd->mysql_error_msg,"Access denied for user",strlen("Access denied for user"))==0) {
+		if (
+			(strncmp(mmsd->mysql_error_msg,"Access denied for user",strlen("Access denied for user"))==0)
+			||
+			(strncmp(mmsd->mysql_error_msg,"ProxySQL Error: Access denied for user",strlen("ProxySQL Error: Access denied for user"))==0)
+		) {
 			proxy_error("Server %s:%d is returning \"Access denied\" for monitoring user\n", mmsd->hostname, mmsd->port);
 		}
 	}
@@ -1403,7 +1407,7 @@ __end_monitor_ping_loop:
 				resultset=NULL;
 			}
 			char *new_query=NULL;
-			new_query=(char *)"SELECT 1 FROM (SELECT hostname,port,ping_error FROM mysql_server_ping_log WHERE hostname='%s' AND port='%s' ORDER BY time_start_us DESC LIMIT %d) a WHERE ping_error IS NOT NULL AND ping_error NOT LIKE 'Access denied for user%%' GROUP BY hostname,port HAVING COUNT(*)=%d";
+			new_query=(char *)"SELECT 1 FROM (SELECT hostname,port,ping_error FROM mysql_server_ping_log WHERE hostname='%s' AND port='%s' ORDER BY time_start_us DESC LIMIT %d) a WHERE ping_error IS NOT NULL AND ping_error NOT LIKE 'Access denied for user%%' AND ping_error NOT LIKE 'ProxySQL Error: Access denied for user%%' GROUP BY hostname,port HAVING COUNT(*)=%d";
 			for (j=0;j<i;j++) {
 				char *buff=(char *)malloc(strlen(new_query)+strlen(addresses[j])+strlen(ports[j])+16);
 				int max_failures=mysql_thread___monitor_ping_max_failures;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -942,6 +942,7 @@ int MySQL_Session::handler_again___status_PINGING_SERVER() {
 	int rc=myconn->async_ping(myds->revents);
 	if (rc==0) {
 		myconn->async_state_machine=ASYNC_IDLE;
+		myconn->unknown_transaction_status = false;
 		if (mysql_thread___multiplexing && (myconn->reusable==true) && myds->myconn->IsActiveTransaction()==false && myds->myconn->MultiplexDisabled()==false) {
 			myds->return_MySQL_Connection_To_Pool();
 		} else {
@@ -2730,6 +2731,7 @@ handler_again:
 								enum session_status st=status;
 								size_t sts=previous_status.size();
 								if (sts) {
+									myconn->unknown_transaction_status = false;
 									myconn->async_state_machine=ASYNC_IDLE;
 									myds->DSS=STATE_MARIADB_GENERIC;
 									st=previous_status.top();
@@ -2769,6 +2771,7 @@ handler_again:
 					if (mysql_thread___multiplexing && (myds->myconn->reusable==true) && myds->myconn->IsActiveTransaction()==false && myds->myconn->MultiplexDisabled()==false) {
 						if (mysql_thread___connection_delay_multiplex_ms && mirror==false) {
 							myds->wait_until=thread->curtime+mysql_thread___connection_delay_multiplex_ms*1000;
+							myconn->unknown_transaction_status = false;
 							myconn->async_state_machine=ASYNC_IDLE;
 							myconn->multiplex_delayed=true;
 							myds->DSS=STATE_MARIADB_GENERIC;
@@ -2796,6 +2799,7 @@ handler_again:
 						}
 					} else {
 						myconn->multiplex_delayed=false;
+						myconn->unknown_transaction_status = false;
 						myconn->async_state_machine=ASYNC_IDLE;
 						myds->DSS=STATE_MARIADB_GENERIC;
 						if (transaction_persistent==true) {
@@ -2813,6 +2817,7 @@ handler_again:
 				} else {
 					if (rc==-1) {
 						int myerr=mysql_errno(myconn->mysql);
+						myconn->compute_unknown_transaction_status();
 						char *errmsg = NULL;
 						if (myerr == 0) {
 							if (CurrentQuery.mysql_stmt) {

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -942,7 +942,7 @@ int MySQL_Session::handler_again___status_PINGING_SERVER() {
 	int rc=myconn->async_ping(myds->revents);
 	if (rc==0) {
 		myconn->async_state_machine=ASYNC_IDLE;
-		myconn->unknown_transaction_status = false;
+		myconn->compute_unknown_transaction_status();
 		if (mysql_thread___multiplexing && (myconn->reusable==true) && myds->myconn->IsActiveTransaction()==false && myds->myconn->MultiplexDisabled()==false) {
 			myds->return_MySQL_Connection_To_Pool();
 		} else {
@@ -2731,7 +2731,6 @@ handler_again:
 								enum session_status st=status;
 								size_t sts=previous_status.size();
 								if (sts) {
-									myconn->unknown_transaction_status = false;
 									myconn->async_state_machine=ASYNC_IDLE;
 									myds->DSS=STATE_MARIADB_GENERIC;
 									st=previous_status.top();
@@ -2771,7 +2770,6 @@ handler_again:
 					if (mysql_thread___multiplexing && (myds->myconn->reusable==true) && myds->myconn->IsActiveTransaction()==false && myds->myconn->MultiplexDisabled()==false) {
 						if (mysql_thread___connection_delay_multiplex_ms && mirror==false) {
 							myds->wait_until=thread->curtime+mysql_thread___connection_delay_multiplex_ms*1000;
-							myconn->unknown_transaction_status = false;
 							myconn->async_state_machine=ASYNC_IDLE;
 							myconn->multiplex_delayed=true;
 							myds->DSS=STATE_MARIADB_GENERIC;
@@ -2799,7 +2797,7 @@ handler_again:
 						}
 					} else {
 						myconn->multiplex_delayed=false;
-						myconn->unknown_transaction_status = false;
+						myconn->compute_unknown_transaction_status();
 						myconn->async_state_machine=ASYNC_IDLE;
 						myds->DSS=STATE_MARIADB_GENERIC;
 						if (transaction_persistent==true) {
@@ -2817,7 +2815,6 @@ handler_again:
 				} else {
 					if (rc==-1) {
 						int myerr=mysql_errno(myconn->mysql);
-						myconn->compute_unknown_transaction_status();
 						char *errmsg = NULL;
 						if (myerr == 0) {
 							if (CurrentQuery.mysql_stmt) {
@@ -4402,6 +4399,7 @@ void MySQL_Session::RequestEnd(MySQL_Data_Stream *myds) {
 		// if there is a mysql connection, clean its status
 		if (myds->myconn) {
 			myds->myconn->async_free_result();
+			myds->myconn->compute_unknown_transaction_status();
 		}
 		myds->free_mysql_real_query();
 	}

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -7070,6 +7070,22 @@ char * ProxySQL_Admin::load_mysql_query_rules_to_runtime() {
 		QP_rule_t * nqpr;
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 			SQLite3_row *r=*it;
+			if (r->fields[4]) {
+				char *pct = NULL;
+				if (strlen(r->fields[4]) >= INET6_ADDRSTRLEN) {
+					proxy_error("Query rule with rule_id=%s has an invalid client_addr: %s\n", r->fields[0], r->fields[4]);
+					continue;
+				}
+				pct = strchr(r->fields[4],'%');
+				if (pct) { // there is a wildcard
+					if (strlen(pct) == 1) {
+						// % is at the end of the string, good
+					} else {
+						proxy_error("Query rule with rule_id=%s has a wildcard that is not at the end of client_addr: %s\n", r->fields[0], r->fields[4]);
+						continue;
+					}
+				}
+			}
 			nqpr=GloQPro->new_query_rule(
 				atoi(r->fields[0]), // rule_id
 				true,

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -49,6 +49,29 @@ MySQL_Connection_userinfo::~MySQL_Connection_userinfo() {
 	if (schemaname) free(schemaname);
 }
 
+void MySQL_Connection::compute_unknown_transaction_status() {
+	if (mysql) {
+		int _myerrno=mysql_errno(mysql);
+		if (_myerrno == 0) {
+			unknown_transaction_status = false; // no error
+			return;
+		}
+		if (_myerrno >= 2000 && _myerrno < 3000) { // client error
+			// do not change it
+			return;
+		}
+		if (_myerrno >= 1000 && _myerrno < 2000) { // server error
+			unknown_transaction_status = true;
+			return;
+		}
+		if (_myerrno >= 3000 && _myerrno < 4000) { // server error
+			unknown_transaction_status = true;
+			return;
+		}
+		// all other cases, server error
+	}
+}
+
 uint64_t MySQL_Connection_userinfo::compute_hash() {
 	int l=0;
 	if (username)
@@ -189,6 +212,7 @@ MySQL_Connection::MySQL_Connection() {
 	largest_query_length=0;
 	multiplex_delayed=false;
 	MyRS=NULL;
+	unknown_transaction_status = false;
 	creation_time=0;
 	processing_multi_statement=false;
 	proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 4, "Creating new MySQL_Connection %p\n", this);
@@ -981,6 +1005,14 @@ handler_again:
 			}
 			break;
 		case ASYNC_QUERY_END:
+			if (mysql) {
+				int _myerrno=mysql_errno(mysql);
+				if (_myerrno == 0) {
+					unknown_transaction_status = false;
+				} else {
+					compute_unknown_transaction_status();
+				}
+			}
 			if (mysql_result) {
 				mysql_free_result(mysql_result);
 				mysql_result=NULL;
@@ -1137,6 +1169,7 @@ int MySQL_Connection::async_connect(short event) {
 		return 0;
 	}
 	if (async_state_machine==ASYNC_CONNECT_SUCCESSFUL) {
+		unknown_transaction_status = false;
 		async_state_machine=ASYNC_IDLE;
 		myds->wait_until=0;
 		creation_time = monotonic_time();
@@ -1145,6 +1178,7 @@ int MySQL_Connection::async_connect(short event) {
 	handler(event);
 	switch (async_state_machine) {
 		case ASYNC_CONNECT_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			myds->wait_until=0;
 			return 0;
@@ -1224,8 +1258,10 @@ int MySQL_Connection::async_query(short event, char *stmt, unsigned long length,
 	
 	if (async_state_machine==ASYNC_QUERY_END) {
 		if (mysql_errno(mysql)) {
+			compute_unknown_transaction_status();
 			return -1;
 		} else {
+			unknown_transaction_status = false;
 			return 0;
 		}
 	}
@@ -1233,17 +1269,21 @@ int MySQL_Connection::async_query(short event, char *stmt, unsigned long length,
 		query.stmt_meta=NULL;
 		async_state_machine=ASYNC_QUERY_END;
 		if (mysql_stmt_errno(query.stmt)) {
+			compute_unknown_transaction_status();
 			return -1;
 		} else {
+			unknown_transaction_status = false;
 			return 0;
 		}
 	}
 	if (async_state_machine==ASYNC_STMT_PREPARE_SUCCESSFUL || async_state_machine==ASYNC_STMT_PREPARE_FAILED) {
 		query.stmt_meta=NULL;
 		if (async_state_machine==ASYNC_STMT_PREPARE_FAILED) {
+			compute_unknown_transaction_status();
 			return -1;
 		} else {
 			*_stmt=query.stmt;
+			unknown_transaction_status = false;
 			return 0;
 		}
 	}
@@ -1273,6 +1313,7 @@ int MySQL_Connection::async_ping(short event) {
 	assert(ret_mysql);
 	switch (async_state_machine) {
 		case ASYNC_PING_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1292,6 +1333,7 @@ int MySQL_Connection::async_ping(short event) {
 	// check again
 	switch (async_state_machine) {
 		case ASYNC_PING_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1314,6 +1356,7 @@ int MySQL_Connection::async_change_user(short event) {
 	assert(ret_mysql);
 	switch (async_state_machine) {
 		case ASYNC_CHANGE_USER_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1333,6 +1376,7 @@ int MySQL_Connection::async_change_user(short event) {
 	// check again
 	switch (async_state_machine) {
 		case ASYNC_CHANGE_USER_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1355,6 +1399,7 @@ int MySQL_Connection::async_select_db(short event) {
 	assert(ret_mysql);
 	switch (async_state_machine) {
 		case ASYNC_INITDB_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1371,6 +1416,7 @@ int MySQL_Connection::async_select_db(short event) {
 	// check again
 	switch (async_state_machine) {
 		case ASYNC_INITDB_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1390,6 +1436,7 @@ int MySQL_Connection::async_set_autocommit(short event, bool ac) {
 	assert(ret_mysql);
 	switch (async_state_machine) {
 		case ASYNC_SET_AUTOCOMMIT_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1407,6 +1454,7 @@ int MySQL_Connection::async_set_autocommit(short event, bool ac) {
 	// check again
 	switch (async_state_machine) {
 		case ASYNC_SET_AUTOCOMMIT_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1426,6 +1474,7 @@ int MySQL_Connection::async_set_names(short event, uint8_t c) {
 	assert(ret_mysql);
 	switch (async_state_machine) {
 		case ASYNC_SET_NAMES_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1443,6 +1492,7 @@ int MySQL_Connection::async_set_names(short event, uint8_t c) {
 	// check again
 	switch (async_state_machine) {
 		case ASYNC_SET_NAMES_SUCCESSFUL:
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 			break;
@@ -1487,6 +1537,7 @@ void MySQL_Connection::async_free_result() {
 			mysql_result=NULL;
 		}
 	}
+	unknown_transaction_status = false;
 	async_state_machine=ASYNC_IDLE;
 	if (MyRS) {
 		delete MyRS;
@@ -1499,7 +1550,7 @@ bool MySQL_Connection::IsActiveTransaction() {
 	bool ret=false;
 	if (mysql) {
 		ret = (mysql->server_status & SERVER_STATUS_IN_TRANS);
-		if (ret == false && (mysql)->net.last_errno) {
+		if (ret == false && (mysql)->net.last_errno && unknown_transaction_status == true) {
 			ret = true;
 		}
 		if (ret == false) {
@@ -1685,8 +1736,10 @@ int MySQL_Connection::async_send_simple_command(short event, char *stmt, unsigne
 	}
 	if (async_state_machine==ASYNC_QUERY_END) {
 		if (mysql_errno(mysql)) {
+			compute_unknown_transaction_status();
 			return -1;
 		} else {
+			unknown_transaction_status = false;
 			async_state_machine=ASYNC_IDLE;
 			return 0;
 		}


### PR DESCRIPTION
This pull request contains fixes from v1.4.8 not yet added to 2.0-lab branch

```
Monitor: do not consider unhealthy ProxySQL's as backends if monitor - a3ffb6a
Missing flag SERVER_STATUS_NO_BACKSLASH_ESCAPES for SQLite3 backends # - d941a1b
Remember if the current connection has an unknown transaction status - 94ad7b7
Remember if the current connection has an unknown transaction status - 18109c6
Disable libssh2 support in curl to fix building on Fedora 27 - 3b74e1c
Fix to return OK packet for SET WAIT_TIMEOUT - 2cb7088
Add support for wildcard in mysql_query_rules.client_addr #1450 - d1a14e6
Disable brotli from curl #1458 - 669c149
```