### PR TITLE
Return error 1290

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -4284,7 +4284,6 @@ handler_again:
 										break;
 									}
 									break;
-								case 1290: // read-only
 								case 1047: // WSREP has not yet prepared node for application use
 								case 1053: // Server shutdown in progress
 									myconn->parent->connect_error(myerr);


### PR DESCRIPTION
**Description:**
Fix for issue #2226. Return error code 1290 to client when backend server started with `--read-only`
**Testing:**
Before fix when client inserts record to the table proxysql disconnects it and prints warning
Server:
```
2019-12-17 09:13:58 MySQL_Session.cpp:4272:handler(): [WARNING] Error during query on (0,127.0.0.1,3306): 1290, The MySQL server is running with the --super-read-only option so it cannot execute this statement
```
CLI:
```
mysql> insert into t (a) values ('1');
ERROR 2013 (HY000): Lost connection to MySQL server during query
```

After fix client is not disconnected. Proxysql returns error 1290 and error message to the client. Proxysql also prints same warning into the log.

```
mysql> insert into t (a) values ('1');
ERROR 1290 (HY000): The MySQL server is running with the --super-read-only option so it cannot execute this statement
```

