### PR TITLE
Closes #3324: Crash and invalid write reported by valgrind for 'test_ps_async-t'

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -187,6 +187,7 @@ mariadb-client-library/mariadb_client/libmariadb/libmariadbclient.a: libssl/open
 	cd mariadb-client-library/mariadb_client && patch unittest/libmariadb/basic-t.c < ../unittest_basic-t.c.patch
 	cd mariadb-client-library/mariadb_client && patch unittest/libmariadb/charset.c < ../unittest_charset.c.patch
 	cd mariadb-client-library/mariadb_client && patch -p0 < ../client_deprecate_eof.patch
+	cd mariadb-client-library/mariadb_client && patch -p0 < ../ps_buffer_stmt_read_all_rows.patch
 	cd mariadb-client-library/mariadb_client && CC=${CC} CXX=${CXX} ${MAKE} mariadbclient
 # cd mariadb-client-library/mariadb_client/include && make my_config.h
 

--- a/deps/mariadb-client-library/ps_buffer_stmt_read_all_rows.patch
+++ b/deps/mariadb-client-library/ps_buffer_stmt_read_all_rows.patch
@@ -1,0 +1,29 @@
+diff --git libmariadb/mariadb_stmt.c libmariadb/mariadb_stmt.c
+index bbc2831..e66d810 100644
+--- libmariadb/mariadb_stmt.c
++++ libmariadb/mariadb_stmt.c
+@@ -207,6 +207,24 @@ int mthd_stmt_read_all_rows(MYSQL_STMT *stmt)
+ 
+   while ((packet_len = ma_net_safe_read(stmt->mysql, &is_data_packet)) != packet_error)
+   {
++    // This change is required due to the new algorithm introduced in ProxySQL in #3295.
++    // ********************************************************************************
++    // DETAILS:
++    // Since #3295 ProxySQL performs a buffering on the resulset received by a prepared
++    // statement. This way ProxySQL doesn't require to retain the whole result of the
++    // prepared statement in memory. For this purpose it's required to free the memory
++    // allocated in 'MYSQL_STMT' via 'ma_free_root'. Because of this, local pointers
++    // within this function pointing to the result data gets invalidated due to stack
++    // swapping. Reinitializing then to the current values pointing to the new allocated
++    // memory for 'MYSQL_STMT' is required. Since this only happens when we force
++    // 'stmt->result.rows' to be '1', it's the only case in which these variables
++    // need a reset.
++    if (stmt->result.rows == 1) {
++      result= &stmt->result;
++      pprevious= &result->data->next;
++    }
++    // ********************************************************************************
++
+     p= stmt->mysql->net.read_pos;
+     // The check is by 'ma_net_safe_read'
+     if (p[0] == 0 || is_data_packet)

--- a/include/mysql_connection.h
+++ b/include/mysql_connection.h
@@ -188,6 +188,14 @@ class MySQL_Connection {
 	void stmt_execute_store_result_start();
 	void stmt_execute_store_result_cont(short event);
 
+	/**
+	 * @brief Process the rows returned by 'async_stmt_execute_store_result'. Extracts all the received
+	 *   rows from 'query.stmt->result.data' but the last one, adds them to 'MyRS', frees the buffer
+	 *   used by 'query.stmt' and allocates a new one with the last row, leaving it ready for being filled
+	 *   with the new rows to be received.
+	 * @param processed_bytes Reference to the already processed bytes to be updated with the rows
+	 *   that are being read and added to 'MyRS'.
+	 */
 	void process_rows_in_ASYNC_STMT_EXECUTE_STORE_RESULT_CONT(unsigned long long& processed_bytes);
 
 	void async_free_result();

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -1253,7 +1253,7 @@ handler_again:
 
 				if (r) {
 					rows_read_inner++;
-					while(rows_read_inner <= query.stmt->result.rows && r->next) {
+					while(rows_read_inner < query.stmt->result.rows) {
 						// it is very important to check rows_read_inner FIRST
 						// because r->next could point to an invalid memory
 						rows_read_inner++;
@@ -1622,8 +1622,9 @@ void MySQL_Connection::process_rows_in_ASYNC_STMT_EXECUTE_STORE_RESULT_CONT(unsi
 		myds->bytes_info.bytes_recv += br;
 		bytes_info.bytes_recv += br;
 		processed_bytes+=br;	// issue #527 : this variable will store the amount of bytes processed during this event
-		//}
-		ir = ir->next;
+		if (irs < query.stmt->result.rows - 2) {
+			ir = ir->next;
+		}
 	}
 	// at this point, ir points to the last row
 	// next, we create a new MYSQL_ROWS that is a copy of the last row

--- a/test/tap/tests/test_ps_async-t.cpp
+++ b/test/tap/tests/test_ps_async-t.cpp
@@ -160,8 +160,8 @@ static int wait_for_mysql(MYSQL *mysql, int status) {
 
 
 const int NUM_ROWS=100;
-const int NUM_ROWS_READ=1000;
-const int NLOOPS=1;
+const std::vector<int> NUM_ROWS_READ { 1000, 1, 2 };
+const int NLOOPS = NUM_ROWS_READ.size();
 
 int select_config_file(MYSQL* mysql, std::string& resultset) {
 	if (mysql_query(mysql, "select config file")) {
@@ -201,7 +201,7 @@ int main(int argc, char** argv) {
 	if(cl.getEnv())
 		return exit_status();
 
-	plan(2*NLOOPS);
+	plan(1 + NLOOPS);
 	diag("Testing PS async store result");
 
 	MYSQL* mysqladmin = mysql_init(NULL);
@@ -287,6 +287,9 @@ int main(int argc, char** argv) {
 	std::string query = "";
 
 	for (int loops=0; loops<NLOOPS; loops++) {
+
+	int IT_NUM_ROWS_READ = NUM_ROWS_READ[loops];
+
 	MYSQL_STMT *stmt2a = mysql_stmt_init(mysql);
 	if (!stmt2a)
 	{
@@ -294,9 +297,9 @@ int main(int argc, char** argv) {
 		return restore_admin(mysqladmin);
 	}
 	// NOTE: the first 2 columns we select are 3 ids, so we can later print and verify
-	query = "SELECT t1.id id1, t2.id id2, t1.id+t2.id id3, t1.k k1, t1.c c1, t1.pad pad1, t2.k k2, t2.c c2, t2.pad pad2 FROM test.sbtest1 t1 JOIN test.sbtest1 t2 ORDER BY t1.id, t2.id LIMIT " + std::to_string(NUM_ROWS_READ);
-	//query = "SELECT t1.id id1, t2.id id2, t1.id+t2.id id3 FROM test.sbtest1 t1 JOIN test.sbtest1 t2 LIMIT " + std::to_string(NUM_ROWS_READ);
-	//query = "SELECT t1.id id1, t2.id id2, t1.id+t2.id id3 FROM test.sbtest1 t1 JOIN test.sbtest1 t2 ORDER BY t1.id, t2.id LIMIT " + std::to_string(NUM_ROWS_READ);
+	query = "SELECT t1.id id1, t2.id id2, t1.id+t2.id id3, t1.k k1, t1.c c1, t1.pad pad1, t2.k k2, t2.c c2, t2.pad pad2 FROM test.sbtest1 t1 JOIN test.sbtest1 t2 ORDER BY t1.id, t2.id LIMIT " + std::to_string(IT_NUM_ROWS_READ);
+	//query = "SELECT t1.id id1, t2.id id2, t1.id+t2.id id3 FROM test.sbtest1 t1 JOIN test.sbtest1 t2 LIMIT " + std::to_string(IT_NUM_ROWS_READ);
+	//query = "SELECT t1.id id1, t2.id id2, t1.id+t2.id id3 FROM test.sbtest1 t1 JOIN test.sbtest1 t2 ORDER BY t1.id, t2.id LIMIT " + std::to_string(IT_NUM_ROWS_READ);
 	if (mysql_stmt_prepare(stmt2a,query.c_str(), query.size())) {
 		fprintf(stderr, "Query error %s\n", mysql_error(mysql));
 		mysql_close(mysql);
@@ -405,7 +408,7 @@ int main(int argc, char** argv) {
 				row_count2a++;		
 			}
 		}
-		ok(row_count2a+rows_read==NUM_ROWS_READ, "Fetched %d rows, expected %d. Details: %d rows processed while buffering, %d at the end", row_count2a+rows_read, NUM_ROWS_READ , rows_read, row_count2a);
+		ok(row_count2a+rows_read==IT_NUM_ROWS_READ, "Fetched %d rows, expected %d. Details: %d rows processed while buffering, %d at the end", row_count2a+rows_read, IT_NUM_ROWS_READ , rows_read, row_count2a);
 	}
 
 	if (prepare_meta_result) {

--- a/test/tap/tests/test_ps_async-t.cpp
+++ b/test/tap/tests/test_ps_async-t.cpp
@@ -331,7 +331,7 @@ int main(int argc, char** argv) {
 			//rows_read++;
 			rows_read_inner++;
 			MYSQL_ROWS *pr = r;
-			while(rows_read_inner <= stmt2a->result.rows && r->next) {
+			while(rows_read_inner < stmt2a->result.rows) {
 				// it is very important to check rows_read_inner FIRST
 				// because r->next could point to an invalid memory
 				rows_read_inner++;
@@ -356,8 +356,10 @@ int main(int argc, char** argv) {
 					memcpy(&id3, (char *)ir->data+row_offset+sizeof(int)*2, sizeof(int));
 					//diag("Row: %d + %d = %d", id1, id2, id3);
 					assert(id3==id1+id2);
-					ir = ir->next;
 					rows_read++;
+					if (irs < stmt2a->result.rows - 2) {
+						ir = ir->next;
+					}
 				}
 				// at this point, ir points to the last row
 				// next, we create a new MYSQL_ROWS that is a copy of the last row
@@ -374,10 +376,7 @@ int main(int argc, char** argv) {
 				// we will now copy back the last row and make it the only row available
 				MYSQL_ROWS *current = (MYSQL_ROWS *)ma_alloc_root(&stmt2a->result.alloc, sizeof(MYSQL_ROWS) + lcopy->length);
 				current->data= (MYSQL_ROW)(current + 1);
-				MYSQL_ROWS **pprevious = &stmt2a->result.data;
-				//current->next = NULL;
-				*pprevious= current;
-				pprevious= &current->next;
+				stmt2a->result.data = current;
 				memcpy((char *)current->data, (char *)lcopy->data, lcopy->length);
 				// we free the copy
 				free(lcopy);

--- a/test/tap/tests/test_ps_large_result-t.cpp
+++ b/test/tap/tests/test_ps_large_result-t.cpp
@@ -331,7 +331,8 @@ int main(int argc, char** argv) {
 	MYSQL_BIND bind3[3];
 	int int_data31;
 	int int_data32;
-	char str_data31[LARGE_STRING_SIZE];
+	char* str_data31 = (char*)malloc(LARGE_STRING_SIZE);
+
 	my_bool is_null3[3];
 	long unsigned int length3[3];
 	my_bool error3[3];
@@ -405,6 +406,9 @@ int main(int argc, char** argv) {
 		ok(false, " %s\n", mysql_error(mysql));
 		return restore_admin(mysqladmin);
 	}
+
+	if (str_data31)
+		free(str_data31);
 
 	if (str_data32)
 		free(str_data32);


### PR DESCRIPTION
Closes #3324.

1. Clean valgrind output for 'test_ps_async-t' after patch: [valgrind-out.txt](https://github.com/sysown/proxysql/files/6062162/valgrind-out.txt)
2. Wireshark capture of the packets received by 'test_ps_async-t' from ProxySQL proving correct sequencing: [ps_async_fixed_proxysql.pcapng.zip](https://github.com/sysown/proxysql/files/6062177/ps_async_fixed_proxysql.pcapng.zip)


