### PR TITLE
set tx_isolation implementation

### DIFF
--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -116,6 +116,7 @@ class MySQL_Session
 	bool handler_again___verify_backend_time_zone();
 	bool handler_again___verify_backend_isolation_level();
 	bool handler_again___verify_backend_transaction_read();
+	bool handler_again___verify_backend_tx_isolation();
 	bool handler_again___verify_backend_character_set_results();
 	bool handler_again___verify_backend_session_track_gtids();
 	bool handler_again___verify_backend_sql_auto_is_null();
@@ -132,6 +133,7 @@ class MySQL_Session
 	bool handler_again___status_SETTING_TIME_ZONE(int *);
 	bool handler_again___status_SETTING_ISOLATION_LEVEL(int *);
 	bool handler_again___status_SETTING_TRANSACTION_READ(int *);
+	bool handler_again___status_SETTING_TX_ISOLATION(int *);
 	bool handler_again___status_SETTING_CHARACTER_SET_RESULTS(int *);
 	bool handler_again___status_SETTING_SESSION_TRACK_GTIDS(int *);
 	bool handler_again___status_SETTING_SQL_AUTO_IS_NULL(int *);

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -21,6 +21,7 @@
 #define MYSQL_DEFAULT_TIME_ZONE	"SYSTEM"
 #define MYSQL_DEFAULT_ISOLATION_LEVEL	"READ COMMITTED"
 #define MYSQL_DEFAULT_TRANSACTION_READ	"WRITE"
+#define MYSQL_DEFAULT_TX_ISOLATION	"READ COMMITTED"
 #define MYSQL_DEFAULT_CHARACTER_SET_RESULTS	"NULL"
 #define MYSQL_DEFAULT_SESSION_TRACK_GTIDS	"OFF"
 #define MYSQL_DEFAULT_SQL_AUTO_IS_NULL	"OFF"
@@ -456,6 +457,7 @@ class MySQL_Threads_Handler
 		char *default_time_zone;
 		char *default_isolation_level;
 		char *default_transaction_read;
+		char *default_tx_isolation;
 		char *default_character_set_results;
 		char *default_session_track_gtids;
 		char *default_sql_auto_is_null;

--- a/include/mysql_connection.h
+++ b/include/mysql_connection.h
@@ -47,6 +47,7 @@ class MySQL_Connection {
 		uint32_t character_set_results_int;
 		uint32_t isolation_level_int;
 		uint32_t transaction_read_int;
+		uint32_t tx_isolation_int;
 		uint32_t session_track_gtids_int;
 		uint32_t sql_auto_is_null_int;
 		uint32_t sql_select_limit_int;
@@ -63,6 +64,7 @@ class MySQL_Connection {
 		char * character_set_results;
 		char * isolation_level;
 		char * transaction_read;
+		char * tx_isolation;
 		char * session_track_gtids;
 		char * sql_auto_is_null;
 		char * sql_select_limit;
@@ -71,6 +73,7 @@ class MySQL_Connection {
 		char * net_write_timeout;
 		char * max_join_size;
 		bool isolation_level_sent;
+		bool tx_isolation_sent;
 		bool transaction_read_sent;
 		bool character_set_results_sent;
 		bool session_track_gtids_sent;

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -154,6 +154,7 @@ enum session_status {
 	SETTING_TIME_ZONE,
 	SETTING_ISOLATION_LEVEL,
 	SETTING_TRANSACTION_READ,
+	SETTING_TX_ISOLATION,
 	SETTING_CHARACTER_SET_RESULTS,
 	SETTING_SESSION_TRACK_GTIDS,
 	SETTING_SQL_AUTO_IS_NULL,
@@ -624,6 +625,7 @@ __thread char *mysql_thread___default_sql_mode;
 __thread char *mysql_thread___default_time_zone;
 __thread char *mysql_thread___default_isolation_level;
 __thread char *mysql_thread___default_transaction_read;
+__thread char *mysql_thread___default_tx_isolation;
 __thread char *mysql_thread___default_character_set_results;
 __thread char *mysql_thread___default_session_track_gtids;
 __thread char *mysql_thread___default_sql_auto_is_null;
@@ -771,6 +773,7 @@ extern __thread char *mysql_thread___default_sql_mode;
 extern __thread char *mysql_thread___default_time_zone;
 extern __thread char *mysql_thread___default_isolation_level;
 extern __thread char *mysql_thread___default_transaction_read;
+extern __thread char *mysql_thread___default_tx_isolation;
 extern __thread char *mysql_thread___default_character_set_results;
 extern __thread char *mysql_thread___default_session_track_gtids;
 extern __thread char *mysql_thread___default_sql_auto_is_null;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -448,7 +448,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.default_time_zone=strdup((char *)MYSQL_DEFAULT_TIME_ZONE);
 	variables.default_isolation_level=strdup((char *)MYSQL_DEFAULT_ISOLATION_LEVEL);
 	variables.default_transaction_read=strdup((char *)MYSQL_DEFAULT_TRANSACTION_READ);
-	variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_ISOLATION_LEVEL);
+	variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_TX_ISOLATION);
 	variables.default_character_set_results=strdup((char *)MYSQL_DEFAULT_CHARACTER_SET_RESULTS);
 	variables.default_session_track_gtids=strdup((char *)MYSQL_DEFAULT_SESSION_TRACK_GTIDS);
 	variables.default_sql_auto_is_null=strdup((char *)MYSQL_DEFAULT_SQL_AUTO_IS_NULL);
@@ -667,7 +667,7 @@ char * MySQL_Threads_Handler::get_variable_string(char *name) {
 	}
 	if (!strcmp(name,"default_tx_isolation")) {
 		if (variables.default_tx_isolation==NULL) {
-			variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_ISOLATION_LEVEL);
+			variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_TX_ISOLATION);
 		}
 		return strdup(variables.default_tx_isolation);
 	}
@@ -973,7 +973,7 @@ char * MySQL_Threads_Handler::get_variable(char *name) {	// this is the public f
 	}
 	if (!strcasecmp(name,"default_tx_isolation")) {
 		if (variables.default_tx_isolation==NULL) {
-			variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_ISOLATION_LEVEL);
+			variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_TX_ISOLATION);
 		}
 		return strdup(variables.default_tx_isolation);
 	}
@@ -2331,7 +2331,7 @@ bool MySQL_Threads_Handler::set_variable(char *name, char *value) {	// this is t
 				variables.default_tx_isolation=strdup(value);
 		}
 		if (variables.default_tx_isolation==NULL) {
-			variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_ISOLATION_LEVEL); // default
+			variables.default_tx_isolation=strdup((char *)MYSQL_DEFAULT_TX_ISOLATION); // default
 		}
 		return true;
 	}

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -208,6 +208,7 @@ MySQL_Connection::MySQL_Connection() {
 	options.init_connect_sent=false;
 	options.character_set_results = NULL;
 	options.isolation_level = NULL;
+	options.tx_isolation = NULL;
 	options.transaction_read = NULL;
 	options.session_track_gtids = NULL;
 	options.sql_auto_is_null = NULL;
@@ -217,6 +218,7 @@ MySQL_Connection::MySQL_Connection() {
 	options.net_write_timeout = NULL;
 	options.max_join_size = NULL;
 	options.isolation_level_sent = false;
+	options.tx_isolation_sent = false;
 	options.transaction_read_sent = false;
 	options.character_set_results_sent = false;
 	options.session_track_gtids_sent = false;
@@ -236,6 +238,7 @@ MySQL_Connection::MySQL_Connection() {
 	options.time_zone=NULL;	// #819
 	options.time_zone_int=0;	// #819
 	options.isolation_level_int=0;
+	options.tx_isolation_int=0;
 	options.transaction_read_int=0;
 	options.character_set_results_int=0;
 	options.session_track_gtids_int=0;
@@ -324,6 +327,10 @@ MySQL_Connection::~MySQL_Connection() {
 	if (options.isolation_level) {
 		free(options.isolation_level);
 		options.isolation_level=NULL;
+	}
+	if (options.tx_isolation) {
+		free(options.tx_isolation);
+		options.tx_isolation=NULL;
 	}
 	if (options.transaction_read) {
 		free(options.transaction_read);
@@ -2094,6 +2101,12 @@ void MySQL_Connection::reset() {
 		free (options.isolation_level);
 		options.isolation_level = NULL;
 		options.isolation_level_sent = false;
+	}
+	options.tx_isolation_int = 0;
+	if (options.tx_isolation) {
+		free (options.tx_isolation);
+		options.tx_isolation = NULL;
+		options.tx_isolation_sent = false;
 	}
 	options.transaction_read_int = 0;
 	if (options.transaction_read) {


### PR DESCRIPTION
Description: 
this feature introduce tx_isolation variable into proxysql. The tx_isolation duplicates isolation level set by `set transaction isolation level`

Testing:
tested with set_testing app. test cases included both `set tx_isolation` ans `set transaction isolation level`