### PR TITLE
fix firewall whitelist rules

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -8076,7 +8076,7 @@ void ProxySQL_Admin::save_mysql_firewall_whitelist_rules_from_runtime(bool _runt
 					rc=sqlite3_reset(statement32); ASSERT_SQLITE_OK(rc, admindb);
 				}
 			} else { // single row
-				rc=sqlite3_bind_int64(statement1, 1, atoi(r1->fields[3])); ASSERT_SQLITE_OK(rc, admindb);
+				rc=sqlite3_bind_int64(statement1, 1, atoi(r1->fields[0])); ASSERT_SQLITE_OK(rc, admindb);
 				rc=sqlite3_bind_text(statement1, 2, r1->fields[1], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb);
 				rc=sqlite3_bind_text(statement1, 3, r1->fields[2], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb);
 				rc=sqlite3_bind_text(statement1, 4, r1->fields[3], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb);


### PR DESCRIPTION
Description:
Fixing issue #2534 
Testing:
```
MySQL [(none)]> select * from runtime_mysql_firewall_whitelist_users;
+--------+----------+----------------+------------+---------+
| active | username | client_address | mode       | comment |
+--------+----------+----------------+------------+---------+
| 1      | root     |                | PROTECTING | comm    |
+--------+----------+----------------+------------+---------+
1 row in set (0.00 sec)

MySQL [(none)]> select * from runtime_mysql_firewall_whitelist_rules;
+--------+----------+----------------+--------------------+--------+--------------------+---------+
| active | username | client_address | schemaname         | flagIN | digest             | comment |
+--------+----------+----------------+--------------------+--------+--------------------+---------+
| 1      | root     |                | information_schema | 0      | 0x37B5362567EE37EF |         |
+--------+----------+----------------+--------------------+--------+--------------------+---------+
1 row in set (0.00 sec)
```

```
MySQL [(none)]> Select 2;
+---+
| 2 |
+---+
| 2 |
+---+
1 row in set (0.00 sec)
```