### PR TITLE
Added fix for mysqldump error related to information_schema

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2400,6 +2400,12 @@ void admin_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *pkt) {
 			run_query=false;
 			goto __run_query;
 		}
+		if (!strncmp("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'session_variables'", query_no_space, strlen("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'session_variables'")))  {
+			l_free(query_length,query);
+			query=l_strdup("SELECT 0 as 'COUNT(*)'");
+			query_length=strlen(query)+1;
+			goto __run_query;
+		}
 		if (!strncmp("SHOW VARIABLES LIKE 'gtid\\_mode'", query_no_space, strlen("SHOW VARIABLES LIKE 'gtid\\_mode'"))) {
 			l_free(query_length,query);
 			query=l_strdup("SELECT variable_name Variable_name, Variable_value Value FROM global_variables WHERE Variable_name='gtid_mode'");


### PR DESCRIPTION
Addresses: ```mysqldump: Couldn't execute 'SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'session_variables'': no such table: INFORMATION_SCHEMA.TABLES (1045)```

Reported in https://github.com/sysown/proxysql/issues/1382