### PR TITLE
Improve centos6 detection

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -10,7 +10,7 @@ MYJEOPT=--enable-xmalloc --enable-prof
 endif
 
 ifneq (,$(wildcard /etc/system-release))
-	CENTOSVER := $(shell cat /etc/system-release | awk '{print $$3}')
+	CENTOSVER := $(shell rpm --eval %rhel)
 else
 	CENTOSVER := Unknown
 endif
@@ -66,7 +66,7 @@ libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
 	cd libmicrohttpd && rm -rf libmicrohttpd-0.9.55 || true
 	cd libmicrohttpd && rm -rf libmicrohttpd-0.9.68 || true
 	cd libmicrohttpd && rm -f libmicrohttpd || true
-ifeq ($(CENTOSVER),6.7)
+ifeq ($(CENTOSVER),6)
 	cd libmicrohttpd && ln -s libmicrohttpd-0.9.55 libmicrohttpd
 	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.55.tar.gz
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ GIT_VERSION := $(shell git describe --long)
 DEPS_PATH=../deps
 
 ifneq (,$(wildcard /etc/system-release))
-	CENTOSVER := $(shell cat /etc/system-release | awk '{print $$3}')
+	CENTOSVER := $(shell rpm --eval %rhel)
 else
 	CENTOSVER := Unknown
 endif
@@ -109,7 +109,7 @@ endif
 ifeq ($(UNAME_S),FreeBSD)
 	MYLIBS+= -lexecinfo
 endif
-ifeq ($(CENTOSVER),6.7)
+ifeq ($(CENTOSVER),6)
 	MYLIBS+= -lgcrypt
 endif
 


### PR DESCRIPTION
Centos6.7 is quite old version and the build can be done on 6.8 6.9 6.10 etc.
Previous code supported only centos6.7 build which is not very useful.
With this change system will detect if it centos6 only.