### PR TITLE
Closes #3187: Galera nodes permanently dropped from runtime_mysql_servers for writer_is_also_reader=2

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -4957,11 +4957,16 @@ void MySQL_HostGroups_Manager::converge_galera_config(int _writer_hostgroup) {
 						}
 					}
 					if (num_backup_writers) { // there are backup writers, only these will be used as readers
-						q=(char *)"DELETE FROM mysql_servers_incoming WHERE hostgroup_id=%d";
-						query=(char *)malloc(strlen(q) + 128);
-						sprintf(query,q, info->reader_hostgroup);
+						// just delete the readers which are right now part of the writer hostgroup, preserving
+						// any current reader which is only in the reader hostgroup. This is because if a server
+						// is only part of the reader hostgroup at this point, means that it's there because of a
+						// reason beyond ProxySQL control, e.g. having READ_ONLY=1.
+						q=(char*)"DELETE FROM mysql_servers_incoming where hostgroup_id=%d and (hostname,port) in (SELECT hostname,port FROM mysql_servers_incoming WHERE hostgroup_id=%d)";
+						query=(char*)malloc(strlen(q) + 128);
+						sprintf(query, q, info->reader_hostgroup, info->writer_hostgroup);
 						mydb->execute(query);
 						free(query);
+
 						q=(char *)"INSERT OR IGNORE INTO mysql_servers_incoming (hostgroup_id,hostname,port,gtid_port,status,weight,compression,max_connections,max_replication_lag,use_ssl,max_latency_ms,comment) SELECT %d,hostname,port,gtid_port,status,weight,compression,max_connections,max_replication_lag,use_ssl,max_latency_ms,comment FROM mysql_servers_incoming WHERE hostgroup_id=%d";
 						query=(char *)malloc(strlen(q) + 128);
 						sprintf(query,q, info->reader_hostgroup, info->backup_writer_hostgroup);


### PR DESCRIPTION
Closes #3187 .