### PR TITLE
Implement retries in case of SQLite3 database is locked

### DIFF
--- a/lib/sqlite3db.cpp
+++ b/lib/sqlite3db.cpp
@@ -57,7 +57,7 @@ bool SQLite3DB::execute(const char *str) {
 	rc=sqlite3_exec(db, str, NULL, 0, &err);
 //	fprintf(stderr,"%d : %s\n", rc, str);
 		if(err!=NULL) {
-			if (rc!=SQLITE_LOCKED) {
+			if (rc!=SQLITE_LOCKED && rc!=SQLITE_BUSY) {
 				proxy_error("SQLITE error: %s --- %s\n", err, str);
 				if (assert_on_error) {
 					assert(err==0);
@@ -66,10 +66,10 @@ bool SQLite3DB::execute(const char *str) {
 			sqlite3_free(err);
 			err=NULL;
 		}
-		if (rc==SQLITE_LOCKED) { // the execution of sqlite3_exec() failed because locked
+		if (rc==SQLITE_LOCKED || rc==SQLITE_BUSY) { // the execution of sqlite3_exec() failed because locked
 			usleep(USLEEP_SQLITE_LOCKED);
 		}
-	} while (rc==SQLITE_LOCKED);
+	} while (rc==SQLITE_LOCKED || rc==SQLITE_BUSY);
 	if (rc==SQLITE_OK) {
 		return true;
 	}
@@ -93,10 +93,10 @@ bool SQLite3DB::execute_statement(const char *str, char **error, int *cols, int 
 		*resultset=NULL;
 		do {
 			rc=sqlite3_step(statement);
-			if (rc==SQLITE_LOCKED) { // the execution of the prepared statement failed because locked
+			if (rc==SQLITE_LOCKED || rc==SQLITE_BUSY) { // the execution of the prepared statement failed because locked
 				usleep(USLEEP_SQLITE_LOCKED);
 			}
-		} while (rc==SQLITE_LOCKED);
+		} while (rc==SQLITE_LOCKED || rc==SQLITE_BUSY);
 		if (rc==SQLITE_DONE) {
 			*affected_rows=sqlite3_changes(db);
 			ret=true;
@@ -130,10 +130,10 @@ bool SQLite3DB::execute_statement_raw(const char *str, char **error, int *cols, 
 		//*resultset=NULL;
 		do {
 			rc=sqlite3_step(*statement);
-			if (rc==SQLITE_LOCKED) { // the execution of the prepared statement failed because locked
+			if (rc==SQLITE_LOCKED || rc==SQLITE_BUSY) { // the execution of the prepared statement failed because locked
 				usleep(USLEEP_SQLITE_LOCKED);
 			}
-		} while (rc==SQLITE_LOCKED);
+		} while (rc==SQLITE_LOCKED || rc==SQLITE_BUSY);
 		if (rc==SQLITE_DONE) {
 			*affected_rows=sqlite3_changes(db);
 			ret=true;


### PR DESCRIPTION

In order to fix the following issue.
https://github.com/sysown/proxysql/issues/1866
https://groups.google.com/forum/#!topic/proxysql/UoN8T38QLAc

We are getting the following error sometimes.
```2019-03-07 12:29:42 sqlite3db.cpp:61:execute(): [ERROR] SQLITE error: database is locked --- DELETE FROM system_memory WHERE timestamp < 1551324582
2019-03-07 12:38:42 sqlite3db.cpp:61:execute(): [ERROR] SQLITE error: database is locked --- DELETE FROM system_cpu WHERE timestamp < 1551325122
2019-03-07 12:42:42 sqlite3db.cpp:61:execute(): [ERROR] SQLITE error: database is locked --- INSERT INTO system_memory_hour SELECT timestamp/3600*3600 , AVG(allocated), AVG(resident), AVG(active), AVG(mapped), AVG(metadata), AVG(retained) FROM system_memory WHERE timestamp >= 1551927600 AND timestamp < 1551927600 GROUP BY timestamp/3600
2019-03-07 12:42:42 sqlite3db.cpp:61:execute(): [ERROR] SQLITE error: database is locked --- DELETE FROM system_memory WHERE timestamp < 1551325362
2019-03-07 12:44:42 sqlite3db.cpp:61:execute(): [ERROR] SQLITE error: database is locked --- DELETE FROM system_cpu WHERE timestamp < 1551325482
2019-03-07 12:44:42 sqlite3db.cpp:61:execute(): [ERROR] SQLITE error: database is locked --- DELETE FROM system_cpu_hour WHERE timestamp < 1520394282
 .
 .
```

These errors seems to correspond to `SQLITE_BUSY` error of SQLite.
https://www.sqlite.org/c3ref/c_abort.html
```
#define SQLITE_BUSY         5   /* The database file is locked */
#define SQLITE_LOCKED       6   /* A table in the database is locked */
```

https://github.com/sysown/proxysql/issues/549
https://github.com/sysown/proxysql/commit/84606e241075a26912b98272749f467494a05f1f
As you avoided it by sleeping when `SQLITE_LOCKED` occurs previously,
I think we can avoid it by sleeping even when `SQLITE_BUSY` occurs.

I was able to compile proxysql by this modification.
I have done test in my Proxysql servers which are in updated module to 5 servers and non-updated module to 1 server.
As a result, I confirmed that these error was occured only on a server which was working the non-updated module.