### PR TITLE
Closes #3458: Fix 'conditional jump or move depends on uninitialised value(s)' detected by Valgrind

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -212,6 +212,8 @@ Query_Info::Query_Info() {
 	waiting_since = 0;
 	affected_rows=0;
 	rows_sent=0;
+	start_time=0;
+	end_time=0;
 }
 
 Query_Info::~Query_Info() {

--- a/test/tap/tests/test_ps_no_store-t.cpp
+++ b/test/tap/tests/test_ps_no_store-t.cpp
@@ -34,6 +34,7 @@ int select_config_file(MYSQL* mysql, std::string& resultset) {
 		fprintf(stderr, "error\n");
 	}
 
+	return 0;
 }
 
 int restore_admin(MYSQL* mysqladmin) {
@@ -41,6 +42,8 @@ int restore_admin(MYSQL* mysqladmin) {
 	MYSQL_QUERY(mysqladmin, "load mysql query rules to runtime");
 	MYSQL_QUERY(mysqladmin, "load mysql servers from disk");
 	MYSQL_QUERY(mysqladmin, "load mysql servers to runtime");
+
+	return 0;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
closes #3458.