### PR TITLE
Fix two print errors debug log in commit func

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1760,14 +1760,14 @@ bool MySQL_HostGroups_Manager::commit() {
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 			SQLite3_row *r=*it;
 			long long ptr=atoll(r->fields[12]); // increase this index every time a new column is added
-			proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 5, "Server %s:%d , weight=%d, status=%d, mem_pointer=%llu, hostgroup=%d, compression=%d\n", r->fields[1], atoi(r->fields[2]), atoi(r->fields[3]), (MySerStatus) atoi(r->fields[4]), ptr, atoi(r->fields[0]), atoi(r->fields[5]));
+			proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 5, "Server %s:%d , weight=%d, status=%d, mem_pointer=%llu, hostgroup=%d, compression=%d\n", r->fields[1], atoi(r->fields[2]), atoi(r->fields[4]), (MySerStatus) atoi(r->fields[5]), ptr, atoi(r->fields[0]), atoi(r->fields[6]));
 			//fprintf(stderr,"%lld\n", ptr);
 			if (ptr==0) {
 				if (GloMTH->variables.hostgroup_manager_verbose) {
 					proxy_info("Creating new server in HG %d : %s:%d , gtid_port=%d, weight=%d, status=%d\n", atoi(r->fields[0]), r->fields[1], atoi(r->fields[2]), atoi(r->fields[3]), atoi(r->fields[4]), (MySerStatus) atoi(r->fields[5]));
 				}
 				MySrvC *mysrvc=new MySrvC(r->fields[1], atoi(r->fields[2]), atoi(r->fields[3]), atoi(r->fields[4]), (MySerStatus) atoi(r->fields[5]), atoi(r->fields[6]), atoi(r->fields[7]), atoi(r->fields[8]), atoi(r->fields[9]), atoi(r->fields[10]), r->fields[11]); // add new fields here if adding more columns in mysql_servers
-				proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 5, "Adding new server %s:%d , weight=%d, status=%d, mem_ptr=%p into hostgroup=%d\n", r->fields[1], atoi(r->fields[2]), atoi(r->fields[3]), (MySerStatus) atoi(r->fields[4]), mysrvc, atoi(r->fields[0]));
+				proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 5, "Adding new server %s:%d , weight=%d, status=%d, mem_ptr=%p into hostgroup=%d\n", r->fields[1], atoi(r->fields[2]), atoi(r->fields[4]), (MySerStatus) atoi(r->fields[5]), mysrvc, atoi(r->fields[0]));
 				add(mysrvc,atoi(r->fields[0]));
 				ptr=(uintptr_t)mysrvc;
 				rc=(*proxy_sqlite3_bind_int64)(statement1, 1, ptr); ASSERT_SQLITE_OK(rc, mydb);


### PR DESCRIPTION
       Fix two print errors debug log in MySQL_HostGroups_Manager::commit func.  For the code at line numbers 1763 and 1770 in the MySQL_HostGroups_Manager::commit function,  the value of the resultset variable comes from the following SQL execution in the debug mode.   

**SQL:**
SELECT
	t1.*,
	t2.gtid_port,
	t2.weight,
	t2.STATUS,
	t2.compression,
	t2.max_connections,
	t2.max_replication_lag,
	t2.use_ssl,
	t2.max_latency_ms,
	t2.COMMENT 
FROM
	mysql_servers t1
	JOIN mysql_servers_incoming t2 ON ( t1.hostgroup_id = t2.hostgroup_id AND t1.hostname = t2.hostname AND t1.PORT = t2.PORT ) 
WHERE
	mem_pointer = 0 
	OR t1.gtid_port <> t2.gtid_port 
	OR t1.weight <> t2.weight 
	OR t1.STATUS <> t2.STATUS 
	OR t1.compression <> t2.compression 
	OR t1.max_connections <> t2.max_connections 
	OR t1.max_replication_lag <> t2.max_replication_lag 
	OR t1.use_ssl <> t2.use_ssl 
	OR t1.max_latency_ms <> t2.max_latency_ms 
	OR t1.COMMENT <> t2.COMMENT
 
CREATE TABLE mysql_servers (
	hostgroup_id INT NOT NULL DEFAULT 0,
	hostname VARCHAR NOT NULL,
	PORT INT NOT NULL DEFAULT 3306,
	gtid_port INT NOT NULL DEFAULT 0,
	weight INT CHECK ( weight >= 0 ) NOT NULL DEFAULT 1,
	STATUS INT CHECK (STATUS IN ( 0, 1, 2, 3, 4 )) NOT NULL DEFAULT 0,
	compression INT CHECK ( compression >= 0 AND compression <= 102400 ) NOT NULL DEFAULT 0,
	max_connections INT CHECK ( max_connections >= 0 ) NOT NULL DEFAULT 1000,
	max_replication_lag INT CHECK ( max_replication_lag >= 0 AND max_replication_lag <= 126144000 ) NOT NULL DEFAULT 0,
	use_ssl INT CHECK (use_ssl IN ( 0, 1 )) NOT NULL DEFAULT 0,
	max_latency_ms INT UNSIGNED CHECK ( max_latency_ms >= 0 ) NOT NULL DEFAULT 0,
	COMMENT VARCHAR NOT NULL DEFAULT '',
	mem_pointer INT NOT NULL DEFAULT 0,
PRIMARY KEY ( hostgroup_id, hostname, PORT ) 
)
 

