### PR TITLE
V2.1.0 Add debug target to TAP tests Makefile

### DIFF
--- a/test/tap/Makefile
+++ b/test/tap/Makefile
@@ -1,4 +1,3 @@
-
 .PHONY: all
 all: tap tests
 
@@ -7,12 +6,12 @@ clean:
 	cd tap && ${MAKE} clean
 	cd tests && ${MAKE} clean
 
-OPT=-O2
+debug: tap tests
 
 .PHONY: tap
 tap: 
-	cd tap && OPTZ="${O0} -ggdb " CC=${CC} CXX=${CXX} ${MAKE}
+	cd tap && CC=${CC} CXX=${CXX} ${MAKE} $(MAKECMDGOALS)
 
 tests: tap
-	cd tests && OPTZ="${O0} -ggdb " CC=${CC} CXX=${CXX} ${MAKE}
+	cd tests && CC=${CC} CXX=${CXX} ${MAKE} $(MAKECMDGOALS)
 

--- a/test/tap/tap/Makefile
+++ b/test/tap/tap/Makefile
@@ -14,6 +14,9 @@ clean:
 
 OPT=-O2
 
+debug: OPT = -O0 -DDEBUG -ggdb
+debug: libtap.a
+
 libtap.a: tap.cpp tap.h command_line.cpp command_line.h utils.cpp utils.h
 	g++ -c tap.cpp command_line.cpp utils.cpp -std=c++11 -I$(JSON_IDIR) -I$(MARIADB_IDIR) $(OPT)
 	ar rcs libtap.a tap.o command_line.o utils.o

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -82,6 +82,8 @@ clean:
 	rm -f *-t galera_1_timeout_count galera_2_timeout_no_count aurora || true
 
 OPT=-O2 -Wl,--no-as-needed
+debug: OPT=-O0 -DDEBUG -ggdb -Wl,--no-as-needed
+debug: tests
 
 tests: $(patsubst %.cpp,%,$(wildcard *-t.cpp))
 testgalera: galera_1_timeout_count galera_2_timeout_no_count


### PR DESCRIPTION
(cherry picked from commit e50b7ae66c0101af9f00e80d0d73f22732964b59)

Description:
related to #2769

This PR adds debug target to tap tests Makefile. It is possible now to build TAP tests like this

cd ./test/tap
make debug

Debug goal adds the following compiler options: -O0 -DDEBUG -ggdb