### PR TITLE
Fixes #2916, #2918, #2919, #2920 and #2921

### DIFF
--- a/include/proxysql_config.h
+++ b/include/proxysql_config.h
@@ -7,8 +7,8 @@ class SQLite3DB;
 extern const char* config_header;
 
 class ProxySQL_Config {
-	SQLite3DB* admindb;
 public:
+	SQLite3DB* admindb;
 	ProxySQL_Config(SQLite3DB* db);
 	virtual ~ProxySQL_Config();
 

--- a/include/proxysql_glovars.hpp
+++ b/include/proxysql_glovars.hpp
@@ -87,6 +87,7 @@ class ProxySQL_GlobalVariables {
 #ifdef PROXYSQLCLICKHOUSE
 		bool clickhouse_server;
 #endif /* PROXYSQLCLICKHOUSE */
+		pthread_mutex_t ext_glomth_mutex;
 	} global;
 	struct mysql {
 		char *server_version;

--- a/include/proxysql_restapi.h
+++ b/include/proxysql_restapi.h
@@ -22,8 +22,8 @@ public:
 };
 
 class ProxySQL_Restapi {
-	SQLite3DB* admindb;
 public:
+	SQLite3DB* admindb;
 	ProxySQL_Restapi(SQLite3DB* db);
 	virtual ~ProxySQL_Restapi();
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -4353,6 +4353,7 @@ void MySQL_Thread::process_all_sessions() {
 }
 
 void MySQL_Thread::refresh_variables() {
+	pthread_mutex_lock(&GloVars.global.ext_glomth_mutex);
 	if (GloMTH==NULL) {
 		return;
 	}
@@ -4531,6 +4532,7 @@ void MySQL_Thread::refresh_variables() {
 	mysql_thread___session_debug=(bool)GloMTH->get_variable_int((char *)"session_debug");
 #endif /* DEBUG */
 	GloMTH->wrunlock();
+	pthread_mutex_unlock(&GloVars.global.ext_glomth_mutex);
 }
 
 MySQL_Thread::MySQL_Thread() {

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -4381,6 +4381,7 @@ void ProxySQL_Admin::vacuum_stats(bool is_admin) {
 
 
 void *child_mysql(void *arg) {
+	if (GloMTH == nullptr) { return NULL; }
 
 	pthread_attr_t thread_attr;
 	size_t tmp_stack_size=0;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -574,11 +574,17 @@ int ProxySQL_Test___GetDigestTable(bool reset, bool use_swap) {
 
 ProxySQL_Config& ProxySQL_Admin::proxysql_config() {
 	static ProxySQL_Config instance = ProxySQL_Config(admindb);
+	if (instance.admindb != admindb) {
+		instance.admindb = admindb;
+	}
 	return instance;
 }
 
 ProxySQL_Restapi& ProxySQL_Admin::proxysql_restapi() {
 	static ProxySQL_Restapi instance = ProxySQL_Restapi(admindb);
+	if (instance.admindb != admindb) {
+		instance.admindb = admindb;
+	}
 	return instance;
 }
 

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -74,6 +74,7 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() {
 //	global.use_proxysql_mem=false;
 	pthread_mutex_init(&global.start_mutex,NULL);
 	pthread_mutex_init(&checksum_mutex,NULL);
+	pthread_mutex_init(&global.ext_glomth_mutex,NULL);
 	epoch_version = 0;
 	checksums_values.updates_cnt = 0;
 	checksums_values.dumped_at = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1153,8 +1153,10 @@ void ProxySQL_Main_shutdown_all_modules() {
 	}
 	if (GloMTH) {
 		cpu_timer t;
+		pthread_mutex_lock(&GloVars.global.ext_glomth_mutex);
 		delete GloMTH;
 		GloMTH=NULL;
+		pthread_mutex_unlock(&GloVars.global.ext_glomth_mutex);
 #ifdef DEBUG
 		std::cerr << "GloMTH shutdown in ";
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -755,6 +755,7 @@ void * mysql_worker_thread_func(void *arg) {
 	worker->run();
 	//delete worker;
 	delete worker;
+	mysql_thread->worker=NULL;
 //	l_mem_destroy(__thr_sfp);
 	__sync_fetch_and_sub(&GloVars.statuses.stack_memory_mysql_threads,tmp_stack_size);
 	return NULL;


### PR DESCRIPTION
Multiple fixes related to race conditions and memory errors occurred during "PROXYSQL STOP" / "PROXYSQL START" cycles. 