### PR TITLE
Use terminate handler for C++ exceptions

### DIFF
--- a/include/proxysql.h
+++ b/include/proxysql.h
@@ -105,6 +105,7 @@ int pkt_com_query(unsigned char *, unsigned int);
 enum MySQL_response_type mysql_response(unsigned char *, unsigned int);
 
 void proxy_error_func(const char *, ...);
+void print_backtrace(void);
 
 #ifdef DEBUG
 void init_debug_struct();

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -106,6 +106,41 @@ void proxy_error_func(const char *fmt, ...) {
 	va_end(ap);	
 };
 
+static void full_write(int fd, const char *buf, size_t len)
+{
+	while (len > 0) {
+		ssize_t ret = write(fd, buf, len);
+
+		if ((ret == -1) && (errno != EINTR))
+			break;
+
+		buf += (size_t) ret;
+		len -= (size_t) ret;
+	}
+}
+
+void print_backtrace(void)
+{
+	static const char start[] = "BACKTRACE ------------\n";
+	static const char end[] = "----------------------\n";
+
+	void *bt[1024];
+	int bt_size;
+	char **bt_syms;
+	int i;
+
+	bt_size = backtrace(bt, 1024);
+	bt_syms = backtrace_symbols(bt, bt_size);
+	full_write(STDERR_FILENO, start, strlen(start));
+	for (i = 1; i < bt_size; i++) {
+		size_t len = strlen(bt_syms[i]);
+		full_write(STDERR_FILENO, bt_syms[i], len);
+		full_write(STDERR_FILENO, "\n", 1);
+	}
+	full_write(STDERR_FILENO, end, strlen(end));
+	free(bt_syms);
+}
+
 #ifdef DEBUG
 void init_debug_struct() {	
 	int i;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1498,6 +1498,14 @@ bool ProxySQL_daemonize_phase3() {
 	return true;
 }
 
+void my_terminate(void) {
+	proxy_error("ProxySQL crashed due to exception\n");
+	print_backtrace();
+}
+
+namespace {
+	static const bool SET_TERMINATE = std::set_terminate(my_terminate);
+}
 
 int main(int argc, const char * argv[]) {
 


### PR DESCRIPTION
Description:
STL library is used extensively. Its classes/methods generate exceptions in case of error. The proxysql should print backtrace into the log in case of unhandled exception.