### PR TITLE
Change the pt-heartbeat query from MIN to MAX due to a possible daisy-chain replication or multi-master setup

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -2138,7 +2138,7 @@ void * monitor_replication_lag_thread(void *arg) {
 		int l = strlen(percona_heartbeat_table);
 		if (l) {
 			use_percona_heartbeat = true;
-			char *base_query = (char *)"SELECT MIN(ROUND(TIMESTAMPDIFF(MICROSECOND, ts, SYSDATE(6))/1000000)) AS Seconds_Behind_Master FROM %s";
+			char *base_query = (char *)"SELECT MAX(ROUND(TIMESTAMPDIFF(MICROSECOND, ts, SYSDATE(6))/1000000)) AS Seconds_Behind_Master FROM %s";
 			char *replication_query = (char *)malloc(strlen(base_query)+l);
 			sprintf(replication_query,base_query,percona_heartbeat_table);
 			mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,replication_query);


### PR DESCRIPTION
Change the pt-heartbeat query from MIN to MAX due to a possible daisy-chain replication or multi-master setup.

Reason: 
In a daisy-chain replication topology, the pt-hearbeat table contains more then 1 row, by changing MIN to MAX we make sure we take the server out of rotation even if the replica is delayed for one server/master only. 
Also that's how `pmp-check-mysql-replication-delay` works by default, please see https://github.com/percona/percona-monitoring-plugins/blob/master/nagios/bin/pmp-check-mysql-replication-delay#L81

Example:
```
mysql> SELECT * FROM heartbeat;
+----------------------------+-----------+------------------+-----------+-----------------------+---------------------+
| ts                         | server_id | file             | position  | relay_master_log_file | exec_master_log_pos |
+----------------------------+-----------+------------------+-----------+-----------------------+---------------------+
| 2021-07-07T16:10:05.003200 | 111105081 | mysql-bin.000129 | 476837706 | mysql-bin.000127      |           477714455 |
| 2021-07-07T16:10:10.003470 | 111105083 | mysql-bin.000127 | 477718106 | mysql-bin.000129      |           476841330 |
+----------------------------+-----------+------------------+-----------+-----------------------+---------------------+
2 rows in set (0.00 sec)

mysql> SELECT MIN(ROUND(TIMESTAMPDIFF(MICROSECOND, ts, SYSDATE(6))/1000000)) AS Seconds_Behind_Master FROM heartbeat;
+-----------------------+
| Seconds_Behind_Master |
+-----------------------+
|                     1 |
+-----------------------+
1 row in set (0.00 sec)

mysql> SELECT MAX(ROUND(TIMESTAMPDIFF(MICROSECOND, ts, SYSDATE(6))/1000000)) AS Seconds_Behind_Master FROM heartbeat;
+-----------------------+
| Seconds_Behind_Master |
+-----------------------+
|                    16 |
+-----------------------+
1 row in set (0.00 sec)
```