### PR TITLE
Add Client_Connections_non_idle to Diamond gauge keys.

### DIFF
--- a/diamond/proxysqlstat.py
+++ b/diamond/proxysqlstat.py
@@ -20,6 +20,7 @@ class ProxySQLCollector(diamond.collector.Collector):
     _GAUGE_KEYS = [
         'Active_Transactions',
         'Client_Connections_connected',
+        'Client_Connections_non_idle',
         'ConnPool_memory_bytes',
         'MySQL_Monitor_Workers',
         'MySQL_Thread_Workers',


### PR DESCRIPTION
I just noticed that my stats looked wrong for active connections, and this was not being published as a gauge metric.  Quick one-liner.