### PR TITLE
mariadb_client: backport patch to fix syntax error in cmake 3.20

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -169,6 +169,7 @@ mariadb-client-library/mariadb_client/libmariadb/libmariadbclient.a: libssl/open
 	cd mariadb-client-library && rm -rf mariadb-connector-c-3.1.9-src
 	cd mariadb-client-library && tar -zxf mariadb-connector-c-3.1.9-src.tar.gz
 	cd mariadb-client-library/mariadb_client && patch ./plugins/auth/CMakeLists.txt < ../plugin_auth_CMakeLists.txt.patch
+	cd mariadb-client-library/mariadb_client && patch -p1 < ../syntax-error-cmake-3.20.patch
 	cd mariadb-client-library/mariadb_client && cmake . -DOPENSSL_ROOT_DIR=$(shell pwd)/libssl/openssl/ -DOPENSSL_LIBRARIES=$(shell pwd)/libssl/openssl/ .
 #	cd mariadb-client-library/mariadb_client && cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl # this is needed on MacOSX
 	cd mariadb-client-library/mariadb_client && patch libmariadb/mariadb_stmt.c < ../mariadb_stmt.c.patch

--- a/deps/mariadb-client-library/syntax-error-cmake-3.20.patch
+++ b/deps/mariadb-client-library/syntax-error-cmake-3.20.patch
@@ -1,0 +1,24 @@
+Upstream: Yes
+From 242cab8cbcd91af882233730a83627d3b12ced83 Mon Sep 17 00:00:00 2001
+From: Vladislav Vaintroub <wlad@mariadb.com>
+Date: Fri, 12 Mar 2021 00:01:11 +0100
+Subject: [PATCH] Fix syntax error in cmake 3.20
+
+---
+ cmake/ConnectorName.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/ConnectorName.cmake b/cmake/ConnectorName.cmake
+index b7bbbad8..357b8ac0 100644
+--- a/cmake/ConnectorName.cmake
++++ b/cmake/ConnectorName.cmake
+@@ -22,7 +22,7 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Windows")
+     SET(MACHINE_NAME "x64")
+   ELSE()
+     SET(MACHINE_NAME "32")
+-  END()
++  ENDIF()
+ ENDIF()
+ 
+ SET(product_name "mysql-connector-c-${CPACK_PACKAGE_VERSION}-${PLATFORM_NAME}${CONCAT_SIGN}${MACHINE_NAME}")
+


### PR DESCRIPTION
Hello,

This backports commit https://github.com/mariadb-corporation/mariadb-connector-c/commit/242cab8cbcd91af882233730a83627d3b12ced83 from mariadb-connector-c to fix builds using `cmake >= 3.20`. The error without this patch is:
```
-- TLS library/version: OpenSSL 1.1.1j
-- SYSTEM_LIBS dl;m;pthread;pthread;dl;m;/home/arnaud/Dev/clevercloud/tmp/proxysql/deps/libssl/openssl/lib/libssl.so;/home/arnaud/Dev/clevercloud/t
mp/proxysql/deps/libssl/openssl/lib/libcrypto.so                         
-- Dynamic column API support: ON                                        
-- SYSTEM processor: x86_64                                              
CMake Error at cmake/ConnectorName.cmake:30 (ENDMACRO):              
  Flow control statements are not properly nested.
Call Stack (most recent call first):                                                                                                               
  CMakeLists.txt:434 (INCLUDE)                                                                                                                     
                                    
                                                                         
-- Configuring incomplete, errors occurred!                  
See also "/home/arnaud/Dev/clevercloud/tmp/proxysql/deps/mariadb-client-library/mariadb_client/CMakeFiles/CMakeOutput.log".
See also "/home/arnaud/Dev/clevercloud/tmp/proxysql/deps/mariadb-client-library/mariadb_client/CMakeFiles/CMakeError.log".
make: *** [Makefile:171: mariadb-client-library/mariadb_client/libmariadb/libmariadbclient.a] Error 1
```

This commit is not yet in a mysql-connector-c release but I guess will be included in the next one. In the meantime, this patch fixes the issue.