### PR TITLE
Closes #3090: Change 'prometheus' metrics names to better follow official naming conventions

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -414,8 +414,8 @@ class MySQL_HostGroups_Manager {
 	 */
 	pthread_mutex_t p_err_map_access;
 
-	void p_update_connection_pool_update_counter(std::string& endpoint_id, std::string& endpoint_addr, std::string& endpoint_port, std::string& hostgroup_id, std::map<std::string, prometheus::Counter*>& m_map, unsigned long long value, p_hg_dyn_counter::metric idx);
-	void p_update_connection_pool_update_gauge(std::string& endpoint_id, std::string& endpoint_addr, std::string& endpoint_port, std::string& hostgroup_id, std::map<std::string, prometheus::Gauge*>& m_map, unsigned long long value, p_hg_dyn_gauge::metric idx);
+	void p_update_connection_pool_update_counter(std::string& endpoint_id, std::map<std::string, std::string> labels, std::map<std::string, prometheus::Counter*>& m_map, unsigned long long value, p_hg_dyn_counter::metric idx);
+	void p_update_connection_pool_update_gauge(std::string& endpoint_id, std::map<std::string, std::string> labels, std::map<std::string, prometheus::Gauge*>& m_map, unsigned long long value, p_hg_dyn_gauge::metric idx);
 
 	public:
 	std::mutex galera_set_writer_mutex;

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -366,16 +366,23 @@ class MySQL_Threads_Handler
 		int monitor_history;
 		int monitor_connect_interval;
 		int monitor_connect_timeout;
+		//! Monitor ping interval. Unit: 'ms'.
 		int monitor_ping_interval;
 		int monitor_ping_max_failures;
+		//! Monitor ping timeout. Unit: 'ms'.
 		int monitor_ping_timeout;
+		//! Monitor read only timeout. Unit: 'ms'.
 		int monitor_read_only_interval;
+		//! Monitor read only timeout. Unit: 'ms'.
 		int monitor_read_only_timeout;
 		int monitor_read_only_max_timeout_count;
 		bool monitor_enabled;
+		//! ProxySQL session wait timeout. Unit: 'ms'.
 		bool monitor_wait_timeout;
 		bool monitor_writer_is_also_reader;
+		//! How frequently a replication lag check is performed. Unit: 'ms'.
 		int monitor_replication_lag_interval;
+		//! Read only check timeout. Unit: 'ms'.
 		int monitor_replication_lag_timeout;
 		int monitor_replication_lag_count;
 		int monitor_groupreplication_healthcheck_interval;
@@ -554,7 +561,7 @@ class MySQL_Threads_Handler
 	SQLite3_result * SQL3_GlobalStatus(bool _memory);
 	bool kill_session(uint32_t _thread_session_id);
 	unsigned long long get_total_mirror_queue();
-	unsigned long long get_status_variable(enum MySQL_Thread_status_variable v_idx, p_th_counter::metric m_idx);
+	unsigned long long get_status_variable(enum MySQL_Thread_status_variable v_idx, p_th_counter::metric m_idx, unsigned long long conv = 0);
 	unsigned int get_active_transations();
 #ifdef IDLE_THREADS
 	unsigned int get_non_idle_client_connections();

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -305,7 +305,6 @@ struct p_th_counter {
 		queries_with_max_lag_ms__delayed,
 		queries_with_max_lag_ms__total_wait_time_us,
 		mysql_unexpected_frontend_com_quit,
-		client_connections_hostgroup_locked,
 		hostgroup_locked_set_cmds,
 		hostgroup_locked_queries,
 		mysql_unexpected_frontend_packets,
@@ -322,6 +321,7 @@ struct p_th_gauge {
 	enum metric {
 		active_transactions = 0,
 		client_connections_non_idle,
+		client_connections_hostgroup_locked,
 		mysql_backend_buffers_bytes,
 		mysql_frontend_buffers_bytes,
 		mysql_session_internal_bytes,
@@ -562,6 +562,7 @@ class MySQL_Threads_Handler
 	bool kill_session(uint32_t _thread_session_id);
 	unsigned long long get_total_mirror_queue();
 	unsigned long long get_status_variable(enum MySQL_Thread_status_variable v_idx, p_th_counter::metric m_idx, unsigned long long conv = 0);
+	unsigned long long get_status_variable(enum MySQL_Thread_status_variable v_idx, p_th_gauge::metric m_idx, unsigned long long conv = 0);
 	unsigned int get_active_transations();
 #ifdef IDLE_THREADS
 	unsigned int get_non_idle_client_connections();

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1015,7 +1015,7 @@ hg_metrics_map = std::make_tuple(
 	hg_counter_vector {
 		std::make_tuple (
 			p_hg_counter::servers_table_version,
-			"proxysql_servers_table_version",
+			"proxysql_servers_table_version_total",
 			"Number of times the \"servers_table\" have been modified.",
 			metric_tags {}
 		),
@@ -1023,7 +1023,7 @@ hg_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_hg_counter::server_connections_created,
-			"proxysql_server_connections",
+			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
 				{ "status", "created" }
@@ -1031,7 +1031,7 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_counter::server_connections_delayed,
-			"proxysql_server_connections",
+			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
 				{ "status", "delayed" }
@@ -1039,7 +1039,7 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_counter::server_connections_aborted,
-			"proxysql_server_connections",
+			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
 				{ "status", "aborted" }
@@ -1050,7 +1050,7 @@ hg_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_hg_counter::client_connections_created,
-			"proxysql_client_connections",
+			"proxysql_client_connections_total",
 			"Total number of client connections created.",
 			metric_tags {
 				{ "status", "created" }
@@ -1058,7 +1058,7 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_counter::client_connections_aborted,
-			"proxysql_client_connections",
+			"proxysql_client_connections_total",
 			"Total number of client failed connections (or closed improperly).",
 			metric_tags {
 				{ "status", "aborted" }
@@ -1068,97 +1068,97 @@ hg_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_hg_counter::com_autocommit,
-			"proxysql_com_autocommit",
+			"proxysql_com_autocommit_total",
 			"Total queries autocommited.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_autocommit_filtered,
-			"proxysql_com_autocommit_filtered",
+			"proxysql_com_autocommit_filtered_total",
 			"Total queries filtered autocommit.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_rollback,
-			"proxysql_com_rollback",
+			"proxysql_com_rollback_total",
 			"Total queries rollbacked.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_rollback_filtered,
-			"proxysql_com_rollback_filtered",
+			"proxysql_com_rollback_filtered_total",
 			"Total queries filtered rollbacked.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_backend_change_user,
-			"proxysql_com_backend_change_user",
+			"proxysql_com_backend_change_user_total",
 			"Total CHANGE_USER queries backend.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_backend_init_db,
-			"proxysql_com_backend_init_db",
+			"proxysql_com_backend_init_db_total",
 			"Total queries backend INIT DB.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_backend_set_names,
-			"proxysql_com_backend_set_names",
+			"proxysql_com_backend_set_names_total",
 			"Total queries backend SET NAMES.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_frontend_init_db,
-			"proxysql_com_frontend_init_db",
+			"proxysql_com_frontend_init_db_total",
 			"Total INIT DB queries frontend.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_frontend_set_names,
-			"proxysql_com_frontend_set_names",
+			"proxysql_com_frontend_set_names_total",
 			"Total SET NAMES frontend queries.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_frontend_use_db,
-			"proxysql_com_frontend_use_db",
+			"proxysql_com_frontend_use_db_total",
 			"Total USE DB queries frontend.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_commit_cnt,
-			"proxysql_com_commit_cnt",
+			"proxysql_com_commit_cnt_total",
 			"Total queries commit.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::com_commit_cnt_filtered,
-			"proxysql_com_commit_cnt_filtered",
+			"proxysql_com_commit_cnt_filtered_total",
 			"Total queries commit filtered.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::selects_for_update__autocommit0,
-			"proxysql_selects_for_update__autocommit0",
+			"proxysql_selects_for_update__autocommit0_total",
 			"Total queries that are SELECT for update or equivalent.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::access_denied_wrong_password,
-			"proxysql_access_denied_wrong_password",
+			"proxysql_access_denied_wrong_password_total",
 			"Total access denied \"wrong password\".",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::access_denied_max_connections,
-			"proxysql_access_denied_max_connections",
+			"proxysql_access_denied_max_connections_total",
 			"Total access denied \"max connections\".",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::access_denied_max_user_connections,
-			"proxysql_access_denied_max_user_connections",
+			"proxysql_access_denied_max_user_connections_total",
 			"Total access denied \"max user connections\".",
 			metric_tags {}
 		),
@@ -1166,13 +1166,13 @@ hg_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get,
-			"proxysql_myhgm_myconnpool_get",
+			"proxysql_myhgm_myconnpool_get_total",
 			"The number of requests made to the connection pool.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get_ok,
-			"proxysql_myhgm_myconnpool_get",
+			"proxysql_myhgm_myconnpool_get_total",
 			"The number of successful requests to the connection pool (i.e. where a connection was available).",
 			metric_tags {
 				{ "status", "ok" }
@@ -1180,7 +1180,7 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get_ping,
-			"proxysql_myhgm_myconnpool_get",
+			"proxysql_myhgm_myconnpool_get_total",
 			"The number of connections that were taken from the pool to run a ping to keep them alive.",
 			metric_tags {
 				{ "purpose", "ping" }
@@ -1190,19 +1190,19 @@ hg_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_push,
-			"proxysql_myhgm_myconnpool_push",
+			"proxysql_myhgm_myconnpool_push_total",
 			"The number of connections returned to the connection pool.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_reset,
-			"proxysql_myhgm_myconnpool_reset",
+			"proxysql_myhgm_myconnpool_reset_total",
 			"The number of connections that have been reset / re-initialized using \"COM_CHANGE_USER\"",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_destroy,
-			"proxysql_myhgm_myconnpool_destroy",
+			"proxysql_myhgm_myconnpool_destroy_total",
 			"The number of connections considered unhealthy and therefore closed.",
 			metric_tags {}
 		)
@@ -1230,7 +1230,7 @@ hg_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_hg_dyn_counter::conn_pool_bytes_data_recv,
-			"proxysql_connection_pool_data_bytes",
+			"proxysql_connpool_data_bytes_total",
 			"Amount of data (sent|recv) from the backend, excluding metadata.",
 			metric_tags {
 				{ "traffic_flow", "recv" }
@@ -1238,7 +1238,7 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::conn_pool_bytes_data_sent,
-			"proxysql_connection_pool_data_bytes",
+			"proxysql_connpool_data_bytes_total",
 			"Amount of data (sent|recv) from the backend, excluding metadata.",
 			metric_tags {
 				{ "traffic_flow", "sent" }
@@ -1249,7 +1249,7 @@ hg_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_conn_err,
-			"proxysql_connection_pool_conn_est",
+			"proxysql_connpool_conns_total",
 			"How many connections have been tried to be established.",
 			metric_tags {
 				{ "status", "err" }
@@ -1257,7 +1257,7 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_conn_ok,
-			"proxysql_connection_pool_conn_est",
+			"proxysql_connpool_conns_total",
 			"How many connections have been tried to be established.",
 			metric_tags {
 				{ "status", "ok" }
@@ -1267,28 +1267,28 @@ hg_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_queries,
-			"proxysql_connection_pool_conn_queries",
+			"proxysql_connpool_conns_queries_total",
 			"The number of queries routed towards this particular backend server.",
 			metric_tags {}
 		),
 		// gtid
 		std::make_tuple (
 			p_hg_dyn_counter::gtid_executed,
-			"proxysql_gtid_executed",
+			"proxysql_gtid_executed_total",
 			"Tracks the number of executed gtid per host and port.",
 			metric_tags {}
 		),
 		// mysql_error
 		std::make_tuple (
 			p_hg_dyn_counter::proxysql_mysql_error,
-			"proxysql_mysql_error",
-			"Tracks the mysql errors generated by proxysql, identifying them by: hostgroup + hostname + port + error_code.",
+			"proxysql_mysql_error_total",
+			"Tracks the mysql errors generated by proxysql.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::mysql_error,
-			"mysql_error",
-			"Tracks the mysql errors encountered, identifying them by: hostgroup + hostname + port + error_code.",
+			"mysql_error_total",
+			"Tracks the mysql errors encountered.",
 			metric_tags {}
 		)
 	},
@@ -1296,7 +1296,7 @@ hg_metrics_map = std::make_tuple(
 	hg_dyn_gauge_vector {
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_conn_free,
-			"proxysql_connection_pool_conn_av",
+			"proxysql_connpool_conns",
 			"How many backend connections are currently (free|used).",
 			metric_tags {
 				{ "status", "free" }
@@ -1304,7 +1304,7 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_conn_used,
-			"proxysql_connection_pool_conn_av",
+			"proxysql_connpool_conns",
 			"How many backend connections are currently (free|used).",
 			metric_tags {
 				{ "status", "used" }
@@ -1312,13 +1312,13 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_latency_us,
-			"proxysql_connection_pool_conn_latency_us",
+			"proxysql_connpool_conns_latency_us",
 			"The currently ping time in microseconds, as reported from Monitor.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_status,
-			"proxysql_connection_pool_conn_status",
+			"proxysql_connpool_conns_status",
 			"The status of the backend server (1 - ONLINE, 2 - SHUNNED, 3 - OFFLINE_SOFT, 4 - OFFLINE_HARD).",
 			metric_tags {}
 		)

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -997,6 +997,14 @@ using hg_gauge_vector = std::vector<hg_gauge_tuple>;
 using hg_dyn_counter_vector = std::vector<hg_dyn_counter_tuple>;
 using hg_dyn_gauge_vector = std::vector<hg_dyn_gauge_tuple>;
 
+/**
+ * @brief Metrics map holding the metrics for the 'MySQL_HostGroups_Manager' module.
+ *
+ * @note Many metrics in this map, share a common "id name", because
+ *  they differ only by label, because of this, HELP is shared between
+ *  them. For better visual identification of this groups they are
+ *  sepparated using a line separator comment.
+ */
 const std::tuple<
 	hg_counter_vector,
 	hg_gauge_vector,
@@ -1011,10 +1019,12 @@ hg_metrics_map = std::make_tuple(
 			"Number of times the \"servers_table\" have been modified.",
 			metric_tags {}
 		),
+
+		// ====================================================================
 		std::make_tuple (
 			p_hg_counter::server_connections_created,
 			"proxysql_server_connections",
-			"Total number of server connections created.",
+			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
 				{ "status", "created" }
 			}
@@ -1022,7 +1032,7 @@ hg_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_hg_counter::server_connections_delayed,
 			"proxysql_server_connections",
-			"Total number of server connections delayed.",
+			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
 				{ "status", "delayed" }
 			}
@@ -1030,11 +1040,14 @@ hg_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_hg_counter::server_connections_aborted,
 			"proxysql_server_connections",
-			"Total number of backend failed connections (or closed improperly).",
+			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
 				{ "status", "aborted" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_hg_counter::client_connections_created,
 			"proxysql_client_connections",
@@ -1051,6 +1064,8 @@ hg_metrics_map = std::make_tuple(
 				{ "status", "aborted" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_hg_counter::com_autocommit,
 			"proxysql_com_autocommit",
@@ -1147,55 +1162,49 @@ hg_metrics_map = std::make_tuple(
 			"Total access denied \"max user connections\".",
 			metric_tags {}
 		),
+
+		// ====================================================================
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get,
-			"proxysql_myhgm_myconnpool",
+			"proxysql_myhgm_myconnpool_get",
 			"The number of requests made to the connection pool.",
-			metric_tags {
-				{ "type", "get" }
-			}
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get_ok,
-			"proxysql_myhgm_myconnpool",
+			"proxysql_myhgm_myconnpool_get",
 			"The number of successful requests to the connection pool (i.e. where a connection was available).",
 			metric_tags {
-				{ "type", "get" },
 				{ "status", "ok" }
 			}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get_ping,
-			"proxysql_myhgm_myconnpool",
+			"proxysql_myhgm_myconnpool_get",
 			"The number of connections that were taken from the pool to run a ping to keep them alive.",
 			metric_tags {
-				{ "type", "get" },
 				{ "purpose", "ping" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_push,
-			"proxysql_myhgm_myconnpool",
+			"proxysql_myhgm_myconnpool_push",
 			"The number of connections returned to the connection pool.",
-			metric_tags {
-				{ "type", "push" }
-			}
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_reset,
-			"proxysql_myhgm_myconnpool",
+			"proxysql_myhgm_myconnpool_reset",
 			"The number of connections that have been reset / re-initialized using \"COM_CHANGE_USER\"",
-			metric_tags {
-				{ "type", "reset" }
-			}
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_destroy,
-			"proxysql_myhgm_myconnpool",
+			"proxysql_myhgm_myconnpool_destroy",
 			"The number of connections considered unhealthy and therefore closed.",
-			metric_tags {
-				{ "type", "destroy" }
-			}
+			metric_tags {}
 		)
 	},
 	// prometheus gauges
@@ -1216,10 +1225,13 @@ hg_metrics_map = std::make_tuple(
 	// prometheus dynamic counters
 	hg_dyn_counter_vector {
 		// connection_pool
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_hg_dyn_counter::conn_pool_bytes_data_recv,
 			"proxysql_connection_pool_data_bytes",
-			"The amount of data received from the backend, excluding metadata.",
+			"Amount of data (sent|recv) from the backend, excluding metadata.",
 			metric_tags {
 				{ "traffic_flow", "recv" }
 			}
@@ -1227,27 +1239,32 @@ hg_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_hg_dyn_counter::conn_pool_bytes_data_sent,
 			"proxysql_connection_pool_data_bytes",
-			"The amount of data sent to the backend, excluding metadata.",
+			"Amount of data (sent|recv) from the backend, excluding metadata.",
 			metric_tags {
 				{ "traffic_flow", "sent" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_conn_err,
-			"proxysql_connection_pool_conn",
-			"How many connections weren't established successfully.",
+			"proxysql_connection_pool_conn_est",
+			"How many connections have been tried to be established.",
 			metric_tags {
 				{ "status", "err" }
 			}
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_conn_ok,
-			"proxysql_connection_pool_conn",
-			"How many connections were established successfully.",
+			"proxysql_connection_pool_conn_est",
+			"How many connections have been tried to be established.",
 			metric_tags {
 				{ "status", "ok" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_queries,
 			"proxysql_connection_pool_conn_queries",
@@ -1277,18 +1294,21 @@ hg_metrics_map = std::make_tuple(
 	},
 	// prometheus dynamic counters
 	hg_dyn_gauge_vector {
-		// NOTE: Maybe free-used could be collapsed
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_conn_free,
-			"proxysql_connection_pool_conn_free",
-			"How many connections are currently free.",
-			metric_tags {}
+			"proxysql_connection_pool_conn_av",
+			"How many backend connections are currently (free|used).",
+			metric_tags {
+				{ "status", "free" }
+			}
 		),
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_conn_used,
-			"proxysql_connection_pool_conn_used",
-			"How many connections are currently used by ProxySQL for sending queries to the backend server.",
-			metric_tags {}
+			"proxysql_connection_pool_conn_av",
+			"How many backend connections are currently (free|used).",
+			metric_tags {
+				{ "status", "used" }
+			}
 		),
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_latency_us,
@@ -3550,7 +3570,7 @@ SQLite3_result * MySQL_HostGroups_Manager::SQL3_Free_Connections() {
 	return result;
 }
 
-void MySQL_HostGroups_Manager::p_update_connection_pool_update_counter(std::string& endpoint_id, std::string& endpoint_addr, std::string& endpoint_port, std::string& hostgroup_id, std::map<std::string, prometheus::Counter*>& m_map, unsigned long long value, p_hg_dyn_counter::metric idx) {
+void MySQL_HostGroups_Manager::p_update_connection_pool_update_counter(std::string& endpoint_id, std::map<std::string, std::string> labels, std::map<std::string, prometheus::Counter*>& m_map, unsigned long long value, p_hg_dyn_counter::metric idx) {
 	const auto& counter_id = m_map.find(endpoint_id);
 	if (counter_id != m_map.end()) {
 		const auto& cur_val = counter_id->second->Value();
@@ -3560,16 +3580,13 @@ void MySQL_HostGroups_Manager::p_update_connection_pool_update_counter(std::stri
 		m_map.insert(
 			{
 				endpoint_id,
-				std::addressof(new_counter->Add({
-					{"endpoint", endpoint_addr + ":" + endpoint_port},
-					{"hostgroup", hostgroup_id }
-				}))
+				std::addressof(new_counter->Add(labels))
 			}
 		);
 	}
 }
 
-void MySQL_HostGroups_Manager::p_update_connection_pool_update_gauge(std::string& endpoint_id, std::string& endpoint_addr, std::string& endpoint_port, std::string& hostgroup_id, std::map<std::string, prometheus::Gauge*>& m_map, unsigned long long value, p_hg_dyn_gauge::metric idx) {
+void MySQL_HostGroups_Manager::p_update_connection_pool_update_gauge(std::string& endpoint_id, std::map<std::string, std::string> labels, std::map<std::string, prometheus::Gauge*>& m_map, unsigned long long value, p_hg_dyn_gauge::metric idx) {
 	const auto& counter_id = m_map.find(endpoint_id);
 	if (counter_id != m_map.end()) {
 		counter_id->second->Set(value);
@@ -3578,10 +3595,7 @@ void MySQL_HostGroups_Manager::p_update_connection_pool_update_gauge(std::string
 		m_map.insert(
 			{
 				endpoint_id,
-				std::addressof(new_counter->Add({
-					{"endpoint", endpoint_addr + ":" + endpoint_port},
-					{"hostgroup", hostgroup_id }
-				}))
+				std::addressof(new_counter->Add(labels))
 			}
 		);
 	}
@@ -3597,43 +3611,57 @@ void MySQL_HostGroups_Manager::p_update_connection_pool() {
 			std::string endpoint_port = std::to_string(mysrvc->port);
 			std::string hostgroup_id = std::to_string(myhgc->hid);
 			std::string endpoint_id = hostgroup_id + ":" + endpoint_addr + ":" + endpoint_port;
+			const std::map<std::string, std::string> common_labels {
+				{"endpoint", endpoint_addr + ":" + endpoint_port},
+				{"hostgroup", hostgroup_id }
+			};
 
 			// proxysql_connection_pool_bytes_data_recv metric
-			p_update_connection_pool_update_counter(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			std::map<std::string, std::string> recv_pool_bytes_labels = common_labels;
+			recv_pool_bytes_labels.insert({"traffic_flow", "recv"});
+			p_update_connection_pool_update_counter(endpoint_id, recv_pool_bytes_labels,
 				status.p_conn_pool_bytes_data_recv_map, mysrvc->bytes_recv, p_hg_dyn_counter::conn_pool_bytes_data_recv);
 
 			// proxysql_connection_pool_bytes_data_sent metric
-			p_update_connection_pool_update_counter(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			std::map<std::string, std::string> sent_pool_bytes_labels = common_labels;
+			sent_pool_bytes_labels.insert({"traffic_flow", "sent"});
+			p_update_connection_pool_update_counter(endpoint_id, sent_pool_bytes_labels,
 				status.p_conn_pool_bytes_data_sent_map, mysrvc->bytes_sent, p_hg_dyn_counter::conn_pool_bytes_data_sent);
 
 			// proxysql_connection_pool_conn_err metric
-			p_update_connection_pool_update_counter(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			std::map<std::string, std::string> pool_conn_err_labels = common_labels;
+			pool_conn_err_labels.insert({"status", "err"});
+			p_update_connection_pool_update_counter(endpoint_id, pool_conn_err_labels,
 				status.p_connection_pool_conn_err_map, mysrvc->connect_ERR, p_hg_dyn_counter::connection_pool_conn_err);
 
-			// proxysql_connection_pool_conn_free metric
-			p_update_connection_pool_update_gauge(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
-				status.p_connection_pool_conn_free_map, mysrvc->ConnectionsFree->conns_length(), p_hg_dyn_gauge::connection_pool_conn_free);
-
-
 			// proxysql_connection_pool_conn_ok metric
-			p_update_connection_pool_update_counter(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			std::map<std::string, std::string> pool_conn_ok_labels = common_labels;
+			pool_conn_ok_labels.insert({"status", "ok"});
+			p_update_connection_pool_update_counter(endpoint_id, pool_conn_ok_labels,
 				status.p_connection_pool_conn_ok_map, mysrvc->connect_OK, p_hg_dyn_counter::connection_pool_conn_ok);
 
+			// proxysql_connection_pool_conn_free metric
+			std::map<std::string, std::string> pool_conn_free_labels = common_labels;
+			pool_conn_free_labels.insert({"status", "free"});
+			p_update_connection_pool_update_gauge(endpoint_id, pool_conn_free_labels,
+				status.p_connection_pool_conn_free_map, mysrvc->ConnectionsFree->conns_length(), p_hg_dyn_gauge::connection_pool_conn_free);
+
 			// proxysql_connection_pool_conn_used metric
-			p_update_connection_pool_update_gauge(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			std::map<std::string, std::string> pool_conn_used_labels = common_labels;
+			pool_conn_used_labels.insert({"status", "used"});
+			p_update_connection_pool_update_gauge(endpoint_id, pool_conn_used_labels,
 				status.p_connection_pool_conn_used_map, mysrvc->ConnectionsUsed->conns_length(), p_hg_dyn_gauge::connection_pool_conn_used);
 
 			// proxysql_connection_pool_latency_us metric
-			p_update_connection_pool_update_gauge(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			p_update_connection_pool_update_gauge(endpoint_id, common_labels,
 				status.p_connection_pool_latency_us_map, mysrvc->current_latency_us, p_hg_dyn_gauge::connection_pool_latency_us);
 
-
 			// proxysql_connection_pool_queries metric
-			p_update_connection_pool_update_counter(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			p_update_connection_pool_update_counter(endpoint_id, common_labels,
 				status.p_connection_pool_queries_map, mysrvc->queries_sent, p_hg_dyn_counter::connection_pool_queries);
 
 			// proxysql_connection_pool_status metric
-			p_update_connection_pool_update_gauge(endpoint_id, endpoint_addr, endpoint_port, hostgroup_id,
+			p_update_connection_pool_update_gauge(endpoint_id, common_labels,
 				status.p_connection_pool_status_map, mysrvc->status + 1, p_hg_dyn_gauge::connection_pool_status);
 		}
 	}

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1006,7 +1006,6 @@ const std::tuple<
 hg_metrics_map = std::make_tuple(
 	hg_counter_vector {
 		std::make_tuple (
-			// TODO: Check this help
 			p_hg_counter::servers_table_version,
 			"proxysql_servers_table_version",
 			"Number of times the \"servers_table\" have been modified.",
@@ -1038,15 +1037,19 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_counter::client_connections_created,
-			"proxysql_client_connections_created",
+			"proxysql_client_connections",
 			"Total number of client connections created.",
-			metric_tags {}
+			metric_tags {
+				{ "status", "created" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::client_connections_aborted,
-			"proxysql_client_connections_aborted",
+			"proxysql_client_connections",
 			"Total number of client failed connections (or closed improperly).",
-			metric_tags {}
+			metric_tags {
+				{ "status", "aborted" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::com_autocommit,
@@ -1146,39 +1149,53 @@ hg_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get,
-			"proxysql_myhgm_myconnpool_get",
+			"proxysql_myhgm_myconnpool",
 			"The number of requests made to the connection pool.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "get" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get_ok,
-			"proxysql_myhgm_myconnpool_get_ok",
+			"proxysql_myhgm_myconnpool",
 			"The number of successful requests to the connection pool (i.e. where a connection was available).",
-			metric_tags {}
+			metric_tags {
+				{ "type", "get" },
+				{ "status", "ok" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_get_ping,
-			"proxysql_myhgm_myconnpool_get_ping",
+			"proxysql_myhgm_myconnpool",
 			"The number of connections that were taken from the pool to run a ping to keep them alive.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "get" },
+				{ "purpose", "ping" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_push,
-			"proxysql_myhgm_myconnpool_push",
+			"proxysql_myhgm_myconnpool",
 			"The number of connections returned to the connection pool.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "push" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_reset,
-			"proxysql_myhgm_myconnpool_reset",
+			"proxysql_myhgm_myconnpool",
 			"The number of connections that have been reset / re-initialized using \"COM_CHANGE_USER\"",
-			metric_tags {}
+			metric_tags {
+				{ "type", "reset" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::myhgm_myconnpool_destroy,
-			"proxysql_myhgm_myconnpool_destroy",
+			"proxysql_myhgm_myconnpool",
 			"The number of connections considered unhealthy and therefore closed.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "destroy" }
+			}
 		)
 	},
 	// prometheus gauges
@@ -1201,27 +1218,35 @@ hg_metrics_map = std::make_tuple(
 		// connection_pool
 		std::make_tuple (
 			p_hg_dyn_counter::conn_pool_bytes_data_recv,
-			"proxysql_connection_pool_bytes_data_recv",
+			"proxysql_connection_pool_data_bytes",
 			"The amount of data received from the backend, excluding metadata.",
-			metric_tags {}
+			metric_tags {
+				{ "traffic_flow", "recv" }
+			}
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::conn_pool_bytes_data_sent,
-			"proxysql_connection_pool_bytes_data_sent",
+			"proxysql_connection_pool_data_bytes",
 			"The amount of data sent to the backend, excluding metadata.",
-			metric_tags {}
+			metric_tags {
+				{ "traffic_flow", "sent" }
+			}
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_conn_err,
-			"proxysql_connection_pool_conn_err",
+			"proxysql_connection_pool_conn",
 			"How many connections weren't established successfully.",
-			metric_tags {}
+			metric_tags {
+				{ "status", "err" }
+			}
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_conn_ok,
-			"proxysql_connection_pool_conn_ok",
+			"proxysql_connection_pool_conn",
 			"How many connections were established successfully.",
-			metric_tags {}
+			metric_tags {
+				{ "status", "ok" }
+			}
 		),
 		std::make_tuple (
 			p_hg_dyn_counter::connection_pool_queries,
@@ -1252,6 +1277,7 @@ hg_metrics_map = std::make_tuple(
 	},
 	// prometheus dynamic counters
 	hg_dyn_gauge_vector {
+		// NOTE: Maybe free-used could be collapsed
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_conn_free,
 			"proxysql_connection_pool_conn_free",

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1292,7 +1292,7 @@ hg_metrics_map = std::make_tuple(
 			metric_tags {}
 		)
 	},
-	// prometheus dynamic counters
+	// prometheus dynamic gauges
 	hg_dyn_gauge_vector {
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_conn_free,

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -573,7 +573,7 @@ mon_metrics_map = std::make_tuple(
 	mon_counter_vector {
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_workers_started,
-			"proxysql_mysql_monitor_workers_started",
+			"proxysql_mysql_monitor_workers_started_total",
 			"Number of MySQL Monitor workers started.",
 			metric_tags {}
 		),
@@ -581,7 +581,7 @@ mon_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_connect_check_ok,
-			"proxysql_mysql_monitor_connect_check",
+			"proxysql_mysql_monitor_connect_check_total",
 			"Number of (succeed|failed) 'connect checks' from 'monitor_connect_thread'.",
 			metric_tags {
 				{ "status", "ok" }
@@ -589,7 +589,7 @@ mon_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_connect_check_err,
-			"proxysql_mysql_monitor_connect_check",
+			"proxysql_mysql_monitor_connect_check_total",
 			"Number of (succeed|failed) 'connect checks' from 'monitor_connect_thread'.",
 			metric_tags {
 				{ "status", "err" }
@@ -600,7 +600,7 @@ mon_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_ping_check_ok,
-			"proxysql_mysql_monitor_ping_check",
+			"proxysql_mysql_monitor_ping_check_total",
 			"Number of (succeed|failed) 'ping checks' from 'monitor_ping_thread'.",
 			metric_tags {
 				{ "status", "ok" }
@@ -608,7 +608,7 @@ mon_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_ping_check_err,
-			"proxysql_mysql_monitor_ping_check",
+			"proxysql_mysql_monitor_ping_check_total",
 			"Number of (succeed|failed) 'ping checks' from 'monitor_ping_thread'.",
 			metric_tags {
 				{ "status", "err" }
@@ -619,7 +619,7 @@ mon_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_read_only_check_ok,
-			"proxysql_mysql_monitor_read_only_check",
+			"proxysql_mysql_monitor_read_only_check_total",
 			"Number of (succeed|failed) 'read only checks' from 'monitor_read_only_thread'.",
 			metric_tags {
 				{ "status", "ok" }
@@ -627,7 +627,7 @@ mon_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_read_only_check_err,
-			"proxysql_mysql_monitor_read_only_check",
+			"proxysql_mysql_monitor_read_only_check_total",
 			"Number of (succeed|failed) 'read only checks' from 'monitor_read_only_thread'.",
 			metric_tags {
 				{ "status", "err" }
@@ -638,7 +638,7 @@ mon_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_replication_lag_check_ok,
-			"proxysql_mysql_monitor_replication_lag_check",
+			"proxysql_mysql_monitor_replication_lag_check_total",
 			"Number of (succeed|failed)'replication lag checks' from 'monitor_replication_lag_thread'.",
 			metric_tags {
 				{ "status", "ok" }
@@ -646,7 +646,7 @@ mon_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_replication_lag_check_err,
-			"proxysql_mysql_monitor_replication_lag_check",
+			"proxysql_mysql_monitor_replication_lag_check_total",
 			"Number of (succeed|failed)'replication lag checks' from 'monitor_replication_lag_thread'.",
 			metric_tags {
 				{ "status", "err" }

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -560,6 +560,14 @@ using mon_gauge_tuple =
 using mon_counter_vector = std::vector<mon_counter_tuple>;
 using mon_gauge_vector = std::vector<mon_gauge_tuple>;
 
+/**
+ * @brief Metrics map holding the metrics for the 'MySQL_Monitor' module.
+ *
+ * @note Some metrics in this map, share a common "id name", because
+ *  they differ only by label, because of this, HELP is shared between
+ *  them. For better visual identification of this groups they are
+ *  sepparated using a line separator comment.
+ */
 const std::tuple<mon_counter_vector, mon_gauge_vector>
 mon_metrics_map = std::make_tuple(
 	mon_counter_vector {
@@ -569,10 +577,12 @@ mon_metrics_map = std::make_tuple(
 			"Number of MySQL Monitor workers started.",
 			metric_tags {}
 		),
+
+		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_connect_check_ok,
 			"proxysql_mysql_monitor_connect_check",
-			"Number of succeed 'connect checks' from 'monitor_connect_thread'.",
+			"Number of (succeed|failed) 'connect checks' from 'monitor_connect_thread'.",
 			metric_tags {
 				{ "status", "ok" }
 			}
@@ -580,15 +590,18 @@ mon_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_connect_check_err,
 			"proxysql_mysql_monitor_connect_check",
-			"Number of succeed 'connect checks' from 'monitor_connect_thread'.",
+			"Number of (succeed|failed) 'connect checks' from 'monitor_connect_thread'.",
 			metric_tags {
 				{ "status", "err" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_ping_check_ok,
 			"proxysql_mysql_monitor_ping_check",
-			"Number of succeed 'ping checks' from 'monitor_ping_thread'.",
+			"Number of (succeed|failed) 'ping checks' from 'monitor_ping_thread'.",
 			metric_tags {
 				{ "status", "ok" }
 			}
@@ -596,15 +609,18 @@ mon_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_ping_check_err,
 			"proxysql_mysql_monitor_ping_check",
-			"Number of failed 'ping checks' from 'monitor_ping_thread'.",
+			"Number of (succeed|failed) 'ping checks' from 'monitor_ping_thread'.",
 			metric_tags {
 				{ "status", "err" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_read_only_check_ok,
 			"proxysql_mysql_monitor_read_only_check",
-			"Number of succeed 'read only checks' from 'monitor_read_only_thread'.",
+			"Number of (succeed|failed) 'read only checks' from 'monitor_read_only_thread'.",
 			metric_tags {
 				{ "status", "ok" }
 			}
@@ -612,15 +628,18 @@ mon_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_read_only_check_err,
 			"proxysql_mysql_monitor_read_only_check",
-			"Number of failed 'read only checks' from 'monitor_read_only_thread'.",
+			"Number of (succeed|failed) 'read only checks' from 'monitor_read_only_thread'.",
 			metric_tags {
 				{ "status", "err" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_replication_lag_check_ok,
 			"proxysql_mysql_monitor_replication_lag_check",
-			"Number of succeed 'replication lag checks' from 'monitor_replication_lag_thread'.",
+			"Number of (succeed|failed)'replication lag checks' from 'monitor_replication_lag_thread'.",
 			metric_tags {
 				{ "status", "ok" }
 			}
@@ -628,11 +647,12 @@ mon_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_mon_counter::mysql_monitor_replication_lag_check_err,
 			"proxysql_mysql_monitor_replication_lag_check",
-			"Number of failed 'replication lag checks' from 'monitor_replication_lag_thread'.",
+			"Number of (succeed|failed)'replication lag checks' from 'monitor_replication_lag_thread'.",
 			metric_tags {
 				{ "status", "err" }
 			}
 		)
+		// ====================================================================
 	},
 	mon_gauge_vector {
 		std::make_tuple (

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -570,75 +570,81 @@ mon_metrics_map = std::make_tuple(
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_connect_check_ok,
-			"proxysql_mysql_monitor_connect_check_ok",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_connect_check",
+			"Number of succeed 'connect checks' from 'monitor_connect_thread'.",
+			metric_tags {
+				{ "status", "ok" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_connect_check_err,
-			"proxysql_mysql_monitor_connect_check_err",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_connect_check",
+			"Number of succeed 'connect checks' from 'monitor_connect_thread'.",
+			metric_tags {
+				{ "status", "err" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_ping_check_ok,
-			"proxysql_mysql_monitor_ping_check_ok",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_ping_check",
+			"Number of succeed 'ping checks' from 'monitor_ping_thread'.",
+			metric_tags {
+				{ "status", "ok" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_ping_check_err,
-			"proxysql_mysql_monitor_ping_check_err",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_ping_check",
+			"Number of failed 'ping checks' from 'monitor_ping_thread'.",
+			metric_tags {
+				{ "status", "err" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_read_only_check_ok,
-			"proxysql_mysql_monitor_read_only_check_ok",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_read_only_check",
+			"Number of succeed 'read only checks' from 'monitor_read_only_thread'.",
+			metric_tags {
+				{ "status", "ok" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_read_only_check_err,
-			"proxysql_mysql_monitor_read_only_check_err",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_read_only_check",
+			"Number of failed 'read only checks' from 'monitor_read_only_thread'.",
+			metric_tags {
+				{ "status", "err" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_replication_lag_check_ok,
-			"proxysql_mysql_monitor_replication_lag_check_ok",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_replication_lag_check",
+			"Number of succeed 'replication lag checks' from 'monitor_replication_lag_thread'.",
+			metric_tags {
+				{ "status", "ok" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_counter::mysql_monitor_replication_lag_check_err,
-			"proxysql_mysql_monitor_replication_lag_check_err",
-			"",
-			metric_tags {}
+			"proxysql_mysql_monitor_replication_lag_check",
+			"Number of failed 'replication lag checks' from 'monitor_replication_lag_thread'.",
+			metric_tags {
+				{ "status", "err" }
+			}
 		)
 	},
 	mon_gauge_vector {
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_gauge::mysql_monitor_workers,
 			"proxysql_mysql_monitor_workers",
-			"",
+			"Number of monitor workers threads.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_mon_gauge::mysql_monitor_workers_aux,
 			"proxysql_mysql_monitor_workers_aux",
-			"",
+			"Number of auxiliary monitor threads.",
 			metric_tags {}
 		)
 	}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -579,13 +579,22 @@ using th_gauge_tuple =
 using th_counter_vector = std::vector<th_counter_tuple>;
 using th_gauge_vector = std::vector<th_gauge_tuple>;
 
+/**
+ * @brief Metrics map holding the metrics for the MySQL_Thread module.
+ *
+ * @note Many metrics in this map, share a common "id name", because
+ *  they differ only by label, because of this, HELP is shared between
+ *  them. For better visual identification of this groups they are
+ *  sepparated using a line separator comment.
+ */
 const std::tuple<th_counter_vector, th_gauge_vector>
 th_metrics_map = std::make_tuple(
 	th_counter_vector {
+		// ====================================================================
 		std::make_tuple (
 			p_th_counter::queries_backends_bytes_sent,
 			"proxysql_queries_backends_bytes",
-			"Total number of bytes sent to backend.",
+			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
 				{ "traffic_flow", "sent" }
 			}
@@ -593,15 +602,18 @@ th_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_th_counter::queries_backends_bytes_recv,
 			"proxysql_queries_backends_bytes",
-			"Total number of bytes received from backend.",
+			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
 				{ "traffic_flow", "received" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_th_counter::queries_frontends_bytes_sent,
 			"proxysql_queries_frontends_bytes",
-			"Total number of bytes sent to frontend.",
+			"Total number of bytes (sent|received) in frontend connections.",
 			metric_tags {
 				{ "traffic_flow", "sent" }
 			}
@@ -609,15 +621,18 @@ th_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_th_counter::queries_frontends_bytes_recv,
 			"proxysql_queries_frontends_bytes",
-			"Total number of bytes received from frontend.",
+			"Total number of bytes (sent|received) in frontend connections.",
 			metric_tags {
 				{ "traffic_flow", "received" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_th_counter::client_connections_created,
 			"proxysql_client_connections",
-			"Total number of client connections created.",
+			"Total number of client connections created or failed (including improperly closed).",
 			metric_tags {
 				{ "status", "created" }
 			}
@@ -625,11 +640,13 @@ th_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_th_counter::client_connections_aborted,
 			"proxysql_client_connections",
-			"Number of client failed connections (or closed improperly).",
+			"Total number of client connections created or failed (including improperly closed).",
 			metric_tags {
 				{ "status", "aborted" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_th_counter::query_processor_time_nsec,
 			"proxysql_query_processor_time_seconds",
@@ -642,10 +659,12 @@ th_metrics_map = std::make_tuple(
 			"Time spent making network calls to communicate with the backends.",
 			metric_tags {}
 		),
+
+		// ====================================================================
 		std::make_tuple (
 			p_th_counter::com_backend_stmt_prepare,
 			"proxysql_com_backend_stmt",
-			"Represents the number of \"PREPARE\" executed by ProxySQL against the backends.",
+			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
 				{ "op", "prepare" }
 			}
@@ -653,7 +672,7 @@ th_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_th_counter::com_backend_stmt_execute,
 			"proxysql_com_backend_stmt",
-			"Represents the number of \"EXECUTE\" executed by ProxySQL against the backends.",
+			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
 				{ "op", "execute" }
 			}
@@ -661,15 +680,18 @@ th_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_th_counter::com_backend_stmt_close,
 			"proxysql_com_backend_stmt",
-			"Represents the number of \"CLOSE\" executed by ProxySQL against the backends.",
+			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
 				{ "op", "close" }
 			}
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_th_counter::com_frontend_stmt_prepare,
 			"proxysql_com_frontend_stmt",
-			"Represents the number of \"PREPARE\" executed by clients.",
+			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
 				{ "op", "prepare" }
 			}
@@ -677,7 +699,7 @@ th_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_th_counter::com_frontend_stmt_execute,
 			"proxysql_com_frontend_stmt",
-			"Represents the number of \"EXECUTE\" executed by clients.",
+			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
 				{ "op", "execute" }
 			}
@@ -685,11 +707,13 @@ th_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_th_counter::com_frontend_stmt_close,
 			"proxysql_com_frontend_stmt",
-			"Represents the number of \"CLOSE\" executed by clients.",
+			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
 				{ "op", "close" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_th_counter::questions,
 			"proxysql_questions",
@@ -714,40 +738,38 @@ th_metrics_map = std::make_tuple(
 			"Total queries with GTID session state.",
 			metric_tags {}
 		),
+
+		// ====================================================================
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_latency_awareness,
-			"proxysql_connpool_get_conn",
+			"proxysql_connpool_get_conn_success",
 			"The connection was picked using the latency awareness algorithm.",
 			metric_tags {
-			    { "status", "success" },
 				{ "algorithm", "latency_awareness" }
 			}
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_immediate,
-			"proxysql_connpool_get_conn",
+			"proxysql_connpool_get_conn_success",
 			"The connection is provided from per-thread cache.",
 			metric_tags {
-				{ "status", "success" },
 				{ "origin", "immediate" }
 			}
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_success,
-			"proxysql_connpool_get_conn",
+			"proxysql_connpool_get_conn_success",
 			"The session is able to get a connection, either from per-thread cache or connection pool.",
-			metric_tags {
-				{ "status", "success" }
-			}
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_failure,
-			"proxysql_connpool_get_conn",
+			"proxysql_connpool_get_conn_failure",
 			"The connection pool cannot provide any connection.",
-			metric_tags {
-				{ "status", "failure" }
-			}
+			metric_tags {}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_th_counter::generated_error_packets,
 			"proxysql_generated_error_packets",

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -593,7 +593,7 @@ th_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_th_counter::queries_backends_bytes_sent,
-			"proxysql_queries_backends_bytes",
+			"proxysql_queries_backends_bytes_total",
 			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
 				{ "traffic_flow", "sent" }
@@ -601,7 +601,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::queries_backends_bytes_recv,
-			"proxysql_queries_backends_bytes",
+			"proxysql_queries_backends_bytes_total",
 			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
 				{ "traffic_flow", "received" }
@@ -612,7 +612,7 @@ th_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_th_counter::queries_frontends_bytes_sent,
-			"proxysql_queries_frontends_bytes",
+			"proxysql_queries_frontends_bytes_total",
 			"Total number of bytes (sent|received) in frontend connections.",
 			metric_tags {
 				{ "traffic_flow", "sent" }
@@ -620,7 +620,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::queries_frontends_bytes_recv,
-			"proxysql_queries_frontends_bytes",
+			"proxysql_queries_frontends_bytes_total",
 			"Total number of bytes (sent|received) in frontend connections.",
 			metric_tags {
 				{ "traffic_flow", "received" }
@@ -631,7 +631,7 @@ th_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_th_counter::client_connections_created,
-			"proxysql_client_connections",
+			"proxysql_client_connections_total",
 			"Total number of client connections created or failed (including improperly closed).",
 			metric_tags {
 				{ "status", "created" }
@@ -639,7 +639,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::client_connections_aborted,
-			"proxysql_client_connections",
+			"proxysql_client_connections_total",
 			"Total number of client connections created or failed (including improperly closed).",
 			metric_tags {
 				{ "status", "aborted" }
@@ -649,13 +649,13 @@ th_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_th_counter::query_processor_time_nsec,
-			"proxysql_query_processor_time_seconds",
+			"proxysql_query_processor_time_seconds_total",
 			"The time spent inside the \"Query Processor\" to determine what action needs to be taken with the query (internal module).",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::backend_query_time_nsec,
-			"proxysql_backend_query_time_seconds",
+			"proxysql_backend_query_time_seconds_total",
 			"Time spent making network calls to communicate with the backends.",
 			metric_tags {}
 		),
@@ -663,7 +663,7 @@ th_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_th_counter::com_backend_stmt_prepare,
-			"proxysql_com_backend_stmt",
+			"proxysql_com_backend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
 				{ "op", "prepare" }
@@ -671,7 +671,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::com_backend_stmt_execute,
-			"proxysql_com_backend_stmt",
+			"proxysql_com_backend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
 				{ "op", "execute" }
@@ -679,7 +679,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::com_backend_stmt_close,
-			"proxysql_com_backend_stmt",
+			"proxysql_com_backend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
 				{ "op", "close" }
@@ -690,7 +690,7 @@ th_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_th_counter::com_frontend_stmt_prepare,
-			"proxysql_com_frontend_stmt",
+			"proxysql_com_frontend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
 				{ "op", "prepare" }
@@ -698,7 +698,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::com_frontend_stmt_execute,
-			"proxysql_com_frontend_stmt",
+			"proxysql_com_frontend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
 				{ "op", "execute" }
@@ -706,7 +706,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::com_frontend_stmt_close,
-			"proxysql_com_frontend_stmt",
+			"proxysql_com_frontend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
 				{ "op", "close" }
@@ -716,25 +716,25 @@ th_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_th_counter::questions,
-			"proxysql_questions",
+			"proxysql_questions_total",
 			"The total number of client requests / statements executed.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::slow_queries,
-			"proxysql_slow_queries",
+			"proxysql_slow_queries_total",
 			"The total number of queries with an execution time greater than \"mysql-long_query_time\" milliseconds.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::gtid_consistent_queries,
-			"proxysql_gtid_consistent_queries",
+			"proxysql_gtid_consistent_queries_total",
 			"Total queries with GTID consistent read.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::gtid_session_collected,
-			"proxysql_gtid_session_collected",
+			"proxysql_gtid_session_collected_total",
 			"Total queries with GTID session state.",
 			metric_tags {}
 		),
@@ -742,7 +742,7 @@ th_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_latency_awareness,
-			"proxysql_connpool_get_conn_success",
+			"proxysql_connpool_get_conn_success_total",
 			"The connection was picked using the latency awareness algorithm.",
 			metric_tags {
 				{ "algorithm", "latency_awareness" }
@@ -750,7 +750,7 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_immediate,
-			"proxysql_connpool_get_conn_success",
+			"proxysql_connpool_get_conn_success_total",
 			"The connection is provided from per-thread cache.",
 			metric_tags {
 				{ "origin", "immediate" }
@@ -758,13 +758,13 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_success,
-			"proxysql_connpool_get_conn_success",
+			"proxysql_connpool_get_conn_success_total",
 			"The session is able to get a connection, either from per-thread cache or connection pool.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_failure,
-			"proxysql_connpool_get_conn_failure",
+			"proxysql_connpool_get_conn_failure_total",
 			"The connection pool cannot provide any connection.",
 			metric_tags {}
 		),
@@ -772,49 +772,49 @@ th_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_th_counter::generated_error_packets,
-			"proxysql_generated_error_packets",
+			"proxysql_generated_error_packets_total",
 			"Total generated error packets.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::max_connect_timeouts,
-			"proxysql_max_connect_timeouts",
+			"proxysql_max_connect_timeouts_total",
 			"Maximum connection timeout reached when trying to connect to backend sever.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::backend_lagging_during_query,
-			"proxysql_backend_lagging_during_query",
+			"proxysql_backend_lagging_during_query_total",
 			"Query failed because server was shunned due to lag.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::backend_offline_during_query,
-			"proxysql_backend_offline_during_query",
+			"proxysql_backend_offline_during_query_total",
 			"Query failed because server was offline.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::queries_with_max_lag_ms,
-			"proxysql_queries_with_max_lag_ms",
+			"proxysql_queries_with_max_lag_ms_total",
 			"Received queries that have a 'max_lag' attribute.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::queries_with_max_lag_ms__delayed,
-			"proxysql_queries_with_max_lag_ms__delayed",
+			"proxysql_queries_with_max_lag_ms__delayed_total",
 			"Query delayed because no connection was selected due to 'max_lag' annotation.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::queries_with_max_lag_ms__total_wait_time_us,
-			"proxysql_queries_with_max_lag_ms__total_wait_time_us",
+			"proxysql_queries_with_max_lag_ms__total_wait_time_us_total",
 			"Total waited time due to connection selection because of 'max_lag' annotation.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_unexpected_frontend_com_quit,
-			"proxysql_mysql_unexpected_frontend_com_quit",
+			"proxysql_mysql_unexpected_frontend_com_quit_total",
 			"Unexpecte 'COM_QUIT' received from the client.",
 			metric_tags {}
 		),
@@ -827,43 +827,43 @@ th_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_th_counter::hostgroup_locked_queries,
-			"proxysql_hostgroup_locked_queries",
+			"proxysql_hostgroup_locked_queries_total",
 			"Query blocked because connection is locked into some hostgroup but is trying to reach other.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_unexpected_frontend_packets,
-			"proxysql_mysql_unexpected_frontend_packets",
+			"proxysql_mysql_unexpected_frontend_packets_total",
 			"Unexpected packet received from client.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::aws_aurora_replicas_skipped_during_query,
-			"proxysql_aws_aurora_replicas_skipped_during_query",
+			"proxysql_aws_aurora_replicas_skipped_during_query_total",
 			"Replicas skipped due to current lag being higher than 'max_lag' annotation.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::automatic_detected_sql_injection,
-			"proxysql_automatic_detected_sql_injection",
+			"proxysql_automatic_detected_sql_injection_total",
 			"Blocked a detected 'sql injection' attempt.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::whitelisted_sqli_fingerprint,
-			"proxysql_whitelisted_sqli_fingerprint",
+			"proxysql_whitelisted_sqli_fingerprint_total",
 			"Detected a whitelisted 'sql injection' fingerprint.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_killed_backend_connections,
-			"proxysql_mysql_killed_backend_connections",
+			"proxysql_mysql_killed_backend_connections_total",
 			"Number of backend connection killed.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_killed_backend_queries,
-			"proxysql_mysql_killed_backend_queries",
+			"proxysql_mysql_killed_backend_queries_total",
 			"Killed backend queries.",
 			metric_tags {}
 		)

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -5959,11 +5959,16 @@ unsigned long long MySQL_Threads_Handler::get_status_variable(
 		}
 	}
 	if (m_idx != p_th_counter::__size) {
+		const auto& cur_val = status_variables.p_counter_array[m_idx]->Value();
+		double final_val = 0;
+
 		if (conv != 0) {
-			const auto& cur_val = status_variables.p_counter_array[m_idx]->Value();
-			const auto& final_val = (q - (cur_val / conv)) * conv;
-			status_variables.p_counter_array[m_idx]->Increment(final_val);
+			final_val = (q - (cur_val / conv)) * conv;
+		} else {
+			final_val = q - cur_val;
 		}
+
+		status_variables.p_counter_array[m_idx]->Increment(final_val);
 	}
 	return q;
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -574,6 +574,14 @@ using admin_gauge_tuple =
 using admin_counter_vector = std::vector<admin_counter_tuple>;
 using admin_gauge_vector = std::vector<admin_gauge_tuple>;
 
+/**
+ * @brief Metrics map holding the metrics for the 'ProxySQL_Admin' module.
+ *
+ * @note Some metrics in this map, share a common "id name", because
+ *  they differ only by label, because of this, HELP is shared between
+ *  them. For better visual identification of this groups they are
+ *  sepparated using a line separator comment.
+ */
 const std::tuple<admin_counter_vector, admin_gauge_vector>
 admin_metrics_map = std::make_tuple(
 	admin_counter_vector {
@@ -604,10 +612,13 @@ admin_metrics_map = std::make_tuple(
 			"Memory used by SQLite.",
 			metric_tags {}
 		),
+
+		// ====================================================================
+
 		std::make_tuple (
 			p_admin_gauge::jemalloc_resident,
 			"proxysql_jemalloc_bytes",
-			"Bytes in physically resident data pages mapped by the allocator.",
+			"Jemalloc memory usage stadistics (resident|active|mapped|metadata).",
 			metric_tags {
 				{ "type", "resident" }
 			}
@@ -615,7 +626,7 @@ admin_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_admin_gauge::jemalloc_active,
 			"proxysql_jemalloc_bytes",
-			"Bytes in pages allocated by the application.",
+			"Jemalloc memory usage stadistics (resident|active|mapped|metadata).",
 			metric_tags {
 				{ "type", "active" }
 			}
@@ -623,7 +634,7 @@ admin_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_admin_gauge::jemalloc_mapped,
 			"proxysql_jemalloc_bytes",
-			"Bytes in extents mapped by the allocator.",
+			"Jemalloc memory usage stadistics (resident|active|mapped|metadata).",
 			metric_tags {
 				{ "type", "mapped" }
 			}
@@ -631,7 +642,7 @@ admin_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_admin_gauge::jemalloc_metadata,
 			"proxysql_jemalloc_bytes",
-			"Bytes dedicated to metadata.",
+			"Jemalloc memory usage stadistics (resident|active|mapped|metadata).",
 			metric_tags {
 				{ "type", "metadata" }
 			}
@@ -639,11 +650,13 @@ admin_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_admin_gauge::jemalloc_retained,
 			"proxysql_jemalloc_bytes",
-			"Bytes in virtual memory mappings that were retained rather than being returned to the operating system.",
+			"Jemalloc memory usage stadistics (resident|active|mapped|metadata).",
 			metric_tags {
 				{ "type", "retained" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_admin_gauge::query_digest_memory_bytes,
 			"proxysql_query_digest_memory_bytes",

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -585,7 +585,7 @@ admin_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_admin_counter::jemalloc_allocated,
-			"proxysql_jemalloc_allocated",
+			"proxysql_jemalloc_allocated_bytes",
 			"Bytes allocated by the application.",
 			metric_tags {}
 		)
@@ -606,34 +606,43 @@ admin_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_admin_gauge::jemalloc_resident,
-			"proxysql_jemalloc_resident",
+			"proxysql_jemalloc_bytes",
 			"Bytes in physically resident data pages mapped by the allocator.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "resident" }
+			}
 		),
 		std::make_tuple (
 			p_admin_gauge::jemalloc_active,
-			"proxysql_jemalloc_active",
+			"proxysql_jemalloc_bytes",
 			"Bytes in pages allocated by the application.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "active" }
+			}
 		),
 		std::make_tuple (
 			p_admin_gauge::jemalloc_mapped,
-			"proxysql_jemalloc_mapped",
+			"proxysql_jemalloc_bytes",
 			"Bytes in extents mapped by the allocator.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "mapped" }
+			}
 		),
 		std::make_tuple (
 			p_admin_gauge::jemalloc_metadata,
-			"proxysql_jemalloc_metadata",
+			"proxysql_jemalloc_bytes",
 			"Bytes dedicated to metadata.",
-			metric_tags {}
+			metric_tags {
+				{ "type", "metadata" }
+			}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::jemalloc_retained,
-			"proxysql_jemalloc_retained",
-			"",
-			metric_tags {}
+			"proxysql_jemalloc_bytes",
+			"Bytes in virtual memory mappings that were retained rather than being returned to the operating system.",
+			metric_tags {
+				{ "type", "retained" }
+			}
 		),
 		std::make_tuple (
 			p_admin_gauge::query_digest_memory_bytes,
@@ -648,59 +657,52 @@ admin_metrics_map = std::make_tuple(
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::mysql_query_rules_memory_bytes,
 			"proxysql_mysql_query_rules_memory_bytes",
-			"",
+			"Number of bytes used by 'mysql_query_rules' rules.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::mysql_firewall_users_table,
-			"proxysql_mysql_firewall_users_table",
-			"",
+			"proxysql_mysql_firewall_users_table_bytes",
+			"Number of bytes used by 'mysql_firewall_users' entries.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
+			// TODO: Check why 'global_mysql_firewall_whitelist_users_result___size' never updated
 			p_admin_gauge::mysql_firewall_users_config,
-			"proxysql_mysql_firewall_users_config",
-			"",
+			"proxysql_mysql_firewall_users_config_bytes",
+			"Full 'mysql_firewall_users' config 'resulset' size.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::mysql_firewall_rules_table,
-			"proxysql_mysql_firewall_rules_table",
-			"",
+			"proxysql_mysql_firewall_rules_table_bytes",
+			"Number of bytes used by 'mysql_firewall_rules' entries.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::mysql_firewall_rules_config,
-			"proxysql_mysql_firewall_rules_config",
-			"",
+			"proxysql_mysql_firewall_rules_config_bytes",
+			"Full 'mysql_firewall_users' config 'resulset' size.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::stack_memory_mysql_threads,
-			"proxysql_stack_memory_mysql_threads",
-			"",
+			"proxysql_stack_memory_mysql_threads_bytes",
+			"Stack size used by 'mysql_threads'.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::stack_memory_admin_threads,
-			"proxysql_stack_memory_admin_threads",
-			"",
+			"proxysql_stack_memory_admin_threads_bytes",
+			"Stack size used by 'admin_threads'.",
 			metric_tags {}
 		),
 		std::make_tuple (
-			// TODO: Add meaningful help
 			p_admin_gauge::stack_memory_cluster_threads,
 			"proxysql_stack_memory_cluster_threads",
-			"",
+			"Stack size used by 'cluster_threads'.",
 			metric_tags {}
 		),
 		// stmt metrics

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -587,13 +587,13 @@ admin_metrics_map = std::make_tuple(
 	admin_counter_vector {
 		std::make_tuple (
 			p_admin_counter::uptime,
-			"proxysql_uptime_seconds",
+			"proxysql_uptime_seconds_total",
 			"The total uptime of ProxySQL.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_admin_counter::jemalloc_allocated,
-			"proxysql_jemalloc_allocated_bytes",
+			"proxysql_jemalloc_allocated_bytes_total",
 			"Bytes allocated by the application.",
 			metric_tags {}
 		)

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -1932,10 +1932,20 @@ using cluster_gauge_tuple =
 using cluster_counter_vector = std::vector<cluster_counter_tuple>;
 using cluster_gauge_vector = std::vector<cluster_gauge_tuple>;
 
+/**
+ * @brief Metrics map holding the metrics for the 'ProxySQL_Cluster' module.
+ *
+ * @note Many metrics in this map, share a common "id name", because
+ *  they differ only by label, because of this, HELP is shared between
+ *  them. For better visual identification of this groups they are
+ *  sepparated using a line separator comment.
+ */
 const std::tuple<cluster_counter_vector, cluster_gauge_vector>
 cluster_metrics_map = std::make_tuple(
 	cluster_counter_vector {
 		// mysql_query_rules
+
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_query_rules_success,
 			"pulled_mysql_query_rules",
@@ -1948,8 +1958,11 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_query_rules' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
 
 		// mysql_servers_*
+
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_success,
 			"pulled_mysql_servers",
@@ -1962,6 +1975,9 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_servers' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_replication_hostgroups_success,
 			"pulled_mysql_servers_replication_hostgroups",
@@ -1974,6 +1990,8 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_servers_replication_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_group_replication_hostgroups_success,
 			"pulled_mysql_servers_group_replication_hostgroups",
@@ -1986,6 +2004,9 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_servers_group_replication_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_galera_hostgroups_success,
 			"pulled_mysql_servers_galera_hostgroups",
@@ -1998,6 +2019,9 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_servers_galera_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_aws_aurora_hostgroups_success,
 			"pulled_mysql_servers_aws_aurora_hostgroups",
@@ -2010,6 +2034,9 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_servers_aws_aurora_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
+
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_runtime_checks_success,
 			"pulled_mysql_servers_runtime_checks",
@@ -2022,8 +2049,11 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_servers_runtime_checks' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
 
 		// mysql_users_*
+
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_users_success,
 			"pulled_mysql_users",
@@ -2036,8 +2066,10 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_users' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
 
 		// proxysql_servers_*
+		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_proxysql_servers_success,
 			"pulled_proxysql_servers",
@@ -2050,31 +2082,32 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times 'mysql_proxysql_servers' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
+		// ====================================================================
 
 		// sync_conflict same epoch
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_mysql_query_rules_share_epoch,
 			"sync_conflict_mysql_query_rules_share_epoch",
 			"Number of times 'mysql_query_rules' has not been synced because they share the same epoch.",
-			metric_tags { { "type", "error" } }
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_mysql_servers_share_epoch,
 			"sync_conflict_mysql_servers_share_epoch",
 			"Number of times 'mysql_servers' has not been synced because they share the same epoch.",
-			metric_tags { { "type", "error" } }
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_proxysql_servers_share_epoch,
 			"sync_conflict_proxysql_servers_share_epoch",
 			"Number of times 'proxysql_servers' has not been synced because they share the same epoch.",
-			metric_tags { { "type", "error" } }
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_mysql_users_share_epoch,
 			"sync_conflict_mysql_users_share_epoch",
 			"Number of times 'mysql_users' has not been synced because they share the same epoch.",
-			metric_tags { { "type", "error" } }
+			metric_tags {}
 		),
 
 		// sync_delayed due to version one
@@ -2082,25 +2115,25 @@ cluster_metrics_map = std::make_tuple(
 			p_cluster_counter::sync_delayed_mysql_query_rules_version_one,
 			"sync_delayed_mysql_query_rules_version_one",
 			"Number of times 'mysql_query_rules' has not been synced because version one doesn't allow sync.",
-			metric_tags { { "type", "warning" } }
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_delayed_mysql_servers_version_one,
 			"sync_delayed_mysql_servers_version_one",
 			"Number of times 'mysql_servers' has not been synced because version one doesn't allow sync.",
-			metric_tags { { "type", "warning" } }
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_delayed_mysql_users_version_one,
 			"sync_delayed_mysql_users_version_one",
 			"Number of times 'mysql_users' has not been synced because version one doesn't allow sync.",
-			metric_tags { { "type", "warning" } }
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_delayed_proxysql_servers_version_one,
 			"sync_delayed_proxysql_servers_version_one",
 			"Number of times 'proxysql_servers' has not been synced because version one doesn't allow sync.",
-			metric_tags { { "type", "warning" } }
+			metric_tags {}
 		)
 	},
 	cluster_gauge_vector {}

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -1948,13 +1948,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_query_rules_success,
-			"pulled_mysql_query_rules",
+			"pulled_mysql_query_rules_total",
 			"Number of times 'mysql_query_rules' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_query_rules_failure,
-			"pulled_mysql_query_rules",
+			"pulled_mysql_query_rules_total",
 			"Number of times 'mysql_query_rules' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -1965,13 +1965,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_success,
-			"pulled_mysql_servers",
+			"pulled_mysql_servers_total",
 			"Number of times 'mysql_servers' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_failure,
-			"pulled_mysql_servers",
+			"pulled_mysql_servers_total",
 			"Number of times 'mysql_servers' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -1980,13 +1980,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_replication_hostgroups_success,
-			"pulled_mysql_servers_replication_hostgroups",
+			"pulled_mysql_servers_replication_hostgroups_total",
 			"Number of times 'mysql_servers_replication_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "successs" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_replication_hostgroups_failure,
-			"pulled_mysql_servers_replication_hostgroups",
+			"pulled_mysql_servers_replication_hostgroups_total",
 			"Number of times 'mysql_servers_replication_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -1994,13 +1994,13 @@ cluster_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_group_replication_hostgroups_success,
-			"pulled_mysql_servers_group_replication_hostgroups",
+			"pulled_mysql_servers_group_replication_hostgroups_total",
 			"Number of times 'mysql_servers_group_replication_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_group_replication_hostgroups_failure,
-			"pulled_mysql_servers_group_replication_hostgroups",
+			"pulled_mysql_servers_group_replication_hostgroups_total",
 			"Number of times 'mysql_servers_group_replication_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -2009,13 +2009,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_galera_hostgroups_success,
-			"pulled_mysql_servers_galera_hostgroups",
+			"pulled_mysql_servers_galera_hostgroups_total",
 			"Number of times 'mysql_servers_galera_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_galera_hostgroups_failure,
-			"pulled_mysql_servers_galera_hostgroups",
+			"pulled_mysql_servers_galera_hostgroups_total",
 			"Number of times 'mysql_servers_galera_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -2024,13 +2024,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_aws_aurora_hostgroups_success,
-			"pulled_mysql_servers_aws_aurora_hostgroups",
+			"pulled_mysql_servers_aws_aurora_hostgroups_total",
 			"Number of times 'mysql_servers_aws_aurora_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_aws_aurora_hostgroups_failure,
-			"pulled_mysql_servers_aws_aurora_hostgroups",
+			"pulled_mysql_servers_aws_aurora_hostgroups_total",
 			"Number of times 'mysql_servers_aws_aurora_hostgroups' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -2039,13 +2039,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_runtime_checks_success,
-			"pulled_mysql_servers_runtime_checks",
+			"pulled_mysql_servers_runtime_checks_total",
 			"Number of times '' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_servers_runtime_checks_failure,
-			"pulled_mysql_servers_runtime_checks",
+			"pulled_mysql_servers_runtime_checks_total",
 			"Number of times 'mysql_servers_runtime_checks' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -2056,13 +2056,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_users_success,
-			"pulled_mysql_users",
+			"pulled_mysql_users_total",
 			"Number of times 'mysql_users' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_mysql_users_failure,
-			"pulled_mysql_users",
+			"pulled_mysql_users_total",
 			"Number of times 'mysql_users' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -2072,13 +2072,13 @@ cluster_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_cluster_counter::pulled_proxysql_servers_success,
-			"pulled_proxysql_servers",
+			"pulled_proxysql_servers_total",
 			"Number of times 'mysql_proxysql_servers' have been pulled from a peer.",
 			metric_tags { { "status", "success" } }
 		),
 		std::make_tuple (
 			p_cluster_counter::pulled_proxysql_servers_failure,
-			"pulled_proxysql_servers",
+			"pulled_proxysql_servers_total",
 			"Number of times 'mysql_proxysql_servers' have been pulled from a peer.",
 			metric_tags { { "status", "failure" } }
 		),
@@ -2087,25 +2087,25 @@ cluster_metrics_map = std::make_tuple(
 		// sync_conflict same epoch
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_mysql_query_rules_share_epoch,
-			"sync_conflict_mysql_query_rules_share_epoch",
+			"sync_conflict_mysql_query_rules_share_epoch_total",
 			"Number of times 'mysql_query_rules' has not been synced because they share the same epoch.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_mysql_servers_share_epoch,
-			"sync_conflict_mysql_servers_share_epoch",
+			"sync_conflict_mysql_servers_share_epoch_total",
 			"Number of times 'mysql_servers' has not been synced because they share the same epoch.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_proxysql_servers_share_epoch,
-			"sync_conflict_proxysql_servers_share_epoch",
+			"sync_conflict_proxysql_servers_share_epoch_total",
 			"Number of times 'proxysql_servers' has not been synced because they share the same epoch.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_conflict_mysql_users_share_epoch,
-			"sync_conflict_mysql_users_share_epoch",
+			"sync_conflict_mysql_users_share_epoch_total",
 			"Number of times 'mysql_users' has not been synced because they share the same epoch.",
 			metric_tags {}
 		),
@@ -2113,25 +2113,25 @@ cluster_metrics_map = std::make_tuple(
 		// sync_delayed due to version one
 		std::make_tuple (
 			p_cluster_counter::sync_delayed_mysql_query_rules_version_one,
-			"sync_delayed_mysql_query_rules_version_one",
+			"sync_delayed_mysql_query_rules_version_one_total",
 			"Number of times 'mysql_query_rules' has not been synced because version one doesn't allow sync.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_delayed_mysql_servers_version_one,
-			"sync_delayed_mysql_servers_version_one",
+			"sync_delayed_mysql_servers_version_one_total",
 			"Number of times 'mysql_servers' has not been synced because version one doesn't allow sync.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_delayed_mysql_users_version_one,
-			"sync_delayed_mysql_users_version_one",
+			"sync_delayed_mysql_users_version_one_total",
 			"Number of times 'mysql_users' has not been synced because version one doesn't allow sync.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_cluster_counter::sync_delayed_proxysql_servers_version_one,
-			"sync_delayed_proxysql_servers_version_one",
+			"sync_delayed_proxysql_servers_version_one_total",
 			"Number of times 'proxysql_servers' has not been synced because version one doesn't allow sync.",
 			metric_tags {}
 		)

--- a/lib/Query_Cache.cpp
+++ b/lib/Query_Cache.cpp
@@ -318,38 +318,46 @@ using qc_gauge_tuple =
 using qc_counter_vector = std::vector<qc_counter_tuple>;
 using qc_gauge_vector = std::vector<qc_gauge_tuple>;
 
+/**
+ * @brief Metrics map holding the metrics for the 'Query_Cache' module.
+ *
+ * @note Many metrics in this map, share a common "id name", because
+ *  they differ only by label, because of this, HELP is shared between
+ *  them. For better visual identification of this groups they are
+ *  sepparated using a line separator comment.
+ */
 const std::tuple<qc_counter_vector, qc_gauge_vector>
 qc_metrics_map = std::make_tuple(
 	qc_counter_vector {
+		// ====================================================================
 		std::make_tuple (
 			p_qc_counter::query_cache_count_get,
-			"proxysql_query_cache_count",
+			"proxysql_query_cache_count_get",
 			"Number of read requests.",
-			metric_tags {
-				{ "op", "get" }
-			}
+			metric_tags {}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_count_get_ok,
-			"proxysql_query_cache_count",
+			"proxysql_query_cache_count_get",
 			"Number of successful read requests.",
 			metric_tags {
-				{ "op", "get" },
 				{ "status", "ok" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_qc_counter::query_cache_count_set,
-			"proxysql_query_cache_count",
+			"proxysql_query_cache_count_set",
 			"Number of write requests.",
-			metric_tags {
-				{ "op", "set" }
-			}
+			metric_tags {}
 		),
+
+		// ====================================================================
 		std::make_tuple (
 			p_qc_counter::query_cache_bytes_in,
 			"proxysql_query_cache_bytes",
-			"Number of bytes written into the Query Cache.",
+			"Number of bytes (read|written) into the Query Cache.",
 			metric_tags {
 				{ "op", "written" }
 			}
@@ -357,11 +365,13 @@ qc_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_qc_counter::query_cache_bytes_out,
 			"proxysql_query_cache_bytes",
-			"Number of bytes read from the Query Cache.",
+			"Number of bytes (read|written) into the Query Cache.",
 			metric_tags {
 				{ "op", "read" }
 			}
 		),
+		// ====================================================================
+
 		std::make_tuple (
 			p_qc_counter::query_cache_purged,
 			"proxysql_query_cache_purged",

--- a/lib/Query_Cache.cpp
+++ b/lib/Query_Cache.cpp
@@ -332,13 +332,13 @@ qc_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_qc_counter::query_cache_count_get,
-			"proxysql_query_cache_count_get",
+			"proxysql_query_cache_count_get_total",
 			"Number of read requests.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_count_get_ok,
-			"proxysql_query_cache_count_get",
+			"proxysql_query_cache_count_get_total",
 			"Number of successful read requests.",
 			metric_tags {
 				{ "status", "ok" }
@@ -348,7 +348,7 @@ qc_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_qc_counter::query_cache_count_set,
-			"proxysql_query_cache_count_set",
+			"proxysql_query_cache_count_set_total",
 			"Number of write requests.",
 			metric_tags {}
 		),
@@ -356,7 +356,7 @@ qc_metrics_map = std::make_tuple(
 		// ====================================================================
 		std::make_tuple (
 			p_qc_counter::query_cache_bytes_in,
-			"proxysql_query_cache_bytes",
+			"proxysql_query_cache_bytes_total",
 			"Number of bytes (read|written) into the Query Cache.",
 			metric_tags {
 				{ "op", "written" }
@@ -364,7 +364,7 @@ qc_metrics_map = std::make_tuple(
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_bytes_out,
-			"proxysql_query_cache_bytes",
+			"proxysql_query_cache_bytes_total",
 			"Number of bytes (read|written) into the Query Cache.",
 			metric_tags {
 				{ "op", "read" }
@@ -374,13 +374,13 @@ qc_metrics_map = std::make_tuple(
 
 		std::make_tuple (
 			p_qc_counter::query_cache_purged,
-			"proxysql_query_cache_purged",
+			"proxysql_query_cache_purged_total",
 			"Number of entries purged by the Query Cache due to TTL expiration.",
 			metric_tags {}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_entries,
-			"proxysql_query_cache_entries",
+			"proxysql_query_cache_entries_total",
 			"Number of entries currently stored in the query cache.",
 			metric_tags {}
 		)

--- a/lib/Query_Cache.cpp
+++ b/lib/Query_Cache.cpp
@@ -323,33 +323,44 @@ qc_metrics_map = std::make_tuple(
 	qc_counter_vector {
 		std::make_tuple (
 			p_qc_counter::query_cache_count_get,
-			"proxysql_query_cache_count_get",
+			"proxysql_query_cache_count",
 			"Number of read requests.",
-			metric_tags {}
+			metric_tags {
+				{ "op", "get" }
+			}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_count_get_ok,
-			"proxysql_query_cache_count_get_ok",
+			"proxysql_query_cache_count",
 			"Number of successful read requests.",
-			metric_tags {}
+			metric_tags {
+				{ "op", "get" },
+				{ "status", "ok" }
+			}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_count_set,
-			"proxysql_query_cache_count_set",
+			"proxysql_query_cache_count",
 			"Number of write requests.",
-			metric_tags {}
+			metric_tags {
+				{ "op", "set" }
+			}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_bytes_in,
-			"proxysql_query_cache_bytes_in",
-			"Number of bytes sent into the Query Cache.",
-			metric_tags {}
+			"proxysql_query_cache_bytes",
+			"Number of bytes written into the Query Cache.",
+			metric_tags {
+				{ "op", "written" }
+			}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_bytes_out,
-			"proxysql_query_cache_bytes_out",
+			"proxysql_query_cache_bytes",
 			"Number of bytes read from the Query Cache.",
-			metric_tags {}
+			metric_tags {
+				{ "op", "read" }
+			}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_purged,
@@ -368,7 +379,7 @@ qc_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_qc_gauge::query_cache_memory_bytes,
 			"proxysql_query_cache_memory_bytes",
-			"Memory currently used by the query cache (more details later).",
+			"Memory currently used by the query cache.",
 			metric_tags {}
 		)
 	}


### PR DESCRIPTION
It also includes:

- Additional help messages for metrics.
- Fixing of invalid metric previously classify as "counter".