### PR TITLE
OSX: compilation fixes

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -82,6 +82,7 @@ else
 	cd libmicrohttpd && ln -s libmicrohttpd-0.9.68 libmicrohttpd
 	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.68.tar.gz
 endif
+	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/mhd_sockets.c < ../mhd_sockets.c-issue-5977.patch
 	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
 microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
 

--- a/deps/libmicrohttpd/mhd_sockets.c-issue-5977.patch
+++ b/deps/libmicrohttpd/mhd_sockets.c-issue-5977.patch
@@ -1,0 +1,8 @@
+@@ -528,6 +528,7 @@ MHD_socket_cork_ (MHD_socket sock,
+        TCP_CORK always flushes socket buffer. */
+     if (0 > send (sock,
+                   &dummy,
++                  0,
+                   0))
+       return 0; /* even force flush failed!? */
+     return 1; /* success */

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3336,10 +3336,12 @@ MySQL_Session * MySQL_Thread::create_new_session_and_client_data_stream(int _fd)
 
 	if (mysql_thread___use_tcp_keepalive) {
 		setsockopt(sess->client_myds->fd, SOL_SOCKET, SO_KEEPALIVE, (char *) &arg_on, sizeof(arg_on));
+#ifdef TCP_KEEPIDLE
 		if (mysql_thread___tcp_keepalive_time > 0) {
 			int keepalive_time = mysql_thread___tcp_keepalive_time;
 			setsockopt(sess->client_myds->fd, IPPROTO_TCP, TCP_KEEPIDLE, (char *) &keepalive_time, sizeof(keepalive_time));
 		}
+#endif
 	}
 
 #ifdef __APPLE__

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,7 +100,7 @@ MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc
 endif
 
 ifeq ($(UNAME_S),Darwin)
-	MYLIBS=-lssl -lre2 -lmariadbclient -lpthread -lm -lz -liconv -lcrypto -lcurl
+	MYLIBS=-lssl -lre2 -lmariadbclient -lpthread -lm -lz -liconv -lcrypto -lcurl -lgnutls
 else
 	CURL_DIR=$(DEPS_PATH)/curl/curl
 	IDIRS+= -L$(CURL_DIR)/include
@@ -118,7 +118,7 @@ endif
 
 LIBPROXYSQLAR=$(LDIR)/libproxysql.a
 ifeq ($(UNAME_S),Darwin)
-	LIBPROXYSQLAR=$(LDIR)/libproxysql.a ../deps/libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a ../deps/libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a ../deps/pcre/pcre/.libs/libpcre.a ../deps/pcre/pcre/.libs/libpcrecpp.a  ../deps/libdaemon/libdaemon/libdaemon/.libs/libdaemon.a  ../deps/libconfig/libconfig/lib/.libs/libconfig++.a ../deps/libconfig/libconfig/lib/.libs/libconfig.a ../deps/curl/curl/lib/.libs/libcurl.a ../deps/sqlite3/sqlite3/sqlite3.o
+	LIBPROXYSQLAR=$(LDIR)/libproxysql.a ../deps/libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a ../deps/libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a ../deps/pcre/pcre/.libs/libpcre.a ../deps/pcre/pcre/.libs/libpcrecpp.a  ../deps/libdaemon/libdaemon/libdaemon/.libs/libdaemon.a  ../deps/libconfig/libconfig/lib/.libs/libconfig++.a ../deps/libconfig/libconfig/lib/.libs/libconfig.a ../deps/curl/curl/lib/.libs/libcurl.a ../deps/sqlite3/sqlite3/sqlite3.o ../deps/libinjection/libinjection/src/libinjection.a  ../deps/libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a ../deps/libev/libev-4.24/.libs/libev.a
 endif
 
 LIBPROXYSQLAR+= $(SSL_LDIR)/libssl.a $(SSL_LDIR)/libcrypto.a


### PR DESCRIPTION
Tried compiling proxysql on a OSX box (Mojave 10.14.2) and ran into a handful of issues:

1. libmicrohttpd fails to compile due to `send()` having a different signature.
This is actually patched [upstream in 0.9.69](https://fossies.org/linux/libmicrohttpd/ChangeLog) so this pull request is just adding a .patch with that fix and applying it

2. Statically linking against libev, libinjection, and libhttpserver
There was an OSX codepath statically linking against a chunk of the bundled dependencies, it was just missing those three.  

3. Dynamically linking the proxysql binary against gnutls
The non-OSX codepath includes -lgnutls already; without this linking fails when including libmicrohttpd

4. TCP_KEEPIDLE is linux-exclusive
This was added in 58b7fecbe along with much-welcome SO_KEEPALIVE support. Wrapped the one use in an `#ifdef`

With those changes applied:
```
~/git_tree/proxysql $ uname
Darwin
~/git_tree/proxysql $ ./src/proxysql --version
ProxySQL version 2.0.14-11-ge9ef83ab, codename Truls
```