### PR TITLE
Use correct package for g++ with RHEL and CentOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,10 @@ Make sure you have installed the equivalent for each of these packages for your 
 
 Shortcut commands for installing pre-requisites:
 ```
-# RHEL / CentOS Based:
+# RHEL / CentOS < 7:
+yum install automake bzip2 cmake make g++ gcc git openssl openssl-devel patch
+
+# CentOS 7.4+ / Fedora 28+:
 yum install automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel patch
 
 # Debian / Ubuntu Based:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ Make sure you have installed the equivalent for each of these packages for your 
 Shortcut commands for installing pre-requisites:
 ```
 # RHEL / CentOS Based:
-yum install automake bzip2 cmake make g++ gcc git openssl openssl-devel patch
+yum install automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel patch
 
 # Debian / Ubuntu Based:
 apt-get install automake bzip2 cmake make g++ gcc git openssl libssl-dev patch

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -1,7 +1,7 @@
 How to operate ProxySQL
 =======================
 
-First of all, ProxySQL is a daemon ran by an angel process. The angel process monitors the daemon and restarts it when it has crashed, in order to minimize downtime. The daemon accepts incoming traffic from MySQL clients and forwards it to backend MySQL servers.
+First of all, ProxySQL is a daemon run by an angel process. The angel process monitors the daemon and restarts it when it has crashed, in order to minimize downtime. The daemon accepts incoming traffic from MySQL clients and forwards it to backend MySQL servers.
 
 The proxy is designed to run for as long as possible without needing to be restarted. Most configurations can be done at runtime, through a configuration system that responds to SQL-like queries (["admin interface"](https://github.com/sysown/proxysql/blob/master/doc/admin_tables.md)). Runtime parameters, server grouping and traffic-related settings can all be changed at runtime.
 


### PR DESCRIPTION
As of CentOS 7.4 and Fedora 28, the correct package name to install `g++` is `gcc-c++`.