### PR TITLE
Initialize interr variable in Galera monitor

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1541,6 +1541,7 @@ void * monitor_galera_thread(void *arg) {
 #endif // DEBUG
 
 	mmsd->t1=start_time;
+	mmsd->interr=0; // reset the value
 
 	bool crc=false;
 	if (mmsd->mysql==NULL) { // we don't have a connection, let's create it


### PR DESCRIPTION
This change initialize the variable _interr_ used in the Galera monitor if the node isn't reachable to avoid a undefined behavior bug and, for this reason, this isn't a reproducible bug and it was detected only after using valgrind.

### A clear description of the issue

If isn't possible to create a MySQL connection in the Galera monitor the code jump to ___exit_monitor_galera_thread_ label, bypassing the interr initialization.

### ProxySQL version
It was detected in the ProxySQL v2.0.12 build.

### OS Version
16.04.1-Ubuntu

### The steps to reproduce the issue
Shutdown a node in a Galera cluster.

### **Full** ProxySQL error log
This isn't a reproducible bug so I don't think that's necessary.