### PR TITLE
Revert to auto configuration of build job num

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,7 @@ ifeq ($(OS),Darwin)
 	NPROCS := $(shell sysctl -n hw.ncpu)
 endif
 
-# Force to 8 for automatic build
-export MAKEOPT=-j 8
-
-#export MAKEOPT=-j ${NPROCS}
+export MAKEOPT=-j ${NPROCS}
 
 ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)
 	SYSTEMD=1


### PR DESCRIPTION
Removing patch to force 8x jobs during build, this was needed to build the previous version of the package.