### PR TITLE
Add basic Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+services:
+  - docker
+
+env:
+  - BUILD_TARGET=centos7
+  - BUILD_TARGET=centos7-dbg
+  - BUILD_TARGET=centos7-clickhouse
+  - BUILD_TARGET=debian9.4
+  - BUILD_TARGET=debian9.4-dbg
+  - BUILD_TARGET=debian9.4-clickhouse
+
+script:
+  - make $BUILD_TARGET


### PR DESCRIPTION
Build all three variants (standard, debug, clickhouse) of ProxySQL for
Centos 7 & Debian 9.4 (eg the newest OSes that use RPM & DEB packaging).