### PR TITLE
Undo error reporting when group replication hosts result set is empty

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -2695,7 +2695,6 @@ void * MySQL_Monitor::monitor_group_replication() {
 //			goto __end_monitor_read_only_loop;
 		} else {
 			if (Group_Replication_Hosts_resultset->rows_count==0) {
-				proxy_error("Group replication hosts result set is empty\n");
 				goto __end_monitor_group_replication_loop;
 			}
 			int us=100;


### PR DESCRIPTION
Wrong error logging. When group replication hostgroups table is empty then erroneous message appears in the log.