### PR TITLE
Remove error message number writers > max writers

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -4541,28 +4541,6 @@ void MySQL_HostGroups_Manager::update_galera_set_writer(char *_hostname, int _po
 			}
 		}
 
-		if (need_converge == false) {
-			SQLite3_result *resultset2=NULL;
-			q = (char *)"SELECT COUNT(*) FROM mysql_servers WHERE hostgroup_id=%d AND status=0";
-			query=(char *)malloc(strlen(q)+32);
-			sprintf(query,q,_writer_hostgroup);
-			mydb->execute_statement(query, &error, &cols , &affected_rows , &resultset2);
-			if (resultset2) {
-				if (resultset2->rows_count) {
-					for (std::vector<SQLite3_row *>::iterator it = resultset2->rows.begin() ; it != resultset2->rows.end(); ++it) {
-						SQLite3_row *r=*it;
-						int nwriters = atoi(r->fields[0]);
-						if (nwriters > max_writers) {
-							proxy_warning("Galera: too many writers in HG %d. Max=%d, current=%d\n", _writer_hostgroup, max_writers, nwriters);
-							need_converge = true;
-						}
-					}
-				}
-				delete resultset2;
-			}
-			free(query);
-		}
-
 		if (need_converge==false) {
 			if (found_writer) { // maybe no-op
 				if (


### PR DESCRIPTION
Due to the fix introduced by this issue: https://github.com/sysown/proxysql/issues/2950 this error message is redundant and confusing, as all hosts are now in the writer hostgroup. Therefore, I suggest that it is removed.