### PR TITLE
Fix a mem leak in flush_ldap_variables___database_to_runtime fun

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -6227,6 +6227,7 @@ void ProxySQL_Admin::flush_ldap_variables___database_to_runtime(SQLite3DB *db, b
 	admindb->execute_statement(q, &error , &cols , &affected_rows , &resultset);
 	if (error) {
 		proxy_error("Error on %s : %s\n", q, error);
+		free(error); //fix a memory leak when call admindb->execute_statement function
 		return;
 	} else {
 		GloMyLdapAuth->wrlock();


### PR DESCRIPTION
Fix a mem leak in flush_ldap_variables___database_to_runtime fun of ProxySQL_Admin class  when call admindb->execute_statement function.  Because in the called function(admindb->execute_statement), the strdup--strdup(sqlite3_errmsg(db)) function is used to allocate memory to store the error message of the sqlite database operation failure.