### PR TITLE
Aurora replication lag: fix for master replication lag

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -4659,7 +4659,7 @@ unsigned int MySQL_Monitor::estimate_lag(char* server_id, AWS_Aurora_status_entr
 		if (!aase[idx] || !aase[idx]->host_statuses)
 			break;
 		for (auto hse : *(aase[idx]->host_statuses)) {
-			if (strcmp(server_id, hse->server_id)==0) {
+			if (strcmp(server_id, hse->server_id)==0 && (unsigned int)hse->replica_lag_ms != 0) {
 				unsigned int ms = std::max(((unsigned int)hse->replica_lag_ms + add_lag_ms), min_lag_ms);
 				if (ms > mlag) mlag = ms;
 				if (!lag) lag = ms;


### PR DESCRIPTION
Description:
This PR handles master replication lag. If the replication lag is equal to 0 then padding/minimum and windowing is not applied.

Testing:
Tested with --sqlite3-server. The `mysql_server_aws_aurora_log` shows estimated lag 0 for replication masters.

```
mysql> select hostname, port, time_start_us, SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, replica_lag_in_milliseconds rl, estimated_lag_ms el, cpu from mysql_server_aws_aurora_log limit 10;
+------------------------+------+------------------+-----------+-------------------------+-----------------------+------------------+----+------------------+
| hostname               | port | time_start_us    | SERVER_ID | SESSION_ID              | LAST_UPDATE_TIMESTAMP | rl               | el | CPU              |
+------------------------+------+------------------+-----------+-------------------------+-----------------------+------------------+----+------------------+
| host.1.11.aws-test.com | 3306 | 1574419600651913 | host.1.11 | MASTER_SESSION_ID       | 2019-11-22 10:46:40   | 0                | 0  | 96.1600036621094 |
| host.1.11.aws-test.com | 3306 | 1574419600651913 | host.1.12 | b80ef4b4-host.1.12-aa01 | 2019-11-22 10:46:40   | 15.25            | 39 | 64.4100036621094 |
| host.1.11.aws-test.com | 3306 | 1574419600651913 | host.1.13 | b80ef4b4-host.1.13-aa01 | 2019-11-22 10:46:40   | 24.3999996185303 | 36 | 13.3100004196167 |
| host.1.11.aws-test.com | 3306 | 1574419600651913 | host.1.14 | b80ef4b4-host.1.14-aa01 | 2019-11-22 10:46:40   | 18.6199989318848 | 29 | 47.9599990844727 |
| host.1.11.aws-test.com | 3306 | 1574419600651913 | host.1.15 | b80ef4b4-host.1.15-aa01 | 2019-11-22 10:46:40   | 20.2000007629395 | 36 | 73.9899978637695 |
| host.1.11.aws-test.com | 3306 | 1574419600651913 | host.1.16 | b80ef4b4-host.1.16-aa01 | 2019-11-22 10:46:40   | 19.8800010681152 | 36 | 8.34000015258789 |
| host.1.11.aws-test.com | 3306 | 1574419601010364 | host.1.11 | MASTER_SESSION_ID       | 2019-11-22 10:46:41   | 0                | 0  | 80.7300033569336 |
| host.1.11.aws-test.com | 3306 | 1574419601010364 | host.1.12 | b80ef4b4-host.1.12-aa01 | 2019-11-22 10:46:41   | 14.5500001907349 | 39 | 68.5299987792969 |
| host.1.11.aws-test.com | 3306 | 1574419601010364 | host.1.13 | b80ef4b4-host.1.13-aa01 | 2019-11-22 10:46:41   | 19.2700004577637 | 34 | 17.9699993133545 |
| host.1.11.aws-test.com | 3306 | 1574419601010364 | host.1.14 | b80ef4b4-host.1.14-aa01 | 2019-11-22 10:46:41   | 19.8899993896484 | 34 | 28.6000003814697 |
+------------------------+------+------------------+-----------+-------------------------+-----------------------+------------------+----+------------------+
10 rows in set (0.07 sec)
```

