### PR TITLE
Add cleaning libconfig-1.7.2 to the `cleanall` target.

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -170,5 +170,6 @@ cleanall:
 	cd google-coredumper && rm -rf google-coredumper || true
 	cd libev && rm -rf libev-4.24 || true
 	cd libssl && rm -rf openssl-1.1.0h || true
+	cd libconfig && rm -rf libconfig-1.7.2 || true
 .PHONY: cleanall
 


### PR DESCRIPTION
Previously `cleanall` wasn't cleaning up the previous compilation of
libconfig, leading to some situations where linking would mysteriously
fail.