### PR TITLE
Debian controlfile and systemd's service update. 

### DIFF
--- a/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
@@ -11,7 +11,7 @@ Architecture: amd64
 # Readme: README.md
 Files: proxysql /usr/bin/
  etc/proxysql.cnf /
- etc/init.d/proxysql /
+ systemd/system/proxysql.service /lib/
  tools/proxysql_galera_checker.sh /usr/share/proxysql/
  tools/proxysql_galera_writer.pl /usr/share/proxysql/
 Description: High performance MySQL proxy
@@ -21,5 +21,8 @@ Description: High performance MySQL proxy
 File: postinst
  #!/bin/sh -e
  if [ ! -d /var/lib/proxysql ]; then mkdir /var/lib/proxysql ; fi
- update-rc.d proxysql defaults
- chmod 600 /etc/proxysql.cnf
+ if ! id -u proxysql > /dev/null 2>&1; then useradd -r -U -s /bin/false  -d /var/lib/proxysql -c "ProxySQL Server"  proxysql; fi
+ chown -R proxysql: /var/lib/proxysql
+ chown root:proxysql /etc/proxysql.cnf
+ chmod 640 /etc/proxysql.cnf
+ systemctl enable proxysql.service

--- a/systemd/system/proxysql.service
+++ b/systemd/system/proxysql.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=High Performance Advanced Proxy for MySQL
+After=network.target
+
+[Service]
+Type=simple
+RuntimeDirectory=proxysql
+#PermissionsStartOnly=true
+#ExecStartPre=/usr/bin/mkdir -p /var/run/proxysql
+#ExecStartPre=/usr/bin/chown -R proxysql: /var/run/proxysql/
+ExecStart=/usr/bin/proxysql -f  -c /etc/proxysql.cnf
+PIDFile=/var/run/proxysql/proxysql.pid
+#StandardError=null  # all output is in stderr
+SyslogIdentifier=proxysql
+Restart=always
+User=proxysql
+Group=proxysql
+PermissionsStartOnly=true
+UMask=0007
+LimitNOFILE=102400
+LimitCORE=1073741824
+ProtectHome=yes
+ReadOnlyPaths=/
+ReadWritePaths=/var/lib/proxysql /var/run/proxysql
+NoNewPrivileges=true
+CapabilityBoundingSet=CAP_SETGID CAP_SETUID CAP_SYS_RESOURCE
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_ALG
+ProtectSystem=full
+PrivateDevices=yes
+ProtectKernelTunables=true
+ProtectControlGroups=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Package ctl file uses service file and not /etc/init.d and service file has more systemd's parameters.
Both have changes to make proxysql running under a non root user (arbitrary named proxysql).
(same PR #1481 but for v2.0.0 branch with little improvements: AF_ALG and RuntimeDirectory)