### PR TITLE
Closes #3135: Fixed crash due to invalid access to already freed 'MyMon_thread'

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1095,6 +1095,7 @@ void ProxySQL_Main_join_all_threads() {
 	if (GloMyMon && MyMon_thread) {
 		cpu_timer t;
 		MyMon_thread->join();
+		MyMon_thread = NULL;
 #ifdef DEBUG
 		std::cerr << "GloMyMon joined in ";
 #endif


### PR DESCRIPTION
Closes #3135.