### PR TITLE
Fix: Read Group Replication Hostgroup Attributes from Configuration File (issue:1718)

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -7647,14 +7647,17 @@ int ProxySQL_Admin::Read_MySQL_Servers_from_configfile() {
                         int reader_hostgroup;
                         int offline_hostgroup;
                         int active=1; // default
-                        int max_writers=1; // default
-                        int writer_is_also_reader=0;
-                        int max_transactions_behind=0;
+                        int max_writers;
+                        int writer_is_also_reader;
+                        int max_transactions_behind;
                         std::string comment="";
                         if (line.lookupValue("writer_hostgroup", writer_hostgroup)==false) continue;
                         if (line.lookupValue("backup_writer_hostgroup", backup_writer_hostgroup)==false) continue;
                         if (line.lookupValue("reader_hostgroup", reader_hostgroup)==false) continue;
                         if (line.lookupValue("offline_hostgroup", offline_hostgroup)==false) continue;
+			if (line.lookupValue("max_writers", max_writers)==false) max_writers=1;
+                        if (line.lookupValue("writer_is_also_reader", writer_is_also_reader)==false) writer_is_also_reader=0;
+		        if (line.lookupValue("max_transactions_behind", max_transactions_behind)==false) max_transactions_behind=0;
                         line.lookupValue("comment", comment);
                         char *o1=strdup(comment.c_str());
                         char *o=escape_string_single_quotes(o1, false);


### PR DESCRIPTION
Purpose
---
- Fix for https://github.com/sysown/proxysql/issues/1718
- reads values for hard-coded variables into the runtime configuration from the configuration file.

Note
---
This is my first contribution to this repo, and I attempted to follow the same convention that was used for the Galera hostgroups.  Hopefully this is deemed helpful. (_oops, I probably need to rebase against v1.4.0_?)