### PR TITLE
No throttle when throttle_max_bytes_per_second_to_client == 0

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -394,7 +394,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.query_digests_max_digest_length=2*1024;
 	variables.query_digests_max_query_length=65000; // legacy default
 	variables.wait_timeout=8*3600*1000;
-	variables.throttle_max_bytes_per_second_to_client=2147483647;
+	variables.throttle_max_bytes_per_second_to_client=0;
 	variables.throttle_ratio_server_to_client=0;
 	variables.max_connections=10*1000;
 	variables.max_stmts_per_connection=20;
@@ -1629,7 +1629,7 @@ bool MySQL_Threads_Handler::set_variable(char *name, char *value) {	// this is t
 #endif // IDLE_THREADS
 	if (!strcasecmp(name,"throttle_max_bytes_per_second_to_client")) {
 		int intv=atoi(value);
-		if (intv >= 1024 && intv <= 2147483647) {
+		if (intv >= 0 && intv <= 2147483647) {
 			variables.throttle_max_bytes_per_second_to_client=intv;
 			return true;
 		} else {

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -1024,7 +1024,7 @@ handler_again:
 					if (
 						(processed_bytes > (unsigned int)mysql_thread___threshold_resultset_size*8)
 							||
-						( mysql_thread___throttle_ratio_server_to_client && (processed_bytes > (unsigned long long)mysql_thread___throttle_max_bytes_per_second_to_client/10*(unsigned long long)mysql_thread___throttle_ratio_server_to_client) )
+						( mysql_thread___throttle_ratio_server_to_client && mysql_thread___throttle_max_bytes_per_second_to_client && (processed_bytes > (unsigned long long)mysql_thread___throttle_max_bytes_per_second_to_client/10*(unsigned long long)mysql_thread___throttle_ratio_server_to_client) )
 					) {
 						next_event(ASYNC_USE_RESULT_CONT); // we temporarily pause
 					} else {


### PR DESCRIPTION
If throttle_max_bytes_per_second_to_client == 0, disable throttling.
This matches the mysql convention of 0 == no limit.