### PR TITLE
Add backend connection status flags to stats_mysql_processlist

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -4396,7 +4396,7 @@ void MySQL_Threads_Handler::Get_Memory_Stats() {
 }
 
 SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
-	const int colnum=14;
+	const int colnum=15;
         char port[NI_MAXSERV];
 	proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 4, "Dumping MySQL Processlist\n");
 	SQLite3_result *result=new SQLite3_result(colnum);
@@ -4414,6 +4414,7 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
 	result->add_column_definition(SQLITE_TEXT,"command");
 	result->add_column_definition(SQLITE_TEXT,"time_ms");
 	result->add_column_definition(SQLITE_TEXT,"info");
+	result->add_column_definition(SQLITE_TEXT,"status_flags");
 	unsigned int i;
 	unsigned int i2;
 //	signal_all_threads(1);
@@ -4549,12 +4550,15 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
 							pta[13]=NULL;
 						}
 					}
+					sprintf(buf,"%d", mc->status_flags);
+					pta[14]=strdup(buf);
 				} else {
 					pta[7]=NULL;
 					pta[8]=NULL;
 					pta[9]=NULL;
 					pta[10]=NULL;
 					pta[13]=NULL;
+					pta[14]=NULL;
 				}
 				switch (sess->status) {
 					case CONNECTING_SERVER:


### PR DESCRIPTION
I recently needed to debug why some connections weren't multiplexing in production.

Being able to see the `status_flags` bitfield from the backend connection is useful for this -- you can see if we're not multiplexing because of local variable use vs. `GET_LOCK` etc. It does pass the raw integer values back -- it might be better to expand out the bit field into text strings? If you think so, I don't mind doing the work to make it more use friendly.

I thought this would be something generally useful to send upstream. Please let me know if there's some style I should be following or a process around creating improvement requests.

---

In MySQL:

```
mysql> select GET_LOCK('foo', 'bar');
+------------------------+
| GET_LOCK('foo', 'bar') |
+------------------------+
|                      1 |
+------------------------+
1 row in set (0.00 sec)
```

In the Admin console:

```
mysql> select status_flags from stats_mysql_processlist;
+--------------+
| status_flags |
+--------------+
| 64           |
+--------------+
1 row in set (0.00 sec)
```