### PR TITLE
Fix `default_track_gtids` config value being ignored

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1574,7 +1574,24 @@ bool MySQL_Session::handler_again___verify_backend__generic_variable(uint32_t *b
 		*be_var = strdup(def);
 		uint32_t tmp_int = SpookyHash::Hash32(*be_var, strlen(*be_var), 10);
 		*be_int = tmp_int;
+
+		switch(status) { // this switch can be replaced with a simple previous_status.push(status), but it is here for readibility
+			case PROCESSING_QUERY:
+				previous_status.push(PROCESSING_QUERY);
+				break;
+			case PROCESSING_STMT_PREPARE:
+				previous_status.push(PROCESSING_STMT_PREPARE);
+				break;
+			case PROCESSING_STMT_EXECUTE:
+				previous_status.push(PROCESSING_STMT_EXECUTE);
+				break;
+			default:
+				assert(0);
+				break;
+		}
+		NEXT_IMMEDIATE_NEW(next_sess_status);
 	}
+
 	if (*fe_int) {
 		if (*fe_int != *be_int) {
 			{


### PR DESCRIPTION
When a new backend connection is opened, the `session_track_gtids` config variable would be set from the default specified in the proxysql configuration, but it was actually never sent to MySQL (via a `SET SESSION` command).

This changes the code to actually send the expected `SET SESSION` command.

---

A reproducible test case can be found here: https://github.com/arthurschreiber/proxysql-issue/tree/default-session-track-gtid-issue