### PR TITLE
V2.0.9 fix hgm leaks

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1028,8 +1028,10 @@ void MySQL_HostGroups_Manager::init() {
 void MySQL_HostGroups_Manager::shutdown() {
 	queue.add(NULL);
 	HGCU_thread->join();
+	delete HGCU_thread;
 	ev_async_send(gtid_ev_loop, gtid_ev_async);
 	GTID_syncer_thread->join();
+	delete GTID_syncer_thread;
 	free(gtid_ev_async);
 }
 

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -640,12 +640,16 @@ static void * HGCU_thread_run() {
 		myconn = (MySQL_Connection *)MyHGM->queue.remove();
 		if (myconn==NULL) {
 			// intentionally exit immediately
+			delete conn_array;
 			return NULL;
 		}
 		conn_array->add(myconn);
 		while (MyHGM->queue.size()) {
 			myconn=(MySQL_Connection *)MyHGM->queue.remove();
-			if (myconn==NULL) return NULL;
+			if (myconn==NULL) {
+				delete conn_array;
+				return NULL;
+			}
 			conn_array->add(myconn);
 		}
 		unsigned int l=conn_array->len;
@@ -738,6 +742,7 @@ static void * HGCU_thread_run() {
 		free(errs);
 		free(ret);
 	}
+	delete conn_array;
 }
 
 

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1873,6 +1873,7 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_table(int *_onlyhg) {
 		}
 		if (resultset) { delete resultset; resultset=NULL; }
 	}
+	delete lst;
 }
 
 void MySQL_HostGroups_Manager::generate_mysql_replication_hostgroups_table() {


### PR DESCRIPTION
Several non-critical memory leaks are fixed.
```
1)
==17674== 8 bytes in 1 blocks are definitely lost in loss record 33 of 441
==17674==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==17674==    by 0x2071B8: MySQL_HostGroups_Manager::init() (MySQL_HostGroups_Manager.cpp:1019)
==17674==    by 0x1F1F44: ProxySQL_Main_init_main_modules() (main.cpp:835)
==17674==    by 0x1F28AA: ProxySQL_Main_init_phase2___not_started() (main.cpp:1127)
==17674==    by 0x1EEF99: main (main.cpp:1587)
==17674==
==17674== 8 bytes in 1 blocks are definitely lost in loss record 34 of 441
==17674==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==17674==    by 0x207225: MySQL_HostGroups_Manager::init() (MySQL_HostGroups_Manager.cpp:1023)
==17674==    by 0x1F1F44: ProxySQL_Main_init_main_modules() (main.cpp:835)
==17674==    by 0x1F28AA: ProxySQL_Main_init_phase2___not_started() (main.cpp:1127)
==17674==    by 0x1EEF99: main (main.cpp:1587)
==17674==

2)
==17674== 16 bytes in 1 blocks are definitely lost in loss record 86 of 441
==17674==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==17674==    by 0x20CA17: HGCU_thread_run() (MySQL_HostGroups_Manager.cpp:637)
==17674==    by 0x5734E6E: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22)
==17674==    by 0x4E3F4A3: start_thread (pthread_create.c:456)
==17674==    by 0x6000D0E: clone (clone.S:97)
==17674==
```

These memory leaks appears only on server shutdown, but we need to remove `definitely lost` record in the valgrind memory report.