### PR TITLE
Fix schemaname output in eventslog_reader_sample

### DIFF
--- a/tools/eventslog_reader_sample.cpp
+++ b/tools/eventslog_reader_sample.cpp
@@ -113,7 +113,7 @@ class MySQL_Event {
 		schemaname=read_string(f,schemaname_len);
 		read_encoded_length((uint64_t *)&client_len,f);
 		client=read_string(f,client_len);
-		cout << "ProxySQL LOG QUERY: thread_id=\"" << thread_id << "\" username=\"" << username << "\" schemaname=" << schemaname << "\" client=\"" << client << "\"";
+		cout << "ProxySQL LOG QUERY: thread_id=\"" << thread_id << "\" username=\"" << username << "\" schemaname=\"" << schemaname << "\" client=\"" << client << "\"";
 		read_encoded_length((uint64_t *)&hid,f);
 		if (hid==UINT64_MAX) {
 			cout << " HID=NULL ";


### PR DESCRIPTION
Right now "schemaname" without one apostrophes, before:
ProxySQL LOG QUERY: thread_id="378394" username="cs_rw" **schemaname=trc"** client="10.101.10.101:48485" HID=10 server="bdb:3306" starttime="2019-05-13 09:09:25.274582" endtime="2019-05-13 09:09:25.275245" duration=663us digest="0x3C82E0201EA10A7B"

After fix:
ProxySQL LOG QUERY: thread_id="378394" username="cs_rw" **schemaname="trc"** client="10.101.10.101:48485" HID=10 server="bdb:3306" starttime="2019-05-13 09:09:25.274582" endtime="2019-05-13 09:09:25.275245" duration=663us digest="0x3C82E0201EA10A7B"