### PR TITLE
Closes #2330: ProxySQL Native Galera support stop to work after PROXYSQL RESTART

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1078,6 +1078,7 @@ void ProxySQL_Main_join_all_threads() {
 	if (GloMyMon && MyMon_thread) {
 		cpu_timer t;
 		MyMon_thread->join();
+		MyMon_thread = NULL;
 #ifdef DEBUG
 		std::cerr << "GloMyMon joined in ";
 #endif


### PR DESCRIPTION
Closes #2330. Monitoring stops working after `PROXYSQL RESTART` due to a non-nullified pointer.

Attached the log with a similar setup of the reported in the issue #2330. Which shows monitoring now working properly after issuing `PROXYSQL RESTART` before the fix, and the proper and expected cluster state after the fix.

[proxysql_2330_logs.tar.gz](https://github.com/sysown/proxysql/files/5735712/proxysql_2330_logs.tar.gz)
