### PR TITLE
Fix data race with global variables

### DIFF
--- a/lib/ClickHouse_Server.cpp
+++ b/lib/ClickHouse_Server.cpp
@@ -338,10 +338,7 @@ extern ClickHouse_Server *GloClickHouseServer;
 
 #define PANIC(msg)  { perror(msg); exit(EXIT_FAILURE); }
 
-static int rc, arg_on=1, arg_off=0;
-
 static pthread_mutex_t sock_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 
 static char * ClickHouse_Server_variables_names[] = {
 	(char *)"hostname",

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -254,8 +254,6 @@ extern char * binary_sha1;
 
 #define PANIC(msg)  { perror(msg); exit(EXIT_FAILURE); }
 
-int rc, arg_on=1, arg_off=0;
-
 pthread_mutex_t sock_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t admin_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t users_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -4575,6 +4573,7 @@ void* child_telnet_also(void* arg)
 static void * admin_main_loop(void *arg)
 {
 	int i;
+	int rc;
 	int version=0;
 	struct pollfd *fds=((struct _main_args *)arg)->fds;
 	int nfds=((struct _main_args *)arg)->nfds;
@@ -7399,6 +7398,8 @@ void ProxySQL_Admin::stats___mysql_global() {
 }
 
 void ProxySQL_Admin::stats___mysql_processlist() {
+	int rc;
+
 	if (!GloMTH) return;
 	mysql_thread___show_processlist_extended = variables.mysql_show_processlist_extended;
 	SQLite3_result * resultset=GloMTH->SQL3_Processlist();
@@ -7576,6 +7577,7 @@ void ProxySQL_Admin::stats___mysql_connection_pool(bool _reset) {
 }
 
 void ProxySQL_Admin::stats___mysql_free_connections() {
+	int rc;
 
 	if (!MyHGM) return;
 	SQLite3_result * resultset=MyHGM->SQL3_Free_Connections();
@@ -9242,6 +9244,8 @@ void ProxySQL_Admin::__add_active_clickhouse_users(char *__user) {
 
 
 void ProxySQL_Admin::dump_checksums_values_table() {
+	int rc;
+
 	pthread_mutex_lock(&GloVars.checksum_mutex);
 	if (GloVars.checksums_values.updates_cnt == GloVars.checksums_values.dumped_at) {
 		// exit immediately


### PR DESCRIPTION
This change removes some global variables used to store the SQLite return value and creates these variables in a local context.

### A clear description of the issue

In some places in the code the global variable `rc` is used to store the return value of SQLite. Such behavior causes write-write data race conditions due to what is likely to be a leftover.

### ProxySQL version
It was detected in the ProxySQL v2.0.10 build.

### OS Version
16.04.1-Ubuntu

### The steps to reproduce the issue
That methods using the global variable are run in parallel.

### **Full** ProxySQL error log
This isn't a reproducible bug so I don't think that's necessary.