### PR TITLE
add mysql thread_id to events log

### DIFF
--- a/include/MySQL_Data_Stream.h
+++ b/include/MySQL_Data_Stream.h
@@ -194,6 +194,7 @@ class MySQL_Data_Stream
 		myconn=mc;
 		myconn->statuses.myconnpoll_get++;
 		mc->myds=this;
+		sess->mysql_tid=myconn->get_mysql_thread_id();
 	}
 
 	// safe way to detach a MySQL Connection

--- a/include/MySQL_Logger.hpp
+++ b/include/MySQL_Logger.hpp
@@ -8,6 +8,7 @@
 class MySQL_Event {
 	private:
 	uint32_t thread_id;
+	unsigned long mysql_thread_id;
 	char *username;
 	char *schemaname;
 	size_t username_len;
@@ -31,7 +32,7 @@ class MySQL_Event {
 	uint64_t affected_rows;
 	uint64_t rows_sent;
 	public:
-	MySQL_Event(log_event_type _et, uint32_t _thread_id, char * _username, char * _schemaname , uint64_t _start_time , uint64_t _end_time , uint64_t _query_digest, char *_client, size_t _client_len);
+	MySQL_Event(log_event_type _et, uint32_t _thread_id, char * _username, char * _schemaname , uint64_t _start_time , uint64_t _end_time , uint64_t _query_digest, char *_client, size_t _client_len, unsigned long tid);
 	uint64_t write(std::fstream *f, MySQL_Session *sess);
 	uint64_t write_query_format_1(std::fstream *f);
 	uint64_t write_query_format_2_json(std::fstream *f);

--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -208,6 +208,7 @@ class MySQL_Session
 	Session_Regex **match_regexes;
 
 	void *ldap_ctx;
+	unsigned long mysql_tid;
 
 	// this variable is relevant only if status == SETTING_VARIABLE
 	enum variable_name changing_variable_idx;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -3790,7 +3790,7 @@ handler_again:
 						if (myerr >= 2000 && myerr < 3000) {
 							bool retry_conn=false;
 							// client error, serious
-							proxy_error("Detected a broken connection during query on (%d,%s,%d,%lu) , FD (Conn:%d , MyDS:%d) : %d, %s\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, myconn->get_mysql_thread_id(), myds->fd, myds->myconn->fd,  myerr, ( errmsg ? errmsg : mysql_error(myconn->mysql)));
+							proxy_error("Detected a broken connection during query on (%d,%s,%d,%lu) , FD (Conn:%d , MyDS:%d) : %d, %s\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, mysql_tid, myds->fd, myds->myconn->fd,  myerr, ( errmsg ? errmsg : mysql_error(myconn->mysql)));
 							if (myds->query_retries_on_failure > 0) {
 								myds->query_retries_on_failure--;
 								if ((myds->myconn->reusable==true) && myds->myconn->IsActiveTransaction()==false && myds->myconn->MultiplexDisabled()==false) {
@@ -3835,9 +3835,9 @@ handler_again:
 							return handler_ret;
 						} else {
 							if (mysql_thread___verbose_query_error) {
-								proxy_warning("Error during query on (%d,%s,%d,%lu) , user \"%s@%s\" , schema \"%s\" , %d, %s . digest_text = \"%s\"\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, myconn->get_mysql_thread_id(), client_myds->myconn->userinfo->username, (client_myds->addr.addr ? client_myds->addr.addr : (char *)"unknown" ), client_myds->myconn->userinfo->schemaname, myerr, ( errmsg ? errmsg : mysql_error(myconn->mysql)), CurrentQuery.QueryParserArgs.digest_text );
+								proxy_warning("Error during query on (%d,%s,%d,%lu) , user \"%s@%s\" , schema \"%s\" , %d, %s . digest_text = \"%s\"\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, mysql_tid, client_myds->myconn->userinfo->username, (client_myds->addr.addr ? client_myds->addr.addr : (char *)"unknown" ), client_myds->myconn->userinfo->schemaname, myerr, ( errmsg ? errmsg : mysql_error(myconn->mysql)), CurrentQuery.QueryParserArgs.digest_text );
 							} else {
-								proxy_warning("Error during query on (%d,%s,%d,%lu): %d, %s\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, myconn->get_mysql_thread_id(), myerr, ( errmsg ? errmsg : mysql_error(myconn->mysql)));
+								proxy_warning("Error during query on (%d,%s,%d,%lu): %d, %s\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, mysql_tid, myerr, ( errmsg ? errmsg : mysql_error(myconn->mysql)));
 							}
 							MyHGM->add_mysql_errors(myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, client_myds->myconn->userinfo->username, (client_myds->addr.addr ? client_myds->addr.addr : (char *)"unknown" ), client_myds->myconn->userinfo->schemaname, myerr, (char *)( errmsg ? errmsg : mysql_error(myconn->mysql)));
 							bool retry_conn=false;
@@ -3901,7 +3901,7 @@ handler_again:
 									//return handler_ret;
 									break;
 								case 1153: // ER_NET_PACKET_TOO_LARGE
-									proxy_warning("Error ER_NET_PACKET_TOO_LARGE during query on (%d,%s,%d,%lu): %d, %s\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, myconn->get_mysql_thread_id(), myerr, mysql_error(myconn->mysql));
+									proxy_warning("Error ER_NET_PACKET_TOO_LARGE during query on (%d,%s,%d,%lu): %d, %s\n", myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, mysql_tid, myerr, mysql_error(myconn->mysql));
 									break;
 								default:
 									break; // continue normally

--- a/tools/eventslog_reader_sample.cpp
+++ b/tools/eventslog_reader_sample.cpp
@@ -91,6 +91,7 @@ char * read_string(std::fstream *f, size_t len) {
 
 class MySQL_Event {
 	private:
+	unsigned long mysql_thread_id;
 	uint32_t thread_id;
 	char *username;
 	char *schemaname;
@@ -129,6 +130,7 @@ class MySQL_Event {
 	void read_query(std::fstream *f) {
 
 		read_encoded_length((uint64_t *)&thread_id,f);
+		read_encoded_length((uint64_t *)&mysql_thread_id,f);
 		read_encoded_length((uint64_t *)&username_len,f);
 		username=read_string(f,username_len);
 		read_encoded_length((uint64_t *)&schemaname_len,f);
@@ -150,7 +152,7 @@ class MySQL_Event {
 				assert(0); // not supported
 				break;
 		}
-		cout << ": thread_id=\"" << thread_id << "\" username=\"" << username << "\" schemaname=\"" << schemaname << "\" client=\"" << client << "\"";
+		cout << ": thread_id=\"" << thread_id << "\" mysql_thread_id=\"" << mysql_thread_id << "\" username=\"" << username << "\" schemaname=\"" << schemaname << "\" client=\"" << client << "\"";
 		read_encoded_length((uint64_t *)&hid,f);
 		if (hid==UINT64_MAX) {
 			cout << " HID=NULL ";


### PR DESCRIPTION
Description:
Add mysql thread_id to events log. This PR is related to #2526 and #2529 

Testing:
1. Query table that doesn't exist
```
MySQL [test]> select * from t2;
ERROR 1146 (42S02): Table 'test.t2' doesn't exist
```
```
2020-02-26 07:59:25 MySQL_Session.cpp:4333:handler(): [WARNING] Error during query on (0,127.0.0.1,3306,57): 1146, Table 'test.t2' doesn't exist
```

2. Execute query that timed out
```
MySQL [test]> select sleep(100);
+------------+
| sleep(100) |
+------------+
|          1 |
+------------+
1 row in set (1.00 sec)
```

```
2020-02-26 07:51:29 MySQL_Session.cpp:128:kill_query_thread(): [WARNING] KILL QUERY 57 on 127.0.0.1:3306
```

```
val@s89830:~/workspace/sysown_proxysql/src$ ../tools/eventslog_reader_sample ./events.log.00000013
ProxySQL LOG COM_QUERY: thread_id="2" mysql_thread_id="57" username="root" schemaname="test" client="127.0.0.1:35394" HID=0 server="127.0.0.1:3306" starttime="2020-02-26 07:51:28.112630" endtime="2020-02-26 07:51:29.115235" duration=1002605us rows_affected=0 rows_sent=1 digest="0xCA0825C1C5C3C490"
select sleep(100)
ProxySQL LOG COM_QUERY: thread_id="2" mysql_thread_id="57" username="root" schemaname="test" client="127.0.0.1:35394" HID=0 server="127.0.0.1:3306" starttime="2020-02-26 07:59:25.946665" endtime="2020-02-26 07:59:25.947311" duration=646us rows_affected=0 rows_sent=0 digest="0x1CA8F88B407B7239"
select * from t2
```
