### PR TITLE
Filter deleted Aurora replicas from auto-discovery

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -3990,7 +3990,7 @@ void * monitor_AWS_Aurora_thread_HG(void *arg) {
 #ifdef TEST_AURORA
 	mmsd->async_exit_status = mysql_query_start(&mmsd->interr, mmsd->mysql, "SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS, CPU FROM REPLICA_HOST_STATUS ORDER BY SERVER_ID");
 #else
-	mmsd->async_exit_status = mysql_query_start(&mmsd->interr, mmsd->mysql, "SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS, CPU FROM INFORMATION_SCHEMA.REPLICA_HOST_STATUS WHERE REPLICA_LAG_IN_MILLISECONDS > 0 OR SESSION_ID = 'MASTER_SESSION_ID' ORDER BY SERVER_ID");
+	mmsd->async_exit_status = mysql_query_start(&mmsd->interr, mmsd->mysql, "SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS, CPU FROM INFORMATION_SCHEMA.REPLICA_HOST_STATUS WHERE (REPLICA_LAG_IN_MILLISECONDS > 0 AND REPLICA_LAG_IN_MILLISECONDS != 900000) OR SESSION_ID = 'MASTER_SESSION_ID' ORDER BY SERVER_ID");
 #endif // TEST_AURORA
 	while (mmsd->async_exit_status) {
 		mmsd->async_exit_status=wait_for_mysql(mmsd->mysql, mmsd->async_exit_status);


### PR DESCRIPTION
Aurora instances that have been deleted still exist in the `INFORMATION_SCHEMA.REPLICA_HOST_STATUS` table, but with a `REPLICA_LAG_IN_MILLISECONDS` set to `900000`. This causes the current autodiscovery query to continue to add entries to `runtime_mysql_servers` for deleted instances, adding unnecessary connection-failure errors to the log as it continues to try to connect to an instance that no longer exists.

To allow auto discovery to remove these deleted instances from the server list, this PR adds `AND REPLICA_LAG_IN_MILLISECONDS != 900000` to the monitor query, which removes it from the query results.

I haven't tested this code change through the existing Aurora automated testing, but I have manually run the new query on an existing Aurora cluster (version `5.7.mysql_aurora.2.04.6`) with a deleted replica instance to verify the correct results:

Old query:
```
mysql> SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS, CPU FROM INFORMATION_SCHEMA.REPLICA_HOST_STATUS WHERE REPLICA_LAG_IN_MILLISECONDS > 0 OR SESSION_ID = 'MASTER_SESSION_ID' ORDER BY SERVER_ID;
+----------------+--------------------------------------+----------------------------+-----------------------------+--------------------+
| SERVER_ID      | SESSION_ID                           | LAST_UPDATE_TIMESTAMP      | REPLICA_LAG_IN_MILLISECONDS | CPU                |
+----------------+--------------------------------------+----------------------------+-----------------------------+--------------------+
| staging-0      | MASTER_SESSION_ID                    | 2019-10-21 21:12:31.836369 |                           0 |                0.5 |
| staging-1      | [id]                                 | 2019-10-21 21:12:31.855021 |          19.878999710083008 | 1.8181818723678589 |
| staging-master | [id]                                 | 2019-10-21 19:39:56.000000 |                      900000 | 12.087912559509277 |
+----------------+--------------------------------------+----------------------------+-----------------------------+--------------------+
3 rows in set (0.00 sec)

```

New query:
```
mysql> SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS, CPU FROM INFORMATION_SCHEMA.REPLICA_HOST_STATUS WHERE (REPLICA_LAG_IN_MILLISECONDS > 0 AND REPLICA_LAG_IN_MILLISECONDS != 900000) OR SESSION_ID = 'MASTER_SESSION_ID' ORDER BY SERVER_ID;
+-----------+--------------------------------------+----------------------------+-----------------------------+--------------------+
| SERVER_ID | SESSION_ID                           | LAST_UPDATE_TIMESTAMP      | REPLICA_LAG_IN_MILLISECONDS | CPU                |
+-----------+--------------------------------------+----------------------------+-----------------------------+--------------------+
| staging-0 | MASTER_SESSION_ID                    | 2019-10-21 21:14:00.018776 |                           0 | 2.6315789222717285 |
| staging-1 | [id]                                 | 2019-10-21 21:13:59.197106 |          19.409000396728516 |  4.142011642456055 |
+-----------+--------------------------------------+----------------------------+-----------------------------+--------------------+
2 rows in set (0.00 sec)

```