### PR TITLE
Add client tracking for CLIENT_PS_MULTI_STATEMENTS

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -3042,6 +3042,7 @@ SQLite3_result * MySQL_HostGroups_Manager::SQL3_Free_Connections() {
 					j["client_flag"]["client_found_rows"] = (_my->client_flag & CLIENT_FOUND_ROWS ? 1 : 0);
 					j["client_flag"]["client_multi_statements"] = (_my->client_flag & CLIENT_MULTI_STATEMENTS ? 1 : 0);
 					j["client_flag"]["client_multi_results"] = (_my->client_flag & CLIENT_MULTI_RESULTS ? 1 : 0);
+					j["client_flag"]["client_ps_multi_results"] = (_my->client_flag & CLIENT_PS_MULTI_RESULTS ? 1 : 0);
 					j["net"]["last_errno"] = _my->net.last_errno;
 					j["net"]["fd"] = _my->net.fd;
 					j["net"]["max_packet_size"] = _my->net.max_packet_size;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -896,6 +896,7 @@ void MySQL_Session::generate_proxysql_internal_session_json(json &j) {
 	j["conn"]["client_flag"]["client_found_rows"] = (client_myds->myconn->options.client_flag & CLIENT_FOUND_ROWS ? 1 : 0);
 	j["conn"]["client_flag"]["client_multi_statements"] = (client_myds->myconn->options.client_flag & CLIENT_MULTI_STATEMENTS ? 1 : 0);
 	j["conn"]["client_flag"]["client_multi_results"] = (client_myds->myconn->options.client_flag & CLIENT_MULTI_RESULTS ? 1 : 0);
+	j["conn"]["client_flag"]["client_ps_multi_results"] = (client_myds->myconn->options.client_flag & CLIENT_PS_MULTI_RESULTS ? 1 : 0);
 	j["conn"]["no_backslash_escapes"] = client_myds->myconn->options.no_backslash_escapes;
 	j["conn"]["status"]["compression"] = client_myds->myconn->get_status_compression();
 	j["conn"]["status"]["transaction"] = client_myds->myconn->get_status_transaction();

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -458,9 +458,11 @@ bool MySQL_Connection::match_tracked_options(MySQL_Connection *c) {
 	if ((cf1 & CLIENT_FOUND_ROWS) == (cf2 & CLIENT_FOUND_ROWS)) {
 		if ((cf1 & CLIENT_MULTI_STATEMENTS) == (cf2 & CLIENT_MULTI_STATEMENTS)) {
 			if ((cf1 & CLIENT_MULTI_RESULTS) == (cf2 & CLIENT_MULTI_RESULTS)) {
-				if ((cf1 & CLIENT_IGNORE_SPACE) == (cf2 & CLIENT_IGNORE_SPACE)) {
-					return true;
-				}
+  			if ((cf1 & CLIENT_PS_MULTI_RESULTS) == (cf2 & CLIENT_PS_MULTI_RESULTS)) {
+	  			if ((cf1 & CLIENT_IGNORE_SPACE) == (cf2 & CLIENT_IGNORE_SPACE)) {
+		  			return true;
+			  	}
+        }
 			}
 		}
 	}
@@ -506,6 +508,9 @@ void MySQL_Connection::connect_start() {
 					}
 					if (orig_client_flags & CLIENT_MULTI_RESULTS) {
 						client_flags |= CLIENT_MULTI_RESULTS;
+					}
+					if (orig_client_flags & CLIENT_PS_MULTI_RESULTS) {
+						client_flags |= CLIENT_PS_MULTI_RESULTS;
 					}
 					if (orig_client_flags & CLIENT_IGNORE_SPACE) {
 						client_flags |= CLIENT_IGNORE_SPACE;


### PR DESCRIPTION
This way we track this option as well for connections and send the same option to be backend and don't multiplex connections with different options.