### PR TITLE
Closes #3288: Added extra logging to 'monitor_replication_lag_thread' when 'Seconds_Behind_Master' is NULL

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -2042,8 +2042,10 @@ __exit_monitor_replication_lag_thread:
 							if (row) {
 								repl_lag=-1; // this is old behavior
 							repl_lag=mysql_thread___monitor_slave_lag_when_null; // new behavior, see 669
-							if (row[j]) { // if Seconds_Behind_Master is not NULL
+								if (row[j]) { // if Seconds_Behind_Master is not NULL
 									repl_lag=atoi(row[j]);
+								} else {
+									proxy_error("Replication lag on server %s:%d is NULL, using the value %d (mysql-monitor_slave_lag_when_null)\n", mmsd->hostname, mmsd->port, mysql_thread___monitor_slave_lag_when_null);
 								}
 							}
 						}


### PR DESCRIPTION
Closes #3288.