### PR TITLE
Prevent duplicate execution of proxysql_galera_checker.sh

### DIFF
--- a/tools/proxysql_galera_checker.sh
+++ b/tools/proxysql_galera_checker.sh
@@ -49,6 +49,15 @@ WRITER_IS_READER="${4:-1}"
 ERR_FILE="${5:-/dev/null}"
 RELOAD_CHECK_FILE="/var/lib/proxysql/reload"
 
+# Prevent duplicate execution
+BASENAME=`basename "$0"`
+pidof -x -o %PPID ${BASENAME}
+ANOTHER_PROCESS_IS_RUNNING=$?
+if [ ${ANOTHER_PROCESS_IS_RUNNING} -eq 0 ]; then
+  echo "`date` ###### Another process is already running. Abort! ######" >> ${ERR_FILE}
+  exit 0
+fi
+
 echo "0" > ${RELOAD_CHECK_FILE}
 
 if [ "$1" = '-h' -o "$1" = '--help'  -o -z "$1" ]


### PR DESCRIPTION
If for some reason the MySQL server is unreachable, proxysql_galera_checker.sh may be duplicated. If it occurs, RELOAD_CHECK_FILE will not work properly. So, I think that it is better for proxysql_galera_checker.sh to have duplicate execution prevention function.