### PR TITLE
Closes #2953: Honor 'wsrep_sst_donor_rejects_queries' avoiding setting a DONOR node offline during a SST

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1966,7 +1966,7 @@ __exit_monitor_galera_thread:
 			}
 		} else {
 			if (fields) { // if we didn't get any error, but fileds is NULL, we are likely hitting bug #1994
-				if (primary_partition == false || wsrep_desync == true || wsrep_local_state!=4) {
+				if (primary_partition == false || wsrep_desync == true || (wsrep_local_state!=4 && (wsrep_local_state != 2 || wsrep_sst_donor_rejects_queries))) {
 					if (primary_partition == false) {
 						MyHGM->update_galera_set_offline(mmsd->hostname, mmsd->port, mmsd->writer_hostgroup, (char *)"primary_partition=NO");
 					} else {


### PR DESCRIPTION
Closes #2953.

This change require several changes in the [galera documentation](https://proxysql.com/documentation/galera-configuration/). Covering how `wsrep_sst_donor_rejects_queries` will be honored, and it's relation with other settings. Official documentation will be updated together with `v2.1.0` release.