### PR TITLE
Check that GIT_VERSION is set in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+ifndef GIT_VERSION
+GIT_VERSION := $(shell git describe --long)
+ifndef GIT_VERSION
+$(error GIT_VERSION is not set)
+endif
+endif
+
 O0=-O0
 O2=-O2
 O1=-O1

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,9 @@
-
-
+ifndef GIT_VERSION
 GIT_VERSION := $(shell git describe --long)
+ifndef GIT_VERSION
+$(error GIT_VERSION is not set)
+endif
+endif
 
 DEPS_PATH=../deps
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,9 @@
-
-
+ifndef GIT_VERSION
 GIT_VERSION := $(shell git describe --long)
+ifndef GIT_VERSION
+$(error GIT_VERSION is not set)
+endif
+endif
 
 DEPS_PATH=../deps
 


### PR DESCRIPTION
Description:
Related to issue #2768 

After applying this PR the proxysql cannot be built if it is located outside of the git, i.e. downloaded as a ZIP archive. To compile porxysql from archive the `GIT_VERSION` should be set as an environment variable:

```
GIT_VERSION=2.0.12-14-local make
```
