### PR TITLE
Fix digest replace null issue

### DIFF
--- a/lib/c_tokenizer.c
+++ b/lib/c_tokenizer.c
@@ -316,7 +316,7 @@ char *mysql_query_digest_and_first_comment(char *s, int _len, char **first_comme
 								if (*(s+1) == 'u' || *(s+1) == 'U') {
 									if (*(s+2) == 'l' || *(s+2) == 'L') {
 										if (*(s+3) == 'l' || *(s+3) == 'L') {
-											if (i==len-3) {
+											if (i==len-4) {
 												*p_r++ = '?';
 												*p_r = 0;
 												return r;


### PR DESCRIPTION
Description:
Fix for issue #2430 
Tests:
Tested with php script and using different queries.
```
 <?php
 // Connect
 $con=mysqli_connect("127.0.0.1","root","a","proxysql_test",6033);
 
 if (!$con)
 {
     die("Connect Error: " . mysqli_connect_error());
 }

 // ExcuteMultiSQL
 $stmt = $con->query("select * from s_user_attributes where userID = NULL and uu = null or aa=NULL");


 mysqli_close($con);
?>
```

```
mysql> select digest_text from stats.stats_mysql_query_digest where digest_text like '%s_user_attributes%';
+---------------------------------------------------------------------------------------------------+
| digest_text                                                                                       |
+---------------------------------------------------------------------------------------------------+
| select * from s_user_attributes where userID = ? and uu = ? or aa=?                               |
+---------------------------------------------------------------------------------------------------+
```