### PR TITLE
V2.0.6 2169

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -22,7 +22,7 @@ libssl/openssl/libssl.a:
 #	cd libssl && tar -zxf openssl-1.1.0h.tar.gz
 	cd libssl && rm -rf openssl-1.1.1b || true
 	cd libssl && tar -zxf openssl-1.1.1b.tar.gz
-	cd libssl/openssl  && ./config
+	cd libssl/openssl  && ./config no-ssl3
 	cd libssl/openssl && CC=${CC} CXX=${CXX} ${MAKE}
 libssl: libssl/openssl/libssl.a
 

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -884,6 +884,15 @@ void MySQL_Session::generate_proxysql_internal_session_json(json &j) {
 	j["client"]["proxy_addr"]["address"] = ( client_myds->proxy_addr.addr ? client_myds->proxy_addr.addr : "" );
 	j["client"]["proxy_addr"]["port"] = client_myds->proxy_addr.port;
 	j["client"]["encrypted"] = client_myds->encrypted;
+	if (client_myds->encrypted) {
+		const SSL_CIPHER *cipher = SSL_get_current_cipher(client_myds->ssl);
+		if (cipher) {
+			const char * name = SSL_CIPHER_get_name(cipher);
+			if (name) {
+				j["client"]["ssl_cipher"] = name;
+			}
+		}
+	}
 	j["client"]["DSS"] = client_myds->DSS;
 	j["default_schema"] = ( default_schema ? default_schema : "" );
 	j["transaction_persistent"] = transaction_persistent;


### PR DESCRIPTION
Disable SSLv3 #2169 
- switched from `SSLv23_server_method()` to `TLS_server_method()`
- enforced min proto version to `TLS1_VERSION` using `SSL_CTX_set_min_proto_version()`
- when inspecting session status, cipher used is exported
