### PR TITLE
Fix Multistatement parsing error

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1311,6 +1311,17 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 		}
 		client_myds->DSS=STATE_QUERY_SENT_NET;
 		if (!c) {
+			client_myds->DSS=STATE_SLEEP;
+			status=WAITING_CLIENT_DATA;
+			if (mirror==false) {
+				RequestEnd(NULL);
+			}
+			free(unstripped);
+			__sync_fetch_and_add(&MyHGM->status.frontend_set_names, 1);
+
+			return false;
+		}
+		if (!c) {
 			char *m = NULL;
 			char *errmsg = NULL;
 			if (collation_specified) {


### PR DESCRIPTION
Description:
Fixes issue #2655 
Testing:
1. Tested with modified script
```
<?php
// Connect
$con=mysqli_connect("127.0.0.1","root","root","proxysql_test",6033);

if (!$con)
{
    die("Connect Error: " . mysqli_connect_error());
}

$query  = "set names utf8; SELECT 2 limit 2;";
if (mysqli_multi_query($con, $query)) {
    echo("OK");
}
else {
    printf("query failed: %s\n", $con->error);
}
mysqli_close($con);
?>
```
2. Tested with automated script in branch `v2.0.11-var`
3. Tested with valgrind

The set names query in multi statement processed w/o error. No memory leaks or regressions were detected because of the fix.