### PR TITLE
Closes #3167: Fixed memory leak in 'save_mysql_servers_runtime_to_database' due to non-freed resultset

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -10676,6 +10676,7 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 		(*proxy_sqlite3_finalize)(statement);
 	}
 	if(resultset) delete resultset;
+	resultset = NULL;
 
 	// dump mysql_galera_hostgroups
 	if (_runtime) {
@@ -10718,6 +10719,8 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 		}
 		(*proxy_sqlite3_finalize)(statement);
 	}
+	if(resultset) delete resultset;
+	resultset = NULL;
 
 	// dump mysql_aws_aurora_hostgroups
 


### PR DESCRIPTION
Closes #3167.

- [x] Valgrind clean output.

[valgrind_clean.log](https://github.com/sysown/proxysql/files/5568520/valgrind_clean.log)
