### PR TITLE
fix multi statement

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1873,7 +1873,7 @@ bool MySQL_Session::handler_again___verify_backend_net_write_timeout() {
 }
 
 bool MySQL_Session::handler_again___verify_backend_multi_statement() {
-	if (client_myds->myconn->options.client_flag & CLIENT_MULTI_STATEMENTS != mybe->server_myds->myconn->options.client_flag & CLIENT_MULTI_STATEMENTS) {
+	if ((client_myds->myconn->options.client_flag & CLIENT_MULTI_STATEMENTS) != (mybe->server_myds->myconn->options.client_flag & CLIENT_MULTI_STATEMENTS)) {
 
 		if (client_myds->myconn->options.client_flag & CLIENT_MULTI_STATEMENTS)
 			mybe->server_myds->myconn->options.client_flag |= CLIENT_MULTI_STATEMENTS;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2607,7 +2607,11 @@ bool MySQL_Session::handler_again___status_SETTING_MULTI_STMT(int *_rc) {
 		previous_status.pop();
 		NEXT_IMMEDIATE_NEW(st);
 	} else {
-		proxy_error("Error setting multistatemnt on server\n");
+		if (rc==-1) {
+			proxy_error("Error setting multistatement on server %s , %d : %d, %s\n", myconn->parent->address, myconn->parent->port, mysql_errno(myconn->mysql), mysql_error(myconn->mysql));
+		} else {
+			// rc==1 , nothing to do for now
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
Description:
Fixes the issue #2631 

Testing:
Tested with scripts related #2298 and #2631 

```
single('SELECT @@report_host');
multi('SELECT 1; SELECT 2;');
```


```
$ php -f test_2631.php
Run using query: SELECT @@report_host
=> No errors

-----
Run using multi_query: SELECT 1; SELECT 2;
=> No errors
1
2
-----
```