### PR TITLE
Closes #3225: *char* being overflow in 'ma_net_safe_read' in `client_deprecate_eof.patch`

### DIFF
--- a/deps/mariadb-client-library/client_deprecate_eof.patch
+++ b/deps/mariadb-client-library/client_deprecate_eof.patch
@@ -101,7 +101,7 @@ index 8c2a99b..249e981 100644
 +  else
 +  {
 +    if (is_data_packet) {
-+        bool deprecate_eof =
++        unsigned long deprecate_eof =
 +            mysql->server_capabilities & CLIENT_DEPRECATE_EOF;
 +        *is_data_packet = TRUE;
 +


### PR DESCRIPTION
Closes #3225.