### PR TITLE
Closes #3262: Fixed memory leak in 'Query_Processor::new_query_rule' due to field 'match_digest' never being freed

### DIFF
--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -371,6 +371,8 @@ static void __delete_query_rule(QP_rule_t *qr) {
 		free(qr->username);
 	if (qr->schemaname)
 		free(qr->schemaname);
+	if (qr->match_digest)
+		free(qr->match_digest);
 	if (qr->match_pattern)
 		free(qr->match_pattern);
 	if (qr->replace_pattern)


### PR DESCRIPTION
Closes #3262.