### PR TITLE
Fix add a mutex lock twice in the process of function call(log_audit_…

### DIFF
--- a/lib/MySQL_Logger.cpp
+++ b/lib/MySQL_Logger.cpp
@@ -234,7 +234,8 @@ void MySQL_Event::write_auth(std::fstream *f, MySQL_Session *sess) {
 	}
 	// for performance reason, we are moving the write lock
 	// right before the write to disk
-	GloMyLogger->wrlock();
+	//GloMyLogger->wrlock();
+	//move wrlock() function to log_audit_entry() function, avoid to get a null pointer in a multithreaded environment
 	*f << j.dump(-1, ' ', false, json::error_handler_t::replace) << std::endl;
 }
 


### PR DESCRIPTION
…entry() -> write() -> write_auth())

Bug description:
      Since fix write event log and audit log coredump(#2427)， i think i left out a code that was not processed, resulting in coredump again in the program of proxysql , when i confige these parameters of auditlog_filename and auditlog_filesize in proxysql.cnf file  or  i set these parameters in proxysql-admin command line.   
the coredump contest:
(gdb) bt
#0  0x00002b224e9981f7 in raise () from /lib64/libc.so.6
#1  0x00002b224e9998e8 in abort () from /lib64/libc.so.6
#2  0x00002b224e991266 in __assert_fail_base () from /lib64/libc.so.6
#3  0x00002b224e991312 in __assert_fail () from /lib64/libc.so.6
#4  0x00000000005b2dc3 in main (argc=5, argv=0x7ffea714fd48) at main.cpp:1664

the proxysql.log contest:
2019-12-06 11:03:07 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:10 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:13 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:16 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:19 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:22 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:25 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:28 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:31 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:34 main.cpp:1659:main(): [ERROR] Watchdog: 8 threads missed a heartbeat
2019-12-06 11:03:34 main.cpp:1663:main(): [ERROR] Watchdog: reached 10 missed heartbeats. Aborting!
proxysql: main.cpp:1664: int main(int, const char**): Assertion `0' failed.
Error: signal 6:
proxysql(_Z13crash_handleri+0x25)[0x5b607c]
/lib64/libc.so.6(+0x35270)[0x2b224e998270]
/lib64/libc.so.6(gsignal+0x37)[0x2b224e9981f7]
/lib64/libc.so.6(abort+0x148)[0x2b224e9998e8]
/lib64/libc.so.6(+0x2e266)[0x2b224e991266]
/lib64/libc.so.6(+0x2e312)[0x2b224e991312]
proxysql(main+0xe3a)[0x5b2dc3]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x2b224e984c05]
proxysql[0x5adaa5]
2019-12-06 11:03:34 main.cpp:1396:ProxySQL_daemonize_phase3(): [ERROR] ProxySQL crashed. Restarting!
2019-12-06 11:03:34 main.cpp:1397:ProxySQL_daemonize_phase3(): [INFO] ProxySQL version _DEBUG

Impact of this fix：
     I analyzed the call relationship of write_auth function of MySQL_Logger.cpp file  in the whole project of proxysql with the source insight ide. I found write_auth function  that was only called by the write function of MySQL_Logger.cpp file in the whole project of proxysql,  and this write function was only called by log_audit_entry function or log_request function of  MySQL_Logger.cpp file in the whole project of proxysql. However, i've added a mutex lock separately in log_audit_entry function and log_request function. And so i think it should delete the code for the wrlock function call in write_auth function, and it doesn't have impact for this time fix.

Bux fix:
Fix add a mutex lock twice in the process of function call(log_audit_entry() -> write() -> write_auth())