### PR TITLE
fix unquoted table name leading to sql errors

### DIFF
--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -2312,7 +2312,7 @@ bool MySQL_Protocol::generate_COM_QUERY_from_COM_FIELD_LIST(PtrSize_t *pkt) {
 		(*myds)->com_field_wild=strdup(wild);
 	}
 
-	char *qt = (char *)"SELECT * FROM %s WHERE 1=0";
+	char *qt = (char *)"SELECT * FROM `%s` WHERE 1=0";
 	q = (char *)malloc(strlen(qt)+strlen(tablename));
 	sprintf(q,qt,tablename);
 	l_free(pkt->size, pkt->ptr);


### PR DESCRIPTION
In lib/MySQL_Protocol.cpp MySQL_Protocol::generate_COM_QUERY_from_COM_FIELD_LIST line 2315 there is a query:
`char *qt = (char *)"SELECT * FROM %s WHERE 1=0";`

The table name here is unquoted, leading to SQL errors if the table name is a keyword or somewhat non-normalized, like:
`2020-05-28 15:36:16 MySQL_Session.cpp:4333:handler(): [WARNING] Error during query on (1,sql1,3306): 1064, You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'groups WHERE 1=0' at line 1`



