### PR TITLE
stats_history.history_mysql_query_digest #2368

### DIFF
--- a/include/ProxySQL_Statistics.hpp
+++ b/include/ProxySQL_Statistics.hpp
@@ -63,6 +63,8 @@
 #define STATSDB_SQLITE_TABLE_MYSQL_QUERY_CACHE_DAY "CREATE TABLE mysql_query_cache_day (timestamp INT NOT NULL, count_GET INT NOT NULL, count_GET_OK INT NOT NULL, count_SET INT NOT NULL, bytes_IN INT NOT NULL, bytes_OUT INT NOT NULL, Entries_Purged INT NOT NULL, Entries_In_Cache INT NOT NULL, Memory_Bytes INT NOT NULL, PRIMARY KEY (timestamp))"
 
 
+#define STATSDB_SQLITE_TABLE_HISTORY_MYSQL_QUERY_DIGEST "CREATE TABLE history_mysql_query_digest (hostgroup INT , schemaname VARCHAR NOT NULL , username VARCHAR NOT NULL , client_address VARCHAR NOT NULL , digest VARCHAR NOT NULL , digest_text VARCHAR NOT NULL , count_star INTEGER NOT NULL , first_seen INTEGER NOT NULL , last_seen INTEGER NOT NULL , sum_time INTEGER NOT NULL , min_time INTEGER NOT NULL , max_time INTEGER NOT NULL , sum_rows_affected INTEGER NOT NULL , sum_rows_sent INTEGER NOT NULL)"
+
 class ProxySQL_Statistics {
 	SQLite3DB *statsdb_mem; // internal statistics DB
 	std::vector<table_def_t *> *tables_defs_statsdb_mem;
@@ -72,6 +74,7 @@ class ProxySQL_Statistics {
 	void drop_tables_defs(std::vector<table_def_t *> *tables_defs);
 	void check_and_build_standard_tables(SQLite3DB *db, std::vector<table_def_t *> *tables_defs);
 	unsigned long long next_timer_MySQL_Threads_Handler;
+	unsigned long long next_timer_mysql_query_digest_to_disk;
 	unsigned long long next_timer_system_cpu;
 #ifndef NOJEM
 	unsigned long long next_timer_system_memory;
@@ -83,6 +86,7 @@ class ProxySQL_Statistics {
 		int stats_mysql_connections;
 		int stats_mysql_query_cache;
 		int stats_system_cpu;
+		int stats_mysql_query_digest_to_disk;
 #ifndef NOJEM
 		int stats_system_memory;
 #endif
@@ -93,6 +97,7 @@ class ProxySQL_Statistics {
 	void init();
 	void print_version();
 	bool MySQL_Threads_Handler_timetoget(unsigned long long);
+	bool mysql_query_digest_to_disk_timetoget(unsigned long long);
 	bool system_cpu_timetoget(unsigned long long);
 #ifndef NOJEM
 	bool system_memory_timetoget(unsigned long long);

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -100,6 +100,7 @@ class ProxySQL_Admin {
 		int stats_mysql_connection_pool;
 		int stats_mysql_connections;
 		int stats_mysql_query_cache;
+		int stats_mysql_query_digest_to_disk;
 		int stats_system_cpu;
 		int stats_system_memory;
 		int mysql_show_processlist_extended;
@@ -309,7 +310,7 @@ class ProxySQL_Admin {
 #endif /* PROXYSQLCLICKHOUSE */
 
 	void vacuum_stats(bool);
-
+	int FlushDigestTableToDisk(SQLite3DB *);
 
 #ifdef TEST_AURORA
 	void enable_aurora_testing();


### PR DESCRIPTION
Implementation of new table stats_history.history_mysql_query_digest #2368

Implemented command `SAVE MYSQL DIGEST TO DISK`.
Save to disk with really minimal memory footprint compared to querying `stats_mysql_query_digest` or `stats_mysql_query_digest_reset` .

Implemented new admin variable `admin-stats_mysql_query_digest_to_disk` to automatically save to disk.