### PR TITLE
Added signal handler installation when running in the foreground

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1753,6 +1753,7 @@ gotofork:
 
 	} else {
 		GloAdmin->flush_error_log();
+		GloVars.install_signal_handler();
 	}
 
 __start_label:


### PR DESCRIPTION
When running in a Docker container with the foreground option I noticed that container restarts were taking too long.  After a little investigation it seems like the cause is due to the signal handlers not being installed in this mode.  After applying this patch I am able to send signals to the proxysql process inside a Docker container and have it respond as needed.