### PR TITLE
V2.1.0 Fix set global variables error

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3472,7 +3472,7 @@ char ** MySQL_Threads_Handler::get_variables_list() {
 // scan both mysql_thread_variables_names AND mysql_tracked_variables
 bool MySQL_Threads_Handler::has_variable(const char *name) {
 	if (strlen(name) > 8) {
-		if (strncmp(name, "default_", 8)) {
+		if (strncmp(name, "default_", 8) == 0) {
 			for (unsigned int i = 0; i < SQL_NAME_LAST ; i++) {
 				size_t var_len = strlen(mysql_tracked_variables[i].internal_variable_name);
 				if (strlen(name) == (var_len+8)) {


### PR DESCRIPTION
Description:
Fixes the issue #2741

Test:
set statement changes default_% variables as expected without an error.
```
mysql> select * from global_variables where variable_name like '%character%';
+----------------------------------------+----------------+
| variable_name                          | variable_value |
+----------------------------------------+----------------+
| mysql-default_character_set_results    | utf8mb4        |
| mysql-default_character_set_connection | utf8mb4        |
| mysql-default_character_set_client     | utf8mb4        |
| mysql-default_character_set_database   | utf8mb4        |
+----------------------------------------+----------------+
4 rows in set (0.00 sec)

mysql> set mysql-default_character_set_client='utf8';
Query OK, 1 row affected (0.00 sec)

mysql> set mysql-default_character_set_connection='utf8';
Query OK, 1 row affected (0.00 sec)

mysql> select * from global_variables where variable_name like '%character%';
+----------------------------------------+----------------+
| variable_name                          | variable_value |
+----------------------------------------+----------------+
| mysql-default_character_set_results    | utf8mb4        |
| mysql-default_character_set_connection | utf8           |
| mysql-default_character_set_client     | utf8           |
| mysql-default_character_set_database   | utf8mb4        |
+----------------------------------------+----------------+
4 rows in set (0.00 sec)
```