### PR TITLE
lib/c_tokenizer.c: remove dead code found by cppcheck

### DIFF
--- a/lib/c_tokenizer.c
+++ b/lib/c_tokenizer.c
@@ -285,16 +285,10 @@ char *mysql_query_digest_and_first_comment(char *s, int _len, char **first_comme
 								if (*(s+1) == 'u' || *(s+1) == 'U') {
 									if (*(s+2) == 'l' || *(s+2) == 'L') {
 										if (*(s+3) == 'l' || *(s+3) == 'L') {
-											if (i==len-3) {
+											if (is_token_char(*(s+4))){
 												*p_r++ = '?';
-												*p_r = 0;
-												return r;
-											} else {
-												if (is_token_char(*(s+4))){
-													*p_r++ = '?';
-													s+=4;
-													i+=4;
-												}
+												s+=4;
+												i+=4;
 											}
 										}
 									}


### PR DESCRIPTION
[lib/c_tokenizer.c:282] -> [lib/c_tokenizer.c:288]: (warning) Opposite inner 'if' condition leads to a dead code block.