### PR TITLE
Close #3520:Fix incorrect log printing and useless class member attributes

### DIFF
--- a/include/MySQL_Monitor.hpp
+++ b/include/MySQL_Monitor.hpp
@@ -196,7 +196,7 @@ class MySQL_Monitor_State_Data {
 	int writer_hostgroup; // used only by group replication
 	bool writer_is_also_reader; // used only by group replication
 	int  max_transactions_behind; // used only by group replication
-	int max_transactions_behind_count; // used only by group replication
+	//int max_transactions_behind_count; // used only by group replication
 	int aws_aurora_max_lag_ms;
 	int aws_aurora_check_timeout_ms;
 	int aws_aurora_add_lag_ms;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1543,7 +1543,7 @@ __exit_monitor_group_replication_thread:
 			if (strncasecmp(mmsd->mysql_error_msg, (char *)"timeout", 7) == 0) {
 				num_timeouts=node->get_timeout_count();
 				proxy_warning("%s:%d : group replication health check timeout count %d. Max threshold %d.\n",
-					mmsd->hostname, mmsd->port, num_timeouts, mmsd->max_transactions_behind_count);
+					mmsd->hostname, mmsd->port, num_timeouts, mysql_thread___monitor_groupreplication_healthcheck_max_timeout_count);
 			}
 		}
 		int lag_counts = 0;
@@ -2950,7 +2950,7 @@ void * MySQL_Monitor::monitor_group_replication() {
 					mmsd->writer_hostgroup=atoi(r->fields[0]);
 					mmsd->writer_is_also_reader=atoi(r->fields[4]);
 					mmsd->max_transactions_behind=atoi(r->fields[5]);
-					mmsd->max_transactions_behind_count=mysql_thread___monitor_groupreplication_max_transactions_behind_count;
+					//mmsd->max_transactions_behind_count=mysql_thread___monitor_groupreplication_max_transactions_behind_count;
 					mmsd->mondb=monitordb;
 					WorkItem* item;
 					item=new WorkItem(mmsd,monitor_group_replication_thread);


### PR DESCRIPTION
Close #3520

According to the parameter mysql-monitor_groupreplication_healthcheck_max_timeout_count description document: https://proxysql.com/documentation/global-variables/mysql-monitor-variables/#mysql-monitor_groupreplication_healthcheck_max_timeout_count.

**The max number of times that proxysql has timeout checking on a mgr node is controlled by a parameter mysql-monitor_groupreplication_healthcheck_max_timeout_count.**

In the following code:
**(1) line number 1545 of MySQL_Monitor.cpp file**
if (mmsd->mysql_error_msg) {
if (strncasecmp(mmsd->mysql_error_msg, (char *)"timeout", 7) == 0) {
num_timeouts=node->get_timeout_count();
proxy_warning("%s:%d : group replication health check timeout count %d. Max threshold %d.\n",
mmsd->hostname, mmsd->port, num_timeouts, mmsd->max_transactions_behind_count);
}
}
**(2) line number 2953 of MySQL_Monitor.cpp file**
mmsd->max_transactions_behind_count=mysql_thread___monitor_groupreplication_max_transactions_behind_count

**The max threshold of group replication health check timeout count is controlled by a parameter mysql-monitor_groupreplication_healthcheck_max_timeout_count, not this parameter: mysql_thread___monitor_groupreplication_max_transactions_behind_count.**

