### PR TITLE
Fix memory leaks in set parser

### DIFF
--- a/lib/set_parser.cpp
+++ b/lib/set_parser.cpp
@@ -119,6 +119,8 @@ std::map<std::string,std::vector<string>> SetParser::parse2() {
 		std::transform(key.begin(), key.end(), key.begin(), ::tolower);
 		result[key] = op;
 	}
+
+	delete opt2;
 	return result;
 }
 
@@ -139,6 +141,8 @@ std::string SetParser::parse_character_set() {
 	string value1, value2, value3, value4;
 	re2::StringPiece input(query);
 	re2::RE2::Consume(&input, re, &value1, &value2, &value3, &value4);
+
+	delete opt2;
 	return value4;
 }
 


### PR DESCRIPTION
Tested with valgrind. These reported memory leaks are fixed:

1)
==19152== 48 bytes in 2 blocks are definitely lost in loss record 188 of 420
==19152==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==19152==    by 0x2DBE80: SetParser::parse_character_set[abi:cxx11]() (set_parser.cpp:126)
==19152==    by 0x249B5D: MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo(_PtrSize_t*, bool*, bool) (MySQL_Session.cpp:6023)
==19152==    by 0x255EDB: MySQL_Session::handler() (MySQL_Session.cpp:3290)
==19152==    by 0x232439: MySQL_Thread::process_all_sessions() (MySQL_Thread.cpp:4392)
==19152==    by 0x23C347: MySQL_Thread::run() (MySQL_Thread.cpp:4125)
==19152==    by 0x1EFFFB: mysql_worker_thread_func(void*) (main.cpp:648)
==19152==    by 0x4E3F4A3: start_thread (pthread_create.c:456)
==19152==    by 0x6000D0E: clone (clone.S:97)
==19152==

2)
==19459== 24 bytes in 1 blocks are definitely lost in loss record 127 of 443
==19459==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==19459==    by 0x2DC495: SetParser::parse2[abi:cxx11]() (set_parser.cpp:77)
==19459==    by 0x24943F: MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo(_PtrSize_t*, bool*, bool) (MySQL_Session.cpp:5972)
==19459==    by 0x255EDB: MySQL_Session::handler() (MySQL_Session.cpp:3290)
==19459==    by 0x232439: MySQL_Thread::process_all_sessions() (MySQL_Thread.cpp:4392)
==19459==    by 0x23C347: MySQL_Thread::run() (MySQL_Thread.cpp:4125)
==19459==    by 0x1EFFFB: mysql_worker_thread_func(void*) (main.cpp:648)
==19459==    by 0x4E3F4A3: start_thread (pthread_create.c:456)
==19459==    by 0x6000D0E: clone (clone.S:97)

