### PR TITLE
Closes #3492:  Fix the incorrect value range of the parameter mysql-default_query_timeout 

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2051,7 +2051,7 @@ char ** MySQL_Threads_Handler::get_variables_list() {
 		// query processor and query digest
 		VariablesPointers_int["auto_increment_delay_multiplex"]  = make_tuple(&variables.auto_increment_delay_multiplex,   0,     1000000, false);
 		VariablesPointers_int["default_query_delay"]             = make_tuple(&variables.default_query_delay,              0,   3600*1000, false);
-		VariablesPointers_int["default_query_timeout"]           = make_tuple(&variables.default_query_timeout,            0,   1000*1000, false);
+		VariablesPointers_int["default_query_timeout"]           = make_tuple(&variables.default_query_timeout,         1000,20*24*3600*1000, false);
 		VariablesPointers_int["query_digests_grouping_limit"]    = make_tuple(&variables.query_digests_grouping_limit,     1,        2089, false);
 		VariablesPointers_int["query_digests_max_digest_length"] = make_tuple(&variables.query_digests_max_digest_length, 16, 1*1024*1024, false);
 		VariablesPointers_int["query_digests_max_query_length"]  = make_tuple(&variables.query_digests_max_query_length,  16, 1*1024*1024, false);


### PR DESCRIPTION
Closes #3492. 

According to the parameter mysql-default_query_timeout description document：https://proxysql.com/documentation/global-variables/mysql-variables/#mysql-default_query_timeout,  
    **mysql-default_query_timeout   Minimum: 1000    Maximum:  1728000000   Type: Integer (milliseconds)**
Fix the incorrect value range of the parameter mysql-default_query_timeout  in MySQL_Thread.cpp file.

**Test situation：**
The test situation after repair is as follows：

Admin> set  mysql-default_query_timeout=3600000;
Query OK, 1 row affected (0.00 sec)

Admin> load mysql variables to runtime;
Query OK, 0 rows affected (0.00 sec)

Admin> select * from global_variables where variable_name='mysql-default_query_timeout';
+-----------------------------+----------------+
| variable_name               | variable_value |
+-----------------------------+----------------+
| mysql-default_query_timeout | 3600000        |
+-----------------------------+----------------+
1 row in set (0.00 sec)

Admin> select * from runtime_global_variables where variable_name='mysql-default_query_timeout';
+-----------------------------+----------------+
| variable_name               | variable_value |
+-----------------------------+----------------+
| mysql-default_query_timeout | 3600000        |
+-----------------------------+----------------+
1 row in set (0.00 sec)
