### PR TITLE
More verbose output for test_ps_hg_routing-t

### DIFF
--- a/test/tap/tests/test_ps_hg_routing-t.cpp
+++ b/test/tap/tests/test_ps_hg_routing-t.cpp
@@ -11,6 +11,8 @@
 #include "command_line.h"
 #include "utils.h"
 
+#include <stdlib.h>
+
 int main(int argc, char** argv) {
 	CommandLine cl;
 	char buf[1024];
@@ -43,11 +45,11 @@ int main(int argc, char** argv) {
 		return exit_status();
 	}
 
-	MYSQL_QUERY(mysql, "drop database if exists test");
 	MYSQL_QUERY(mysql, "create database if not exists test");
-	sprintf(buf, "create table if not exists test.test1 (c1 varchar(%d) primary key, c2 varchar(%d))", STRING_SIZE, STRING_SIZE);
+	MYSQL_QUERY(mysql, "drop table if exists test.ps_hg_routing");
+	sprintf(buf, "create table if not exists test.ps_hg_routing (c1 varchar(%d) primary key, c2 varchar(%d))", STRING_SIZE, STRING_SIZE);
 	MYSQL_QUERY(mysql, buf);
-	MYSQL_QUERY(mysql, "insert into test.test1 (c1,c2) values ('abcdef', 'abcdef')");
+	MYSQL_QUERY(mysql, "insert into test.ps_hg_routing (c1,c2) values ('abcdef', 'abcdef')");
 
 	MYSQL_QUERY(mysqladmin, "update global_variables set variable_value='true' where variable_name='mysql-forward_autocommit'");
 	MYSQL_QUERY(mysqladmin, "update global_variables set variable_value='false' where variable_name='mysql-enforce_autocommit_on_reads'");
@@ -60,6 +62,13 @@ int main(int argc, char** argv) {
 	MYSQL_QUERY(mysqladmin, "insert into mysql_query_rules (rule_id, active, flagIN, match_digest, negate_match_pattern, re_modifiers, destination_hostgroup, apply) values (200, 1, 0, '^SELECT', 0, 'CASELESS', 1, 1)");
 	MYSQL_QUERY(mysqladmin, "load mysql query rules to runtime");
 
+	std::string q0 = (const std::string)"mysql -h " + cl.host + (const std::string)" -u " + cl.admin_username + " -p" + cl.admin_password + " -P " + std::to_string(cl.admin_port) + " -t -e ";
+	std::string q1 = q0 + "\"SELECT * FROM mysql_servers\"";
+	std::string q2 = q0 + "\"SELECT * FROM mysql_query_rules\"";
+
+	system(q1.c_str());
+	system(q2.c_str());
+
 	MYSQL_QUERY(mysql, "set autocommit=0");
 	MYSQL_STMT *stmt = mysql_stmt_init(mysql);
 	if (!stmt)
@@ -68,7 +77,7 @@ int main(int argc, char** argv) {
 		return exit_status();
 	}
 
-	std::string query = "SELECT * FROM test.test1";
+	std::string query = "SELECT * FROM test.ps_hg_routing";
 	if (mysql_stmt_prepare(stmt, query.c_str(), query.size())) {
 		ok(false, "Query error %s\n", mysql_error(mysql));
 		mysql_close(mysql);
@@ -76,7 +85,7 @@ int main(int argc, char** argv) {
 		return exit_status();
 	}
 
-	MYSQL_QUERY(mysql, "update test.test1 set c1='aaaaaa'");
+	MYSQL_QUERY(mysql, "update test.ps_hg_routing set c1='aaaaaa'");
 
 	MYSQL_BIND bind[2];
 	char char_data0[STRING_SIZE];
@@ -102,19 +111,19 @@ int main(int argc, char** argv) {
 
 	if (mysql_stmt_execute(stmt))
 	{
-		ok(false, " %s\n", mysql_stmt_error(stmt));
+		ok(false, "mysql_stmt_execute at line %d failed: %s\n", __LINE__ , mysql_stmt_error(stmt));
 		return exit_status();
 	}
 
 	if (mysql_stmt_bind_result(stmt, bind))
 	{
-		ok(false, " %s\n", mysql_stmt_error(stmt));
+		ok(false, "mysql_stmt_bind_result at line %d failed: %s\n", __LINE__ , mysql_stmt_error(stmt));
 		return exit_status();
 	}
 
 	if (mysql_stmt_store_result(stmt))
 	{
-		ok(false, " %s\n", mysql_stmt_error(stmt));
+		ok(false, "mysql_stmt_store_result at line %d failed: %s\n", __LINE__ , mysql_stmt_error(stmt));
 		return exit_status();
 	}
 
@@ -124,7 +133,7 @@ int main(int argc, char** argv) {
 
 	if (mysql_stmt_close(stmt))
 	{
-		ok(false, " %s\n", mysql_error(mysql));
+		ok(false, "mysql_stmt_close at line %d failed: %s\n", __LINE__ , mysql_error(mysql));
 		return exit_status();
 	}
 

--- a/test/tap/tests/test_ps_hg_routing-t.cpp
+++ b/test/tap/tests/test_ps_hg_routing-t.cpp
@@ -59,8 +59,10 @@ int main(int argc, char** argv) {
 
 	MYSQL_QUERY(mysqladmin, "delete from mysql_query_rules");
 	MYSQL_QUERY(mysqladmin, "insert into mysql_query_rules (rule_id, active, flagIN, match_digest, negate_match_pattern, re_modifiers, destination_hostgroup, apply) values (100, 1, 0, '^SELECT.*FOR UPDATE$', 0, 'CASELESS', 0, 1)");
-	MYSQL_QUERY(mysqladmin, "insert into mysql_query_rules (rule_id, active, flagIN, match_digest, negate_match_pattern, re_modifiers, destination_hostgroup, apply) values (200, 1, 0, '^SELECT', 0, 'CASELESS', 1, 1)");
+	MYSQL_QUERY(mysqladmin, "insert into mysql_query_rules (rule_id, active, flagIN, match_digest, negate_match_pattern, re_modifiers, destination_hostgroup, apply) values (200, 1, 0, '^SELECT', 0, 'CASELESS', 2, 1)");
 	MYSQL_QUERY(mysqladmin, "load mysql query rules to runtime");
+	MYSQL_QUERY(mysqladmin, "INSERT INTO mysql_servers SELECT 2, hostname, port, gtid_port, status, weight, compression, max_connections, max_replication_lag, use_ssl, max_latency_ms, comment FROM mysql_servers WHERE hostgroup_id=0");
+	MYSQL_QUERY(mysqladmin, "LOAD MYSQL SERVERS TO RUNTIME");
 
 	std::string q0 = (const std::string)"mysql -h " + cl.host + (const std::string)" -u " + cl.admin_username + " -p" + cl.admin_password + " -P " + std::to_string(cl.admin_port) + " -t -e ";
 	std::string q1 = q0 + "\"SELECT * FROM mysql_servers\"";
@@ -79,7 +81,7 @@ int main(int argc, char** argv) {
 
 	std::string query = "SELECT * FROM test.ps_hg_routing";
 	if (mysql_stmt_prepare(stmt, query.c_str(), query.size())) {
-		ok(false, "Query error %s\n", mysql_error(mysql));
+		ok(false, "mysql_stmt_prepare at line %d failed: %s\n", __LINE__ , mysql_error(mysql));
 		mysql_close(mysql);
 		mysql_library_end();
 		return exit_status();
@@ -142,6 +144,9 @@ int main(int argc, char** argv) {
 
 	MYSQL_QUERY(mysqladmin, "load mysql query rules from disk");
 	MYSQL_QUERY(mysqladmin, "load mysql query rules to runtime");
+
+	MYSQL_QUERY(mysqladmin, "DELETE FROM mysql_servers WHERE hostgroup_id=2");
+	MYSQL_QUERY(mysqladmin, "LOAD MYSQL SERVERS TO RUNTIME");
 
 	mysql_close(mysql);
 	mysql_close(mysqladmin);


### PR DESCRIPTION
Added __LINE__ in output
Use table ps_hg_routing instead of test1
Use system() to output the current configuration


This PR adds more verbose output, to identify why it randomly fails