### PR TITLE
Fixed shun recovery time calculation

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1338,7 +1338,7 @@ MySrvC *MyHGC::get_random_MySrvC() {
 			// most of the follow code is copied from few lines above
 			time_t t;
 			t=time(NULL);
-			int max_wait_sec = ( mysql_thread___shun_recovery_time_sec * 1000 >= mysql_thread___connect_timeout_server_max ? mysql_thread___connect_timeout_server_max/100 - 1 : mysql_thread___shun_recovery_time_sec/10 );
+			int max_wait_sec = ( mysql_thread___shun_recovery_time_sec * 1000 >= mysql_thread___connect_timeout_server_max ? mysql_thread___connect_timeout_server_max/10000 - 1 : mysql_thread___shun_recovery_time_sec/10 );
 			if (max_wait_sec < 1) { // min wait time should be at least 1 second
 				max_wait_sec = 1;
 			}


### PR DESCRIPTION
If shun recovery time >= max_connection timeout, the desperate attempt
of recovering a node currently gets multiplied by 9 instead of reduced
to a 10%