### PR TITLE
Check if build_target var is defined in entrypoint.bash

### DIFF
--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -26,7 +26,12 @@ else
 fi
 ${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
-${MAKE} ${MAKEOPT} "${build_target}"
+
+if [[ -z ${build_target} ]] ; then
+  ${MAKE} ${MAKEOPT}
+else
+  ${MAKE} ${MAKEOPT} "${build_target}"
+fi
 # Prepare package files and build RPM
 cp /root/ctl/proxysql.ctl /opt/proxysql/proxysql.ctl
 sed -i "s/PKG_VERSION_CURVER/${CURVER}/g" /opt/proxysql/proxysql.ctl

--- a/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
@@ -22,7 +22,12 @@ else
 fi
 ${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
-${MAKE} ${MAKEOPT} "${build_target}"
+
+if [[ -z ${build_target} ]] ; then
+  ${MAKE} ${MAKEOPT}
+else
+  ${MAKE} ${MAKEOPT} "${build_target}"
+fi
 
 # Prepare package files and build RPM
 echo "==> Packaging"


### PR DESCRIPTION
Currently `make` fails if `build_target` is `null`:

`make: *** empty string invalid as file name.  Stop.`