### PR TITLE
Closes #3376: Invalid timestamps reported for 'first_seen' and 'last_seen' fields from 'stats_mysql_errors'

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -5951,17 +5951,10 @@ class MySQL_Errors_stats {
 		sprintf(buf,"%llu",count_star);
 		pta[7]=strdup(buf);
 
-		time_t __now;
-		time(&__now);
-		unsigned long long curtime=monotonic_time();
-		time_t seen_time;
-
-		seen_time= __now - curtime/1000000 + first_seen/1000000;
-		sprintf(buf,"%ld", seen_time);
+		sprintf(buf,"%ld", first_seen);
 		pta[8]=strdup(buf);
 
-		seen_time= __now - curtime/1000000 + last_seen/1000000;
-		sprintf(buf,"%ld", seen_time);
+		sprintf(buf,"%ld", last_seen);
 		pta[9]=strdup(buf);
 
 		assert(last_error);


### PR DESCRIPTION
closes #3376.

As a prove of the issue resolution, I'm pasting here the results of analogous operations as the user performed in the report which showed the issue:

```
mysql> select * from stats_mysql_errors;
+-----------+-----------+-------+----------+----------------+--------------------+-------+------------+------------+------------+----------------------------------------------------+
| hostgroup | hostname  | port  | username | client_address | schemaname         | errno | count_star | first_seen | last_seen  | last_error                                         |
+-----------+-----------+-------+----------+----------------+--------------------+-------+------------+------------+------------+----------------------------------------------------+
| 0         | 127.0.0.1 | 13306 | root     | 127.0.0.1      | information_schema | 1054  | 1          | 1619523458 | 1619523458 | Unknown column 'intentional_error' in 'field list' |
+-----------+-----------+-------+----------+----------------+--------------------+-------+------------+------------+------------+----------------------------------------------------+
1 row in set (0.00 sec)
```

The converted timestamps of the operation:

```
mysql> select first_seen, last_seen, from_unixtime(first_seen),from_unixtime(last_seen) from stats_mysql_errors;
+------------+------------+---------------------------+--------------------------+
| first_seen | last_seen  | from_unixtime(first_seen) | from_unixtime(last_seen) |
+------------+------------+---------------------------+--------------------------+
| 1619523458 | 1619523458 | 2021-04-27 11:37:38       | 2021-04-27 11:37:38      |
+------------+------------+---------------------------+--------------------------+
```

The system timestamp:
```
$ timedatectl
               Local time: Tue 2021-04-27 13:38:12 CEST
           Universal time: Tue 2021-04-27 11:38:12 UTC
                 RTC time: Tue 2021-04-27 13:38:16
                Time zone: Europe/Madrid (CEST, +0200)
System clock synchronized: no
              NTP service: inactive
          RTC in local TZ: no
```