### PR TITLE
Fix QPO timeout overflow

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -3605,7 +3605,9 @@ handler_again:
 					mybe->server_myds->wait_until=0;
 					if (qpo) {
 						if (qpo->timeout > 0) {
-							mybe->server_myds->wait_until=thread->curtime+qpo->timeout*1000;
+							unsigned long long qr_timeout=qpo->timeout;
+							mybe->server_myds->wait_until=thread->curtime;
+							mybe->server_myds->wait_until+=qr_timeout*1000;
 						}
 					}
 					if (mysql_thread___default_query_timeout) {


### PR DESCRIPTION
Description:
Fixes integer overflow for query rules timeout

Verification:

1. Set query rules with timeout value equals to one hour.
```
INSERT INTO mysql_query_rules (rule_id,active,match_digest,destination_hostgroup,timeout,apply) VALUES (1,1,'^SELECT.*FOR UPDATE$',0,3600*1000,1), (2,1,'^SELECT',1,3600*1000,1);
load mysql query rules to runtime; save mysql query rules to disk;
```
2. Execute query

```
$ time mysql -uroot -proot -h127.0.0.1 -P6033 -e "select 1, sleep(3601)"
mysql: [Warning] Using a password on the command line interface can be insecure.
+---+-------------+
| 1 | sleep(3601) |
+---+-------------+
| 1 |           1 |
+---+-------------+

real    60m0.013s
user    0m0.012s
sys     0m0.000s
```
The query ended as expected after 1 hour.


