### PR TITLE
Fix build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,13 +26,13 @@ Make sure you have installed the equivalent for each of these packages for your 
 Shortcut commands for installing pre-requisites:
 ```
 # RHEL / CentOS < 7:
-yum install automake bzip2 cmake make g++ gcc git openssl openssl-devel patch
+yum install -y automake bzip2 cmake make g++ gcc git openssl openssl-devel gnutls libtool patch
 
 # CentOS 7.4+ / Fedora 28+:
-yum install automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel patch
+yum install -y automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel gnutls gnutls-devel libtool patch
 
 # Debian / Ubuntu Based:
-apt-get install automake bzip2 cmake make g++ gcc git openssl libssl-dev patch
+apt-get install -y automake bzip2 cmake make g++ gcc git openssl libssl-dev libgnutls28-dev libtool patch
 ```
 
 On Mac OSX, Proxysql's dependencies are not fully satisfied by the tools included with the XCode/clang toolkit. The Proxysql build system needs to be told where to find non-system `curl` (and possibly `openssl`) libraries. Using the [Homebrew](https://brew.sh/) OSX package manager, dependencies can be installed and located on OSX like this:


### PR DESCRIPTION
I've been trying to play with Proxysql's codebase and I found something that breaks `make` on Ubuntu/Debian.

https://github.com/sysown/proxysql/commit/1673249da4d3564f154515824e9d09cd6019b82f introduced `libhttpserver` dependency, but `INSTALL.md` wasn't update to include dependencies of that libary:

 * libgnutls for HTTPS support
 * libtool for `toolize` used by libhttpserver's Makefile

I was also surprised that there's no publicly accessible CI integration - would you be open to accepting a PR that would add it?