### PR TITLE
Consistent reads from db replicas using unit-of-work identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,9 @@ heaptrack.*
 
 #tap tests
 *-t
+config/secrets.yml
+*~
+proxysql.db
+proxysql_stats.db
+proxysql.db.bak
+*.pem

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -191,7 +191,7 @@ class MyHGC {	// MySQL Host Group Container
 	MySrvList *mysrvs;
 	MyHGC(int);
 	~MyHGC();
-	MySrvC *get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, int max_lag_ms, MySQL_Session *sess);
+	MySrvC *get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, int max_lag_ms, MySQL_Session *sess, uint32_t server_hash = 0);
 };
 
 class Group_Replication_Info {
@@ -379,7 +379,7 @@ class MySQL_HostGroups_Manager {
 	
 	void MyConn_add_to_pool(MySQL_Connection *);
 
-	MySQL_Connection * get_MyConn_from_pool(unsigned int hid, MySQL_Session *sess, bool ff, char * gtid_uuid, uint64_t gtid_trxid, int max_lag_ms);
+	MySQL_Connection * get_MyConn_from_pool(unsigned int hid, MySQL_Session *sess, bool ff, char * gtid_uuid, uint64_t gtid_trxid, int max_lag_ms, uint32_t server_hash);
 
 	void drop_all_idle_connections();
 	int get_multiple_idle_connections(int, unsigned long long, MySQL_Connection **, int);

--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -94,7 +94,7 @@ class MySQL_Session
 	void handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_PROCESS_KILL(PtrSize_t *);
 	bool handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo(PtrSize_t *, bool *lock_hostgroup, bool ps=false);
 
-	void handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED__get_connection();	
+	void handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED__get_connection(uint32_t server_hash);	
 
 	void return_proxysql_internal(PtrSize_t *);
 	bool handler_special_queries(PtrSize_t *);
@@ -121,7 +121,7 @@ class MySQL_Session
 	bool handler_again___status_SETTING_SESSION_TRACK_GTIDS(int *);
 	bool handler_again___status_CHANGING_CHARSET(int *_rc);
 	bool handler_again___status_CHANGING_SCHEMA(int *);
-	bool handler_again___status_CONNECTING_SERVER(int *);
+	bool handler_again___status_CONNECTING_SERVER(int *, uint32_t server_hash);
 	bool handler_again___status_CHANGING_USER_SERVER(int *);
 	bool handler_again___status_CHANGING_AUTOCOMMIT(int *);
 	bool handler_again___status_SETTING_MULTI_STMT(int *_rc);

--- a/include/proxysql_glovars.hpp
+++ b/include/proxysql_glovars.hpp
@@ -59,6 +59,9 @@ class ProxySQL_GlobalVariables {
 	char * execute_on_exit_failure;
 	char * web_interface_plugin;
 	char * ldap_auth_plugin;
+	char *query_parser_token_delimiters;
+	char *query_parser_key_value_delimiters;
+	char *unit_of_work_identifiers;
 	struct  {
 		unsigned long long start_time;
 		bool gdbg;

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -125,6 +125,7 @@ class Query_Processor_Output {
 	int timeout;
 	int retries;
 	int delay;
+	uint32_t server_hash;
 	char *error_msg;
 	char *OK_msg;
 	int sticky_conn;
@@ -162,6 +163,7 @@ class Query_Processor_Output {
 		timeout=-1;
 		retries=-1;
 		delay=-1;
+		server_hash=(uint32_t)0;
 		sticky_conn=-1;
 		multiplex=-1;
 		gtid_from_hostgroup=-1;
@@ -300,7 +302,7 @@ class Query_Processor {
 
 	void query_parser_init(SQP_par_t *qp, char *query, int query_length, int flags);
 	enum MYSQL_COM_QUERY_command query_parser_command_type(SQP_par_t *qp);
-	bool query_parser_first_comment(Query_Processor_Output *qpo, char *fc);
+	void query_parser_first_comment(Query_Processor_Output *qpo, char *fc);
 	void query_parser_free(SQP_par_t *qp);
 	char * get_digest_text(SQP_par_t *qp);
 	uint64_t get_digest(SQP_par_t *qp);

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2428,7 +2428,7 @@ bool MySQL_Session::handler_again___status_CHANGING_SCHEMA(int *_rc) {
 }
 
 
-bool MySQL_Session::handler_again___status_CONNECTING_SERVER(int *_rc) { 
+bool MySQL_Session::handler_again___status_CONNECTING_SERVER(int *_rc, uint32_t server_hash) { 
 	//fprintf(stderr,"CONNECTING_SERVER\n");
 	unsigned long long curtime=monotonic_time();
 	thread->atomic_curtime=curtime;
@@ -2466,7 +2466,7 @@ bool MySQL_Session::handler_again___status_CONNECTING_SERVER(int *_rc) {
 		}
 	}
 	if (mybe->server_myds->myconn==NULL) {
-		handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED__get_connection();
+		handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED__get_connection(server_hash);
 	}
 	if (mybe->server_myds->myconn==NULL) {
 		if (mirror) {
@@ -4177,7 +4177,7 @@ handler_again:
 		case CONNECTING_SERVER:
 			{
 				int rc=0;
-				if (handler_again___status_CONNECTING_SERVER(&rc))
+				if (handler_again___status_CONNECTING_SERVER(&rc, qpo->server_hash))
 					goto handler_again;	// we changed status
 				if (rc==1) //handler_again___status_CONNECTING_SERVER returns 1
 					goto __exit_DSS__STATE_NOT_INITIALIZED;
@@ -5756,7 +5756,7 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 	}
 }
 
-void MySQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED__get_connection() {
+void MySQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED__get_connection(uint32_t server_hash) {
 			// Get a MySQL Connection
 
 		MySQL_Connection *mc=NULL;
@@ -5809,16 +5809,16 @@ void MySQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 					}
 				}
 				uuid[n]='\0';
-				mc=thread->get_MyConn_local(mybe->hostgroup_id, this, uuid, trxid, -1);
+				mc = (server_hash != 0) ? NULL : thread->get_MyConn_local(mybe->hostgroup_id, this, uuid, trxid, -1);
 			} else {
-				mc=thread->get_MyConn_local(mybe->hostgroup_id, this, NULL, 0, (int)qpo->max_lag_ms);
+				mc = (server_hash != 0) ? NULL : thread->get_MyConn_local(mybe->hostgroup_id, this, NULL, 0, (int)qpo->max_lag_ms);
 			}
 		}
 		if (mc==NULL) {
 			if (trxid) {
-				mc=MyHGM->get_MyConn_from_pool(mybe->hostgroup_id, this, session_fast_forward, uuid, trxid, -1);
+				mc=MyHGM->get_MyConn_from_pool(mybe->hostgroup_id, this, session_fast_forward, uuid, trxid, -1, server_hash);
 			} else {
-				mc=MyHGM->get_MyConn_from_pool(mybe->hostgroup_id, this, session_fast_forward, NULL, 0, (int)qpo->max_lag_ms);
+				mc=MyHGM->get_MyConn_from_pool(mybe->hostgroup_id, this, session_fast_forward, NULL, 0, (int)qpo->max_lag_ms, server_hash);
 			}
 		} else {
 			thread->status_variables.ConnPool_get_conn_immediate++;

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -42,6 +42,18 @@ ProxySQL_GlobalVariables::~ProxySQL_GlobalVariables() {
 		free(ldap_auth_plugin);
 		ldap_auth_plugin = NULL;
 	}
+	if (query_parser_token_delimiters) {
+		free(query_parser_token_delimiters);
+		query_parser_token_delimiters = NULL;
+	}
+	if (query_parser_key_value_delimiters) {
+		free(query_parser_key_value_delimiters);
+		query_parser_key_value_delimiters = NULL;
+	}
+	if (unit_of_work_identifiers) {
+		free(unit_of_work_identifiers);
+		unit_of_work_identifiers = NULL;
+	}
 };
 
 ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
@@ -80,6 +92,9 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 	checksums_values.global_checksum = 0;
 	execute_on_exit_failure = NULL;
 	ldap_auth_plugin = NULL;
+	query_parser_token_delimiters = strdup(";");
+	query_parser_key_value_delimiters = strdup("=");
+	unit_of_work_identifiers = NULL;
 #ifdef DEBUG
 	global.gdb=0;
 #endif

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -2367,15 +2367,15 @@ __exit__query_parser_command_type:
 	return ret;
 }
 
-bool Query_Processor::query_parser_first_comment(Query_Processor_Output *qpo, char *fc) {
-	bool ret=false;
+void Query_Processor::query_parser_first_comment(Query_Processor_Output *qpo, char *fc) {
 	tokenizer_t tok;
-	tokenizer( &tok, fc, ";", TOKENIZER_NO_EMPTIES );
 	const char* token;
+
+	tokenizer (&tok, fc, GloVars.query_parser_token_delimiters, TOKENIZER_NO_EMPTIES);
 	for ( token = tokenize( &tok ) ; token ;  token = tokenize( &tok ) ) {
 		char *key=NULL;
 		char *value=NULL;
-    c_split_2(token, "=", &key, &value);
+		c_split_2(token, GloVars.query_parser_key_value_delimiters, &key, &value);
 		remove_spaces(key);
 		remove_spaces(value);
 		if (strlen(key)) {
@@ -2386,37 +2386,37 @@ bool Query_Processor::query_parser_first_comment(Query_Processor_Output *qpo, ch
 					qpo->cache_ttl=t;
 				}
 			}
-			if (!strcasecmp(key,"query_delay")) {
+			else if (!strcasecmp(key,"query_delay")) {
 				if (c >= '0' && c <= '9') { // it is a digit
 					int t=atoi(value);
 					qpo->delay=t;
 				}
 			}
-			if (!strcasecmp(key,"query_retries")) {
+			else if (!strcasecmp(key,"query_retries")) {
 				if (c >= '0' && c <= '9') { // it is a digit
 					int t=atoi(value);
 					qpo->retries=t;
 				}
 			}
-			if (!strcasecmp(key,"query_timeout")) {
+			else if (!strcasecmp(key,"query_timeout")) {
 				if (c >= '0' && c <= '9') { // it is a digit
 					int t=atoi(value);
 					qpo->timeout=t;
 				}
 			}
-			if (!strcasecmp(key,"hostgroup")) {
+			else if (!strcasecmp(key,"hostgroup")) {
 				if (c >= '0' && c <= '9') { // it is a digit
 					int t=atoi(value);
 					qpo->destination_hostgroup=t;
 				}
 			}
-			if (!strcasecmp(key,"mirror")) {
+			else if (!strcasecmp(key,"mirror")) {
 				if (c >= '0' && c <= '9') { // it is a digit
 					int t=atoi(value);
 					qpo->mirror_hostgroup=t;
 				}
 			}
-			if (!strcasecmp(key,"max_lag_ms")) {
+			else if (!strcasecmp(key,"max_lag_ms")) {
 				if (c >= '0' && c <= '9') { // it is a digit
 					int t=atoi(value);
 					if (t >= 0 && t <= 600000) {
@@ -2424,7 +2424,7 @@ bool Query_Processor::query_parser_first_comment(Query_Processor_Output *qpo, ch
 					}
 				}
 			}
-			if (!strcasecmp(key,"min_epoch_ms")) {
+			else if (!strcasecmp(key,"min_epoch_ms")) {
 				if (c >= '0' && c <= '9') { // it is a digit
 					unsigned long long now_us = realtime_time();
 					unsigned long long now_ms = now_us/1000;
@@ -2436,7 +2436,7 @@ bool Query_Processor::query_parser_first_comment(Query_Processor_Output *qpo, ch
 					}
 				}
 			}
-			if (!strcasecmp(key,"min_gtid")) {
+			else if (!strcasecmp(key,"min_gtid")) {
 				size_t l = strlen(value);
 				if (is_valid_gtid(value, l)) {
 					char *buf=(char*)malloc(l+1);
@@ -2446,6 +2446,20 @@ bool Query_Processor::query_parser_first_comment(Query_Processor_Output *qpo, ch
 				} else {
 					proxy_warning("Invalid gtid value=%s\n", value);
 				}
+			} else if (GloVars.unit_of_work_identifiers) {
+				tokenizer_t names;
+				tokenizer (&names, GloVars.unit_of_work_identifiers, ",", TOKENIZER_NO_EMPTIES);
+				const char* unit_of_work_name;
+
+				while ((unit_of_work_name = tokenize(&names))) {
+					if (!strcasecmp(key, unit_of_work_name)) {
+						qpo->server_hash = max(SpookyHash::Hash32(value, strlen(value), qpo->server_hash), (uint32_t)1);
+						// We use the current hash as the seed; if multiple IDs are passed, they will
+						// in effect chain together to yield a unique hash for that sequence.
+						// Make it at least 1 because the default value of 0 means undefined.
+						break;
+					}
+				}
 			}
 		}
 
@@ -2454,7 +2468,6 @@ bool Query_Processor::query_parser_first_comment(Query_Processor_Output *qpo, ch
 		free(value);
 	}
 	free_tokenizer( &tok );
-	return ret;
 }
 
 bool Query_Processor::is_valid_gtid(char *gtid, size_t gtid_len) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -852,6 +852,32 @@ void ProxySQL_Main_process_global_variables(int argc, const char **argv) {
 				GloVars.ldap_auth_plugin=strdup(ldap_auth_plugin.c_str());
 			}
 		}
+		if (root.exists("query_parser_token_delimiters")==true) {
+			string query_parser_token_delimiters;
+			bool rc;
+			rc=root.lookupValue("query_parser_token_delimiters", query_parser_token_delimiters);
+			if (rc==true) {
+				if (GloVars.query_parser_token_delimiters) free (GloVars.query_parser_token_delimiters);
+				GloVars.query_parser_token_delimiters=strdup(query_parser_token_delimiters.c_str());
+			}
+		}
+		if (root.exists("query_parser_key_value_delimiters")==true) {
+			string query_parser_key_value_delimiters;
+			bool rc;
+			rc=root.lookupValue("query_parser_key_value_delimiters", query_parser_key_value_delimiters);
+			if (rc==true) {
+				if (GloVars.query_parser_key_value_delimiters) free (GloVars.query_parser_key_value_delimiters);
+				GloVars.query_parser_key_value_delimiters=strdup(query_parser_key_value_delimiters.c_str());
+			}
+		}
+		if (root.exists("unit_of_work_identifiers")==true) {
+			string unit_of_work_identifiers;
+			bool rc;
+			rc=root.lookupValue("unit_of_work_identifiers", unit_of_work_identifiers);
+			if (rc==true) {
+				GloVars.unit_of_work_identifiers=strdup(unit_of_work_identifiers.c_str());
+			}
+		}
 	} else {
 		proxy_warning("Unable to open config file %s\n", GloVars.config_file); // issue #705
 		if (GloVars.__cmd_proxysql_config_file) {


### PR DESCRIPTION
This provides a way of ensuring that a series of database requests will be forwarded to one server as long as a user-defined unit-of-work identifier (or a series of such identifiers) remains the same across the series of requests.  This is done by using the identifier(s), received via query comment fields, to generate a numeric hash which is ultimately used to index into the list of configured servers within a hostgroup.

The identifier names are defined by setting the `unit_of_work_identifiers` global variable to a comma-delimited string containing one or more identifier names, e.g. `"request_id,job_id"`.  Any of these names can then be used to declare unique identifiers to consistently route requests to a single server without any need for the application to be aware of the available servers.

Also, the delimiters between comment fields and within key-value pairs have been made configurable for all query comment fields using the global variables `query_parser_token_delimiters` and `query_parser_key_value_delimiters`.  If not specified, these variables default to the standard `;` and `=` delimiters.

@renecannao 