### PR TITLE
add parameter monitor_sbm_when_null_algorithm，when max_replication_lag > monitor_slave_lag_when_null， solve  set slave online when this slave seconds_behind_master is null

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -547,7 +547,9 @@ class MySQL_HostGroups_Manager {
 	void push_MyConn_to_pool_array(MySQL_Connection **, unsigned int);
 	void destroy_MyConn_from_pool(MySQL_Connection *, bool _lock=true);	
 
-	void replication_lag_action(int, char*, unsigned int, int);
+	void set_slave_status_when_slave_abnormal(int, char*, unsigned int, int, MySrvC*);
+        void set_slave_status_when_slave_normal(int, char*, unsigned int, int, MySrvC*);
+        void replication_lag_action(int, char*, unsigned int, int, bool);
 	void read_only_action(char *hostname, int port, int read_only);
 	unsigned int get_servers_table_version();
 	void wait_servers_table_version(unsigned, unsigned);

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -380,6 +380,7 @@ class MySQL_Threads_Handler
 		//! ProxySQL session wait timeout. Unit: 'ms'.
 		bool monitor_wait_timeout;
 		bool monitor_writer_is_also_reader;
+		bool monitor_sbm_when_null_algorithm; //true: when seconds_behind_master(sbm) is null,use new algorithm, false: use monitor_slave_lag_when_null
 		//! How frequently a replication lag check is performed. Unit: 'ms'.
 		int monitor_replication_lag_interval;
 		//! Read only check timeout. Unit: 'ms'.

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -979,6 +979,7 @@ extern __thread int mysql_thread___monitor_read_only_timeout;
 extern __thread int mysql_thread___monitor_read_only_max_timeout_count;
 extern __thread bool mysql_thread___monitor_wait_timeout;
 extern __thread bool mysql_thread___monitor_writer_is_also_reader;
+extern __thread bool mysql_thread___monitor_sbm_when_null_algorithm;
 extern __thread int mysql_thread___monitor_replication_lag_interval;
 extern __thread int mysql_thread___monitor_replication_lag_timeout;
 extern __thread int mysql_thread___monitor_replication_lag_count;

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -827,6 +827,7 @@ __thread int mysql_thread___monitor_read_only_timeout;
 __thread int mysql_thread___monitor_read_only_max_timeout_count;
 __thread bool mysql_thread___monitor_wait_timeout;
 __thread bool mysql_thread___monitor_writer_is_also_reader;
+__thread bool mysql_thread___monitor_sbm_when_null_algorithm;
 __thread int mysql_thread___monitor_replication_lag_interval;
 __thread int mysql_thread___monitor_replication_lag_timeout;
 __thread int mysql_thread___monitor_replication_lag_count;

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -3341,7 +3341,48 @@ void MySQL_HostGroups_Manager::add(MySrvC *mysrvc, unsigned int _hid) {
 	myhgc->mysrvs->add(mysrvc);
 }
 
-void MySQL_HostGroups_Manager::replication_lag_action(int _hid, char *address, unsigned int port, int current_replication_lag) {
+void MySQL_HostGroups_Manager::set_slave_status_when_slave_abnormal(int _hid, char *address, unsigned int port, int current_replication_lag, MySrvC *mysrvc) {
+     if (
+//		  (current_replication_lag==-1 )
+//		  ||
+		  (current_replication_lag>=0 && ((unsigned int)current_replication_lag > mysrvc->max_replication_lag))
+		) {
+		    // always increase the counter
+		    mysrvc->cur_replication_lag_count += 1;
+		    if (mysrvc->cur_replication_lag_count >= mysql_thread___monitor_replication_lag_count) {
+		        proxy_warning("Shunning server %s:%d from HG %u with replication lag of %d second, count number: '%d'\n", address, port, _hid, current_replication_lag, mysrvc->cur_replication_lag_count);
+			    mysrvc->status=MYSQL_SERVER_STATUS_SHUNNED_REPLICATION_LAG;
+		    } else {
+                proxy_info(
+                  "Not shunning server "
+                  "%s:%d from HG %u with "
+                  "replication lag of %d "
+                  "second, count number: "
+                  "'%d' < "
+                  "replication_lag_count: "
+                  "'%d'\n",
+                  address, port, _hid,
+                  current_replication_lag,
+                  mysrvc->cur_replication_lag_count,
+                  mysql_thread___monitor_replication_lag_count);
+            }
+          } else {
+				mysrvc->cur_replication_lag_count = 0;
+		}
+}
+
+void MySQL_HostGroups_Manager::set_slave_status_when_slave_normal(int _hid, char *address, unsigned int port, int current_replication_lag, MySrvC *mysrvc) {
+   if(
+        (current_replication_lag>=0 && ((unsigned int)current_replication_lag <= mysrvc->max_replication_lag))
+		||(current_replication_lag==-2) // see issue 959
+	) {
+		  mysrvc->status=MYSQL_SERVER_STATUS_ONLINE;
+		  proxy_warning("Re-enabling server %s:%d from HG %u with replication lag of %d second\n", address, port, _hid, current_replication_lag);
+		  mysrvc->cur_replication_lag_count = 0;
+	}
+}
+
+void MySQL_HostGroups_Manager::replication_lag_action(int _hid, char *address, unsigned int port, int current_replication_lag, bool slave_sbm_isnot_null) {
 	GloAdmin->mysql_servers_wrlock();
 	wrlock();
 	int i,j;
@@ -3352,40 +3393,24 @@ void MySQL_HostGroups_Manager::replication_lag_action(int _hid, char *address, u
 			MySrvC *mysrvc=(MySrvC *)myhgc->mysrvs->servers->index(j);
 			if (strcmp(mysrvc->address,address)==0 && mysrvc->port==port) {
 				if (mysrvc->status==MYSQL_SERVER_STATUS_ONLINE) {
-					if (
-//						(current_replication_lag==-1 )
-//						||
-						(current_replication_lag>=0 && ((unsigned int)current_replication_lag > mysrvc->max_replication_lag))
-					) {
-						// always increase the counter
-						mysrvc->cur_replication_lag_count += 1;
-						if (mysrvc->cur_replication_lag_count >= mysql_thread___monitor_replication_lag_count) {
-							proxy_warning("Shunning server %s:%d from HG %u with replication lag of %d second, count number: '%d'\n", address, port, myhgc->hid, current_replication_lag, mysrvc->cur_replication_lag_count);
-							mysrvc->status=MYSQL_SERVER_STATUS_SHUNNED_REPLICATION_LAG;
-						} else {
-							proxy_info(
-								"Not shunning server %s:%d from HG %u with replication lag of %d second, count number: '%d' < replication_lag_count: '%d'\n",
-								address,
-								port,
-								myhgc->hid,
-								current_replication_lag,
-								mysrvc->cur_replication_lag_count,
-								mysql_thread___monitor_replication_lag_count
-							);
-						}
-					} else {
-						mysrvc->cur_replication_lag_count = 0;
-					}
+					if(mysql_thread___monitor_sbm_when_null_algorithm){  //new algorithm
+					   if(slave_sbm_isnot_null) {
+                          this->set_slave_status_when_slave_abnormal(_hid, address, port, current_replication_lag, mysrvc);
+					   }else {
+                          proxy_warning("Shunning server %s:%d from HG %u with seconds_behind_master of this slave is null!\n", address, port, myhgc->hid);
+			              mysrvc->status=MYSQL_SERVER_STATUS_SHUNNED_REPLICATION_LAG;
+					   }  
+					} else {  //backward compatible
+						this->set_slave_status_when_slave_abnormal(_hid, address, port, current_replication_lag, mysrvc);
+					}		
 				} else {
 					if (mysrvc->status==MYSQL_SERVER_STATUS_SHUNNED_REPLICATION_LAG) {
-						if (
-							(current_replication_lag>=0 && ((unsigned int)current_replication_lag <= mysrvc->max_replication_lag))
-							||
-							(current_replication_lag==-2) // see issue 959
-						) {
-							mysrvc->status=MYSQL_SERVER_STATUS_ONLINE;
-							proxy_warning("Re-enabling server %s:%d from HG %u with replication lag of %d second\n", address, port, myhgc->hid, current_replication_lag);
-							mysrvc->cur_replication_lag_count = 0;
+						if(mysql_thread___monitor_sbm_when_null_algorithm){  //new algorithm
+					       if(slave_sbm_isnot_null) {
+                              this->set_slave_status_when_slave_normal(_hid, address, port, current_replication_lag, mysrvc);
+						   }
+						} else { //backward compatible
+                           this->set_slave_status_when_slave_normal(_hid, address, port, current_replication_lag, mysrvc);
 						}
 					}
 				}

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -2206,6 +2206,7 @@ __exit_monitor_replication_lag_thread:
 	{
 		sqlite3_stmt *statement=NULL;
 		//sqlite3 *mondb=mmsd->mondb->get_db();
+		bool slave_sbm_isnot_null=true; //true: seconds_behind_master is not null,false: seconds_behind_master is null
 		int rc;
 		char *query=NULL;
 
@@ -2250,8 +2251,13 @@ __exit_monitor_replication_lag_thread:
 								if (row[j]) { // if Seconds_Behind_Master is not NULL
 									repl_lag=atoi(row[j]);
 								} else {
-									proxy_error("Replication lag on server %s:%d is NULL, using the value %d (mysql-monitor_slave_lag_when_null)\n", mmsd->hostname, mmsd->port, mysql_thread___monitor_slave_lag_when_null);
-									MyHGM->p_update_mysql_error_counter(p_mysql_error_type::proxysql, mmsd->hostgroup_id, mmsd->hostname, mmsd->port, ER_PROXYSQL_SRV_NULL_REPLICATION_LAG);
+									if(mysql_thread___monitor_sbm_when_null_algorithm){  //new algorithm
+									     slave_sbm_isnot_null=false; //sbm is null
+									     proxy_warning("Seconds_behind_master(sbm) of the slave server %s:%d is NULL, please check it.\n", mmsd->hostname, mmsd->port);
+									} else {  //backward compatible
+									     proxy_error("Replication lag on server %s:%d is NULL, using the value %d (mysql-monitor_slave_lag_when_null)\n", mmsd->hostname, mmsd->port, mysql_thread___monitor_slave_lag_when_null);
+									     MyHGM->p_update_mysql_error_counter(p_mysql_error_type::proxysql, mmsd->hostgroup_id, mmsd->hostname, mmsd->port, ER_PROXYSQL_SRV_NULL_REPLICATION_LAG);
+									}
 								}
 							}
 						}
@@ -2275,7 +2281,7 @@ __exit_monitor_replication_lag_thread:
 				SAFE_SQLITE3_STEP2(statement);
 				rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 				rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
-				MyHGM->replication_lag_action(mmsd->hostgroup_id, mmsd->hostname, mmsd->port, repl_lag);
+				MyHGM->replication_lag_action(mmsd->hostgroup_id, mmsd->hostname, mmsd->port, repl_lag, slave_sbm_isnot_null);
 			(*proxy_sqlite3_finalize)(statement);
 			if (mmsd->mysql_error_msg == NULL) {
 				replication_lag_success = true;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -471,6 +471,7 @@ static char * mysql_thread_variables_names[]= {
 	(char *)"monitor_threads_queue_maxsize",
 	(char *)"monitor_wait_timeout",
 	(char *)"monitor_writer_is_also_reader",
+	(char *)"monitor_sbm_when_null_algorithm",
 	(char *)"max_allowed_packet",
 	(char *)"tcp_keepalive_time",
 	(char *)"use_tcp_keepalive",
@@ -1057,6 +1058,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.monitor_replication_lag_use_percona_heartbeat=strdup((char *)"");
 	variables.monitor_wait_timeout=true;
 	variables.monitor_writer_is_also_reader=true;
+	variables.monitor_sbm_when_null_algorithm=true;
 	variables.max_allowed_packet=64*1024*1024;
 	variables.automatic_detect_sqli=false;
 	variables.firewall_whitelist_enabled=false;
@@ -1420,6 +1422,7 @@ int MySQL_Threads_Handler::get_variable_int(const char *name) {
 		}
 		if (a == 's') {
 			if (!strcmp(name,"monitor_slave_lag_when_null")) return (int)variables.monitor_slave_lag_when_null;
+			if (!strcmp(name,"monitor_sbm_when_null_algorithm")) return (int)variables.monitor_sbm_when_null_algorithm;
 		}
 	}
 	char a = name[0];
@@ -1794,6 +1797,9 @@ char * MySQL_Threads_Handler::get_variable(char *name) {	// this is the public f
 		}
 		if (!strcasecmp(name,"monitor_writer_is_also_reader")) {
 			return strdup((variables.monitor_writer_is_also_reader ? "true" : "false"));
+		}
+		if (!strcasecmp(name,"monitor_sbm_when_null_algorithm")) {
+			return strdup((variables.monitor_sbm_when_null_algorithm ? "true" : "false"));
 		}
 		if (!strcasecmp(name,"monitor_wait_timeout")) {
 			return strdup((variables.monitor_wait_timeout ? "true" : "false"));
@@ -2450,6 +2456,17 @@ bool MySQL_Threads_Handler::set_variable(char *name, const char *value) {	// thi
 			}
 			if (strcasecmp(value,"false")==0 || strcasecmp(value,"0")==0) {
 				variables.monitor_writer_is_also_reader=false;
+				return true;
+			}
+			return false;
+		}
+		if (!strcasecmp(name,"monitor_sbm_when_null_algorithm")) {
+			if (strcasecmp(value,"true")==0 || strcasecmp(value,"1")==0) {
+				variables.monitor_sbm_when_null_algorithm=true;
+				return true;
+			}
+			if (strcasecmp(value,"false")==0 || strcasecmp(value,"0")==0) {
+				variables.monitor_sbm_when_null_algorithm=false;
 				return true;
 			}
 			return false;
@@ -4997,6 +5014,7 @@ void MySQL_Thread::refresh_variables() {
 
 	mysql_thread___monitor_wait_timeout=(bool)GloMTH->get_variable_int((char *)"monitor_wait_timeout");
 	mysql_thread___monitor_writer_is_also_reader=(bool)GloMTH->get_variable_int((char *)"monitor_writer_is_also_reader");
+	mysql_thread___monitor_sbm_when_null_algorithm=(bool)GloMTH->get_variable_int((char *)"monitor_sbm_when_null_algorithm");
 	mysql_thread___monitor_enabled=(bool)GloMTH->get_variable_int((char *)"monitor_enabled");
 	mysql_thread___monitor_history=GloMTH->get_variable_int((char *)"monitor_history");
 	mysql_thread___monitor_connect_interval=GloMTH->get_variable_int((char *)"monitor_connect_interval");


### PR DESCRIPTION
      add parameter monitor_sbm_when_null_algorithm，when max_replication_lag > monitor_slave_lag_when_null， solve  set slave online problem when this slave seconds_behind_master is null. 

     monitor_sbm_when_null_algorithm： 
              true-- when seconds_behind_master(sbm) is null, use new algorithm, 
              false --- use monitor_slave_lag_when_null,  backward compatible. 

