### PR TITLE
Closes #3431: Fix crashes  due to mmsd is null when add an invalid host name to the mysql_servers table

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -4171,10 +4171,7 @@ void * monitor_AWS_Aurora_thread_HG(void *arg) {
 
 	while (GloMyMon->shutdown==false && mysql_thread___monitor_enabled==true && exit_now==false) {
 
-		if (mmsd) {
-			delete mmsd;
-			mmsd = NULL;
-		}
+		
 		unsigned int glover;
 		t1=monotonic_time();
 
@@ -4262,7 +4259,11 @@ void * monitor_AWS_Aurora_thread_HG(void *arg) {
 			proxy_info("Running check for AWS Aurora writer HG %u on %s:%d\n", wHG , hpa[cur_host_idx].host, hpa[cur_host_idx].port);
 		}
 #endif // TEST_AURORA
-		mmsd = NULL;
+		if (mmsd) {
+			delete mmsd;
+			mmsd = NULL;
+		}
+		//mmsd = NULL;
 		mmsd = new MySQL_Monitor_State_Data(hpa[cur_host_idx].host, hpa[cur_host_idx].port, NULL, hpa[cur_host_idx].use_ssl);
 		mmsd->writer_hostgroup = wHG;
 		mmsd->aws_aurora_check_timeout_ms = check_timeout_ms;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -4248,7 +4248,7 @@ void * monitor_AWS_Aurora_thread_HG(void *arg) {
 		}
 #endif // TEST_AURORA
 
-		if (found_pingable_host == false) {
+		if (found_pingable_host == false&&mmsd) {
 			proxy_error("No node is pingable for AWS Aurora cluster with writer HG %u\n", wHG);
 			MyHGM->p_update_mysql_error_counter(p_mysql_error_type::proxysql, mmsd->hostgroup_id, mmsd->hostname, mmsd->port, ER_PROXYSQL_AWS_NO_PINGABLE_SRV);
 			next_loop_at = t1 + check_interval_ms * 1000;


### PR DESCRIPTION
Closes #3431.

**Test situation：**
When it add  an invalid host name to the mysql_servers table,  and insert table mysql_aws_aurora_hostgroups:

insert into mysql_aws_aurora_hostgroups(writer_hostgroup,reader_hostgroup,active,domain_name,comment)
values(10,20,1,'.com','mysql_aws_aurora_hostgroups');
load mysql servers to runtime;
save mysql servers to disk;

insert into mysql_servers(hostgroup_id,hostname,port,weight,max_connections)values
(10,'aurora-mysql-1-instance-1',3306,1,1000),
(20,'aurora-mysql-1-instance-1',3306,30,1000),
(20,'aurora-mysql-1-instance-2',3306,70,1000);
load mysql servers to runtime;
save mysql servers to disk;

select hostgroup_id,hostname,port,status,weight,max_connections from runtime_mysql_servers;
+--------------+---------------------------+------+--------+--------+-------------+-----------------+
| hostgroup_id | hostname                  | port | status | weight | compression | max_connections |
+--------------+---------------------------+------+--------+--------+-------------+-----------------+
| 10           | aurora-mysql-1-instance-1 | 3306 | ONLINE | 1      | 0           | 1000            |
| 20           | aurora-mysql-1-instance-1 | 3306 | ONLINE | 30     | 0           | 1000            |
| 20           | aurora-mysql-1-instance-2 | 3306 | ONLINE | 70     | 0           | 1000            |
+--------------+---------------------------+------+--------+--------+-------------+-----------------+

It cause proxysql  coredump,   coredump info（ **mmsd = 0x0** , in func monitor_AWS_Aurora_thread_HG line 4254  of  the version 2.1.1 proxysql ）:

(gdb) bt full
#0  0x00000000008f7051 in monitor_AWS_Aurora_thread_HG (arg=0x7f181cc70880) at MySQL_Monitor.cpp:4254
        glover = 2
        rHG = 20
        max_lag_ms = 600000
        min_lag_ms = 30
        MySQL_Monitor__thread_MySQL_Thread_Variables_version = 2
        ase_idx = 6
        next_loop_at = 3116309400
        num_hosts = 2
        cur_host_idx = 1
        add_lag_ms = 30
        exit_now = false
        crc = true
        found_pingable_host = false
        check_interval_ms = 1000
        mysql_thr = 0x7f181a8d0000
        hpa = 0x7f181a8c0d00
        current_raw_checksum = 13941933782202003786
        start_time = 3115323481
        lag_num_checks = 1
        initial_raw_checksum = 13941933782202003786
        rnd = 1
        rc_ping = false
        mmsd = 0x0
        __func__ = "monitor_AWS_Aurora_thread_HG"
        lasts_ase = {0x7f181a8c1ae0, 0x7f181a8c1b20, 0x7f181a8c1b60, 0x7f181a8c1ba0, 0x7f181a8c1be0, 0x7f181a8c1c20, 0x7f181a8c15e0, 0x7f181a8c1660, 
          0x7f181a8c16e0, 0x7f181a8c1760, 0x7f181a8c17e0, 0x7f181a8c1860, 0x7f181a8c18e0, 0x7f181a8c1960, 0x7f181a8c19e0, 0x7f181a8c1a60}
        wHG = 10
        check_timeout_ms = 800
        t1 = 3116309559
#1  0x00007f181f0cedd5 in start_thread () from /lib64/libpthread.so.0
No symbol table info available.
#2  0x00007f181dfb702d in clone () from /lib64/libc.so.6
No symbol table info available.

