### PR TITLE
Fixed path of proxysql.service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ install: src/proxysql
 	install -m 0600 etc/proxysql.cnf /etc
 	if [ ! -d /var/lib/proxysql ]; then mkdir /var/lib/proxysql ; fi
 ifeq ($(SYSTEMD), 1)
-	install -m 0644 systemd/proxysql.service /usr/lib/systemd/system/
+	install -m 0644 systemd/system/proxysql.service /usr/lib/systemd/system/
 	systemctl enable proxysql.service
 else
 	install -m 0755 etc/init.d/proxysql /etc/init.d

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)
 else
 	SYSTEMD=0
 endif
+USERCHECK := $(shell getent passwd proxysql)
+GROUPCHECK := $(shell getent group proxysql)
 
 .PHONY: default
 default: build_deps build_lib build_src
@@ -346,10 +348,15 @@ cleanbuild:
 	cd lib && ${MAKE} clean
 	cd src && ${MAKE} clean
 
+.PHONY: install
 install: src/proxysql
 	install -m 0755 src/proxysql /usr/bin
 	install -m 0600 etc/proxysql.cnf /etc
 	if [ ! -d /var/lib/proxysql ]; then mkdir /var/lib/proxysql ; fi
+ifeq ($(findstring proxysql,$(USERCHECK)),)
+	@echo "Creating proxysql user and group"
+	useradd -r -U -s /bin/false proxysql
+endif
 ifeq ($(SYSTEMD), 1)
 	install -m 0644 systemd/system/proxysql.service /usr/lib/systemd/system/
 	systemctl enable proxysql.service
@@ -370,35 +377,44 @@ endif
 endif
 endif
 endif
-.PHONY: install
+endif
 
+.PHONY: uninstall
 uninstall:
-	rm /etc/proxysql.cnf
-	rm /usr/bin/proxysql
-	rmdir /var/lib/proxysql 2>/dev/null || true
+	if [ -f /etc/proxysql.cnf ]; then rm /etc/proxysql.cnf ; fi
+	if [ -f /usr/bin/proxysql ]; then rm /usr/bin/proxysql ; fi
+	if [ -d /var/lib/proxysql ]; then rmdir /var/lib/proxysql 2>/dev/null || true ; fi
 ifeq ($(SYSTEMD), 1)
 		systemctl stop proxysql.service
-		rm /usr/lib/systemd/system/proxysql.service
+		if [ -f /usr/lib/systemd/system/proxysql.service ]; then rm /usr/lib/systemd/system/proxysql.service ; fi
+		find /etc/systemd -name "proxysql.service" -exec rm {} \;
+		systemctl daemon-reload
 else
 ifeq ($(DISTRO),"CentOS Linux")
 		chkconfig --level 0123456 proxysql off
-		rm /etc/init.d/proxysql
+		if [ -f /etc/init.d/proxysql ]; then rm /etc/init.d/proxysql ; fi
 else
 ifeq ($(DISTRO),"Red Hat Enterprise Linux Server")
 		chkconfig --level 0123456 proxysql off
-		rm /etc/init.d/proxysql
+		if [ -f /etc/init.d/proxysql ]; then rm /etc/init.d/proxysql ; fi
 else
 ifeq ($(DISTRO),"Ubuntu")
-		rm /etc/init.d/proxysql
+		if [ -f /etc/init.d/proxysql ]; then rm /etc/init.d/proxysql ; fi
 		update-rc.d proxysql remove
 else
 ifeq ($(DISTRO),"Debian GNU/Linux")
-		rm /etc/init.d/proxysql
+		if [ -f /etc/init.d/proxysql ]; then rm /etc/init.d/proxysql ; fi
 		update-rc.d proxysql remove
 endif
 endif
 endif
 endif
 endif
+ifneq ($(findstring proxysql,$(USERCHECK)),)
+	@echo "Deleting proxysql user"
+	userdel proxysql
 endif
-.PHONY: uninstall
+ifneq ($(findstring proxysql,$(GROUPCHECK)),)
+	@echo "Deleting proxysql group"
+	groupdel proxysql
+endif


### PR DESCRIPTION
Given that the proxysql.service file has been moved to the subfolder systemd/system, the path in the Makefile had to be updated as well.