### PR TITLE
Closes #3159: Added patch to replace 'std::regex' in favor of 're2' in libhttpserver for 'GCC' versions under 4.9

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -68,6 +68,7 @@ ifeq ($(REQUIRE_PATCH), true)
 	cd libhttpserver/libhttpserver && patch src/httpserver/http_resource.hpp < ../http_resource.hpp.patch
 	cd libhttpserver/libhttpserver && patch src/httpserver/http_response.hpp < ../http_response.hpp.patch
 	cd libhttpserver/libhttpserver && patch src/httpserver/string_response.hpp < ../string_response.hpp.patch
+	cd libhttpserver/libhttpserver && patch -p0 < ../re2_regex.patch
 endif
 ifeq ($(UNAME_S),FreeBSD)
 	sed -i -e 's/\/bin\/bash/\/usr\/local\/bin\/bash/' libhttpserver/libhttpserver/bootstrap
@@ -211,7 +212,7 @@ re2/re2/obj/libre2.a:
 	cd re2 && tar -zxf re2.tar.gz
 #	cd re2/re2 && sed -i -e 's/-O3 -g /-O3 -fPIC /' Makefile
 #	cd re2 && patch re2/util/mutex.h < mutex.h.patch
-	cd re2/re2 && sed -i -e 's/-O3 /-O3 -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
+	cd re2/re2 && sed -i -e 's/-O3 /-O3 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
 	cd re2/re2 && CC=${CC} CXX=${CXX} ${MAKE}
 
 re2: re2/re2/obj/libre2.a

--- a/deps/libhttpserver/re2_regex.patch
+++ b/deps/libhttpserver/re2_regex.patch
@@ -1,0 +1,151 @@
+diff --git examples/Makefile.am examples/Makefile.am
+index 318a7a8..2f5e1fb 100644
+--- examples/Makefile.am
++++ examples/Makefile.am
+@@ -16,8 +16,12 @@
+ #     License along with this library; if not, write to the Free Software
+ #     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+-LDADD = $(top_builddir)/src/libhttpserver.la
+-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/httpserver/
++DEPS_PATH=$(top_srcdir)/../../
++RE2_PATH=$(DEPS_PATH)/re2/re2
++RE2_IDIR=$(RE2_PATH)
++
++LDADD = $(top_builddir)/src/libhttpserver.la -L$(RE2_PATH)/obj -lre2
++AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/httpserver/ -I$(RE2_IDIR)
+ METASOURCES = AUTO
+ noinst_PROGRAMS = hello_world service minimal_hello_world custom_error allowing_disallowing_methods handlers hello_with_get_arg setting_headers custom_access_log basic_authentication digest_authentication minimal_https minimal_file_response minimal_deferred url_registration minimal_ip_ban benchmark_select benchmark_threads benchmark_nodelay deferred_with_accumulator
+ 
+diff --git src/Makefile.am src/Makefile.am
+index 5e549bb..ddb05ea 100644
+--- src/Makefile.am
++++ src/Makefile.am
+@@ -16,7 +16,11 @@
+ #     License along with this library; if not, write to the Free Software
+ #     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+-AM_CPPFLAGS = -I../ -I$(srcdir)/httpserver/
++DEPS_PATH=$(top_srcdir)/../../
++RE2_PATH=$(DEPS_PATH)/re2/re2
++RE2_IDIR=$(RE2_PATH)
++
++AM_CPPFLAGS = -I../ -I$(srcdir)/httpserver/ -I$(RE2_IDIR)
+ METASOURCES = AUTO
+ lib_LTLIBRARIES = libhttpserver.la
+ libhttpserver_la_SOURCES = string_utilities.cpp webserver.cpp http_utils.cpp http_request.cpp http_response.cpp string_response.cpp basic_auth_fail_response.cpp digest_auth_fail_response.cpp deferred_response.cpp file_response.cpp http_resource.cpp details/http_endpoint.cpp
+@@ -37,7 +41,7 @@ endif
+ 
+ libhttpserver_la_CFLAGS = $(AM_CFLAGS)
+ libhttpserver_la_CXXFLAGS = $(AM_CXXFLAGS)
+-libhttpserver_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined
++libhttpserver_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -L$(RE2_PATH)/obj -lre2
+ 
+ install-data-hook:
+ 	(mkdir -p $(DESTDIR)$(includedir) && cd $(DESTDIR)$(includedir) && $(LN_S) -f httpserver.hpp httpserverpp)
+diff --git src/details/http_endpoint.cpp src/details/http_endpoint.cpp
+index be76ddd..b6738a0 100644
+--- src/details/http_endpoint.cpp
++++ src/details/http_endpoint.cpp
+@@ -46,6 +46,7 @@ http_endpoint::http_endpoint
+     bool registration,
+     bool use_regex
+ ):
++    re_url_normalized(new re2::RE2("")),
+     family_url(family),
+     reg_compiled(false)
+ {
+@@ -124,9 +125,19 @@ http_endpoint::http_endpoint
+         url_normalized += "$";
+         try
+         {
+-            re_url_normalized = std::regex(url_normalized, std::regex::extended | std::regex::icase | std::regex::nosubs);
++            re2::RE2::Options opts {};
++            opts.set_case_sensitive(true);
++            opts.set_never_capture(true);
++
++            re_url_normalized.reset(
++                new re2::RE2(url_normalized, opts)
++            );
++
++            if (re_url_normalized->ok() != true) {
++                throw std::invalid_argument("Invalid regex supplied to re2");
++            }
+         }
+-        catch (std::regex_error& e)
++        catch (std::invalid_argument& e)
+         {
+             throw std::invalid_argument("Not a valid regex in URL: " + url_normalized);
+         }
+@@ -140,7 +151,7 @@ http_endpoint::http_endpoint(const http_endpoint& h):
+     url_pars(h.url_pars),
+     url_pieces(h.url_pieces),
+     chunk_positions(h.chunk_positions),
+-    re_url_normalized(h.re_url_normalized),
++    re_url_normalized(new re2::RE2(h.re_url_normalized->pattern())),
+     family_url(h.family_url),
+     reg_compiled(h.reg_compiled)
+ {
+@@ -152,7 +163,7 @@ http_endpoint& http_endpoint::operator =(const http_endpoint& h)
+     url_normalized = h.url_normalized;
+     family_url = h.family_url;
+     reg_compiled = h.reg_compiled;
+-    re_url_normalized = h.re_url_normalized;
++    re_url_normalized.reset(new re2::RE2(h.re_url_normalized->pattern()));
+     url_pars = h.url_pars;
+     url_pieces = h.url_pieces;
+     chunk_positions = h.chunk_positions;
+@@ -170,7 +181,7 @@ bool http_endpoint::match(const http_endpoint& url) const
+ 
+     if(!family_url || url.url_pieces.size() < url_pieces.size())
+     {
+-        return regex_match(url.url_complete, re_url_normalized);
++        return RE2::FullMatch(url.url_complete, *re_url_normalized);
+     }
+ 
+     string nn = "/";
+@@ -180,7 +191,7 @@ bool http_endpoint::match(const http_endpoint& url) const
+         nn += (first ? "" : "/") + url.url_pieces[i];
+         first = false;
+     }
+-    return regex_match(nn, re_url_normalized);
++    return RE2::FullMatch(nn, *re_url_normalized);
+ }
+ 
+ };
+diff --git src/httpserver/details/http_endpoint.hpp src/httpserver/details/http_endpoint.hpp
+index 147956a..2afd42f 100644
+--- src/httpserver/details/http_endpoint.hpp
++++ src/httpserver/details/http_endpoint.hpp
+@@ -25,11 +25,12 @@
+ #ifndef _HTTP_ENDPOINT_HPP_
+ #define _HTTP_ENDPOINT_HPP_
+ 
+-#include <regex>
++#include "re2/re2.h"
+ #include <stdexcept>
+ #include <string>
+ #include <utility>
+ #include <vector>
++#include <memory>
+ 
+ namespace httpserver
+ {
+@@ -136,7 +137,7 @@ class http_endpoint
+         http_endpoint():
+             url_complete("/"),
+             url_normalized("/"),
+-            re_url_normalized(std::regex("")), // initialize empty
++            re_url_normalized(new re2::RE2("")), // initialize empty
+             family_url(false),
+             reg_compiled(false)
+         {
+@@ -187,7 +188,7 @@ class http_endpoint
+         /**
+          * Regex used in comparisons
+         **/
+-        std::regex re_url_normalized;
++        std::unique_ptr<re2::RE2> re_url_normalized;
+ 
+         /**
+          * Boolean indicating wheter the endpoint represents a family


### PR DESCRIPTION
Closes #3159.