### PR TITLE
V2.0.3 tuenti

### DIFF
--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -26,7 +26,7 @@ else
 fi
 ${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
-${MAKE} ${MAKEOPT} "${build_target}"
+${MAKE} ${MAKEOPT} ${build_target}
 # Prepare package files and build RPM
 cp /root/ctl/proxysql.ctl /opt/proxysql/proxysql.ctl
 sed -i "s/PKG_VERSION_CURVER/${CURVER}/g" /opt/proxysql/proxysql.ctl

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -4195,7 +4195,7 @@ void MySQL_HostGroups_Manager::update_galera_set_offline(char *_hostname, int _p
 	char *query=NULL;
 	char *q=NULL;
 	char *error=NULL;
-	q=(char *)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=backup_writer_hostgroup OR hostgroup_id=reader_hostgroup WHERE hostname='%s' AND port=%d AND status<>3";
+	q=(char *)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=backup_writer_hostgroup OR hostgroup_id=reader_hostgroup WHERE hostname='%s' AND port=%d";
 	query=(char *)malloc(strlen(q)+strlen(_hostname)+1024); // increased this buffer as it is used for other queries too
 	sprintf(query,q,_hostname,_port);
 
@@ -4334,7 +4334,7 @@ void MySQL_HostGroups_Manager::update_galera_set_read_only(char *_hostname, int 
 	char *query=NULL;
 	char *q=NULL;
 	char *error=NULL;
-	q=(char *)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=backup_writer_hostgroup OR hostgroup_id=offline_hostgroup WHERE hostname='%s' AND port=%d AND status<>3";
+	q=(char *)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=backup_writer_hostgroup OR hostgroup_id=offline_hostgroup WHERE hostname='%s' AND port=%d";
 	query=(char *)malloc(strlen(q)+strlen(_hostname)+32);
 	sprintf(query,q,_hostname,_port);
 	mydb->execute_statement(query, &error, &cols , &affected_rows , &resultset);
@@ -4414,7 +4414,7 @@ void MySQL_HostGroups_Manager::update_galera_set_writer(char *_hostname, int _po
 	char *query=NULL;
 	char *q=NULL;
 	char *error=NULL;
-	q=(char *)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=reader_hostgroup OR hostgroup_id=backup_writer_hostgroup OR hostgroup_id=offline_hostgroup WHERE hostname='%s' AND port=%d AND status<>3";
+	q=(char *)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=reader_hostgroup OR hostgroup_id=backup_writer_hostgroup OR hostgroup_id=offline_hostgroup WHERE hostname='%s' AND port=%d";
 	query=(char *)malloc(strlen(q)+strlen(_hostname)+32);
 	sprintf(query,q,_hostname,_port);
   mydb->execute_statement(query, &error, &cols , &affected_rows , &resultset);

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1585,9 +1585,9 @@ __exit_monitor_galera_thread:
 		if (l<110) {
 			s=buf;
 		}	else {
-			s=(char *)malloc(l+16);
+			s=(char *)malloc(l+32);
 		}
-		sprintf(s,"%s:%d",mmsd->hostname,mmsd->port);
+		sprintf(s,"%s:%d:%d",mmsd->hostname, mmsd->port, mmsd->writer_hostgroup);
 		bool primary_partition = false;
 		bool read_only=true;
 		bool wsrep_desync = true;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -565,7 +565,12 @@ MySQL_Monitor::MySQL_Monitor() {
 	monitordb->execute("CREATE INDEX IF NOT EXISTS idx_galera_log_time_start ON mysql_server_galera_log (time_start_us)");
 	monitordb->execute("CREATE INDEX IF NOT EXISTS idx_aws_aurora_log_time_start ON mysql_server_aws_aurora_log (time_start_us)");
 
+#ifdef DEBUG
+	num_threads=1;
+#else
 	num_threads=2;
+#endif
+
 	aux_threads=0;
 	started_threads=0;
 

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -611,7 +611,7 @@ bool MySQL_Protocol::generate_pkt_OK(bool send, void **ptr, unsigned int *len, u
 	_ptr[l]=0x00; l++;
 	l+=write_encoded_length(_ptr+l, affected_rows, affected_rows_len, affected_rows_prefix);
 	l+=write_encoded_length(_ptr+l, last_insert_id, last_insert_id_len, last_insert_id_prefix);
-	int16_t internal_status = status;
+	int16_t internal_status = server_status;
 	if (sess) {
 		switch (sess->session_type) {
 			case PROXYSQL_SESSION_SQLITE:

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1505,7 +1505,11 @@ bool MySQL_Threads_Handler::set_variable(char *name, char *value) {	// this is t
 		}
 		if (!strcasecmp(name,"monitor_threads_min")) {
 			int intv=atoi(value);
+#ifdef DEBUG
+			if (true) {
+#else
 			if (intv >= 2 && intv <= 16) {
+#endif
 				variables.monitor_threads_min = intv;
 				return true;
 			} else {
@@ -1514,7 +1518,11 @@ bool MySQL_Threads_Handler::set_variable(char *name, char *value) {	// this is t
 		}
 		if (!strcasecmp(name,"monitor_threads_max")) {
 			int intv=atoi(value);
+#ifdef DEBUG
+			if (true) {
+#else
 			if (intv >= 4 && intv <= 256) {
+#endif
 				variables.monitor_threads_max = intv;
 				return true;
 			} else {


### PR DESCRIPTION
This PR tries to fix the galera HG management when you have multiple nodes shared between different galera HGs. Also it fixes the management of shunned nodes that were deleted from runtime, and now are moved properly to the offline HG so they can be recovered when they are back online automatically.

Also a couple of changes that i found useful for debugging, such as having the runtime sqlite db on file on debug compilations so you can check the contents in real time, and also allow any amount of monitor threads also in debug, so the behaviour of them can be debugged in a easier way.