### PR TITLE
Fix cache size calculation integer overflow

### DIFF
--- a/lib/Query_Cache.cpp
+++ b/lib/Query_Cache.cpp
@@ -294,7 +294,7 @@ void KV_BtreeArray::empty() {
 };
 
 uint64_t Query_Cache::get_data_size_total() {
-	int r=0;
+	uint64_t r=0;
 	int i;
 	for (i=0; i<SHARED_QUERY_CACHE_HASH_TABLES; i++) {
 		r+=KVs[i]->get_data_size();


### PR DESCRIPTION
This is to fix the issues outlined in https://github.com/sysown/proxysql/issues/2815

An int overflow causes the return value to be messed up, falsely reporting exabytes of cache once it hits ~2.1GB and then starts purging entries.

Signed-off-by: Mark Knapp <mknapp@hudson-trading.com>