### PR TITLE
V2.0.12 Session variable group_concat_max_len

### DIFF
--- a/include/MySQL_Variables.h
+++ b/include/MySQL_Variables.h
@@ -29,6 +29,9 @@ class MySQL_Variables {
 	static update_var updaters[SQL_NAME_LAST];
 
 public:
+	std::string variables_regexp;
+
+public:
 	MySQL_Variables();
 
 	virtual ~MySQL_Variables();

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -166,6 +166,7 @@ enum variable_name {
 	SQL_MAX_JOIN_SIZE,
 	SQL_LOG_BIN,
 	SQL_WSREP_SYNC_WAIT,
+	SQL_GROUP_CONCAT_MAX_LEN,
 	SQL_NAME_LAST
 };
 
@@ -1010,6 +1011,7 @@ mysql_variable_st mysql_tracked_variables[] {
     { SQL_MAX_JOIN_SIZE,        SETTING_VARIABLE,     false, false, true, true,  false, (char *)"max_join_size", (char *)"max_join_size", (char *)"18446744073709551615" } ,
     { SQL_LOG_BIN,              SETTING_VARIABLE,     false, false, true, false, false, (char *)"sql_log_bin", (char *)"sql_log_bin", (char *)"1" } ,
     { SQL_WSREP_SYNC_WAIT,      SETTING_VARIABLE,     false, false, true, true,  false, (char *)"wsrep_sync_wait", (char *)"wsrep_sync_wait", (char *)"0" } ,
+    { SQL_GROUP_CONCAT_MAX_LEN, SETTING_VARIABLE,     false, false, true, true,  false, (char *)"group_concat_max_len", (char *)"group_concat_max_len", (char *)"1024" } ,
 };
 #else
 extern mysql_variable_st mysql_tracked_variables[];

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -5052,7 +5052,7 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 								return false;
 							}
 						}
-					} else if ( (var == "sql_select_limit") || (var == "net_write_timeout") || (var == "max_join_size") || (var == "wsrep_sync_wait") ) {
+					} else if ( (var == "sql_select_limit") || (var == "net_write_timeout") || (var == "max_join_size") || (var == "wsrep_sync_wait") || (var == "group_concat_max_len") ) {
 						int idx = SQL_NAME_LAST;
 						for (int i = 0 ; i < SQL_NAME_LAST ; i++) {
 							if (mysql_tracked_variables[i].is_number) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3373,7 +3373,11 @@ bool MySQL_Thread::init() {
 
 	match_regexes=(Session_Regex **)malloc(sizeof(Session_Regex *)*4);
 	match_regexes[0]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)SQL_LOG_BIN( *)(:|)=( *)");
-	match_regexes[1]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)(SQL_MODE|TIME_ZONE|CHARACTER_SET_RESULTS|CHARACTER_SET_CLIENT|CHARACTER_SET_DATABASE|SESSION_TRACK_GTIDS|SQL_AUTO_IS_NULL|SQL_SELECT_LIMIT|SQL_SAFE_UPDATES|COLLATION_CONNECTION|CHARACTER_SET_CONNECTION|NET_WRITE_TIMEOUT|WSREP_SYNC_WAIT|TX_ISOLATION|GROUP_CONCAT_MAX_LEN|MAX_JOIN_SIZE( *)(:|)=( *))");
+
+	std::stringstream ss;
+	ss << "^SET (|SESSION |@@|@@session.)(" << mysql_variables.variables_regexp << "SESSION_TRACK_GTIDS|TX_ISOLATION( *)(:|)=( *))";
+	match_regexes[1]=new Session_Regex((char *)ss.str().c_str());
+
 	match_regexes[2]=new Session_Regex((char *)"^SET(?: +)(|SESSION +)TRANSACTION(?: +)(?:(?:(ISOLATION(?: +)LEVEL)(?: +)(REPEATABLE(?: +)READ|READ(?: +)COMMITTED|READ(?: +)UNCOMMITTED|SERIALIZABLE))|(?:(READ)(?: +)(WRITE|ONLY)))");
 	match_regexes[3]=new Session_Regex((char *)"^(set)(?: +)((charset)|(character +set))(?: )");
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3373,7 +3373,7 @@ bool MySQL_Thread::init() {
 
 	match_regexes=(Session_Regex **)malloc(sizeof(Session_Regex *)*4);
 	match_regexes[0]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)SQL_LOG_BIN( *)(:|)=( *)");
-	match_regexes[1]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)(SQL_MODE|TIME_ZONE|CHARACTER_SET_RESULTS|CHARACTER_SET_CLIENT|CHARACTER_SET_DATABASE|SESSION_TRACK_GTIDS|SQL_AUTO_IS_NULL|SQL_SELECT_LIMIT|SQL_SAFE_UPDATES|COLLATION_CONNECTION|CHARACTER_SET_CONNECTION|NET_WRITE_TIMEOUT|WSREP_SYNC_WAIT|TX_ISOLATION|MAX_JOIN_SIZE( *)(:|)=( *))");
+	match_regexes[1]=new Session_Regex((char *)"^SET (|SESSION |@@|@@session.)(SQL_MODE|TIME_ZONE|CHARACTER_SET_RESULTS|CHARACTER_SET_CLIENT|CHARACTER_SET_DATABASE|SESSION_TRACK_GTIDS|SQL_AUTO_IS_NULL|SQL_SELECT_LIMIT|SQL_SAFE_UPDATES|COLLATION_CONNECTION|CHARACTER_SET_CONNECTION|NET_WRITE_TIMEOUT|WSREP_SYNC_WAIT|TX_ISOLATION|GROUP_CONCAT_MAX_LEN|MAX_JOIN_SIZE( *)(:|)=( *))");
 	match_regexes[2]=new Session_Regex((char *)"^SET(?: +)(|SESSION +)TRANSACTION(?: +)(?:(?:(ISOLATION(?: +)LEVEL)(?: +)(REPEATABLE(?: +)READ|READ(?: +)COMMITTED|READ(?: +)UNCOMMITTED|SERIALIZABLE))|(?:(READ)(?: +)(WRITE|ONLY)))");
 	match_regexes[3]=new Session_Regex((char *)"^(set)(?: +)((charset)|(character +set))(?: )");
 

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -37,6 +37,7 @@ MySQL_Variables::MySQL_Variables() {
 			case SQL_NET_WRITE_TIMEOUT:
 			case SQL_MAX_JOIN_SIZE:
 			case SQL_WSREP_SYNC_WAIT:
+			case SQL_GROUP_CONCAT_MAX_LEN:
 				MySQL_Variables::verifiers[i] = verify_server_variable;
 				MySQL_Variables::updaters[i] = update_server_variable;
 				break;

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -20,33 +20,22 @@ update_var MySQL_Variables::updaters[SQL_NAME_LAST];
 
 
 MySQL_Variables::MySQL_Variables() {
+	variables_regexp = "";
 	for (auto i = 0; i < SQL_NAME_LAST; i++) {
-		switch(i) {
-			case SQL_SAFE_UPDATES:
-			case SQL_SELECT_LIMIT:
-			case SQL_SQL_MODE:
-			case SQL_TIME_ZONE:
-			case SQL_CHARACTER_SET_RESULTS:
-			case SQL_CHARACTER_SET_CONNECTION:
-			case SQL_CHARACTER_SET_CLIENT:
-			case SQL_CHARACTER_SET_DATABASE:
-			case SQL_ISOLATION_LEVEL:
-			case SQL_TRANSACTION_READ:
-			case SQL_SQL_AUTO_IS_NULL:
-			case SQL_COLLATION_CONNECTION:
-			case SQL_NET_WRITE_TIMEOUT:
-			case SQL_MAX_JOIN_SIZE:
-			case SQL_WSREP_SYNC_WAIT:
-			case SQL_GROUP_CONCAT_MAX_LEN:
-				MySQL_Variables::verifiers[i] = verify_server_variable;
-				MySQL_Variables::updaters[i] = update_server_variable;
-				break;
-			case SQL_LOG_BIN:
-				MySQL_Variables::verifiers[i] = verify_server_variable;
-				MySQL_Variables::updaters[i] = logbin_update_server_variable;
-				break;
-			default:
-				MySQL_Variables::updaters[i] = NULL;
+		if (i == SQL_CHARACTER_SET || i == SQL_CHARACTER_ACTION || i == SQL_SET_NAMES) {
+			MySQL_Variables::updaters[i] = NULL;
+			MySQL_Variables::verifiers[i] = NULL;
+		}
+		else if (i == SQL_LOG_BIN) {
+			MySQL_Variables::verifiers[i] = verify_server_variable;
+			MySQL_Variables::updaters[i] = logbin_update_server_variable;
+		} else {
+			MySQL_Variables::verifiers[i] = verify_server_variable;
+			MySQL_Variables::updaters[i] = update_server_variable;
+		}
+		if (mysql_tracked_variables[i].status == SETTING_VARIABLE) {
+			variables_regexp += mysql_tracked_variables[i].set_variable_name;
+			variables_regexp += "|";
 		}
 	}
 }
@@ -535,3 +524,4 @@ bool MySQL_Variables::parse_variable_number(MySQL_Session *sess, int idx, string
 	}
 	return true;
 }
+

--- a/test/tap/tests/proxysql_reference_select_config_file.cnf
+++ b/test/tap/tests/proxysql_reference_select_config_file.cnf
@@ -98,6 +98,7 @@ mysql_variables =
 	default_character_set_results="mysql"
 	default_charset="mysql"
 	default_collation_connection="mysql"
+	default_group_concat_max_len="mysql"
 	default_isolation_level="mysql"
 	default_max_join_size="mysql"
 	default_max_latency_ms="mysql"

--- a/test/tap/tests/set_testing-t.cpp
+++ b/test/tap/tests/set_testing-t.cpp
@@ -162,21 +162,21 @@ void queryVariables(MYSQL *mysql, json& j) {
 			" ('hostname', 'sql_log_bin', 'sql_mode', 'init_connect', 'time_zone', 'autocommit', 'sql_auto_is_null', "
 			" 'sql_safe_updates', 'max_join_size', 'net_write_timeout', 'sql_select_limit', "
 			" 'sql_select_limit', 'character_set_results', 'tx_isolation', 'tx_read_only', "
-			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database');";
+			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'group_concat_max_len');";
 	}
 	if (is_cluster) {
 		query << "SELECT /* mysql " << mysql << " */ * FROM performance_schema.session_variables WHERE variable_name IN "
 			" ('hostname', 'sql_log_bin', 'sql_mode', 'init_connect', 'time_zone', 'autocommit', 'sql_auto_is_null', "
 			" 'sql_safe_updates', 'session_track_gtids', 'max_join_size', 'net_write_timeout', 'sql_select_limit', "
 			" 'sql_select_limit', 'character_set_results', 'transaction_isolation', 'transaction_read_only', "
-			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'wsrep_sync_wait');";
+			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'wsrep_sync_wait', 'group_concat_max_len');";
 	}
 	if (!is_mariadb && !is_cluster) {
 		query << "SELECT /* mysql " << mysql << " */ * FROM performance_schema.session_variables WHERE variable_name IN "
 			" ('hostname', 'sql_log_bin', 'sql_mode', 'init_connect', 'time_zone', 'autocommit', 'sql_auto_is_null', "
 			" 'sql_safe_updates', 'session_track_gtids', 'max_join_size', 'net_write_timeout', 'sql_select_limit', "
 			" 'sql_select_limit', 'character_set_results', 'transaction_isolation', 'transaction_read_only', "
-			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database');";
+			" 'sql_auto_is_null', 'collation_connection', 'character_set_connection', 'character_set_client', 'character_set_database', 'group_concat_max_len');";
 	}
 	//fprintf(stderr, "TRACE : QUERY 3 : variables %s\n", query.str().c_str());
 	if (mysql_query(mysql, query.str().c_str())) {

--- a/test/tap/tests/set_testing-t.csv
+++ b/test/tap/tests/set_testing-t.csv
@@ -62,3 +62,5 @@
 "set max_join_size=18446744073709551615", "{'max_join_size':'18446744073709551615'}"
 "set wsrep_sync_wait=1", "{'wsrep_sync_wait':'1'}"
 "set wsrep_sync_wait=0", "{'wsrep_sync_wait':'0'}"
+"set group_concat_max_len=2048", "{'group_concat_max_len':'2048'}"
+"set group_concat_max_len=4096", "{'group_concat_max_len':'4096'}"


### PR DESCRIPTION
Description:
Track variable group_concat_max_len
Automated tests are updated.

Manual testing:
```
mysql> select * from performance_schema.session_variables where variable_name like '%group_concat_%';
+----------------------+----------------+
| VARIABLE_NAME        | VARIABLE_VALUE |
+----------------------+----------------+
| group_concat_max_len | 1024           |
+----------------------+----------------+
1 row in set (0.00 sec)

mysql> set group_concat_max_len=4096;
Query OK, 0 rows affected (0.00 sec)

mysql> select * from performance_schema.session_variables where variable_name like '%group_concat_%';
+----------------------+----------------+
| VARIABLE_NAME        | VARIABLE_VALUE |
+----------------------+----------------+
| group_concat_max_len | 4096           |
+----------------------+----------------+
1 row in set (0.00 sec)
```