### PR TITLE
Fix race condition on KILL CONNECTION

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2797,7 +2797,8 @@ void MySQL_HostGroups_Manager::destroy_MyConn_from_pool(MySQL_Connection *c, boo
 				switch (myerr) {
 					case 1231:
 						break;
-					default: {
+					default:
+					if (c->mysql->thread_id) {
 						MySQL_Connection_userinfo *ui=c->userinfo;
 						char *auth_password=NULL;
 						if (ui->password) {
@@ -2817,7 +2818,7 @@ void MySQL_HostGroups_Manager::destroy_MyConn_from_pool(MySQL_Connection *c, boo
 							proxy_error("Thread creation\n");
 							assert(0);
 						}
-						}
+					}
 						break;
 				}
 			}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -164,8 +164,9 @@ void * kill_query_thread(void *arg) {
 	}
 	// FIXME: these 2 calls are blocking, fortunately on their own thread
 	mysql_query(mysql,buf);
-	mysql_close(mysql);
 __exit_kill_query_thread:
+	if (mysql)
+		mysql_close(mysql);
 	delete ka;
 	return NULL;
 }


### PR DESCRIPTION
Fixed a race condition that could possible lead to a leak of file descriptors
when running KILL CONNECTION on backend