### PR TITLE
V2.0.9 unsigned charset

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2928,6 +2928,9 @@ bool MySQL_Session::handler_again___status_CHANGING_CHARSET(int *_rc) {
 	MySQL_Data_Stream *myds=mybe->server_myds;
 	MySQL_Connection *myconn=myds->myconn;
 	char msg[128];
+	const MARIADB_CHARSET_INFO *ci = NULL;
+	const char* replace_collation = "";
+	const char* not_supported_collation = "";
 
 	/* Validate that server can support client's charset */
 	if (client_myds->myconn->options.charset >= 255 && myconn->mysql->server_version[0] != '8') {
@@ -2941,8 +2944,16 @@ bool MySQL_Session::handler_again___status_CHANGING_CHARSET(int *_rc) {
 				*_rc=-1;
 				return false;
 			case HANDLE_UNKNOWN_CHARSET__REPLACE_WITH_DEFAULT_VERBOSE:
-				proxy_warning("Server doesn't support collation id %d. Replace it with default charset %d.\n",
-						client_myds->myconn->options.charset, mysql_thread___default_charset);
+				ci = proxysql_find_charset_nr(client_myds->myconn->options.charset);
+				if (ci)	not_supported_collation = ci->name;
+
+				ci = proxysql_find_charset_nr(mysql_thread___default_charset);
+				if (ci)	replace_collation = ci->name;
+
+				proxy_warning("Server doesn't support collation (%d) %s. Replacing it with the configured default (%d) %s.\n",
+						client_myds->myconn->options.charset, not_supported_collation, 
+						mysql_thread___default_charset, replace_collation);
+
 				client_myds->myconn->options.charset=mysql_thread___default_charset;
 				break;
 			case HANDLE_UNKNOWN_CHARSET__REPLACE_WITH_DEFAULT:

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2937,8 +2937,8 @@ bool MySQL_Session::handler_again___status_CHANGING_CHARSET(int *_rc) {
 		switch(mysql_thread___handle_unknown_charset) {
 			case HANDLE_UNKNOWN_CHARSET__DISCONNECT_CLIENT:
 				snprintf(msg,sizeof(msg),"Can't initialize character set %d",client_myds->myconn->options.charset);
-				proxy_error("Can't initialize character set on %s, %d: Error %d (%s). Closing connection.\n",
-						myconn->parent->address, myconn->parent->port, 2019, msg);
+				proxy_error("Can't initialize character set on %s, %d: Error %d (%s). Closing client connection %s:%d.\n",
+						myconn->parent->address, myconn->parent->port, 2019, msg, client_myds->addr.addr, client_myds->addr.port);
 				myds->destroy_MySQL_Connection_From_Pool(false);
 				myds->fd=0;
 				*_rc=-1;
@@ -2950,9 +2950,9 @@ bool MySQL_Session::handler_again___status_CHANGING_CHARSET(int *_rc) {
 				ci = proxysql_find_charset_nr(mysql_thread___default_charset);
 				if (ci)	replace_collation = ci->name;
 
-				proxy_warning("Server doesn't support collation (%d) %s. Replacing it with the configured default (%d) %s.\n",
+				proxy_warning("Server doesn't support collation (%d) %s. Replacing it with the configured default (%d) %s. Client %s:%d\n",
 						client_myds->myconn->options.charset, not_supported_collation, 
-						mysql_thread___default_charset, replace_collation);
+						mysql_thread___default_charset, replace_collation, client_myds->addr.addr, client_myds->addr.port);
 
 				client_myds->myconn->options.charset=mysql_thread___default_charset;
 				break;

--- a/test/tap/tap/Makefile
+++ b/test/tap/tap/Makefile
@@ -1,17 +1,15 @@
 INCLUDE=../../../deps/json
 
 .PHONY: all
-all: tap
+all: libtap.a
 
 .PHONY: clean
 clean:
 	rm -f *.o libtap.a || true
 
-
 OPT=-O2
 
-tap: tap.cpp tap.h command_line.cpp command_line.h
-	g++ -c tap.cpp command_line.cpp  -std=c++11 -I$(INCLUDE)
+libtap.a: tap.cpp tap.h command_line.cpp command_line.h
+	g++ -c tap.cpp command_line.cpp  -std=c++11 -I$(INCLUDE) $(OPT)
 	ar rcs libtap.a tap.o command_line.o
-
 

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -23,11 +23,11 @@ SRC=basic-t.cpp set_character_set-t.cpp charset_unsigned_int-t.cpp
 tests: basic-t set_character_set-t charset_unsigned_int-t
 
 basic-t: $(LIBDIR)/libtap.a
-	g++ basic-t.cpp -I$(INCLUDEDIR) -L$(LIBDIR) -std=c++11 -ltap -o basic-t
+	g++ basic-t.cpp -I$(INCLUDEDIR) -L$(LIBDIR) $(OPT) -std=c++11 -ltap -o basic-t
 
 set_character_set-t: set_character_set-t.cpp $(LIBDIR)/libtap.a
-	g++ set_character_set-t.cpp -I$(INCLUDEDIR) -I$(MARIADB_IDIR) -L$(LIBDIR) -std=c++11 $(STATIC_LIBS) -ltap -lssl -lcrypto -ldl -lpthread -o set_character_set-t
+	g++ set_character_set-t.cpp -I$(INCLUDEDIR) -I$(MARIADB_IDIR) -L$(LIBDIR) $(OPT) -std=c++11 $(STATIC_LIBS) -ltap -lssl -lcrypto -ldl -lpthread -o set_character_set-t
 
 charset_unsigned_int-t: charset_unsigned_int-t.cpp $(LIBDIR)/libtap.a
-	g++ charset_unsigned_int-t.cpp -I$(INCLUDEDIR) -I$(MARIADB_IDIR) -L$(LIBDIR) -std=c++11 $(STATIC_LIBS) -ltap -lssl -lcrypto -ldl -lpthread -o charset_unsigned_int-t
+	g++ charset_unsigned_int-t.cpp -I$(INCLUDEDIR) -I$(MARIADB_IDIR) -L$(LIBDIR) $(OPT) -std=c++11 $(STATIC_LIBS) -ltap -lssl -lcrypto -ldl -lpthread -o charset_unsigned_int-t
 

--- a/test/tap/tests/charset_unsigned_int-t.cpp
+++ b/test/tap/tests/charset_unsigned_int-t.cpp
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
 	}
 	else {
 		show_variable(mysql_b, var_collation_connection, var_value);
-		ok(var_value.compare("utf8mb4_0900_ai_ci") == 0, "Collation >255 is set"); // ok_5
+		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation >255 is set"); // ok_5
 	}
 	mysql_close(mysql_b);
 
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
 	}
 	else {
 		show_variable(mysql_c, var_collation_connection, var_value);
-		ok(var_value.compare("utf8mb4_0900_ai_ci") == 0, "Collation >255 is set"); // ok_6
+		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation >255 is set"); // ok_6
 	}
 
 	mysql_close(mysql_c);

--- a/test/tap/tests/charset_unsigned_int-t.cpp
+++ b/test/tap/tests/charset_unsigned_int-t.cpp
@@ -114,14 +114,14 @@ int main(int argc, char** argv) {
 
 	if (mysql_query(mysql, "set names 'utf8'")) return exit_status();
 	show_variable(mysql, var_collation_connection, var_value);
-	ok(var_value.compare("utf8_general_ci") == 0, "Initial client character set"); // ok_1
+	ok(var_value.compare("utf8_general_ci") == 0, "Initial client character set. Actual %s", var_value.c_str()); // ok_1
 
 	if (mysql_query(mysql, "set names utf8mb4 collate utf8mb4_croatian_ci")) return exit_status();
 	show_variable(mysql, var_collation_connection, var_value);
 	std::string version;
 	get_server_version(mysql, version);
 	if (version.data()[0] == '5') {
-		ok(var_value.compare("utf8mb4_general_ci") == 0, "Backend is mysql version < 8.0. Collation is reduced to utf8mb4_general_ci as expected"); // ok_2
+		ok(var_value.compare("utf8mb4_general_ci") == 0, "Backend is mysql version < 8.0. Actual collation %s", var_value.c_str()); // ok_2
 	} else {
 		ok(var_value.compare("utf8mb4_croatian_ci") == 0, "Backend is mysql version >= 8.0. Collation is set as expected to utf8mb4_croatian_ci"); // ok_2
 	}
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
 	if (mysql_query(mysql_a, "save mysql variables to disk")) return exit_status();
 
 	show_admin_global_variable(mysql_a, var_name, var_value);
-	ok(var_value.compare("utf8mb4") == 0, "Default charset utf8mb4 is set in admin"); // ok_4
+	ok(var_value.compare("utf8mb4") == 0, "Default charset utf8mb4 is set in admin. Actual %s", var_value.c_str()); // ok_4
 
 	mysql_close(mysql_a);
 
@@ -159,11 +159,11 @@ int main(int argc, char** argv) {
 	get_server_version(mysql_b, version);
 	if (version.data()[0] == '5') {
 		show_variable(mysql_b, var_collation_connection, var_value);
-		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation 255 is set, because proxyserver changed it"); // ok_5
+		ok(var_value.compare("latin1_swedish_ci") == 0, "Collation <255 is set. Actual %s", var_value.c_str()); // ok_5
 	}
 	else {
 		show_variable(mysql_b, var_collation_connection, var_value);
-		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation >255 is set"); // ok_5
+		ok(var_value.compare("latin1_swedish_ci") == 0, "Collation >255 is set. Actual %s", var_value.c_str()); // ok_5
 	}
 	mysql_close(mysql_b);
 
@@ -177,11 +177,11 @@ int main(int argc, char** argv) {
 	if (get_server_version(mysql_c, version)) return exit_status();
 	if (version.data()[0] == '5') {
 		show_variable(mysql_c, var_collation_connection, var_value);
-		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation 255 is set, because proxyserver changed it"); // ok_6
+		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation <255 is set. Actual %s", var_value.c_str()); // ok_6
 	}
 	else {
 		show_variable(mysql_c, var_collation_connection, var_value);
-		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation >255 is set"); // ok_6
+		ok(var_value.compare("utf8mb4_general_ci") == 0, "Collation >255 is set. %s", var_value.c_str()); // ok_6
 	}
 
 	mysql_close(mysql_c);


### PR DESCRIPTION
Description:
1. Log message contains client host:port.
2. Test automation expected values changed after static linking to mariadb client library.

Tests:
1. Automation tests
2. Tested with local client, tested with remote client