### PR TITLE
Adjust proxysql init.d 

### DIFF
--- a/etc/init.d/proxysql
+++ b/etc/init.d/proxysql
@@ -148,7 +148,7 @@ stop() {
   if [ "X$pid" = "X" ]
 	then
 		echo "ProxySQL was not running."
-		exit 0
+		return 0
 	else
 		# Note: we send a kill to all the processes, not just to the child
 		for i in `pgrep -x proxysql` ; do


### PR DESCRIPTION
How about `return` instead of `exit`?

Most of users expect that `restart` command will start the process, even though the process was not running