### PR TITLE
Implementation of SQLI fingerprints whitelist

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -172,6 +172,7 @@ class MySQL_Thread
 		unsigned long long hostgroup_locked_queries;
 		unsigned long long aws_aurora_replicas_skipped_during_query;
 		unsigned long long automatic_detected_sqli;
+		unsigned long long whitelisted_sqli_fingerprint;
 		unsigned int active_transactions;
 	} status_variables;
 
@@ -480,6 +481,7 @@ class MySQL_Threads_Handler
 	unsigned long long get_hostgroup_locked_queries();
 	unsigned long long get_aws_aurora_replicas_skipped_during_query();
 	unsigned long long get_automatic_detected_sqli();
+	unsigned long long get_whitelisted_sqli_fingerprint();
 	unsigned long long get_backend_lagging_during_query();
 	unsigned long long get_backend_offline_during_query();
 	unsigned long long get_queries_with_max_lag_ms();

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -240,6 +240,7 @@ class ProxySQL_Admin {
 	void save_mysql_firewall_from_runtime(bool);
 	void save_mysql_firewall_whitelist_users_from_runtime(bool, SQLite3_result *);
 	void save_mysql_firewall_whitelist_rules_from_runtime(bool, SQLite3_result *);
+	void save_mysql_firewall_whitelist_sqli_fingerprints_from_runtime(bool, SQLite3_result *);
 
 	void load_scheduler_to_runtime();
 	void save_scheduler_runtime_to_database(bool);

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1619,7 +1619,7 @@ bool MySQL_HostGroups_Manager::commit() {
 	unsigned long long curtime2=monotonic_time();
 	curtime1 = curtime1/1000;
 	curtime2 = curtime2/1000;
-	proxy_info("MySQL_HostGroups_Manager::commit() locked for %lluus\n", curtime2-curtime1);
+	proxy_info("MySQL_HostGroups_Manager::commit() locked for %llums\n", curtime2-curtime1);
 
 	if (GloMTH) {
 		GloMTH->signal_all_threads(1);

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -3158,9 +3158,7 @@ __get_pkts_from_client:
 	for (j=0; j< ( client_myds->PSarrayIN ? client_myds->PSarrayIN->len : 0)  || (mirror==true && status==WAITING_CLIENT_DATA) ;) {
 		if (mirror==false) {
 			client_myds->PSarrayIN->remove_index(0,&pkt);
-			//proxy_info("pkt = %s\n", (char *)pkt.ptr+5); // 20191211 -- DELETEME
 		}
-		//proxy_info("status = %d\n", status); // 20191211 -- DELETEME
 		switch (status) {
 
 			case CONNECTING_CLIENT:
@@ -3195,7 +3193,6 @@ __get_pkts_from_client:
 							break;
 					}
 				}
-				//proxy_info("client_myds->DSS = %d\n", client_myds->DSS); // 20191211 -- DELETEME
 				switch (client_myds->DSS) {
 					case STATE_SLEEP_MULTI_PACKET:
 						if (client_myds->multi_pkt.ptr==NULL) {
@@ -3288,7 +3285,6 @@ __get_pkts_from_client:
 							case _MYSQL_COM_QUERY:
 								__sync_add_and_fetch(&thread->status_variables.queries,1);
 								if (session_type == PROXYSQL_SESSION_MYSQL) {
-									//proxy_info("query = %s\n", (char *)pkt.ptr+5); // 20191211 -- DELETEME
 									bool rc_break=false;
 									bool lock_hostgroup = false;
 									if (session_fast_forward==false) {

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -2077,7 +2077,7 @@ __exit_process_mysql_query:
 			proxy_error("Firewall problem: unknown user\n");
 			assert(0);
 		}
-	} else {		
+	} else {
 		ret->firewall_whitelist_mode = WUS_NOT_FOUND;
 	}
 	return ret;

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -529,6 +529,7 @@ Query_Processor::Query_Processor() {
 	pthread_mutex_init(&global_mysql_firewall_whitelist_mutex, NULL);
 	global_mysql_firewall_whitelist_users_runtime = NULL;
 	global_mysql_firewall_whitelist_rules_runtime = NULL;
+	global_mysql_firewall_whitelist_sqli_fingerprints_runtime = NULL;
 	global_mysql_firewall_whitelist_users_map___size = 0;
 	global_mysql_firewall_whitelist_users_result___size = 0;
 	global_mysql_firewall_whitelist_rules_map___size = 0;
@@ -652,6 +653,10 @@ Query_Processor::~Query_Processor() {
 	if (global_mysql_firewall_whitelist_rules_runtime) {
 		delete global_mysql_firewall_whitelist_rules_runtime;
 		global_mysql_firewall_whitelist_rules_runtime = NULL;
+	}
+	if (global_mysql_firewall_whitelist_sqli_fingerprints_runtime) {
+		delete global_mysql_firewall_whitelist_sqli_fingerprints_runtime;
+		global_mysql_firewall_whitelist_sqli_fingerprints_runtime = NULL;
 	}
 };
 
@@ -2072,6 +2077,8 @@ __exit_process_mysql_query:
 			proxy_error("Firewall problem: unknown user\n");
 			assert(0);
 		}
+	} else {		
+		ret->firewall_whitelist_mode = WUS_NOT_FOUND;
 	}
 	return ret;
 };
@@ -2795,8 +2802,35 @@ void Query_Processor::query_parser_free(SQP_par_t *qp) {
 	}
 };
 
+bool Query_Processor::whitelisted_sqli_fingerprint(char *_s) {
+	bool ret = false;
+	string s = _s;
+	pthread_mutex_lock(&global_mysql_firewall_whitelist_mutex);
+	for (std::vector<std::string>::iterator it = global_mysql_firewall_whitelist_sqli_fingerprints.begin() ; ret == false && it != global_mysql_firewall_whitelist_sqli_fingerprints.end(); ++it) {
+		if (s == *it) {
+			ret = true;
+		}
+	}
+	pthread_mutex_unlock(&global_mysql_firewall_whitelist_mutex);
+	return ret;
+}
+
+void Query_Processor::load_mysql_firewall_sqli_fingerprints(SQLite3_result *resultset) {
+	global_mysql_firewall_whitelist_sqli_fingerprints.erase(global_mysql_firewall_whitelist_sqli_fingerprints.begin(), global_mysql_firewall_whitelist_sqli_fingerprints.end());
+	// perform the inserts
+	for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
+		SQLite3_row *r=*it;
+		int active = atoi(r->fields[0]);
+		if (active == 0) {
+			continue;
+		}
+		char * fingerprint = r->fields[1];
+		string s = fingerprint;
+		global_mysql_firewall_whitelist_sqli_fingerprints.push_back(s);
+	}
+}
+
 void Query_Processor::load_mysql_firewall_users(SQLite3_result *resultset) {
-	// remove all pointer array, and set mode to OFF
 	unsigned long long tot_size = 0;
 	std::unordered_map<std::string, int>::iterator it;
 	for (it = global_mysql_firewall_whitelist_users.begin() ; it != global_mysql_firewall_whitelist_users.end(); ++it) {
@@ -3042,7 +3076,7 @@ int Query_Processor::testing___find_HG_in_mysql_query_rules_fast_routing(char *u
 	return ret;
 }
 
-void Query_Processor::get_current_mysql_firewall_whitelist(SQLite3_result **u, SQLite3_result **r) {
+void Query_Processor::get_current_mysql_firewall_whitelist(SQLite3_result **u, SQLite3_result **r, SQLite3_result **sf) {
 	pthread_mutex_lock(&global_mysql_firewall_whitelist_mutex);
 	if (global_mysql_firewall_whitelist_rules_runtime) {
 		*r = new SQLite3_result(global_mysql_firewall_whitelist_rules_runtime);
@@ -3050,10 +3084,13 @@ void Query_Processor::get_current_mysql_firewall_whitelist(SQLite3_result **u, S
 	if (global_mysql_firewall_whitelist_users_runtime) {
 		*u = new SQLite3_result(global_mysql_firewall_whitelist_users_runtime);
 	}
+	if (global_mysql_firewall_whitelist_sqli_fingerprints_runtime) {
+		*sf = new SQLite3_result(global_mysql_firewall_whitelist_sqli_fingerprints_runtime);
+	}
 	pthread_mutex_unlock(&global_mysql_firewall_whitelist_mutex);
 }
 
-void Query_Processor::load_mysql_firewall(SQLite3_result *u, SQLite3_result *r) {
+void Query_Processor::load_mysql_firewall(SQLite3_result *u, SQLite3_result *r, SQLite3_result *sf) {
 	pthread_mutex_lock(&global_mysql_firewall_whitelist_mutex);
 	if (global_mysql_firewall_whitelist_rules_runtime) {
 		delete global_mysql_firewall_whitelist_rules_runtime;
@@ -3066,9 +3103,14 @@ void Query_Processor::load_mysql_firewall(SQLite3_result *u, SQLite3_result *r) 
 		global_mysql_firewall_whitelist_users_runtime = NULL;
 	}
 	global_mysql_firewall_whitelist_users_runtime = u;
-	global_mysql_firewall_whitelist_users_result___size = u->get_size();
+	if (global_mysql_firewall_whitelist_sqli_fingerprints_runtime) {
+		delete global_mysql_firewall_whitelist_sqli_fingerprints_runtime;
+		global_mysql_firewall_whitelist_sqli_fingerprints_runtime = NULL;
+	}
+	global_mysql_firewall_whitelist_sqli_fingerprints_runtime = sf;
 	load_mysql_firewall_users(global_mysql_firewall_whitelist_users_runtime);
 	load_mysql_firewall_rules(global_mysql_firewall_whitelist_rules_runtime);
+	load_mysql_firewall_sqli_fingerprints(global_mysql_firewall_whitelist_sqli_fingerprints_runtime);
 	pthread_mutex_unlock(&global_mysql_firewall_whitelist_mutex);
 	return;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -961,8 +961,9 @@ void ProxySQL_Main_init_Auth_module() {
 
 void ProxySQL_Main_init_Query_module() {
 	GloQPro = new Query_Processor();
-  GloQPro->print_version();
+	GloQPro->print_version();
 	GloAdmin->init_mysql_query_rules();
+	GloAdmin->init_mysql_firewall();
 }
 
 void ProxySQL_Main_init_MySQL_Threads_Handler_module() {


### PR DESCRIPTION
libsqlinjection generates a lot of false positives.
This commit introduces a new table: mysql_firewall_whitelist_sqli_fingerprints
This table can list fingerprints generated by libsqlinjection:
  if the fingerprint is listed in this table, proxysql will consider it as
  a false positive.

This commit also enables SQLi algorithm only if the query is not already
explicitly whitelisted.