### PR TITLE
Enhancements on AWS Aurora module

### DIFF
--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -51,6 +51,7 @@ class Query_Info {
 	bool have_affected_rows;
 	uint64_t affected_rows;
 	uint64_t rows_sent;
+	uint64_t waiting_since;
 
 	Query_Info();
 	~Query_Info();

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -228,6 +228,8 @@ class MySQL_Thread
 		unsigned long long queries_slow;
 		unsigned long long queries_gtid;
 		unsigned long long queries_with_max_lag_ms;
+		unsigned long long queries_with_max_lag_ms__delayed;
+		unsigned long long queries_with_max_lag_ms__total_wait_time_us;
 		unsigned long long queries_backends_bytes_sent;
 		unsigned long long queries_backends_bytes_recv;
 		unsigned long long queries_frontends_bytes_sent;
@@ -541,6 +543,8 @@ class MySQL_Threads_Handler
 	unsigned long long get_backend_lagging_during_query();
 	unsigned long long get_backend_offline_during_query();
 	unsigned long long get_queries_with_max_lag_ms();
+	unsigned long long get_queries_with_max_lag_ms__delayed();
+	unsigned long long get_queries_with_max_lag_ms__total_wait_time_us();
 	unsigned long long get_killed_connections();
 	unsigned long long get_killed_queries();
 	iface_info *MLM_find_iface_from_fd(int fd) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -4050,6 +4050,8 @@ MySQL_Thread::MySQL_Thread() {
 	status_variables.backend_lagging_during_query = 0;
 	status_variables.backend_offline_during_query = 0;
 	status_variables.queries_with_max_lag_ms = 0;
+	status_variables.queries_with_max_lag_ms__delayed = 0;
+	status_variables.queries_with_max_lag_ms__total_wait_time_us = 0;
 	status_variables.unexpected_com_quit = 0;
 	status_variables.unexpected_packet = 0;
 	status_variables.killed_connections = 0;
@@ -4582,6 +4584,18 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_GlobalStatus(bool _memory) {
 	{	// queries_with_max_lag_ms
 		pta[0]=(char *)"queries_with_max_lag_ms";
 		sprintf(buf,"%llu",get_queries_with_max_lag_ms());
+		pta[1]=buf;
+		result->add_row(pta);
+	}
+	{	// queries_with_max_lag_ms__delayed
+		pta[0]=(char *)"queries_with_max_lag_ms__delayed";
+		sprintf(buf,"%llu",get_queries_with_max_lag_ms__delayed());
+		pta[1]=buf;
+		result->add_row(pta);
+	}
+	{	// queries_with_max_lag_ms__total_wait_time_us
+		pta[0]=(char *)"queries_with_max_lag_ms__total_wait_time_us";
+		sprintf(buf,"%llu",get_queries_with_max_lag_ms__total_wait_time_us());
 		pta[1]=buf;
 		result->add_row(pta);
 	}
@@ -5618,6 +5632,32 @@ unsigned long long MySQL_Threads_Handler::get_queries_with_max_lag_ms() {
 			MySQL_Thread *thr=(MySQL_Thread *)mysql_threads[i].worker;
 			if (thr)
 				q+=__sync_fetch_and_add(&thr->status_variables.queries_with_max_lag_ms,0);
+		}
+	}
+	return q;
+}
+
+unsigned long long MySQL_Threads_Handler::get_queries_with_max_lag_ms__delayed() {
+	unsigned long long q=0;
+	unsigned int i;
+	for (i=0;i<num_threads;i++) {
+		if (mysql_threads) {
+			MySQL_Thread *thr=(MySQL_Thread *)mysql_threads[i].worker;
+			if (thr)
+				q+=__sync_fetch_and_add(&thr->status_variables.queries_with_max_lag_ms__delayed,0);
+		}
+	}
+	return q;
+}
+
+unsigned long long MySQL_Threads_Handler::get_queries_with_max_lag_ms__total_wait_time_us() {
+	unsigned long long q=0;
+	unsigned int i;
+	for (i=0;i<num_threads;i++) {
+		if (mysql_threads) {
+			MySQL_Thread *thr=(MySQL_Thread *)mysql_threads[i].worker;
+			if (thr)
+				q+=__sync_fetch_and_add(&thr->status_variables.queries_with_max_lag_ms__total_wait_time_us,0);
 		}
 	}
 	return q;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -8234,11 +8234,11 @@ void ProxySQL_Admin::load_mysql_servers_to_runtime() {
 	if (resultset) delete resultset;
 	resultset=NULL;
 
-#ifdef TEST_AURORA // temporary enabled only for testing purpose
+//#ifdef TEST_AURORA // temporary enabled only for testing purpose
 	query=(char *)"SELECT a.* FROM mysql_aws_aurora_hostgroups a LEFT JOIN mysql_aws_aurora_hostgroups b ON (a.writer_hostgroup=b.reader_hostgroup) WHERE b.reader_hostgroup IS NULL";
-#else
-	query=(char *)"SELECT a.* FROM mysql_aws_aurora_hostgroups a WHERE 1=0";
-#endif
+//#else
+//	query=(char *)"SELECT a.* FROM mysql_aws_aurora_hostgroups a WHERE 1=0";
+//#endif
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "%s\n", query);
 	admindb->execute_statement(query, &error , &cols , &affected_rows , &resultset_aws_aurora);
 	if (error) {


### PR DESCRIPTION
Enhancements on AWS Aurora module
    
Added 2 new status variables:
- `queries_with_max_lag_ms__delayed`
- `queries_with_max_lag_ms__total_wait_time_us`

Do not get replication lag from replicas if the value is 0

Fixed an error in the computation of `max_lag_ms`
