### PR TITLE
Tune logic for waiting on read replicas

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2755,7 +2755,11 @@ bool MySQL_Session::handler_again___status_CONNECTING_SERVER(int *_rc) {
 				PROXY_TRACE();
 			}
 			char buf[256];
-			sprintf(buf,"Max connect timeout reached while reaching hostgroup %d after %llums", current_hostgroup, (thread->curtime - CurrentQuery.start_time)/1000 );
+			if (qpo->min_gtid) {
+				sprintf(buf,"Gave up waiting for GTID on hostgroup %d after %llums", current_hostgroup, (thread->curtime - CurrentQuery.start_time)/1000 );
+			} else {
+				sprintf(buf,"Max connect timeout reached while reaching hostgroup %d after %llums", current_hostgroup, (thread->curtime - CurrentQuery.start_time)/1000 );
+			}
 			if (thread) {
 				thread->status_variables.max_connect_timeout_err++;
 			}


### PR DESCRIPTION
Passing `min_gtid` annotation on a query (https://github.com/sysown/proxysql/pull/2469) without backends being up to date will make ProxySQL wait for `connect_timeout_server`, and then reply with `Max connect timeout reached while reaching hostgroup 1`.

`connect_timeout_server` is a global setting, and if in your setup it's a multiple seconds value, you may not wait to make the client wait that long. We'd rather return "no replicas caught up" as early as possible.

I'm looking to make the case of "waiting for GTID" treated differently from the case of "waiting for hostgroup to become available" (for instance because it's tripped on max_connections).

There's couple things I want to do:

* Reply with a custom error message ("Gave up waiting for GTID...")
* Don't wait for as long as `connect_timeout_server` for replicas to catch up. Maybe introduce another global (or per host group?) setting to configure that?

Thoughts? @renecannao 