### PR TITLE
Include apt-transport-https

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Alternatively you can also use the available repositories:
 
 Adding repository:
 ```bash
-apt-get install -y lsb-release
+apt-get install -y lsb-release apt-transport-https
 wget -O - 'https://repo.proxysql.com/ProxySQL/repo_pub_key' | apt-key add -
 echo deb https://repo.proxysql.com/ProxySQL/proxysql-2.0.x/$(lsb_release -sc)/ ./ \
 | tee /etc/apt/sources.list.d/proxysql.list


### PR DESCRIPTION
On Debian systems, the package `apt-transport-https` is not installed by default, and if you follow the instructions as written in the README.md, you will get an error like this:

```
E: The method driver /usr/lib/apt/methods/https could not be found.
N: Is the package apt-transport-https installed?
E: Failed to fetch https://repo.proxysql.com/ProxySQL/proxysql-2.0.x/stretch/./InRelease  
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

This simply adds the package to the install instructions for Debian/Ubuntu systems. If it is already installed, it will not produce any additional issue.