### PR TITLE
Reset data stream status after switching users.

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2589,7 +2589,8 @@ bool MySQL_Session::handler_again___status_CHANGING_USER_SERVER(int *_rc) {
 		__sync_fetch_and_add(&MyHGM->status.backend_change_user, 1);
 		myds->myconn->userinfo->set(client_myds->myconn->userinfo);
 		myds->myconn->reset();
-		st=previous_status.top();
+		myds->DSS = STATE_MARIADB_GENERIC;
+		st = previous_status.top();
 		previous_status.pop();
 		NEXT_IMMEDIATE_NEW(st);
 	} else {


### PR DESCRIPTION
When a backend connection is reused for a different user, the data stream status is set to `STATE_MARIADB_QUERY`, but was not set back to `STATE_MARIADB_GENERIC` once the user was switched successfully.

This caused additional connection setup (like executing `init_connect`) to be skipped on the first query after switching users. If another query using the the same user was executed, this new query would end up performing this additional connection setup.

By setting the data stream status back to `STATE_MARIADB_GENERIC`, we can ensure connection setup happens correctly after switching users.