### PR TITLE
Fix #3103 miss handling of session reset and sessions list

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -190,6 +190,7 @@ class MySQL_Thread
   void poll_listener_del(int sock);
   void register_session(MySQL_Session*, bool up_start=true);
   void unregister_session(int);
+  void unregister_session(MySQL_Session*);
   struct pollfd * get_pollfd(unsigned int i);
   bool process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned int n);
   void process_all_sessions();

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6389,11 +6389,9 @@ void MySQL_Session::create_new_session_and_reset_connection(MySQL_Data_Stream *_
 		thread->mypolls.add(POLLIN|POLLOUT, new_myds->fd, new_myds, thread->curtime);
 	}
 
-	// store the idx now in case handler mutates the list of sessions to stop bugs like #2460
-	unsigned int sess_idx = thread->mysql_sessions->len - 1;
 	int rc = new_sess->handler();
 	if (rc == -1) {
-		thread->unregister_session(sess_idx);
+		thread->unregister_session(new_sess);
 		delete new_sess;
 	}
 }

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6388,9 +6388,11 @@ void MySQL_Session::create_new_session_and_reset_connection(MySQL_Data_Stream *_
 	if (new_myds->mypolls==NULL) {
 		thread->mypolls.add(POLLIN|POLLOUT, new_myds->fd, new_myds, thread->curtime);
 	}
-	int rc = new_sess->handler();
+
+	// store the idx now in case handler mutates the list of sessions to stop bugs like #2460
+    unsigned int sess_idx = thread->mysql_sessions->len-1;
+    int rc = new_sess->handler();
 	if (rc==-1) {
-		unsigned int sess_idx = thread->mysql_sessions->len-1;
 		thread->unregister_session(sess_idx);
 		delete new_sess;
 	}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6390,9 +6390,9 @@ void MySQL_Session::create_new_session_and_reset_connection(MySQL_Data_Stream *_
 	}
 
 	// store the idx now in case handler mutates the list of sessions to stop bugs like #2460
-    unsigned int sess_idx = thread->mysql_sessions->len-1;
-    int rc = new_sess->handler();
-	if (rc==-1) {
+	unsigned int sess_idx = thread->mysql_sessions->len - 1;
+	int rc = new_sess->handler();
+	if (rc == -1) {
 		thread->unregister_session(sess_idx);
 		delete new_sess;
 	}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3527,6 +3527,14 @@ void MySQL_Thread::unregister_session(int idx) {
 	mysql_sessions->remove_index_fast(idx);
 }
 
+void MySQL_Thread::unregister_session(MySQL_Session *_sess) {
+	if (mysql_sessions==NULL) return;
+	if (mysql_sessions->pdata[mysql_sessions->len-1] == _sess) {
+		mysql_sessions->remove_index_fast(mysql_sessions->len - 1);
+	} else {
+		mysql_sessions->remove_fast(_sess);
+	}
+}
 
 // main loop
 void MySQL_Thread::run() {

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -1406,8 +1406,8 @@ void MySQL_Data_Stream::return_MySQL_Connection_To_Pool() {
 		||
 		( mc->local_stmts->get_num_backend_stmts() > (unsigned int)GloMTH->variables.max_stmts_per_connection )
 	) {
-	    // do not try to reset connections if the session is already resetting bug: #2460
-		if (mysql_thread___reset_connection_algorithm == 2 && sess->status != RESETTING_CONNECTION ) {
+		// do not try to reset connections if the session is already resetting bug: #2460
+		if (mysql_thread___reset_connection_algorithm == 2 && sess->status != RESETTING_CONNECTION) {
 			sess->create_new_session_and_reset_connection(this);
 		} else {
 			destroy_MySQL_Connection_From_Pool(true);

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -1406,7 +1406,8 @@ void MySQL_Data_Stream::return_MySQL_Connection_To_Pool() {
 		||
 		( mc->local_stmts->get_num_backend_stmts() > (unsigned int)GloMTH->variables.max_stmts_per_connection )
 	) {
-		if (mysql_thread___reset_connection_algorithm == 2) {
+	    // do not try to reset connections if the session is already resetting bug: #2460
+		if (mysql_thread___reset_connection_algorithm == 2 && sess->status != RESETTING_CONNECTION ) {
 			sess->create_new_session_and_reset_connection(this);
 		} else {
 			destroy_MySQL_Connection_From_Pool(true);


### PR DESCRIPTION
Taking a look at #2460 if mybes and mybe are truly both null you would expect there to be a path where they are assigned to this state. I could not find one apart from when a session is being destroyed.

Turns out that since create_new_session_and_reset_connection assumes that the session at the end of the list is the one it created after running the handler you can end up removing the wrong session from the list and then delete the session still in the list.

This was cased by return_MySQL_Connection_To_Pool calling create_new_session_and_reset_connection if the connection has reached max statements or age while resetting.

Checking if the session is currently resetting the connection stops the loop but it seemed like a good idea to also store the index of the session before running the handler so that future additions/refactors don't cause the session list to get into a bad state.