### PR TITLE
Fixed client connection errors when nodes have high weight and a cras…

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -80,7 +80,7 @@ class MySrvC {	// MySQL Server Container
 	char *address;
 	uint16_t port;
 	uint16_t flags;
-	unsigned int weight;
+	uint64_t weight;
 	enum MySerStatus status;
 	unsigned int compression;
 	unsigned int max_connections;

--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -203,7 +203,7 @@ class MySQL_Session
 	MySQL_Backend * find_or_create_backend(int, MySQL_Data_Stream *_myds=NULL);
 	
 	void SQLite3_to_MySQL(SQLite3_result *, char *, int , MySQL_Protocol *);
-	void MySQL_Result_to_MySQL_wire(MYSQL *mysql, MySQL_ResultSet *MyRS, MySQL_Data_Stream *_myds=NULL);
+	void MySQL_Result_to_MySQL_wire(MySQL_Connection *conn, MySQL_Data_Stream *_myds=NULL);
 	void MySQL_Stmt_Result_to_MySQL_wire(MYSQL_STMT *stmt, MySQL_Connection *myconn);
 	unsigned int NumActiveTransactions();
 	bool HasOfflineBackends();

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1289,8 +1289,8 @@ void MySQL_HostGroups_Manager::push_MyConn_to_pool_array(MySQL_Connection **ca) 
 MySrvC *MyHGC::get_random_MySrvC() {
 	MySrvC *mysrvc=NULL;
 	unsigned int j;
-	unsigned int sum=0;
-	unsigned int TotalUsedConn=0;
+	uint64_t sum=0;
+	uint64_t TotalUsedConn=0;
 	unsigned int l=mysrvs->cnt();
 	if (l) {
 		//int j=0;
@@ -1372,14 +1372,14 @@ MySrvC *MyHGC::get_random_MySrvC() {
 			return NULL; // if we reach here, we couldn't find any target
 		}
 
-		unsigned int New_sum=0;
+		uint64_t New_sum=0;
 		unsigned int New_TotalUsedConn=0;
 
 		// we will now scan again to ignore overloaded server
 		for (j=0; j<l; j++) {
 			mysrvc=mysrvs->idx(j);
 			if (mysrvc->status==MYSQL_SERVER_STATUS_ONLINE) { // consider this server only if ONLINE
-				unsigned int len=mysrvc->ConnectionsUsed->conns_length();
+				uint64_t len=mysrvc->ConnectionsUsed->conns_length();
 				if (len < mysrvc->max_connections) { // consider this server only if didn't reach max_connections
 					if ( mysrvc->current_latency_us < ( mysrvc->max_latency_us ? mysrvc->max_latency_us : mysql_thread___default_max_latency_ms*1000 ) ) { // consider the host only if not too far
 						if ((len * sum) <= (TotalUsedConn * mysrvc->weight * 1.5 + 1)) {
@@ -1396,13 +1396,13 @@ MySrvC *MyHGC::get_random_MySrvC() {
 			return NULL; // if we reach here, we couldn't find any target
 		}
 
-		unsigned int k;
+		uint64_t k;
 		if (New_sum > 32768) {
 			k=rand()%New_sum;
 		} else {
 			k=fastrand()%New_sum;
 		}
-  	k++;
+		k++;
 		New_sum=0;
 
 		for (j=0; j<l; j++) {

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2708,7 +2708,7 @@ handler_again:
 
 					switch (status) {
 						case PROCESSING_QUERY:
-							MySQL_Result_to_MySQL_wire(myconn->mysql, myconn->MyRS);
+							MySQL_Result_to_MySQL_wire(myconn);
 							break;
 						case PROCESSING_STMT_PREPARE:
 							{
@@ -2956,6 +2956,7 @@ handler_again:
 										}
 									}
 									myds->destroy_MySQL_Connection_From_Pool(true);
+									myconn = nullptr;
 									myds->fd=0;
 									if (retry_conn) {
 										myds->DSS=STATE_NOT_INITIALIZED;
@@ -2989,7 +2990,7 @@ handler_again:
 
 							switch (status) {
 								case PROCESSING_QUERY:
-									MySQL_Result_to_MySQL_wire(myconn->mysql, myconn->MyRS, myds);
+									MySQL_Result_to_MySQL_wire(myconn, myds);
 									break;
 								case PROCESSING_STMT_PREPARE:
 									{
@@ -3053,7 +3054,7 @@ handler_again:
 								break;
 							// rc==2 : a multi-resultset (or multi statement) was detected, and the current statement is completed
 							case 2:
-								MySQL_Result_to_MySQL_wire(myconn->mysql, myconn->MyRS);
+								MySQL_Result_to_MySQL_wire(myconn);
 								  if (myconn->MyRS) { // we also need to clear MyRS, so that the next staement will recreate it if needed
 										delete myconn->MyRS;
 										myconn->MyRS=NULL;
@@ -4286,12 +4287,15 @@ void MySQL_Session::MySQL_Stmt_Result_to_MySQL_wire(MYSQL_STMT *stmt, MySQL_Conn
 	}
 }
 
-void MySQL_Session::MySQL_Result_to_MySQL_wire(MYSQL *mysql, MySQL_ResultSet *MyRS, MySQL_Data_Stream *_myds) {
-        if (mysql == NULL) {
-                // error
-                client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,client_myds->pkt_sid+1, 2013, (char *)"HY000" ,(char *)"Lost connection to MySQL server during query");
-                return;
-        }
+void MySQL_Session::MySQL_Result_to_MySQL_wire(MySQL_Connection *conn, MySQL_Data_Stream *_myds) {
+	if (conn == nullptr || conn->mysql == nullptr) {
+			// error
+			client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,client_myds->pkt_sid+1, 2013, (char *)"HY000" ,(char *)"Lost connection to MySQL server during query");
+			return;
+	}
+
+	MySQL_ResultSet* MyRS = conn->MyRS;
+	MYSQL* mysql = conn->mysql;
 	if (MyRS) {
 		assert(MyRS->result);
 		bool transfer_started=MyRS->transfer_started;


### PR DESCRIPTION
…h when 'WSREP has not yet prepared node for application use'

If you use have nodes with high weights, you can have an overflow when calculating the
load in the nodes in a HG.

When a 'WSREP has not yet prepared node for application use' arises, proxysql deleted
the connection and tried to use it later