### PR TITLE
SELECT CONFIG INTO OUTFILE

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2480,6 +2480,58 @@ bool admin_handler_command_load_or_save(char *query_no_space, unsigned int query
 
 	}
 
+	if (!strncasecmp("SAVE CONFIG TO FILE", query_no_space, strlen("SAVE CONFIG TO FILE"))) {
+		std::string fileName = query_no_space + strlen("SAVE CONFIG TO FILE");
+
+		fileName.erase(0, fileName.find_first_not_of("\t\n\v\f\r "));
+		fileName.erase(fileName.find_last_not_of("\t\n\v\f\r ") + 1);
+		if (fileName.size() == 0) {
+			proxy_error("ProxySQL Admin Error: empty file name\n");
+			SPA->send_MySQL_ERR(&sess->client_myds->myprot, "ProxySQL Admin Error: empty file name");
+			return false;
+		}
+		std::string data;
+		data.reserve(100000);
+		data += config_header;
+		int rc = pa->proxysql_config().Write_Global_Variables_to_configfile(data);
+		rc = pa->proxysql_config().Write_MySQL_Users_to_configfile(data);
+		rc = pa->proxysql_config().Write_MySQL_Query_Rules_to_configfile(data);
+		rc = pa->proxysql_config().Write_MySQL_Servers_to_configfile(data);
+		rc = pa->proxysql_config().Write_Scheduler_to_configfile(data);
+		rc = pa->proxysql_config().Write_ProxySQL_Servers_to_configfile(data);
+		if (rc) {
+			std::stringstream ss;
+			proxy_error("ProxySQL Admin Error: Cannot extract configuration\n");
+			SPA->send_MySQL_ERR(&sess->client_myds->myprot, "ProxySQL Admin Error: Cannot extract configuration");
+			return false;
+		} else {
+			std::ofstream out;
+			out.open(fileName);
+			if (out.is_open()) {
+				out << data;
+				out.close();
+				if (!out) {
+					std::stringstream ss;
+					ss << "ProxySQL Admin Error: Error writing file " << fileName;
+					proxy_error("%s\n", ss.str().c_str());
+					SPA->send_MySQL_ERR(&sess->client_myds->myprot, (char*)ss.str().c_str());
+					return false;
+				} else {
+					std::stringstream ss;
+					ss << "File " << fileName << " is saved.";
+					SPA->send_MySQL_OK(&sess->client_myds->myprot, (char*)ss.str().c_str());
+					return false;
+				}
+			} else {
+				std::stringstream ss;
+				ss << "ProxySQL Admin Error: Cannot open file " << fileName;
+				proxy_error("%s\n", ss.str().c_str());
+				SPA->send_MySQL_ERR(&sess->client_myds->myprot, (char*)ss.str().c_str());
+				return false;
+			}
+		}
+	}
+
 	return true;
 }
 
@@ -3791,8 +3843,8 @@ void admin_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *pkt) {
 		goto __run_query;
 	}
 
-	if (!strncasecmp("SELECT CONFIG TO", query_no_space, strlen("SELECT CONFIG TO"))) {
-		std::string fileName = query_no_space + strlen("SELECT CONFIG TO");
+	if (!strncasecmp("SELECT CONFIG INTO OUTFILE", query_no_space, strlen("SELECT CONFIG INTO OUTFILE"))) {
+		std::string fileName = query_no_space + strlen("SELECT CONFIG INTO OUTFILE");
 		fileName.erase(0, fileName.find_first_not_of("\t\n\v\f\r "));
 		fileName.erase(fileName.find_last_not_of("\t\n\v\f\r ") + 1);
 		if (fileName.size() == 0) {

--- a/test/tap/tests/select_config_file-t.cpp
+++ b/test/tap/tests/select_config_file-t.cpp
@@ -15,7 +15,7 @@
 
 int select_config_file(MYSQL* mysql, std::string& resultset) {
 	if (mysql_query(mysql, "select config file")) {
-	    fprintf(stderr, "File %s, line %d, Error: %s\n",
+	    fprintf(stderr, "File %s, line %d, Error: 2 %s\n",
 	              __FILE__, __LINE__, mysql_error(mysql));
 		return exit_status();
 	}
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
 		return exit_status();
 
 	plan(1);
-	diag("Testing SELECT CONFIG FILE");
+	diag("Testing SELECT CONFIG INTO OUTFILE");
 
 	MYSQL* mysql = mysql_init(NULL);
 	if (!mysql)
@@ -108,6 +108,12 @@ int main(int argc, char** argv) {
 
 		ok(!str.compare(resultset), "Files are equal");
 	}
+
+#if 0
+	std::ofstream out("output.cnf");
+	out << resultset;
+	out.close();
+#endif
 
 	MYSQL_QUERY(mysql, "load mysql variables from disk");
 	MYSQL_QUERY(mysql, "load admin variables from disk");


### PR DESCRIPTION
Description:

Changed command from `select config to` to `select config into outfile`. Also alias `save config to file` is added.

Testing:

```
MySQL [(none)]> select config into outfile /tmp/f1;
Query OK, 9179 rows affected (0.00 sec)
File /tmp/f1 is saved.
```

```
MySQL [(none)]> save config to file /tmp/f3;
Query OK, 0 rows affected (0.00 sec)
File /tmp/f3 is saved.
```