### PR TITLE
Tune shun time if ping interval is too low #1833

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -283,10 +283,16 @@ void MySrvC::connect_error(int err_num) {
 			break;
 	}
 	time_t t=time(NULL);
-	if (t!=time_last_detected_error) {
+	if (t > time_last_detected_error) {
 		time_last_detected_error=t;
 		connect_ERR_at_time_last_detected_error=1;
 	} else {
+		if (t < time_last_detected_error) {
+			// time_last_detected_error is in the future
+			// this means that monitor has a ping interval too big and tuned that in the future
+			return;
+		}
+		// same time
 		int max_failures = ( mysql_thread___shun_on_failures > mysql_thread___connect_retries_on_failure ? mysql_thread___connect_retries_on_failure : mysql_thread___shun_on_failures) ;
 		if (__sync_add_and_fetch(&connect_ERR_at_time_last_detected_error,1) >= (unsigned int)max_failures) {
 			bool _shu=false;
@@ -1310,7 +1316,7 @@ MySrvC *MyHGC::get_random_MySrvC() {
 						if (max_wait_sec < 1) { // min wait time should be at least 1 second
 							max_wait_sec = 1;
 						}
-						if ((t - mysrvc->time_last_detected_error) > max_wait_sec) {
+						if (t > mysrvc->time_last_detected_error && (t - mysrvc->time_last_detected_error) > max_wait_sec) {
 							if (
 								(mysrvc->shunned_and_kill_all_connections==false) // it is safe to bring it back online
 								||
@@ -2172,6 +2178,18 @@ bool MySQL_HostGroups_Manager::shun_and_killall(char *hostname, int port) {
 							break;
 						default:
 							break;
+					}
+					// if Monitor is enabled and mysql-monitor_ping_interval is
+					// set too high, ProxySQL will unshun hosts that are not
+					// available. For this reason time_last_detected_error will
+					// be tuned in the future
+					if (mysql_thread___monitor_enabled) {
+						int a = mysql_thread___shun_recovery_time_sec;
+						int b = mysql_thread___monitor_ping_interval;
+						b = b/1000;
+						if (b > a) {
+							t = t + (b - a);
+						}
 					}
 					mysrvc->time_last_detected_error = t;
 				}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -347,7 +347,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.monitor_history=600000;
 	variables.monitor_connect_interval=120000;
 	variables.monitor_connect_timeout=600;
-	variables.monitor_ping_interval=60000;
+	variables.monitor_ping_interval=8000;
 	variables.monitor_ping_max_failures=3;
 	variables.monitor_ping_timeout=1000;
 	variables.monitor_read_only_interval=1000;


### PR DESCRIPTION
When shunning a node, evaluate the different between
`mysql-monitor_ping_interval` and `mysql-shun_recovery_time_sec`, and postpone
in the future when the server needs to be recovered