### PR TITLE
Fix galera query in maint_mode

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1589,7 +1589,7 @@ void * monitor_galera_thread(void *arg) {
 			mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,"SELECT (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
 			"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
 			"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
-			"(SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , SELECT 'DISABLED' pxc_maint_mode");
+			"(SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , (SELECT 'DISABLED') pxc_maint_mode");
 		}
 #endif // TEST_GALERA
 	}


### PR DESCRIPTION
Fix #2537 

Tested like this:
```
MySQL [(none)]> SELECT 1, SELECT 'DISABLED' pxc_maint_mode;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SELECT 'DISABLED' pxc_maint_mode' at line 1
MySQL [(none)]> SELECT 1, (SELECT 'DISABLED') pxc_maint_mode;
+---+----------------+
| 1 | pxc_maint_mode |
+---+----------------+
| 1 | DISABLED       |
+---+----------------+
1 row in set (0.00 sec)
```