### PR TITLE
Add systemd readiness notification when applicable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build_lib: build_deps
 
 .PHONY: build_src
 build_src: build_deps build_lib
-	cd src && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
 
 .PHONY: build_deps_debug
 build_deps_debug:
@@ -54,7 +54,7 @@ build_lib_debug: build_deps_debug
 
 .PHONY: build_src_debug
 build_src_debug: build_deps build_lib_debug
-	cd src && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
 
 .PHONY: build_deps_clickhouse
 build_deps_clickhouse:
@@ -74,11 +74,11 @@ build_lib_debug_clickhouse: build_deps_debug_clickhouse
 
 .PHONY: build_src_clickhouse
 build_src_clickhouse: build_deps_clickhouse build_lib_clickhouse
-	cd src && OPTZ="${O2} -ggdb" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O2} -ggdb" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
 
 .PHONY: build_src_debug_clickhouse
 build_src_debug_clickhouse: build_deps build_lib_debug_clickhouse
-	cd src && OPTZ="${O0} -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O0} -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
 
 
 .PHONY: clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,6 +65,10 @@ endif
 
 MYCXXFLAGS=-std=c++11 $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH)
 
+ifeq ($(SYSTEMD),1)
+CXXFLAGS+= -DSYSTEMD
+endif
+
 LDFLAGS+=
 NOJEMALLOC := $(shell echo $(NOJEMALLOC))
 ifeq ($(NOJEMALLOC),1)
@@ -81,6 +85,10 @@ ifeq ($(UNAME_S),Linux)
 endif
 ifeq ($(UNAME_S),FreeBSD)
 	MYLIBS+= -lexecinfo
+endif
+
+ifeq ($(SYSTEMD),1)
+	MYLIBS+= -lsystemd
 endif
 
 LIBPROXYSQLAR=$(LDIR)/libproxysql.a

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,11 @@
 #include <fcntl.h>
 #endif
 
+#ifdef SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
+
 //#define PROXYSQL_EXTERN
 #include "cpp.h"
 
@@ -1032,6 +1037,10 @@ __start_label:
 		unsigned int missed_heartbeats = 0;
 		unsigned long long previous_time = monotonic_time();
 		unsigned int inner_loops = 0;
+#ifdef SYSTEMD
+                sd_notifyf(0, "READY=1\n"
+                              "STATUS=ProxySQL is now processing requests...");
+#endif
 		while (glovars.shutdown==0) {
 			usleep(200000);
 			if (disable_watchdog) {
@@ -1100,6 +1109,9 @@ __start_label:
 
 __shutdown:
 
+#ifdef SYSTEMD
+        sd_notify(0, "STOPPING=1");
+#endif
 	proxy_info("Starting shutdown...\n");
 
 	ProxySQL_Main_init_phase4___shutdown();

--- a/systemd/proxysql.service
+++ b/systemd/proxysql.service
@@ -3,7 +3,7 @@ Description=High Performance Advanced Proxy for MySQL
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 User=mysql
 Group=mysql
 PermissionsStartOnly=true


### PR DESCRIPTION
In order to properly order units, let systemd know when ProxySQL is
ready to accept connections.