### PR TITLE
V2.0.12 group concat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DEBUG=${ALL_DEBUG}
 #export OPTZ
 #export EXTRALINK
 export MAKE
-export CURVER?=2.0.11
+export CURVER?=2.0.12
 ifneq (,$(wildcard /etc/os-release))
 	DISTRO := $(shell gawk -F= '/^NAME/{print $$2}' /etc/os-release)
 else

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -166,6 +166,7 @@ enum variable_name {
 	SQL_MAX_JOIN_SIZE,
 	SQL_LOG_BIN,
 	SQL_WSREP_SYNC_WAIT,
+	SQL_GROUP_CONCAT_MAX_LEN,
 	SQL_NAME_LAST
 };
 
@@ -1010,6 +1011,7 @@ mysql_variable_st mysql_tracked_variables[] {
     { SQL_MAX_JOIN_SIZE,        SETTING_VARIABLE,     false, false, true, true,  false, (char *)"max_join_size", (char *)"max_join_size", (char *)"18446744073709551615" } ,
     { SQL_LOG_BIN,              SETTING_VARIABLE,     false, false, true, false, false, (char *)"sql_log_bin", (char *)"sql_log_bin", (char *)"1" } ,
     { SQL_WSREP_SYNC_WAIT,      SETTING_VARIABLE,     false, false, true, true,  false, (char *)"wsrep_sync_wait", (char *)"wsrep_sync_wait", (char *)"0" } ,
+    { SQL_GROUP_CONCAT_MAX_LEN, SETTING_VARIABLE,     false, false, true, true,  false, (char *)"group_concat_max_len", (char *)"group_concat_max_len", (char *)"1024" } ,
 };
 #else
 extern mysql_variable_st mysql_tracked_variables[];

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -5052,7 +5052,7 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 								return false;
 							}
 						}
-					} else if ( (var == "sql_select_limit") || (var == "net_write_timeout") || (var == "max_join_size") || (var == "wsrep_sync_wait") ) {
+					} else if ( (var == "sql_select_limit") || (var == "net_write_timeout") || (var == "max_join_size") || (var == "wsrep_sync_wait") || (var == "group_concat_max_len") ) {
 						int idx = SQL_NAME_LAST;
 						for (int i = 0 ; i < SQL_NAME_LAST ; i++) {
 							if (mysql_tracked_variables[i].is_number) {

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2308,7 +2308,36 @@ bool MySQL_Session::handler_again___status_SETTING_MULTI_STMT(int *_rc) {
 		NEXT_IMMEDIATE_NEW(st);
 	} else {
 		if (rc==-1) {
-			proxy_error("Error setting multistatement on server %s , %d : %d, %s\n", myconn->parent->address, myconn->parent->port, mysql_errno(myconn->mysql), mysql_error(myconn->mysql));
+			// the command failed
+			int myerr=mysql_errno(myconn->mysql);
+			if (myerr >= 2000) {
+				bool retry_conn=false;
+				// client error, serious
+				proxy_error("Detected a broken connection during setting MYSQL_OPTION_MULTI_STATEMENTS on %s , %d : %d, %s\n", myconn->parent->address, myconn->parent->port, myerr, mysql_error(myconn->mysql));
+				//if ((myds->myconn->reusable==true) && ((myds->myprot.prot_status & SERVER_STATUS_IN_TRANS)==0)) {
+				if ((myds->myconn->reusable==true) && myds->myconn->IsActiveTransaction()==false && myds->myconn->MultiplexDisabled()==false) {
+					retry_conn=true;
+				}
+				myds->destroy_MySQL_Connection_From_Pool(false);
+				myds->fd=0;
+				if (retry_conn) {
+					myds->DSS=STATE_NOT_INITIALIZED;
+					NEXT_IMMEDIATE_NEW(CONNECTING_SERVER);
+				}
+				*_rc=-1; // an error happened, we should destroy the Session
+				return ret;
+			} else {
+				proxy_warning("Error during MYSQL_OPTION_MULTI_STATEMENTS : %d, %s\n", myerr, mysql_error(myconn->mysql));
+				// we won't go back to PROCESSING_QUERY
+				st=previous_status.top();
+				previous_status.pop();
+				char sqlstate[10];
+				sprintf(sqlstate,"%s",mysql_sqlstate(myconn->mysql));
+				client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,1,mysql_errno(myconn->mysql),sqlstate,mysql_error(myconn->mysql));
+				myds->destroy_MySQL_Connection_From_Pool(true);
+				myds->fd=0;
+				RequestEnd(myds);
+			}
 		} else {
 			// rc==1 , nothing to do for now
 		}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3373,7 +3373,7 @@ bool MySQL_Thread::init() {
 
 	match_regexes=(Session_Regex **)malloc(sizeof(Session_Regex *)*4);
 	match_regexes[0]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)SQL_LOG_BIN( *)(:|)=( *)");
-	match_regexes[1]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)(SQL_MODE|TIME_ZONE|CHARACTER_SET_RESULTS|CHARACTER_SET_CLIENT|CHARACTER_SET_DATABASE|SESSION_TRACK_GTIDS|SQL_AUTO_IS_NULL|SQL_SELECT_LIMIT|SQL_SAFE_UPDATES|COLLATION_CONNECTION|CHARACTER_SET_CONNECTION|NET_WRITE_TIMEOUT|WSREP_SYNC_WAIT|TX_ISOLATION|MAX_JOIN_SIZE( *)(:|)=( *))");
+	match_regexes[1]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)(SQL_MODE|TIME_ZONE|CHARACTER_SET_RESULTS|CHARACTER_SET_CLIENT|CHARACTER_SET_DATABASE|SESSION_TRACK_GTIDS|SQL_AUTO_IS_NULL|SQL_SELECT_LIMIT|SQL_SAFE_UPDATES|COLLATION_CONNECTION|CHARACTER_SET_CONNECTION|NET_WRITE_TIMEOUT|WSREP_SYNC_WAIT|TX_ISOLATION|GROUP_CONCAT_MAX_LEN|MAX_JOIN_SIZE( *)(:|)=( *))");
 	match_regexes[2]=new Session_Regex((char *)"^SET(?: +)(|SESSION +)TRANSACTION(?: +)(?:(?:(ISOLATION(?: +)LEVEL)(?: +)(REPEATABLE(?: +)READ|READ(?: +)COMMITTED|READ(?: +)UNCOMMITTED|SERIALIZABLE))|(?:(READ)(?: +)(WRITE|ONLY)))");
 	match_regexes[3]=new Session_Regex((char *)"^(set)(?: +)((charset)|(character +set))(?: )");
 

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -37,6 +37,7 @@ MySQL_Variables::MySQL_Variables() {
 			case SQL_NET_WRITE_TIMEOUT:
 			case SQL_MAX_JOIN_SIZE:
 			case SQL_WSREP_SYNC_WAIT:
+			case SQL_GROUP_CONCAT_MAX_LEN:
 				MySQL_Variables::verifiers[i] = verify_server_variable;
 				MySQL_Variables::updaters[i] = update_server_variable;
 				break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -935,7 +935,6 @@ void ProxySQL_Main_init_main_modules() {
 	GloQPro=NULL;
 	GloMTH=NULL;
 	GloMyAuth=NULL;
-	GloMyLdapAuth = NULL;
 #ifdef PROXYSQLCLICKHOUSE
 	GloClickHouseAuth=NULL;
 #endif /* PROXYSQLCLICKHOUSE */
@@ -1212,6 +1211,7 @@ void ProxySQL_Main_init() {
 
 
 static void LoadPlugins() {
+	GloMyLdapAuth = NULL;
 	if (GloVars.web_interface_plugin) {
 		dlerror();
 		char * dlsym_error = NULL;

--- a/test/tap/tap/command_line.cpp
+++ b/test/tap/tap/command_line.cpp
@@ -13,7 +13,7 @@
 using nlohmann::json;
 
 CommandLine::CommandLine() :
-	host(NULL), username(NULL), password(NULL), admin_username(NULL), admin_password(NULL) {}
+	host(NULL), username(NULL), password(NULL), admin_username(NULL), admin_password(NULL), workdir() {}
 
 CommandLine::~CommandLine() {
 	if (host)
@@ -26,11 +26,13 @@ CommandLine::~CommandLine() {
 		free(admin_username);
 	if (admin_password)
 		free(admin_password);
+	if (workdir)
+		free(workdir);
 }
 
 int CommandLine::parse(int argc, char** argv) {
 	int opt;
-	while ((opt = getopt(argc, argv, "ncsu:p:h:P:")) != -1) {
+	while ((opt = getopt(argc, argv, "ncsu:p:h:P:W:")) != -1) {
 		switch (opt) {
 			case 'c':
 				checksum = true;
@@ -59,11 +61,14 @@ int CommandLine::parse(int argc, char** argv) {
 			case 'U':
 				admin_username = strdup(optarg);
 				break;
+			case 'W':
+				workdir = strdup(optarg);
+				break;
 			case 'S':
 				admin_password = strdup(optarg);
 				break;
 			default: /* '?' */
-				fprintf(stderr, "Usage: %s -u username -p password -h host [ -P port ] [ -A port ] [ -U admin_username ] [ -S admin_password ] [ -c ] [ -s ] [ -n ]\n", argv[0]);
+				fprintf(stderr, "Usage: %s -u username -p password -h host [ -P port ] [ -A port ] [ -U admin_username ] [ -S admin_password ] [ -W workdir] [ -c ] [ -s ] [ -n ]\n", argv[0]);
 				return 0;
 		}
 	}
@@ -101,6 +106,7 @@ int CommandLine::read(const std::string& file) {
 	admin_port = 6032;
 	username = strdup("root");
 	password = strdup("a");
+	workdir = strdup("./tests/");
 	return 0;
 }
 
@@ -151,6 +157,10 @@ int CommandLine::getEnv() {
 		env_port=6032;
 	if(env_port>0 && env_port<65536)
 		admin_port=env_port;
+
+	value=getenv("TAP_WORKDIR");
+	if(!value) return -1;
+	workdir = strdup(value);
 
 	return 0;
 }

--- a/test/tap/tap/command_line.cpp
+++ b/test/tap/tap/command_line.cpp
@@ -13,7 +13,7 @@
 using nlohmann::json;
 
 CommandLine::CommandLine() :
-	host(NULL), username(NULL), password(NULL), admin_username(NULL), admin_password(NULL), workdir() {}
+	host(NULL), username(NULL), password(NULL), admin_username(NULL), admin_password(NULL), workdir(NULL) {}
 
 CommandLine::~CommandLine() {
 	if (host)

--- a/test/tap/tap/command_line.h
+++ b/test/tap/tap/command_line.h
@@ -17,6 +17,7 @@ class CommandLine {
 	char* admin_password;
 	int	 port;
 	int admin_port;
+	char* workdir;
 
 	int read(const std::string& file);
 	int getEnv();

--- a/test/tap/tests/proxysql_reference_select_config_file.cnf
+++ b/test/tap/tests/proxysql_reference_select_config_file.cnf
@@ -98,6 +98,7 @@ mysql_variables =
 	default_character_set_results="mysql"
 	default_charset="mysql"
 	default_collation_connection="mysql"
+	default_group_concat_max_len="mysql"
 	default_isolation_level="mysql"
 	default_max_join_size="mysql"
 	default_max_latency_ms="mysql"

--- a/test/tap/tests/select_config_file-t.cpp
+++ b/test/tap/tests/select_config_file-t.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 
 	{
 		std::ifstream inFile;
-		inFile.open("./tests/proxysql_reference_select_config_file.cnf"); //open the input file
+		inFile.open(std::string(cl.workdir) + "/proxysql_reference_select_config_file.cnf"); //open the input file
 
 		std::stringstream strStream;
 		strStream << inFile.rdbuf(); //read the file

--- a/test/tap/tests/set_testing-t.cpp
+++ b/test/tap/tests/set_testing-t.cpp
@@ -510,11 +510,11 @@ void * my_conn_thread(void *arg) {
 
 int main(int argc, char *argv[]) {
 	CommandLine cl;
-	std::string fileName("./tests/set_testing-t.csv");
 
 	if(cl.getEnv())
 		return exit_status();
 
+	std::string fileName(std::string(cl.workdir) + "/set_testing-t.csv");
 	MYSQL* mysqladmin = mysql_init(NULL);
 	if (!mysqladmin)
 		return exit_status();

--- a/test/tap/tests/set_testing-t.cpp
+++ b/test/tap/tests/set_testing-t.cpp
@@ -162,21 +162,21 @@ void queryVariables(MYSQL *mysql, json& j) {
 			" ('hostname', 'sql_log_bin', 'sql_mode', 'init_connect', 'time_zone', 'autocommit', 'sql_auto_is_null', "
 			" 'sql_safe_updates', 'max_join_size', 'net_write_timeout', 'sql_select_limit', "
 			" 'sql_select_limit', 'character_set_results', 'tx_isolation', 'tx_read_only', "
-			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database');";
+			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'group_concat_max_len');";
 	}
 	if (is_cluster) {
 		query << "SELECT /* mysql " << mysql << " */ * FROM performance_schema.session_variables WHERE variable_name IN "
 			" ('hostname', 'sql_log_bin', 'sql_mode', 'init_connect', 'time_zone', 'autocommit', 'sql_auto_is_null', "
 			" 'sql_safe_updates', 'session_track_gtids', 'max_join_size', 'net_write_timeout', 'sql_select_limit', "
 			" 'sql_select_limit', 'character_set_results', 'transaction_isolation', 'transaction_read_only', "
-			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'wsrep_sync_wait');";
+			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'wsrep_sync_wait', 'group_concat_max_len');";
 	}
 	if (!is_mariadb && !is_cluster) {
 		query << "SELECT /* mysql " << mysql << " */ * FROM performance_schema.session_variables WHERE variable_name IN "
 			" ('hostname', 'sql_log_bin', 'sql_mode', 'init_connect', 'time_zone', 'autocommit', 'sql_auto_is_null', "
 			" 'sql_safe_updates', 'session_track_gtids', 'max_join_size', 'net_write_timeout', 'sql_select_limit', "
 			" 'sql_select_limit', 'character_set_results', 'transaction_isolation', 'transaction_read_only', "
-			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database');";
+			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'group_concat_max_len');";
 	}
 	//fprintf(stderr, "TRACE : QUERY 3 : variables %s\n", query.str().c_str());
 	if (mysql_query(mysql, query.str().c_str())) {

--- a/test/tap/tests/set_testing-t.csv
+++ b/test/tap/tests/set_testing-t.csv
@@ -62,3 +62,5 @@
 "set max_join_size=18446744073709551615", "{'max_join_size':'18446744073709551615'}"
 "set wsrep_sync_wait=1", "{'wsrep_sync_wait':'1'}"
 "set wsrep_sync_wait=0", "{'wsrep_sync_wait':'0'}"
+"set group_concat_max_len=2048", "{'group_concat_max_len':'2048'}"
+"set group_concat_max_len=4096", "{'group_concat_max_len':'4096'}"

--- a/test/tap/tests/test_ps_large_result-t.cpp
+++ b/test/tap/tests/test_ps_large_result-t.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
 	}
 	MYSQL_QUERY(mysql, q.str().c_str());
 	ok(true, "%d row inserted. Waiting for possible replication on test server 30(s)", NUM_ROWS);
-	sleep(30);
+	sleep(120);
 
 	MYSQL_STMT *stmt1 = mysql_stmt_init(mysql);
 	if (!stmt1)


### PR DESCRIPTION
Description:
Track variable group_concat_max_len
Automated tests are updated.

Manual testing:
```
mysql> select * from performance_schema.session_variables where variable_name like '%group_concat_%';
+----------------------+----------------+
| VARIABLE_NAME        | VARIABLE_VALUE |
+----------------------+----------------+
| group_concat_max_len | 1024           |
+----------------------+----------------+
1 row in set (0.00 sec)

mysql> set group_concat_max_len=4096;
Query OK, 0 rows affected (0.00 sec)

mysql> select * from performance_schema.session_variables where variable_name like '%group_concat_%';
+----------------------+----------------+
| VARIABLE_NAME        | VARIABLE_VALUE |
+----------------------+----------------+
| group_concat_max_len | 4096           |
+----------------------+----------------+
1 row in set (0.00 sec)
```