### PR TITLE
Merge ClickHouse support into main packages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=centos7
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   centos7_dbg_build:
@@ -56,20 +57,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  centos7_ch_build:
-    image: proxysql/packaging:build-centos7
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rhel7/rpmmacros/:/root/
-      - ./docker/images/proxysql/rhel-compliant/rhel7/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-centos7
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   centos8_build:
     image: proxysql/packaging:build-centos8
     volumes:
@@ -81,6 +68,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=centos8
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   centos8_dbg_build:
@@ -97,20 +85,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  centos8_ch_build:
-    image: proxysql/packaging:build-centos8
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rhel7/rpmmacros/:/root/
-      - ./docker/images/proxysql/rhel-compliant/rhel7/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-centos8
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   fedora24_build:
     image: proxysql/packaging:build-fedora24
     volumes:
@@ -122,6 +96,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=fedora24
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   fedora24_dbg_build:
@@ -138,20 +113,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  fedora24_ch_build:
-    image: proxysql/packaging:build-fedora24
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
-      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-fedora24
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   fedora27_build:
     image: proxysql/packaging:build-fedora27
     volumes:
@@ -163,6 +124,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=fedora27
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   fedora27_dbg_build:
@@ -179,20 +141,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  fedora27_ch_build:
-    image: proxysql/packaging:build-fedora27
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
-      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-fedora27
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   fedora28_build:
     image: proxysql/packaging:build-fedora28
     volumes:
@@ -204,6 +152,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=fedora28
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   fedora28_dbg_build:
@@ -218,20 +167,6 @@ services:
       - CURVER
       - PKG_RELEASE=dbg-fedora28
       - PROXYSQL_BUILD_TYPE=debug
-    command:
-      - /opt/entrypoint/entrypoint.bash
-  fedora28_ch_build:
-    image: proxysql/packaging:build-fedora28
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
-      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-fedora28
-      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   debian8_build:
@@ -272,6 +207,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=debian9
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   debian9_dbg_build:
@@ -288,20 +224,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  debian9_ch_build:
-    image: proxysql/packaging:build-debian9
-    volumes:
-      - ./docker/images/proxysql/deb-compliant/ctl/:/root/ctl/
-      - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-debian9
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   debian9.4_build:
     image: proxysql/packaging:build-debian9.4
     volumes:
@@ -313,6 +235,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=debian9.4
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   debian9.4_dbg_build:
@@ -329,20 +252,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  debian9.4_ch_build:
-    image: proxysql/packaging:build-debian9.4
-    volumes:
-      - ./docker/images/proxysql/deb-compliant/ctl/:/root/ctl/
-      - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-debian9.4
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   debian10_build:
     image: proxysql/packaging:build-debian10
     volumes:
@@ -354,6 +263,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=debian10
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   debian10_dbg_build:
@@ -368,20 +278,6 @@ services:
       - CURVER
       - PKG_RELEASE=dbg-debian10
       - PROXYSQL_BUILD_TYPE=debug
-    command:
-      - /opt/entrypoint/entrypoint.bash
-  debian10_ch_build:
-    image: proxysql/packaging:build-debian10
-    volumes:
-      - ./docker/images/proxysql/deb-compliant/latest-package/ctl/:/root/ctl/
-      - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-debian10
-      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   ubuntu14_build:
@@ -422,6 +318,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=ubuntu16
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   ubuntu16_dbg_build:
@@ -438,20 +335,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  ubuntu16_ch_build:
-    image: proxysql/packaging:build-ubuntu16
-    volumes:
-      - ./docker/images/proxysql/deb-compliant/pre-systemd/ctl/:/root/ctl/
-      - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-ubuntu16
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   ubuntu18_build:
     image: proxysql/packaging:build-ubuntu18
     volumes:
@@ -463,6 +346,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=ubuntu18
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   ubuntu18_dbg_build:
@@ -479,20 +363,6 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
     command:
       - /opt/entrypoint/entrypoint.bash
-  ubuntu18_ch_build:
-    image: proxysql/packaging:build-ubuntu18
-    volumes:
-      - ./docker/images/proxysql/deb-compliant/latest-package/ctl/:/root/ctl/
-      - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-ubuntu18
-      - PROXYSQL_BUILD_TYPE=clickhouse
-    command:
-      - /opt/entrypoint/entrypoint.bash
   ubuntu20_build:
     image: proxysql/packaging:build-ubuntu20
     volumes:
@@ -504,6 +374,7 @@ services:
       - MAKEOPT
       - CURVER
       - PKG_RELEASE=ubuntu20
+      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash
   ubuntu20_dbg_build:
@@ -518,19 +389,5 @@ services:
       - CURVER
       - PKG_RELEASE=dbg-ubuntu20
       - PROXYSQL_BUILD_TYPE=debug
-    command:
-      - /opt/entrypoint/entrypoint.bash
-  ubuntu20_ch_build:
-    image: proxysql/packaging:build-ubuntu20
-    volumes:
-      - ./docker/images/proxysql/deb-compliant/latest-package/ctl/:/root/ctl/
-      - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=clickhouse-ubuntu20
-      - PROXYSQL_BUILD_TYPE=clickhouse
     command:
       - /opt/entrypoint/entrypoint.bash


### PR DESCRIPTION
This unifies the standard and ClickHouse packages i.e. standard packages will now have ClickHouse support by default