### PR TITLE
Fix gcc 4.8 vs. 4.9 typos.

### DIFF
--- a/compile_examples.txt
+++ b/compile_examples.txt
@@ -13,10 +13,10 @@ CXX=clang++-3.6 CC=clang-3.6 CPPFLAGS="-I/usr/include/c++/4.8/ -I/usr/include/x8
 ## On FreeBSD
 
 ## compile using gcc 4.8
-CC=gcc49 CXX=g++49 LIBS="-Wl,-rpath=/usr/local/lib/gcc48 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
+CC=gcc48 CXX=g++48 LIBS="-Wl,-rpath=/usr/local/lib/gcc48 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
 
 ## compile using gcc 4.9
-CC=gcc48 CXX=g++48 LIBS="-Wl,-rpath=/usr/local/lib/gcc49 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
+CC=gcc49 CXX=g++49 LIBS="-Wl,-rpath=/usr/local/lib/gcc49 -liconv" CPPFLAGS=-D_GLIBCXX_USE_C99 gmake
 
 ## compile using clang 3.7
 CC=clang37 CXX=clang++37 gmake


### PR DESCRIPTION
Appears to be  a bad copy/paste. The instructions for gcc 4.8 appear to be using gcc 4.9 and the instructions for gcc 4.9 appear to be using gcc 4.8.