### PR TITLE
Remove hardcoded capabilities that the client uses

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -105,6 +105,7 @@ mariadb-client-library/mariadb_client/libmariadb/libmariadbclient.a: libssl/open
 	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_password.c < ../ma_password.c.patch
 #	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_secure.c < ../ma_secure.c.patch
 	cd mariadb-client-library/mariadb_client && patch include/mysql.h < ../mysql.h.patch
+	cd mariadb-client-library/mariadb_client && patch include/mariadb_com.h < ../mariadb_com.h.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_alloc.c < ../ma_alloc.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_charset.c < ../ma_charset.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_pvio.c < ../ma_pvio.c.patch

--- a/deps/mariadb-client-library/mariadb_com.h.patch
+++ b/deps/mariadb-client-library/mariadb_com.h.patch
@@ -1,0 +1,11 @@
+--- include/mariadb_com.h.old  2019-08-16 10:31:33.982265001 +0000
++++ include/mariadb_com.h      2019-08-16 10:32:03.048790998 +0000
+@@ -206,8 +206,6 @@
+                                  CLIENT_LONG_FLAG |\
+                                  CLIENT_TRANSACTIONS |\
+                                  CLIENT_SECURE_CONNECTION |\
+-                                 CLIENT_MULTI_RESULTS | \
+-                                 CLIENT_PS_MULTI_RESULTS |\
+                                  CLIENT_PROTOCOL_41 |\
+                                  CLIENT_PLUGIN_AUTH |\
+                                  CLIENT_SESSION_TRACKING |\


### PR DESCRIPTION
These hardcoded capabilities end up being set on all backend connections ProxySQL makes. We don't want CLIENT_MULTI_RESULTS & CLIENT_PS_MULTI_RESULTS to be enabled hardcoded, but they should be dependent on the client connecting to ProxySQL.

Having this mismatch meant that any connection that was not setting these flags would not be multiplexed with subsequent connections as the client of client flags would not match.

cc @renecannao & @shlomi-noach as we have been debugging this problem trying to find what was the cause of the connection churn we were seeing. 