### PR TITLE
Allow TLSv1.1 and TLSv1.2 backend connections with OpenSSL 1.0.x

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -78,6 +78,7 @@ mariadb-client-library/mariadb_client/include/my_config.h:
 	cd mariadb-client-library/mariadb_client && patch libmariadb/mysql_async.c < ../mysql_async.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/password.c < ../password.c.patch
 #	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_secure.c < ../ma_secure.c.patch
+	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_secure.c < ../ma_secure.c_tls.patch
 	cd mariadb-client-library/mariadb_client && patch include/mysql.h < ../mysql.h.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/my_alloc.c < ../my_alloc.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/my_charset.c < ../my_charset.c.patch

--- a/deps/mariadb-client-library/ma_secure.c_tls.patch
+++ b/deps/mariadb-client-library/ma_secure.c_tls.patch
@@ -1,0 +1,8 @@
+173c173,174
+<     if (!(SSL_context= SSL_CTX_new(TLSv1_client_method())))
+---
+>     /* SSLv23_client_method() also gives TLSv1.x */
+>     if (!(SSL_context= SSL_CTX_new(SSLv23_client_method())))
+179a181,182
+>     SSL_set_options(SSL_context, SSL_OP_NO_SSLv2);
+>     SSL_set_options(SSL_context, SSL_OP_NO_SSLv3);


### PR DESCRIPTION
Use `SSLv23_client_method()` instead `TLSv1_client_method()`.
Then restrict to TLSv1.0 and newer by setting `SSL_OP_NO_SSLv2` and `SSL_OP_NO_SSLv3`.

The long term fix is to upgrade to MariaDB Connector/C 3.x or newer.
This is for building and deploying on CentOS 7.