### PR TITLE
feat: Add logrotate script and update log location

### DIFF
--- a/docker/images/proxysql/deb-compliant/bionic-package/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/bionic-package/ctl/proxysql.ctl
@@ -11,6 +11,7 @@ Architecture: amd64
 # Readme: README.md
 Files: proxysql /usr/bin/
  etc/proxysql.cnf /etc/
+ etc/logrotate.d/proxysql /etc/logrotate.d/proxysql
  systemd/system/proxysql.service /lib/systemd/system/
  tools/proxysql_galera_checker.sh /usr/share/proxysql/tools/
  tools/proxysql_galera_writer.pl /usr/share/proxysql/tools/

--- a/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
@@ -11,6 +11,7 @@ Architecture: amd64
 # Readme: README.md
 Files: proxysql /usr/bin/
  etc/proxysql.cnf /
+ etc/logrotate.d/proxysql /etc/logrotate.d/proxysql
  systemd/system/proxysql.service /lib/
  tools/proxysql_galera_checker.sh /usr/share/proxysql/
  tools/proxysql_galera_writer.pl /usr/share/proxysql/

--- a/docker/images/proxysql/deb-compliant/pre-systemd/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/pre-systemd/ctl/proxysql.ctl
@@ -11,6 +11,7 @@ Architecture: amd64
 # Readme: README.md
 Files: proxysql /usr/bin/
  etc/proxysql.cnf /
+ etc/logrotate.d/proxysql /etc/logrotate.d/proxysql
  etc/init.d/proxysql /
  tools/proxysql_galera_checker.sh /usr/share/proxysql/
  tools/proxysql_galera_writer.pl /usr/share/proxysql/

--- a/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -56,10 +56,10 @@ rm -rf /var/run/%{name}
 %defattr(-,root,root,-)
 %config(noreplace) %{_sysconfdir}/%{name}.cnf
 %attr(640,root,%{name}) %{_sysconfdir}/%{name}.cnf
+%config(noreplace) %attr(640,root,%{name}) %{_sysconfdir}/logrotate.d/%{name}
 %{_bindir}/*
 %{_sysconfdir}/init.d/%{name}
 /usr/share/proxysql/tools/proxysql_galera_checker.sh
 /usr/share/proxysql/tools/proxysql_galera_writer.pl
 
 %changelog
-

--- a/etc/logrotate.d/proxysql
+++ b/etc/logrotate.d/proxysql
@@ -1,0 +1,5 @@
+/var/log/proxysql.log {
+    missingok
+    notifempty
+    copytruncate
+}

--- a/etc/proxysql.cnf
+++ b/etc/proxysql.cnf
@@ -32,6 +32,7 @@
 ########################################################################################
 
 datadir="/var/lib/proxysql"
+errorlog="/var/log/proxysql.log"
 
 admin_variables=
 {


### PR DESCRIPTION
Write to /var/log/proxysql.log by default, and add a logrotate script
which manages this path.

Unfortunately, the logrotate script can't use `PROXYSQL FLUSH LOGS;` to
tell ProxySQL to rotate file handles*, so we use copytruncate instead.
It would be nice if ProxySQL could rotate file handles following a
signal in future...

\* For two reasons:
1. There's no safe / standard way to find admin credentials
2. mysql(1) client may not be installed