### PR TITLE
sfrezefo hack for Azure Database for MySQL / MariaDB

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -317,6 +317,8 @@ class MySQL_Threads_Handler
 		bool query_digests_normalize_digest_text;
 		bool query_digests_track_hostname;
 		bool default_reconnect;
+		// sfrezefo hack for azure username
+		bool azure_gen1_username;
 		bool have_compress;
 		bool have_ssl;
 		bool client_found_rows;

--- a/include/mysql_connection.h
+++ b/include/mysql_connection.h
@@ -104,6 +104,8 @@ class MySQL_Connection {
 	MySQL_ResultSet *MyRS_reuse;
 	MySrvC *parent;
 	MySQL_Connection_userinfo *userinfo;
+	// sfrezefo as async call requires it to live longer than calling block
+	char newusername[128];
 	MySQL_Data_Stream *myds;
 	enum MySerStatus server_status; // this to solve a side effect of #774
 

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -733,6 +733,8 @@ __thread unsigned int mysql_thread___handle_unknown_charset;
 __thread int mysql_thread___poll_timeout;
 __thread int mysql_thread___poll_timeout_on_failure;
 __thread bool mysql_thread___connection_warming;
+// sfrezefo hack for azure username
+__thread bool mysql_thread___azure_gen1_username;
 __thread bool mysql_thread___have_compress;
 __thread bool mysql_thread___have_ssl;
 __thread bool mysql_thread___client_found_rows;
@@ -878,6 +880,8 @@ extern __thread unsigned int mysql_thread___handle_unknown_charset;
 extern __thread int mysql_thread___poll_timeout;
 extern __thread int mysql_thread___poll_timeout_on_failure;
 extern __thread bool mysql_thread___connection_warming;
+// sfrezefo hack for azure username
+extern __thread bool mysql_thread___azure_gen1_username;
 extern __thread bool mysql_thread___have_compress;
 extern __thread bool mysql_thread___have_ssl;
 extern __thread bool mysql_thread___client_found_rows;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -922,7 +922,23 @@ bool MySQL_Monitor_State_Data::create_new_connection() {
 		mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname);
 		MYSQL *myrc=NULL;
 		if (port) {
-			myrc=mysql_real_connect(mysql, hostname, mysql_thread___monitor_username, mysql_thread___monitor_password, NULL, port, NULL, 0);
+			// sfrezefo hack for azure
+			if((mysql_thread___azure_gen1_username) && (strstr(hostname, "mysql.database.azure.com") || strstr(hostname, "mariadb.database.azure.com"))) {
+				char newusername[128];
+				strcpy(newusername, mysql_thread___monitor_username);
+				strcat(newusername,"@");
+				char *firstdot = hostname;
+				char *endhostname = hostname + strlen(hostname);
+				int i = strlen(newusername);
+				while ((*firstdot != '.') && (firstdot != endhostname)) {
+					newusername[i++] = *firstdot;
+					firstdot++;
+				}
+				newusername[i]='\0';
+				myrc=mysql_real_connect(mysql, hostname, newusername, mysql_thread___monitor_password, NULL, port, NULL, 0);
+			} else {
+				myrc=mysql_real_connect(mysql, hostname, mysql_thread___monitor_username, mysql_thread___monitor_password, NULL, port, NULL, 0);
+			}
 		} else {
 			myrc=mysql_real_connect(mysql, "localhost", mysql_thread___monitor_username, mysql_thread___monitor_password, NULL, 0, hostname, 0);
 		}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -140,7 +140,23 @@ void * kill_query_thread(void *arg) {
 			default:
 				break;
 		}
-		ret=mysql_real_connect(mysql,ka->hostname,ka->username,ka->password,NULL,ka->port,NULL,0);
+		// sfrezefo hack for  azure username
+		if((mysql_thread___azure_gen1_username) && (strstr(ka->hostname, "mysql.database.azure.com") || strstr(ka->hostname, "mariadb.database.azure.com"))) {
+			char newusername[128];
+			strcpy(newusername, ka->username);
+			strcat(newusername,"@");
+			char *firstdot = ka->hostname;
+			char *endhostname = ka->hostname + strlen(ka->hostname);
+			int i = strlen(newusername);
+			while ((*firstdot != '.') && (firstdot != endhostname)) {
+				newusername[i++] = *firstdot;
+				firstdot++;
+			}
+			newusername[i]='\0';
+			ret=mysql_real_connect(mysql,ka->hostname,newusername,ka->password,NULL,ka->port,NULL,0);
+		} else {
+			ret=mysql_real_connect(mysql,ka->hostname,ka->username,ka->password,NULL,ka->port,NULL,0);
+		}
 	} else {
 		switch (ka->kill_type) {
 			case KILL_QUERY:

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -701,7 +701,22 @@ void MySQL_Connection::connect_start() {
 		}
 	}
 	if (parent->port) {
-		async_exit_status=mysql_real_connect_start(&ret_mysql, mysql, parent->address, userinfo->username, auth_password, userinfo->schemaname, parent->port, NULL, client_flags);
+		// sfrezefo hack for azure username
+		if((mysql_thread___azure_gen1_username) && (strstr(parent->address, "mysql.database.azure.com") || strstr(parent->address, "mariadb.database.azure.com"))) {
+			strcpy(newusername, userinfo->username);
+			strcat(newusername,"@");
+			char *firstdot = parent->address;
+			char *endhostname = parent->address + strlen(parent->address);
+			int i = strlen(newusername);
+			while ((*firstdot != '.') && (firstdot != endhostname)) {
+				newusername[i++] = *firstdot;
+				firstdot++;
+			}
+			newusername[i]='\0';
+			async_exit_status=mysql_real_connect_start(&ret_mysql, mysql, parent->address, newusername, auth_password, userinfo->schemaname, parent->port, NULL, client_flags);
+		} else {
+			async_exit_status=mysql_real_connect_start(&ret_mysql, mysql, parent->address, userinfo->username, auth_password, userinfo->schemaname, parent->port, NULL, client_flags);
+		}
 	} else {
 		async_exit_status=mysql_real_connect_start(&ret_mysql, mysql, "localhost", userinfo->username, auth_password, userinfo->schemaname, parent->port, parent->address, client_flags);
 	}

--- a/src/proxysql.cfg
+++ b/src/proxysql.cfg
@@ -37,6 +37,8 @@ mysql_variables=
 	max_connections=2048
 	default_query_delay=0
 	default_query_timeout=10000
+	# sfrezefo hack for azure username
+	azure_gen1_username=false
 	have_compress=true
 	poll_timeout=2000
 	interfaces="0.0.0.0:6033"


### PR DESCRIPTION
Hello,

A little hack to make proxysql compatible with Azure Database for MySQL / MariaDB.
When connecting to an azure database it requires the  username to embed the database name. 
This currently make it impossible to user proxysql when we have multiple backends. The typical case is a master with replicas for read/write splitting. As I am a very occasional developper better review the code ;-)

https://serge.frezefond.com/2020/06/using-proxysql-with-azure-database-for-mysql-mariadb/