### PR TITLE
Handle large queries with SSL enabled

### DIFF
--- a/include/MySQL_Data_Stream.h
+++ b/include/MySQL_Data_Stream.h
@@ -210,5 +210,7 @@ class MySQL_Data_Stream
 	void free_mysql_real_query();	
 	void reinit_queues();
 	void destroy_queues();
+
+	bool data_in_rbio();
 };
 #endif /* __CLASS_MYSQL_DATA_STREAM_H */

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -4139,7 +4139,18 @@ bool MySQL_Thread::process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned
 									rb = 0; // exit loop
 								}
 							} else {
-								rb = 0; // exit loop
+								bool set_rb_zero = true;
+								if (rb > 0 && myds->myds_type == MYDS_FRONTEND) {
+									if (myds->encrypted == true) {
+										if (SSL_is_init_finished(myds->ssl)) {
+											if (myds->data_in_rbio()) {
+												set_rb_zero = false;
+											}
+										}
+									}
+								}
+								if (set_rb_zero)
+									rb = 0; // exit loop
 							}
 						} while (rb > 0);
 


### PR DESCRIPTION
This commit fixes the following bug:
if a client connection uses SSL and sends a query larger than 32KB, the query is never executed and the connection hang