### PR TITLE
Monitor expired password and failed pings

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -2382,7 +2382,7 @@ VALGRIND_ENABLE_ERROR_REPORTING;
 				resultset=NULL;
 			}
 			char *new_query=NULL;
-			new_query=(char *)"SELECT 1 FROM (SELECT hostname,port,ping_error FROM mysql_server_ping_log WHERE hostname='%s' AND port='%s' ORDER BY time_start_us DESC LIMIT %d) a WHERE ping_error IS NOT NULL AND ping_error NOT LIKE 'Access denied for user%%' AND ping_error NOT LIKE 'ProxySQL Error: Access denied for user%%' GROUP BY hostname,port HAVING COUNT(*)=%d";
+			new_query=(char *)"SELECT 1 FROM (SELECT hostname,port,ping_error FROM mysql_server_ping_log WHERE hostname='%s' AND port='%s' ORDER BY time_start_us DESC LIMIT %d) a WHERE ping_error IS NOT NULL AND ping_error NOT LIKE 'Access denied for user%%' AND ping_error NOT LIKE 'ProxySQL Error: Access denied for user%%' AND ping_error NOT LIKE 'Your password has expired.%%' GROUP BY hostname,port HAVING COUNT(*)=%d";
 			for (j=0;j<i;j++) {
 				char *buff=(char *)malloc(strlen(new_query)+strlen(addresses[j])+strlen(ports[j])+16);
 				int max_failures=mysql_thread___monitor_ping_max_failures;


### PR DESCRIPTION
Description:
Do not disable server when password is expired. (issue #2503 )

Test:
```
MySQL [test]> alter user 'monitor'@'%' password expire;
Query OK, 0 rows affected (0.10 sec)

MySQL [test]> flush privileges;
Query OK, 0 rows affected (0.03 sec)
```

After restart proxysql monitor connects to server and puts message in `mysql_server_ping_log`. Server is not shunned after three pings.

```
MySQL [(none)]> select * from mysql_server_ping_log;
+-----------+------+------------------+----------------------+---------------------------------------------------------------------------------------------------------+
| hostname  | port | time_start_us    | ping_success_time_us | ping_error                                                                                              |
+-----------+------+------------------+----------------------+---------------------------------------------------------------------------------------------------------+
| 127.0.0.1 | 3306 | 1580644622092704 | 0                    | Your password has expired. To log in you must change it using a client that supports expired passwords. |
| 127.0.0.1 | 3306 | 1580644632157394 | 0                    | Your password has expired. To log in you must change it using a client that supports expired passwords. |
| 127.0.0.1 | 3306 | 1580644642161557 | 0                    | Your password has expired. To log in you must change it using a client that supports expired passwords. |
+-----------+------+------------------+----------------------+---------------------------------------------------------------------------------------------------------+
3 rows in set (0.00 sec)
```
