### PR TITLE
Fix set_parser RE2 Pattern for sql_mode

### DIFF
--- a/lib/set_parser.cpp
+++ b/lib/set_parser.cpp
@@ -35,7 +35,7 @@ std::map<std::string,std::vector<string>> SetParser::parse() {
 #define VAR "(\\w+)"
 #define SPACES " *"
 //#define VAR_VALUE "((?:[\\w/\\d:\\+\\-]|,)+)"
-#define VAR_VALUE "((?:CONCAT\\((?:REPLACE\\()+@@sql_mode,(?:(?:'|\\w|,| |\"|\\))+(?:\\)))|(?:[\\w/\\d:\\+\\-]|,)+|(?:)))"
+#define VAR_VALUE "((?:CONCAT\\((?:(REPLACE|CONCAT)\\()+@@sql_mode,(?:(?:'|\\w|,| |\"|\\))+(?:\\)))|(?:[\\w/\\d:\\+\\-]|,)+|(?:)))"
 
   const string pattern="(?:" NAMES SPACES QUOTES NAME_VALUE QUOTES "(?: +COLLATE +" QUOTES NAME_VALUE QUOTES "|)" "|" SESSION VAR SPACES "(?:|:)=" SPACES QUOTES VAR_VALUE QUOTES ") *,? *";
   re2::RE2 re(pattern, *opt2);


### PR DESCRIPTION
I added the CONCAT function to the nested parsing pattern.

see 
#1904

As per the issue, I found a problem when parsing sql_mode.
When parsing the SESSION variable, it seems that interpretation becomes impossible if CONCAT function is nested.

SQL to be parsed.

```
SET @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ', STRICT_ALL_TABLES'), ', NO_AUTO_VALUE_ON_ZERO');
```

This session variable is commonly used in RoR.


Expected results.

```
key = sql_mode
value = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO')
```

Actual results.

```
key = sql_mode
value = CONCAT
```

error log

```
# cat proxysql.log | grep sql_mode | head -n1
2019-02-14 10:47:29 MySQL_Session.cpp:1610:handler_again___status_SETTING_SQL_MODE(): [WARNING] Error while setting SQL_MODE: 1231, Variable 'sql_mode' can't be set to the value of 'CONCAT'
```

#1519 

If the CONCAT function is nested like this issue, there is a possibility that a SQL error has occurred.
I solved my environmental problem with this fix.

Please let me know if I need to add test code.
Thanks!!