### PR TITLE
Fix memory leaks of idle threads

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3470,15 +3470,17 @@ bool MySQL_Thread::init() {
 	assert(mysql_sessions);
 
 #ifdef IDLE_THREADS
-	idle_mysql_sessions = new PtrArray();
-	resume_mysql_sessions = new PtrArray();
+	if (GloVars.global.idle_threads) {
+		idle_mysql_sessions = new PtrArray();
+		resume_mysql_sessions = new PtrArray();
 
-	myexchange.idle_mysql_sessions = new PtrArray();
-	myexchange.resume_mysql_sessions = new PtrArray();
-	pthread_mutex_init(&myexchange.mutex_idles,NULL);
-	pthread_mutex_init(&myexchange.mutex_resumes,NULL);
-	assert(idle_mysql_sessions);
-	assert(resume_mysql_sessions);
+		myexchange.idle_mysql_sessions = new PtrArray();
+		myexchange.resume_mysql_sessions = new PtrArray();
+		pthread_mutex_init(&myexchange.mutex_idles,NULL);
+		pthread_mutex_init(&myexchange.mutex_resumes,NULL);
+		assert(idle_mysql_sessions);
+		assert(resume_mysql_sessions);
+	}
 #endif // IDLE_THREADS
 
 	pthread_mutex_init(&kq.m,NULL);


### PR DESCRIPTION
Description:
Idle threads variables are deleted when IDLE_THREADS macro is defined and proxysql is started with command line option --idle-threads. However, these variables are allocated only when IDLE_THREADS is defined. When proxysql is started w/o --idle-threads option valgrind reports memory leaks:

```
==19459== 64 bytes in 4 blocks are definitely lost in loss record 233 of 443
==19459==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==19459==    by 0x23406D: MySQL_Thread::init() (MySQL_Thread.cpp:3458)
==19459==    by 0x1EFFD3: mysql_worker_thread_func(void*) (main.cpp:642)
==19459==    by 0x4E3F4A3: start_thread (pthread_create.c:456)
==19459==    by 0x6000D0E: clone (clone.S:97)
==19459==
==19459== 64 bytes in 4 blocks are definitely lost in loss record 234 of 443
==19459==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==19459==    by 0x234093: MySQL_Thread::init() (MySQL_Thread.cpp:3459)
==19459==    by 0x1EFFD3: mysql_worker_thread_func(void*) (main.cpp:642)
==19459==    by 0x4E3F4A3: start_thread (pthread_create.c:456)
==19459==    by 0x6000D0E: clone (clone.S:97)
==19459==
==19459== 64 bytes in 4 blocks are definitely lost in loss record 235 of 443
==19459==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==19459==    by 0x2340B9: MySQL_Thread::init() (MySQL_Thread.cpp:3461)
==19459==    by 0x1EFFD3: mysql_worker_thread_func(void*) (main.cpp:642)
==19459==    by 0x4E3F4A3: start_thread (pthread_create.c:456)
==19459==    by 0x6000D0E: clone (clone.S:97)
==19459==
==19459== 64 bytes in 4 blocks are definitely lost in loss record 236 of 443
==19459==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==19459==    by 0x2340DF: MySQL_Thread::init() (MySQL_Thread.cpp:3462)
==19459==    by 0x1EFFD3: mysql_worker_thread_func(void*) (main.cpp:642)
==19459==    by 0x4E3F4A3: start_thread (pthread_create.c:456)
==19459==    by 0x6000D0E: clone (clone.S:97)
==19459==
```

Tests:
- tested with and without --idle-threads and checked memory reports in valgrind.