### PR TITLE
Add a start for ProxySQL on CentOS/RHEL

### DIFF
--- a/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -43,7 +43,7 @@ chown -R %{name}: /var/lib/%{name} /var/run/%{name}
 chown root:%{name} /etc/%{name}.cnf
 chmod 640 /etc/%{name}.cnf
 chkconfig --add %{name}
-#systemctl enable proxysql.service
+/sbin/service %{name} restart >/dev/null 2>&1 || :
 
 %preun
 /etc/init.d/%{name} stop


### PR DESCRIPTION
This would address #2192
I'm not entirely sure the motivation for removing the service start, but in an environment where patching is performed with `yum update` being run across a class of hosts, I've had to run patches for hosts with ProxySQL updates with `yum update proxysql -y && service restart proxysql`

This bakes the restart into the `%post` section of the spec file and suppresses the output of the service restart. 