### PR TITLE
Closes #3147: Fixed return code for 'MYSQL_QUERY' macro in 'tap/utils.h'

### DIFF
--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -10,7 +10,7 @@
 		if (mysql_query(mysql, query)) { \
 			fprintf(stderr, "File %s, line %d, Error: %s\n", \
 					__FILE__, __LINE__, mysql_error(mysql)); \
-			return exit_status(); \
+			return EXIT_FAILURE; \
 		} \
 	} while(0)
 


### PR DESCRIPTION
Closes #3147 .