### PR TITLE
Fixing an inifinite loop in case of multi-statements and closed backend connection

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -3904,8 +3904,15 @@ bool MySQL_Session::handler_minus1_ClientLibraryError(MySQL_Data_Stream *myds, i
 			if (myds->myconn->MyRS && myds->myconn->MyRS->transfer_started) {
 			// transfer to frontend has started, we cannot retry
 			} else {
-				retry_conn=true;
-				proxy_warning("Retrying query.\n");
+				if (myds->myconn->mysql->server_status & SERVER_MORE_RESULTS_EXIST) {
+					// transfer to frontend has started, because this is, at least,
+					// the second resultset coming from the server
+					// we cannot retry
+					proxy_warning("Disabling query retry because SERVER_MORE_RESULTS_EXIST is set\n");
+				} else {
+					retry_conn=true;
+					proxy_warning("Retrying query.\n");
+				}
 			}
 		}
 	}

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -1459,14 +1459,19 @@ handler_again:
 				} else {
 					compute_unknown_transaction_status();
 				}
+				if (_myerrno < 2000) {
+					// we can continue only if the error is coming from the backend.
+					// (or if zero)
+					// if the error comes from the client library, something terribly
+					// wrong happened and we cannot continue
+					if (mysql->server_status & SERVER_MORE_RESULTS_EXIST) {
+						async_state_machine=ASYNC_NEXT_RESULT_START;
+					}
+				}
 			}
 			if (mysql_result) {
 				mysql_free_result(mysql_result);
 				mysql_result=NULL;
-			}
-			//if (mysql_next_result(mysql)==0) {
-			if (mysql->server_status & SERVER_MORE_RESULTS_EXIST) {
-				async_state_machine=ASYNC_NEXT_RESULT_START;
 			}
 			break;
 		case ASYNC_SET_AUTOCOMMIT_START:


### PR DESCRIPTION
If a backend connection was terminated in the middle of the execution of multiple
statements in a multi-statements command, the worker thread was entering an infinite loop.
Furthermore, this commit disables query retry in case of multi-statements if the first one
completed successfully

This fixes #3339

This commit is the port to 2.1 of 90a4922ed8712dada76f604f85ea3cab31f5fe1f