### PR TITLE
Dry run ProxySQL query rules

### DIFF
--- a/include/MySQL_Logger.hpp
+++ b/include/MySQL_Logger.hpp
@@ -30,6 +30,7 @@ class MySQL_Event {
 	bool have_rows_sent;
 	uint64_t affected_rows;
 	uint64_t rows_sent;
+	char *query_rule_info;
 	public:
 	MySQL_Event(log_event_type _et, uint32_t _thread_id, char * _username, char * _schemaname , uint64_t _start_time , uint64_t _end_time , uint64_t _query_digest, char *_client, size_t _client_len);
 	uint64_t write(std::fstream *f, MySQL_Session *sess);
@@ -41,6 +42,7 @@ class MySQL_Event {
 	void set_extra_info(char *);
 	void set_affected_rows(uint64_t ar);
 	void set_rows_sent(uint64_t rs);
+	void set_query_rule_info(char *);
 };
 
 class MySQL_Logger {
@@ -83,7 +85,7 @@ class MySQL_Logger {
 	void events_set_base_filename();
 	void audit_set_datadir(char *);
 	void audit_set_base_filename();
-	void log_request(MySQL_Session *, MySQL_Data_Stream *);
+	void log_request(MySQL_Session *, MySQL_Data_Stream *, const char *e = NULL);
 	void log_audit_entry(log_event_type, MySQL_Session *, MySQL_Data_Stream *, char *e = NULL);
 	void flush();
 	void wrlock();

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -39,6 +39,11 @@ enum log_event_type {
 	PROXYSQL_COM_STMT_PREPARE
 };
 
+// event logging types
+#define LOG_EVENTS_TO_BINARY_FILES 1
+#define LOG_EVENTS_TO_JSON_FILES 2
+#define LOG_EVENTS_TO_INFO_MESSAGES 3
+
 enum cred_username_type { USERNAME_BACKEND, USERNAME_FRONTEND };
 
 enum MDB_ASYNC_ST { // MariaDB Async State Machine

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -139,6 +139,8 @@ class Query_Processor_Output {
 	char *min_gtid;
 	bool create_new_conn;
 	std::string *new_query;
+	std::string query_rule_log;
+	uint64_t query_rule_hits;
 	void * operator new(size_t size) {
 		return l_alloc(size);
 	}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6644,11 +6644,11 @@ void MySQL_Session::LogQuery(MySQL_Data_Stream *myds) {
 
 	if (qpo) {
 		if (qpo->log==1) {
-			GloMyLogger->log_request(this, myds);	// we send for logging only if logging is enabled for this query
+			GloMyLogger->log_request(this, myds, qpo->query_rule_log.c_str());	// we send for logging only if logging is enabled for this query
 		} else {
 			if (qpo->log==-1) {
 				if (mysql_thread___eventslog_default_log==1) {
-					GloMyLogger->log_request(this, myds);	// we send for logging only if enabled by default
+					GloMyLogger->log_request(this, myds, NULL);	// we send for logging only if enabled by default
 				}
 			}
 		}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1108,7 +1108,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.eventslog_filename=strdup((char *)""); // proxysql-mysql-eventslog is recommended
 	variables.eventslog_filesize=100*1024*1024;
 	variables.eventslog_default_log=0;
-	variables.eventslog_format=1;
+	variables.eventslog_format=LOG_EVENTS_TO_BINARY_FILES;
 	variables.auditlog_filename=strdup((char *)"");
 	variables.auditlog_filesize=100*1024*1024;
 	//variables.server_capabilities=CLIENT_FOUND_ROWS | CLIENT_PROTOCOL_41 | CLIENT_IGNORE_SIGPIPE | CLIENT_TRANSACTIONS | CLIENT_SECURE_CONNECTION | CLIENT_CONNECT_WITH_DB;
@@ -2920,17 +2920,20 @@ bool MySQL_Threads_Handler::set_variable(char *name, const char *value) {	// thi
 	}
 	if (!strcasecmp(name,"eventslog_format")) {
 		int intv=atoi(value);
-		if (intv >= 1 && intv <= 2) {
-			if (variables.eventslog_format!=intv) {
+		switch (intv) {
+		case LOG_EVENTS_TO_BINARY_FILES:
+		case LOG_EVENTS_TO_JSON_FILES:
+		case LOG_EVENTS_TO_INFO_MESSAGES:
+			if (variables.eventslog_format != intv) {
 				// if we are switching format, we need to switch file too
 				if (GloMyLogger) {
-					proxy_info("Switching query logging format from %d to %d\n", variables.eventslog_format , intv);
+					proxy_info("Switching query logging format from %d to %d\n", variables.eventslog_format, intv);
 					GloMyLogger->flush_log();
 				}
 				variables.eventslog_format=intv;
 			}
 			return true;
-		} else {
+		default:
 			return false;
 		}
 	}

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -11126,7 +11126,7 @@ char * ProxySQL_Admin::load_mysql_query_rules_to_runtime() {
 	int affected_rows=0;
 	if (GloQPro==NULL) return (char *)"Global Query Processor not started: command impossible to run";
 	SQLite3_result *resultset=NULL;
-	char *query=(char *)"SELECT rule_id, username, schemaname, flagIN, client_addr, proxy_addr, proxy_port, digest, match_digest, match_pattern, negate_match_pattern, re_modifiers, flagOUT, replace_pattern, destination_hostgroup, cache_ttl, cache_empty_result, cache_timeout, reconnect, timeout, retries, delay, next_query_flagIN, mirror_flagOUT, mirror_hostgroup, error_msg, ok_msg, sticky_conn, multiplex, gtid_from_hostgroup, log, apply, attributes, comment FROM main.mysql_query_rules WHERE active=1 ORDER BY rule_id";
+	char *query=(char *)"SELECT rule_id, username, schemaname, flagIN, client_addr, proxy_addr, proxy_port, digest, match_digest, match_pattern, negate_match_pattern, re_modifiers, flagOUT, replace_pattern, destination_hostgroup, cache_ttl, cache_empty_result, cache_timeout, reconnect, timeout, retries, delay, next_query_flagIN, mirror_flagOUT, mirror_hostgroup, error_msg, ok_msg, sticky_conn, multiplex, gtid_from_hostgroup, log, apply, attributes, comment, active FROM main.mysql_query_rules ORDER BY rule_id";
 	admindb->execute_statement(query, &error , &cols , &affected_rows , &resultset);
 	char *error2 = NULL;
 	int cols2 = 0;
@@ -11180,7 +11180,7 @@ char * ProxySQL_Admin::load_mysql_query_rules_to_runtime() {
 			}
 			nqpr=GloQPro->new_query_rule(
 				atoi(r->fields[0]), // rule_id
-				true,
+				atoi(r->fields[34]), // active
 				r->fields[1],	// username
 				r->fields[2],	// schemaname
 				atoi(r->fields[3]),	// flagIN


### PR DESCRIPTION
Issue: https://github.com/sysown/proxysql/issues/3367

This PR allows ProxySQL's query rules to be in dry run mode. When a rule is in dry run mode, the rule would not actually perform its action, it would simply log matched queries and the action that would have been taken. Once an author is confident that their rule is working correctly, they can change the rule from dry run mode to active mode, where the rule would actually take action.

This PR only adds dry run modes for reject, rewrite, and reroute rules (`error_msg`, `replace_pattern`, `destination_hostgroup`).

Here is what query rule modes would look like:
![](https://screenshot.click/21-23-gkzg1-q7l4w.png)

If this method of defining dry run query rules is not preferred, an alternative solution would be to add a ` dryrun` column.

An additional field has been added to query logging output only in JSON mode. The field is called `query_rule_info`, and contains a JSON blob potentially containing the following sub-fields (some or all may be present):
`query_rule_id`: id in the mysql_query_rules table
`query_rule_active`: "true" or "false", based on active in the mysql_query_rules table
`original_query`: if the rule is active and pattern replacement has been done, this is the original query before replacement
`rewritten_query`: if the rule is active and pattern replacement has been done, this is the query executed
`dry_run_original_query`: if the rule is inactive and pattern replacement would be done, this is the original query before replacement
`dry_run_rewritten_query`: if the rule is inactive and pattern replacement would be done, this would be the new query after replacement


This is what example JSON would look like:
```
{
  "client": "172.22.0.1:48966",
  "digest": "0x242E0927FD9A4850",
  "duration_us": 0,
  "endtime": "2020-09-30 19:31:26.913234",
  "endtime_timestamp_us": 1601494286913234,
  "event": "COM_QUERY",
  "hostgroup_id": 0,
  "query": "select 4, @@server_id",
  "query_rule_info": "{\"dry_run_hostgroup\":1,\"dry_run_original_query\":\"select 4, @@server_id\",\"dry_run_rewritten_query\":\"select 400, @@server_id\",\"query_rule_active\":false,\"query_rule_id\":104}",
  "rows_affected": 0,
  "rows_sent": 1,
  "schemaname": "demo",
  "server": "mysql-m1:3306",
  "starttime": "2020-09-30 19:31:26.913234",
  "starttime_timestamp_us": 1601494286913234,
  "thread_id": 1,
  "username": "app_writer"
}
```

Additional logging enhancement that can be broken up into a separate PR:
This PR also adds the ability to log to `stderr`. You would simply set `eventslog_format=3` in `mysql_variables` through `proxysql.cnf` or the admin console. This makes viewing logs much easier than going through a file and will avoid any issues that come with filling up the disk when writing logs to a file. 

The logs will only happen on the `n`th query matching each rule, where `n` is any power of 2. If this behaviour isn't desired, it can be removed or put behind a variable that will let users choose whether they want logs to happen all the time or only on powers of 2.

Original author: @saunderst