### PR TITLE
Closes #3419: Add cluster synchronization support for global 'ldap-%' variables and 'mysql_ldap_mapping' provided by 'ldap_auth_plugin' 

### DIFF
--- a/include/ProxySQL_Cluster.hpp
+++ b/include/ProxySQL_Cluster.hpp
@@ -154,6 +154,9 @@ struct p_cluster_counter {
 		pulled_ldap_variables_success,
 		pulled_ldap_variables_failure,
 
+		pulled_mysql_ldap_mapping_success,
+		pulled_mysql_ldap_mapping_failure,
+
 		sync_conflict_mysql_query_rules_share_epoch,
 		sync_conflict_mysql_servers_share_epoch,
 		sync_conflict_proxysql_servers_share_epoch,

--- a/include/ProxySQL_Cluster.hpp
+++ b/include/ProxySQL_Cluster.hpp
@@ -86,6 +86,7 @@ class ProxySQL_Node_Entry {
 	struct {
 		ProxySQL_Checksum_Value_2 admin_variables;
 		ProxySQL_Checksum_Value_2 mysql_variables;
+		ProxySQL_Checksum_Value_2 ldap_variables;
 		ProxySQL_Checksum_Value_2 mysql_query_rules;
 		ProxySQL_Checksum_Value_2 mysql_servers;
 		ProxySQL_Checksum_Value_2 mysql_users;
@@ -116,6 +117,7 @@ class ProxySQL_Cluster_Nodes {
 	void get_peer_to_sync_mysql_users(char **host, uint16_t *port);
 	void get_peer_to_sync_mysql_variables(char **host, uint16_t *port);
 	void get_peer_to_sync_admin_variables(char **host, uint16_t* port);
+	void get_peer_to_sync_ldap_variables(char **host, uint16_t *port);
 	void get_peer_to_sync_proxysql_servers(char **host, uint16_t *port);
 };
 
@@ -149,12 +151,16 @@ struct p_cluster_counter {
 		pulled_admin_variables_success,
 		pulled_admin_variables_failure,
 
+		pulled_ldap_variables_success,
+		pulled_ldap_variables_failure,
+
 		sync_conflict_mysql_query_rules_share_epoch,
 		sync_conflict_mysql_servers_share_epoch,
 		sync_conflict_proxysql_servers_share_epoch,
 		sync_conflict_mysql_users_share_epoch,
 		sync_conflict_mysql_variables_share_epoch,
 		sync_conflict_admin_variables_share_epoch,
+		sync_conflict_ldap_variables_share_epoch,
 
 		sync_delayed_mysql_query_rules_version_one,
 		sync_delayed_mysql_servers_version_one,
@@ -162,6 +168,7 @@ struct p_cluster_counter {
 		sync_delayed_proxysql_servers_version_one,
 		sync_delayed_mysql_variables_version_one,
 		sync_delayed_admin_variables_version_one,
+		sync_delayed_ldap_variables_version_one,
 
 		__size
 	};
@@ -225,12 +232,14 @@ class ProxySQL_Cluster {
 	int cluster_mysql_users_diffs_before_sync;
 	int cluster_proxysql_servers_diffs_before_sync;
 	int cluster_mysql_variables_diffs_before_sync;
+	int cluster_ldap_variables_diffs_before_sync;
 	int cluster_admin_variables_diffs_before_sync;
 	bool cluster_mysql_query_rules_save_to_disk;
 	bool cluster_mysql_servers_save_to_disk;
 	bool cluster_mysql_users_save_to_disk;
 	bool cluster_proxysql_servers_save_to_disk;
 	bool cluster_mysql_variables_save_to_disk;
+	bool cluster_ldap_variables_save_to_disk;
 	bool cluster_admin_variables_save_to_disk;
 	ProxySQL_Cluster();
 	~ProxySQL_Cluster();

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -152,12 +152,14 @@ class ProxySQL_Admin {
 		int cluster_proxysql_servers_diffs_before_sync;
 		int cluster_mysql_variables_diffs_before_sync;
 		int cluster_admin_variables_diffs_before_sync;
+		int cluster_ldap_variables_diffs_before_sync;
 		bool cluster_mysql_query_rules_save_to_disk;
 		bool cluster_mysql_servers_save_to_disk;
 		bool cluster_mysql_users_save_to_disk;
 		bool cluster_proxysql_servers_save_to_disk;
 		bool cluster_mysql_variables_save_to_disk;
 		bool cluster_admin_variables_save_to_disk;
+		bool cluster_ldap_variables_save_to_disk;
 		int stats_mysql_connection_pool;
 		int stats_mysql_connections;
 		int stats_mysql_query_cache;
@@ -262,6 +264,7 @@ class ProxySQL_Admin {
 		bool checksum_mysql_users;
 		bool checksum_mysql_variables;
 		bool checksum_admin_variables;
+		bool checksum_ldap_variables;
 	} checksum_variables;
 	void public_add_active_users(enum cred_username_type usertype, char *user=NULL) {
 		__add_active_users(usertype, user);
@@ -311,6 +314,7 @@ class ProxySQL_Admin {
 	void flush_mysql_variables__from_memory_to_disk();
 	void flush_admin_variables__from_disk_to_memory();
 	void flush_admin_variables__from_memory_to_disk();
+	void flush_ldap_variables__from_memory_to_disk();
 
 	void load_mysql_servers_to_runtime();
 	void save_mysql_servers_from_runtime();

--- a/include/proxysql_glovars.hpp
+++ b/include/proxysql_glovars.hpp
@@ -111,6 +111,7 @@ class ProxySQL_GlobalVariables {
 		ProxySQL_Checksum_Value mysql_servers;
 		ProxySQL_Checksum_Value mysql_users;
 		ProxySQL_Checksum_Value mysql_variables;
+		ProxySQL_Checksum_Value ldap_variables;
 		ProxySQL_Checksum_Value proxysql_servers;
 		uint64_t global_checksum;
 		unsigned long long updates_cnt;

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -763,12 +763,12 @@ void ProxySQL_Node_Entry::set_checksums(MYSQL_RES *_r) {
 				}
 			}
 			if ((v->epoch == own_epoch) && v->diff_check && ((v->diff_check % (diff_lv*10)) == 0)) {
-				proxy_error("Cluster: detected a peer %s:%d with ldap_variables version %llu, epoch %llu, diff_check %u, checksum %s. Own version: %llu, epoch: %llu, checksum %s. Sync conflict, epoch times are EQUAL, can't determine which server holds the latest config, we won't sync. This message will be repeated every %llu checks until LOAD MYSQL VARIABLES TO RUNTIME is executed on candidate master.\n", hostname, port, v->version, v->epoch, v->diff_check, v->checksum, own_version, own_epoch, own_checksum, (diff_lv*10));
+				proxy_error("Cluster: detected a peer %s:%d with ldap_variables version %llu, epoch %llu, diff_check %u, checksum %s. Own version: %llu, epoch: %llu, checksum %s. Sync conflict, epoch times are EQUAL, can't determine which server holds the latest config, we won't sync. This message will be repeated every %llu checks until LOAD LDAP VARIABLES is executed on candidate master.\n", hostname, port, v->version, v->epoch, v->diff_check, v->checksum, own_version, own_epoch, own_checksum, (diff_lv*10));
 				GloProxyCluster->metrics.p_counter_array[p_cluster_counter::sync_conflict_ldap_variables_share_epoch]->Increment();
 			}
 		} else {
 			if (v->diff_check && (v->diff_check % (diff_lv*10)) == 0) {
-				proxy_warning("Cluster: detected a peer %s:%d with ldap_variables version %llu, epoch %llu, diff_check %u. Own version: %llu, epoch: %llu. diff_check is increasing, but version 1 doesn't allow sync. This message will be repeated every %llu checks until LOAD MYSQL VARIABLES TO RUNTIME is executed on candidate master.\n", hostname, port, v->version, v->epoch, v->diff_check, own_version, own_epoch, (diff_lv*10));
+				proxy_warning("Cluster: detected a peer %s:%d with ldap_variables version %llu, epoch %llu, diff_check %u. Own version: %llu, epoch: %llu. diff_check is increasing, but version 1 doesn't allow sync. This message will be repeated every %llu checks until LOAD LDAP VARIABLES TO RUNTIME is executed on candidate master.\n", hostname, port, v->version, v->epoch, v->diff_check, own_version, own_epoch, (diff_lv*10));
 				GloProxyCluster->metrics.p_counter_array[p_cluster_counter::sync_delayed_ldap_variables_version_one]->Increment();
 			}
 		}

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -1001,7 +1001,7 @@ void ProxySQL_Cluster::pull_mysql_users_from_peer() {
 					proxy_info("Cluster: Fetching MySQL Users from peer %s:%d completed\n", hostname, port);
 					proxy_info("Cluster: Loading to runtime MySQL Users from peer %s:%d\n", hostname, port);
 					GloAdmin->init_users();
-					if (GloProxyCluster->cluster_mysql_query_rules_save_to_disk == true) {
+					if (GloProxyCluster->cluster_mysql_users_save_to_disk == true) {
 						proxy_info("Cluster: Saving to disk MySQL Users from peer %s:%d\n", hostname, port);
 						GloAdmin->flush_mysql_users__from_memory_to_disk();
 					} else {

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -1016,7 +1016,7 @@ void ProxySQL_Cluster::pull_mysql_users_from_peer() {
 				if (GloMyLdapAuth) {
 					rc_query = mysql_query(
 						conn,
-						"SELECT priority, frontend_entity, backend_entity, comment FROM mysql_ldap_mapping"
+						"SELECT priority, frontend_entity, backend_entity, comment FROM runtime_mysql_ldap_mapping"
 					);
 
 					if (rc_query == 0) {

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -5,6 +5,7 @@
 #include "prometheus_helpers.h"
 
 #include "ProxySQL_Cluster.hpp"
+#include "MySQL_LDAP_Authentication.hpp"
 
 #ifdef DEBUG
 #define DEB "_DEBUG"
@@ -37,8 +38,8 @@
 static char *NODE_COMPUTE_DELIMITER=(char *)"-gtyw23a-"; // a random string used for hashing
 
 extern ProxySQL_Cluster * GloProxyCluster;
-
 extern ProxySQL_Admin *GloAdmin;
+extern MySQL_LDAP_Authentication* GloMyLdapAuth;
 
 typedef struct _proxy_node_address_t {
 	pthread_t thrid;
@@ -495,6 +496,26 @@ void ProxySQL_Node_Entry::set_checksums(MYSQL_RES *_r) {
 			}
 			continue;
 		}
+		if (GloMyLdapAuth && strcmp(row[0],"ldap_variables")==0) {
+			checksums_values.ldap_variables.version = atoll(row[1]);
+			checksums_values.ldap_variables.epoch = atoll(row[2]);
+			checksums_values.ldap_variables.last_updated = now;
+			if (strcmp(checksums_values.ldap_variables.checksum, row[3])) {
+				strcpy(checksums_values.ldap_variables.checksum, row[3]);
+				checksums_values.ldap_variables.last_changed = now;
+				checksums_values.ldap_variables.diff_check = 1;
+				proxy_info("Cluster: detected a new checksum for ldap_variables from peer %s:%d, version %llu, epoch %llu, checksum %s . Not syncing yet ...\n", hostname, port, checksums_values.ldap_variables.version, checksums_values.ldap_variables.epoch, checksums_values.ldap_variables.checksum);
+				if (strcmp(checksums_values.ldap_variables.checksum, GloVars.checksums_values.ldap_variables.checksum) == 0) {
+					proxy_info("Cluster: checksum for ldap_variables from peer %s:%d matches with local checksum %s , we won't sync.\n", hostname, port, GloVars.checksums_values.ldap_variables.checksum);
+				}
+			} else {
+				checksums_values.ldap_variables.diff_check++;
+			}
+			if (strcmp(checksums_values.ldap_variables.checksum, GloVars.checksums_values.ldap_variables.checksum) == 0) {
+				checksums_values.ldap_variables.diff_check = 0;
+			}
+			continue;
+		}
 	}
 	if (_r == NULL) {
 		ProxySQL_Checksum_Value_2 *v = NULL;
@@ -540,6 +561,13 @@ void ProxySQL_Node_Entry::set_checksums(MYSQL_RES *_r) {
 		}
 		if (v->diff_check)
 			v->diff_check++;
+		v = &checksums_values.ldap_variables;
+		v->last_updated = now;
+		if (strcmp(v->checksum, GloVars.checksums_values.ldap_variables.checksum) == 0) {
+			v->diff_check = 0;
+		}
+		if (v->diff_check)
+			v->diff_check++;
 	}
 	pthread_mutex_unlock(&GloVars.checksum_mutex);
 	// we now do a series of checks, and we take action
@@ -550,6 +578,7 @@ void ProxySQL_Node_Entry::set_checksums(MYSQL_RES *_r) {
 	unsigned int diff_mu = (unsigned int)__sync_fetch_and_add(&GloProxyCluster->cluster_mysql_users_diffs_before_sync,0);
 	unsigned int diff_ps = (unsigned int)__sync_fetch_and_add(&GloProxyCluster->cluster_proxysql_servers_diffs_before_sync,0);
 	unsigned int diff_mv = (unsigned int)__sync_fetch_and_add(&GloProxyCluster->cluster_mysql_variables_diffs_before_sync,0);
+	unsigned int diff_lv = (unsigned int)__sync_fetch_and_add(&GloProxyCluster->cluster_ldap_variables_diffs_before_sync,0);
 	unsigned int diff_av = (unsigned int)__sync_fetch_and_add(&GloProxyCluster->cluster_admin_variables_diffs_before_sync,0);
 	ProxySQL_Checksum_Value_2 *v = NULL;
 	if (diff_mqr) {
@@ -713,6 +742,34 @@ void ProxySQL_Node_Entry::set_checksums(MYSQL_RES *_r) {
 			if (v->diff_check && (v->diff_check % (diff_av*10)) == 0) {
 				proxy_warning("Cluster: detected a peer %s:%d with admin_variables version %llu, epoch %llu, diff_check %u. Own version: %llu, epoch: %llu. diff_check is increasing, but version 1 doesn't allow sync. This message will be repeated every %llu checks until LOAD ADMIN VARIABLES TO RUNTIME is executed on candidate master.\n", hostname, port, v->version, v->epoch, v->diff_check, own_version, own_epoch, (diff_av*10));
 				GloProxyCluster->metrics.p_counter_array[p_cluster_counter::sync_delayed_admin_variables_version_one]->Increment();
+			}
+		}
+	}
+	if (GloMyLdapAuth && diff_lv) {
+		v = &checksums_values.ldap_variables;
+		unsigned long long own_version = __sync_fetch_and_add(&GloVars.checksums_values.ldap_variables.version, 0);
+		unsigned long long own_epoch = __sync_fetch_and_add(&GloVars.checksums_values.ldap_variables.epoch, 0);
+		char* own_checksum = __sync_fetch_and_add(&GloVars.checksums_values.ldap_variables.checksum, 0);
+
+		if (v->version > 1) {
+			if (
+				(own_version == 1) // we just booted
+				||
+				(v->epoch > own_epoch) // epoch is newer
+			) {
+				if (v->diff_check >= diff_lv) {
+					proxy_info("Cluster: detected a peer %s:%d with ldap_variables version %llu, epoch %llu, diff_check %u. Own version: %llu, epoch: %llu. Proceeding with remote sync\n", hostname, port, v->version, v->epoch, v->diff_check, own_version, own_epoch);
+					GloProxyCluster->pull_global_variables_from_peer("ldap");
+				}
+			}
+			if ((v->epoch == own_epoch) && v->diff_check && ((v->diff_check % (diff_lv*10)) == 0)) {
+				proxy_error("Cluster: detected a peer %s:%d with ldap_variables version %llu, epoch %llu, diff_check %u, checksum %s. Own version: %llu, epoch: %llu, checksum %s. Sync conflict, epoch times are EQUAL, can't determine which server holds the latest config, we won't sync. This message will be repeated every %llu checks until LOAD MYSQL VARIABLES TO RUNTIME is executed on candidate master.\n", hostname, port, v->version, v->epoch, v->diff_check, v->checksum, own_version, own_epoch, own_checksum, (diff_lv*10));
+				GloProxyCluster->metrics.p_counter_array[p_cluster_counter::sync_conflict_ldap_variables_share_epoch]->Increment();
+			}
+		} else {
+			if (v->diff_check && (v->diff_check % (diff_lv*10)) == 0) {
+				proxy_warning("Cluster: detected a peer %s:%d with ldap_variables version %llu, epoch %llu, diff_check %u. Own version: %llu, epoch: %llu. diff_check is increasing, but version 1 doesn't allow sync. This message will be repeated every %llu checks until LOAD MYSQL VARIABLES TO RUNTIME is executed on candidate master.\n", hostname, port, v->version, v->epoch, v->diff_check, own_version, own_epoch, (diff_lv*10));
+				GloProxyCluster->metrics.p_counter_array[p_cluster_counter::sync_delayed_ldap_variables_version_one]->Increment();
 			}
 		}
 	}
@@ -1377,16 +1434,25 @@ void ProxySQL_Cluster::pull_global_variables_from_peer(const std::string& var_ty
 		vars_type_str = const_cast<char*>("Admin");
 		success_metric = p_cluster_counter::pulled_admin_variables_success;
 		failure_metric = p_cluster_counter::pulled_admin_variables_failure;
+	} else if (var_type == "ldap") {
+		vars_type_str = const_cast<char*>("LDAP");
+		success_metric = p_cluster_counter::pulled_ldap_variables_success;
+		failure_metric = p_cluster_counter::pulled_ldap_variables_failure;
 	} else {
-		proxy_error("Invalid parameter supplied to 'pull_global_variables_from_peer': var_type=%s", var_type.c_str());
+		proxy_error("Invalid parameter supplied to 'pull_global_variables_from_peer': var_type=%s\n", var_type.c_str());
 		assert(0);
 	}
 
 	pthread_mutex_lock(&GloProxyCluster->update_mysql_variables_mutex);
 	if (var_type == "mysql") {
 		nodes.get_peer_to_sync_mysql_variables(&hostname, &port);
-	} else {
+	} else if (var_type == "admin") {
 		nodes.get_peer_to_sync_admin_variables(&hostname, &port);
+	} else if (var_type == "ldap"){
+		nodes.get_peer_to_sync_ldap_variables(&hostname, &port);
+	} else {
+		proxy_error("Invalid parameter supplied to 'pull_global_variables_from_peer': var_type=%s\n", var_type.c_str());
+		assert(0);
 	}
 
 	if (hostname) {
@@ -1450,13 +1516,23 @@ void ProxySQL_Cluster::pull_global_variables_from_peer(const std::string& var_ty
 							proxy_info("Cluster: Saving to disk MySQL Variables from peer %s:%d\n", hostname, port);
 							GloAdmin->flush_mysql_variables__from_memory_to_disk();
 						}
-					} else {
+					} else if (var_type == "admin") {
 						GloAdmin->load_admin_variables_to_runtime();
 
 						if (GloProxyCluster->cluster_admin_variables_save_to_disk == true) {
 							proxy_info("Cluster: Saving to disk Admin Variables from peer %s:%d\n", hostname, port);
 							GloAdmin->flush_admin_variables__from_memory_to_disk();
 						}
+					} else if (var_type == "ldap") {
+						GloAdmin->load_ldap_variables_to_runtime();
+
+						if (GloProxyCluster->cluster_ldap_variables_save_to_disk == true) {
+							proxy_info("Cluster: Saving to disk LDAP Variables from peer %s:%d\n", hostname, port);
+							GloAdmin->flush_ldap_variables__from_memory_to_disk();
+						}
+					} else {
+						proxy_error("Invalid parameter supplied to 'pull_global_variables_from_peer': var_type=%s\n", var_type.c_str());
+						assert(0);
 					}
 					metrics.p_counter_array[success_metric]->Increment();
 				} else {
@@ -1973,6 +2049,48 @@ void ProxySQL_Cluster_Nodes::get_peer_to_sync_admin_variables(char **host, uint1
 	}
 }
 
+void ProxySQL_Cluster_Nodes::get_peer_to_sync_ldap_variables(char **host, uint16_t *port) {
+	unsigned long long version = 0;
+	unsigned long long epoch = 0;
+	unsigned long long max_epoch = 0;
+	char *hostname = NULL;
+	uint16_t p = 0;
+	unsigned int diff_mu = (unsigned int)__sync_fetch_and_add(&GloProxyCluster->cluster_ldap_variables_diffs_before_sync,0);
+	for (std::unordered_map<uint64_t, ProxySQL_Node_Entry *>::iterator it = umap_proxy_nodes.begin(); it != umap_proxy_nodes.end();) {
+		ProxySQL_Node_Entry * node = it->second;
+		ProxySQL_Checksum_Value_2 * v = &node->checksums_values.ldap_variables;
+		if (v->version > 1) {
+			if ( v->epoch > epoch ) {
+				max_epoch = v->epoch;
+				if (v->diff_check > diff_mu) {
+					epoch = v->epoch;
+					version = v->version;
+					if (hostname) {
+						free(hostname);
+					}
+					hostname=strdup(node->get_hostname());
+					p = node->get_port();
+				}
+			}
+		}
+		it++;
+	}
+	if (epoch) {
+		if (max_epoch > epoch) {
+			proxy_warning("Cluster: detected a peer with ldap_variables epoch %llu, but not enough diff_check. We won't sync from epoch %llu: temporarily skipping sync\n", max_epoch, epoch);
+			if (hostname) {
+				free(hostname);
+				hostname = NULL;
+			}
+		}
+	}
+	if (hostname) {
+		*host = hostname;
+		*port = p;
+		proxy_info("Cluster: detected peer %s:%d with ldap_variables version %llu, epoch %llu\n", hostname, p, version, epoch);
+	}
+}
+
 void ProxySQL_Cluster_Nodes::get_peer_to_sync_proxysql_servers(char **host, uint16_t *port) {
 	unsigned long long version = 0;
 	unsigned long long epoch = 0;
@@ -2454,6 +2572,26 @@ cluster_metrics_map = std::make_tuple(
 			}
 		),
 
+		// ldap_variables_*
+		std::make_tuple (
+			p_cluster_counter::pulled_ldap_variables_success,
+			"proxysql_cluster_pulled_total",
+			"Number of times a 'module' have been pulled from a peer.",
+			metric_tags {
+				{ "module_name", "ldap_variables" },
+				{ "status", "success" }
+			}
+		),
+		std::make_tuple (
+			p_cluster_counter::pulled_ldap_variables_failure,
+			"proxysql_cluster_pulled_total",
+			"Number of times a 'module' have been pulled from a peer.",
+			metric_tags {
+				{ "module_name", "ldap_variables" },
+				{ "status", "failure" }
+			}
+		),
+
 		// sync_conflict same epoch
 		// ====================================================================
 		std::make_tuple (
@@ -2507,6 +2645,15 @@ cluster_metrics_map = std::make_tuple(
 			"Number of times a 'module' has not been able to be synced.",
 			metric_tags {
 				{ "module_name", "admin_variables" },
+				{ "reason", "servers_share_epoch" }
+			}
+		),
+		std::make_tuple (
+			p_cluster_counter::sync_conflict_ldap_variables_share_epoch,
+			"proxysql_cluster_syn_conflict_total",
+			"Number of times a 'module' has not been able to be synced.",
+			metric_tags {
+				{ "module_name", "ldap_variables" },
 				{ "reason", "servers_share_epoch" }
 			}
 		),
@@ -2567,7 +2714,16 @@ cluster_metrics_map = std::make_tuple(
 				{ "module_name", "admin_variables" },
 				{ "reason", "version_one" }
 			}
-		)
+		),
+		std::make_tuple (
+			p_cluster_counter::sync_delayed_ldap_variables_version_one,
+			"proxysql_cluster_syn_conflict_total",
+			"Number of times a 'module' has not been able to be synced.",
+			metric_tags {
+				{ "module_name", "ldap_variables" },
+				{ "reason", "version_one" }
+			}
+		),
 		// ====================================================================
 	},
 	cluster_gauge_vector {}

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -7,6 +7,10 @@
 #include "SpookyV2.h"
 #include <cxxabi.h>
 
+#include "MySQL_LDAP_Authentication.hpp"
+
+extern MySQL_LDAP_Authentication* GloMyLdapAuth;
+
 static void term_handler(int sig) {
   proxy_warning("Received TERM signal: shutdown in progress...\n");
 #ifdef DEBUG
@@ -366,6 +370,13 @@ uint64_t ProxySQL_GlobalVariables::generate_global_checksum() {
 	if (v->version) {
 		myhash.Update(v->checksum,strlen(v->checksum));
 		myhash.Update(&v->version,sizeof(v->version));
+	}
+	if (GloMyLdapAuth) {
+		v = &checksums_values.ldap_variables;
+		if (v->version) {
+			myhash.Update(v->checksum,strlen(v->checksum));
+			myhash.Update(&v->version,sizeof(v->version));
+		}
 	}
 	uint64_t h1, h2;
 	myhash.Final(&h1, &h2);

--- a/test/tap/tests/sqlite3-t.cpp
+++ b/test/tap/tests/sqlite3-t.cpp
@@ -6,9 +6,12 @@
 #include <cstring>
 #include <memory>
 #include <openssl/ssl.h>
+
 #include "proxysql_structs.h"
-#include "proxysql_glovars.hpp"
 #include "sqlite3db.h"
+#include "MySQL_LDAP_Authentication.hpp"
+
+MySQL_LDAP_Authentication* GloMyLdapAuth = nullptr;
 
 int main() {
 	SQLite3DB::LoadPlugin(NULL);


### PR DESCRIPTION
closes #3419.