### PR TITLE
fix for galera set writer

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -6,6 +6,7 @@
 
 #include <thread>
 #include <iostream>
+#include <mutex>
 
 #include "thread.h"
 #include "wqueue.h"
@@ -313,6 +314,7 @@ class MySQL_HostGroups_Manager {
 	umap_mysql_errors mysql_errors_umap;
 
 	public:
+	std::mutex galera_set_writer_mutex;
 	pthread_rwlock_t gtid_rwlock;
 	std::unordered_map <string, GTID_Server_Data *> gtid_map;
 	struct ev_async * gtid_ev_async;

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -4493,7 +4493,7 @@ void MySQL_HostGroups_Manager::update_galera_set_read_only(char *_hostname, int 
 			sprintf(query, q, info->reader_hostgroup, _hostname, _port, info->writer_hostgroup, info->backup_writer_hostgroup, info->offline_hostgroup);
 			mydb->execute(query);
 			//free(query);
-			q=(char *)"DELETE FROM mysql_servers_incoming WHERE hostname='%s' AND port=%d AND hostgroup_id in (%d, %d, %d) FROM mysql_galera_hostgroups WHERE writer_hostgroup=%d)";
+			q=(char *)"DELETE FROM mysql_servers_incoming WHERE hostname='%s' AND port=%d AND hostgroup_id in (%d, %d, %d)";
 			//query=(char *)malloc(strlen(q)+strlen(_hostname)+64);
 			sprintf(query,q,_hostname,_port, info->offline_hostgroup, info->backup_writer_hostgroup, info->writer_hostgroup, info->writer_hostgroup);
 			mydb->execute(query);
@@ -4555,8 +4555,7 @@ Galera_Info *MySQL_HostGroups_Manager::get_galera_node_info(int hostgroup) {
 }
 
 void MySQL_HostGroups_Manager::update_galera_set_writer(char *_hostname, int _port, int _writer_hostgroup) {
-	std::mutex local_mutex;
-	std::lock_guard<std::mutex> lock(local_mutex);
+	std::lock_guard<std::mutex> lock(galera_set_writer_mutex);
 	int cols=0;
 	int affected_rows=0;
 	SQLite3_result *resultset=NULL;
@@ -4566,7 +4565,7 @@ void MySQL_HostGroups_Manager::update_galera_set_writer(char *_hostname, int _po
 	q=(char *)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=reader_hostgroup OR hostgroup_id=backup_writer_hostgroup OR hostgroup_id=offline_hostgroup WHERE hostname='%s' AND port=%d";
 	query=(char *)malloc(strlen(q)+strlen(_hostname)+32);
 	sprintf(query,q,_hostname,_port);
-  mydb->execute_statement(query, &error, &cols , &affected_rows , &resultset);
+	mydb->execute_statement(query, &error, &cols , &affected_rows , &resultset);
 	if (error) {
 		free(error);
 		error=NULL;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -9955,6 +9955,7 @@ void ProxySQL_Admin::load_mysql_servers_to_runtime() {
 	}
 	// commit all the changes
 	MyHGM->commit();
+	GloAdmin->save_mysql_servers_runtime_to_database(true);
 
 	// clean up
 	if (resultset) delete resultset;


### PR DESCRIPTION
Description:
1. Fix for #2683
2. Fixes issue in galera when writer_is_also_reader=2

Tested with script:
```
#!/bin/bash

mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "select * from runtime_mysql_servers"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "update mysql_galera_hostgroups set writer_is_also_reader=0"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "load mysql servers to runtime"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "select * from runtime_mysql_servers"
sleep 10
echo "================"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "select * from runtime_mysql_servers"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "select * from runtime_mysql_servers"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "update mysql_galera_hostgroups set writer_is_also_reader=2"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "load mysql servers to runtime"
sleep 3
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "select * from runtime_mysql_servers"
sleep 10
echo "================"
mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "select * from runtime_mysql_servers"
```