### PR TITLE
install signal handlers for the foreground process

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1577,6 +1577,7 @@ gotofork:
 
 	} else {
 		GloAdmin->flush_error_log();
+		GloVars.install_signal_handler();
 	}
 
 __start_label:


### PR DESCRIPTION
When proxysql is running in the foreground, the signal handlers are not getting installed. This issue makes it difficult, to run proxysql in a k8s/docker based environment, as it prevents proxysql to shut down gracefully. When proxysql runs in a docker container, it gets PID 1, thus the OS default signal handlers are not getting installed, makes proxysql to ignore SIGTERM.

This change installs the same signal handlers being used for background operation to the foreground process.