### PR TITLE
Fix for error log issue

### DIFF
--- a/docker/images/proxysql/deb-compliant/bionic-package/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/bionic-package/ctl/proxysql.ctl
@@ -11,7 +11,7 @@ Architecture: amd64
 # Readme: README.md
 Files: proxysql /usr/bin/
  etc/proxysql.cnf /etc/
- etc/logrotate.d/proxysql /etc/logrotate.d/proxysql
+ etc/logrotate.d/proxysql /etc/logrotate.d/
  systemd/system/proxysql.service /lib/systemd/system/
  tools/proxysql_galera_checker.sh /usr/share/proxysql/tools/
  tools/proxysql_galera_writer.pl /usr/share/proxysql/tools/

--- a/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
@@ -11,7 +11,7 @@ Architecture: amd64
 # Readme: README.md
 Files: proxysql /usr/bin/
  etc/proxysql.cnf /
- etc/logrotate.d/proxysql /etc/logrotate.d/proxysql
+ etc/logrotate.d/proxysql /etc/logrotate.d/
  systemd/system/proxysql.service /lib/
  tools/proxysql_galera_checker.sh /usr/share/proxysql/
  tools/proxysql_galera_writer.pl /usr/share/proxysql/

--- a/etc/logrotate.d/proxysql
+++ b/etc/logrotate.d/proxysql
@@ -1,4 +1,4 @@
-/var/log/proxysql.log {
+/var/lib/proxysql/proxysql.log {
     missingok
     notifempty
     copytruncate

--- a/etc/proxysql.cnf
+++ b/etc/proxysql.cnf
@@ -32,7 +32,7 @@
 ########################################################################################
 
 datadir="/var/lib/proxysql"
-errorlog="/var/log/proxysql.log"
+errorlog="/var/lib/proxysql/proxysql.log"
 
 admin_variables=
 {


### PR DESCRIPTION
- Move default errorlog path back to /var/lib/proxysql
- Modified logrotate to point to /var/lib/proxysql/proxysql.log
- Includes fix for https://github.com/sysown/proxysql/issues/1973