### PR TITLE
Closes #3125: Renamed 'interval_ms' from 'restapi_routes' table into 'timeout_ms'

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -223,6 +223,7 @@ class ProxySQL_Admin {
 	void disk_upgrade_mysql_servers();
 	void disk_upgrade_mysql_users();
 	void disk_upgrade_scheduler();
+	void disk_upgrade_rest_api_routes();
 
 #ifdef DEBUG
 	void add_credentials(char *type, char *credentials, int hostgroup_id);

--- a/include/proxysql_restapi.h
+++ b/include/proxysql_restapi.h
@@ -12,7 +12,7 @@ class Restapi_Row {
 public:
 	unsigned int id;
 	bool is_active;
-	unsigned int interval_ms;
+	unsigned int timeout_ms;
 	std::string method;
 	std::string uri;
 	std::string script;

--- a/lib/ProxySQL_Config.cpp
+++ b/lib/ProxySQL_Config.cpp
@@ -368,7 +368,7 @@ int ProxySQL_Config::Write_Restapi_to_configfile(std::string& data) {
 				data += "\t{\n";
 				addField(data, "id", r->fields[0], "");
 				addField(data, "active", r->fields[1], "");
-				addField(data, "interval_ms", r->fields[2], "");
+				addField(data, "timeout_ms", r->fields[2], "");
 				addField(data, "method", r->fields[3], "");
 				addField(data, "uri", r->fields[4]);
 				addField(data, "script", r->fields[5]);
@@ -401,8 +401,8 @@ int ProxySQL_Config::Read_Restapi_from_configfile() {
 		const Setting &route = routes[i];
 		int id;
 		int active=1;
-		// variable for parsing interval_ms
-		int interval_ms=0;
+		// variable for parsing timeout_ms
+		int timeout_ms=0;
 
 		std::string method;
 		std::string uri;
@@ -415,7 +415,9 @@ int ProxySQL_Config::Read_Restapi_from_configfile() {
 			continue;
 		}
 		route.lookupValue("active", active);
-		route.lookupValue("interval_ms", interval_ms);
+		if (route.lookupValue("interval_ms", timeout_ms) == false) {
+			route.lookupValue("timeout_ms", timeout_ms);
+		}
 		if (route.lookupValue("method", method)==false) {
 			proxy_error("Admin: detected a restapi route in config file without a mandatory method\n");
 			continue;
@@ -434,7 +436,7 @@ int ProxySQL_Config::Read_Restapi_from_configfile() {
 		query_len+=strlen(q) +
 			strlen(std::to_string(id).c_str()) +
 			strlen(std::to_string(active).c_str()) +
-			strlen(std::to_string(interval_ms).c_str()) +
+			strlen(std::to_string(timeout_ms).c_str()) +
 			strlen(method.c_str()) +
 			strlen(uri.c_str()) +
 			strlen(script.c_str()) +
@@ -443,7 +445,7 @@ int ProxySQL_Config::Read_Restapi_from_configfile() {
 		char *query=(char *)malloc(query_len);
 		sprintf(query, q,
 			id, active,
-			interval_ms,
+			timeout_ms,
 			method.c_str(),
 			uri.c_str(),
 			script.c_str(),

--- a/lib/ProxySQL_Restapi.cpp
+++ b/lib/ProxySQL_Restapi.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 
 Restapi_Row::Restapi_Row(unsigned int _id, bool _is_active, unsigned int _in, const std::string& _method, const std::string& _uri, const std::string& _script, const std::string& _comment) :
-	id(_id), is_active(_is_active), interval_ms(_in), method(_method), uri(_uri), script(_script), comment(_comment) {}
+	id(_id), is_active(_is_active), timeout_ms(_in), method(_method), uri(_uri), script(_script), comment(_comment) {}
 
 ProxySQL_Restapi::ProxySQL_Restapi(SQLite3DB* db) {
 	assert(db);
@@ -37,8 +37,8 @@ void ProxySQL_Restapi::update_restapi_table(SQLite3_result *resultset) {
 		if (atoi(r->fields[1])) {
 			is_active=true;
 		}
-		unsigned int interval_ms=strtoul(r->fields[2], NULL, 10);
-		Restapi_Rows.push_back({id, is_active, interval_ms, r->fields[3], r->fields[4], r->fields[5], r->fields[6]});
+		unsigned int timeout_ms=strtoul(r->fields[2], NULL, 10);
+		Restapi_Rows.push_back({id, is_active, timeout_ms, r->fields[3], r->fields[4], r->fields[5], r->fields[6]});
 	}
 
 	// increase version
@@ -79,7 +79,7 @@ void ProxySQL_Restapi::save_restapi_runtime_to_database(bool _runtime) {
 	for (auto r : Restapi_Rows) {
 		std::stringstream ss;
 		ss << "INSERT INTO " << table << " VALUES(" << r.id << "," <<  r.is_active << ","
-			<< r.interval_ms << ",'" << r.method << "','" << r.uri << "','" << r.script << "','" << r.comment << "')";
+			<< r.timeout_ms << ",'" << r.method << "','" << r.uri << "','" << r.script << "','" << r.comment << "')";
 
 		admindb->execute(ss.str().c_str());
 	}


### PR DESCRIPTION
Closes #3125.