### PR TITLE
[WIP] Adding support for PROXYSQL GCOV DUMP|RESET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ $(error GIT_VERSION is not set)
 endif
 endif
 
+### NOTES:
+### to compile without jemalloc, set environment variable NOJEMALLOC=1
+### to compile with gcov code coverage, set environment variable WITHGCOV=1
+
 O0=-O0
 O2=-O2
 O1=-O1

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -76,6 +76,13 @@ else
 NOJEM=
 endif
 
+WITHGCOVVAR := $(shell echo $(WITHGCOV))
+ifeq ($(WITHGCOVVAR),1)
+WGCOV=-DWITHGCOV --coverage -lgcov
+else
+WGCOV=
+endif
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 NOJEM=-DNOJEM
@@ -93,7 +100,7 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 
-MYCFLAGS=$(IDIRS) $(OPTZ) $(DEBUG) -Wall -DGITVERSION=\"$(GIT_VERSION)\" $(NOJEM)
+MYCFLAGS=$(IDIRS) $(OPTZ) $(DEBUG) -Wall -DGITVERSION=\"$(GIT_VERSION)\" $(NOJEM) $(WGCOV)
 MYCXXFLAGS=-std=c++11 $(MYCFLAGS) $(PSQLCH)
 
 default: libproxysql.a
@@ -124,7 +131,7 @@ $(ODIR):
 
 
 clean:
-	rm -f *.pid $(ODIR)/*.oo $(ODIR)/*.o *.ko *.so *~ core libproxysql.a
+	rm -f *.pid $(ODIR)/*.oo $(ODIR)/*.o $(ODIR)/*.gcno $(ODIR)/*.gcda *.ko *.so *~ core libproxysql.a
 
 
 ## self note

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -49,8 +49,8 @@
 
 
 #ifdef WITHGCOV
-extern void __gcov_dump();
-extern void __gcov_reset();
+extern "C" void __gcov_dump();
+extern "C" void __gcov_reset();
 #endif
 //#define MYSQL_THREAD_IMPLEMENTATION
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -47,6 +47,11 @@
 #include "platform.h"
 #include "microhttpd.h"
 
+
+#ifdef WITHGCOV
+extern void __gcov_dump();
+extern void __gcov_reset();
+#endif
 //#define MYSQL_THREAD_IMPLEMENTATION
 
 #define SELECT_VERSION_COMMENT "select @@version_comment limit 1"
@@ -1408,6 +1413,21 @@ bool admin_handler_command_proxysql(char *query_no_space, unsigned int query_no_
 	if (query_no_space_length==strlen("PROXYSQL MEMPROFILE STOP") && !strncasecmp("PROXYSQL MEMPROFILE STOP",query_no_space, query_no_space_length)) {
 		bool en=false;
 		mallctl("prof.active", NULL, NULL, &en, sizeof(bool));
+		SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL);
+		return false;
+	}
+#endif
+
+#ifdef WITHGCOV
+	if (query_no_space_length==strlen("PROXYSQL GCOV DUMP") && !strncasecmp("PROXYSQL GCOV DUMP",query_no_space, query_no_space_length)) {
+		proxy_info("Received %s command\n", query_no_space);
+		__gcov_dump();
+		SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL);
+		return false;
+	}
+	if (query_no_space_length==strlen("PROXYSQL GCOV RESET") && !strncasecmp("PROXYSQL GCOV RESET",query_no_space, query_no_space_length)) {
+		proxy_info("Received %s command\n", query_no_space);
+		__gcov_reset();
 		SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL);
 		return false;
 	}

--- a/src/Makefile
+++ b/src/Makefile
@@ -93,9 +93,19 @@ else
 PSQLCH=
 endif
 
-MYCXXFLAGS=-std=c++11 $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH) -DGITVERSION=\"$(GIT_VERSION)\"
+WITHGCOVVAR := $(shell echo $(WITHGCOV))
+ifeq ($(WITHGCOVVAR),1)
+WGCOV=-DWITHGCOV --coverage
+else
+WGCOV=
+endif
 
-LDFLAGS+=
+MYCXXFLAGS=-std=c++11 $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH) -DGITVERSION=\"$(GIT_VERSION)\" $(WGCOV)
+
+ifeq ($(WITHGCOVVAR),1)
+LDFLAGS+= -lgcov --coverage
+endif
+
 NOJEMALLOC := $(shell echo $(NOJEMALLOC))
 ifeq ($(NOJEMALLOC),1)
 MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev -Wl,-Bdynamic -lgnutls -lpthread -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core $(EXTRALINK)
@@ -152,5 +162,5 @@ $(LIBPROXYSQLAR):
 default: $(EXECUTABLE)
 
 clean:
-	rm -f *.pid $(ODIR)/*.o *~ core perf.data* heaptrack.proxysql.* $(EXECUTABLE)
+	rm -f *.pid $(ODIR)/*.o $(ODIR)/*.gcno $(ODIR)/*.gcda *~ core perf.data* heaptrack.proxysql.* $(EXECUTABLE)
 

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -83,8 +83,15 @@ all: tests
 clean:
 	rm -f *-t galera_1_timeout_count galera_2_timeout_no_count aurora || true
 
-OPT=-O2 -Wl,--no-as-needed
-debug: OPT=-O0 -DDEBUG -ggdb -Wl,--no-as-needed
+WITHGCOVVAR := $(shell echo $(WITHGCOV))
+ifeq ($(WITHGCOVVAR),1)
+WGCOV=-DWITHGCOV --coverage
+else
+WGCOV=
+endif
+
+OPT=-O2 $(WGCOV) -Wl,--no-as-needed
+debug: OPT=-O0 -DDEBUG $(WGCOV) -ggdb -Wl,--no-as-needed
 debug: tests
 
 tests: $(patsubst %.cpp,%,$(wildcard *-t.cpp)) setparser_test


### PR DESCRIPTION
Adding two new Admin commands:
PROXYSQL GCOV DUMP
PROXYSQL GCOV RESET

These will call __gcov_dump() and __gcov_reset()

This feature is enabled when built with env var `WITHGCOV=1`