### PR TITLE
Closes #3500: Unsupported 'LOAD DATA LOCAL INFILE' command

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -535,6 +535,7 @@ class MySQL_Threads_Handler
 		bool client_session_track_gtid;
 		bool enable_client_deprecate_eof;
 		bool enable_server_deprecate_eof;
+		bool enable_load_data_local_infile;
 		bool log_mysql_warnings_enabled;
 	} variables;
 	struct {

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -798,6 +798,7 @@ __thread int mysql_thread___query_digests_grouping_limit;
 __thread bool mysql_thread___enable_client_deprecate_eof;
 __thread bool mysql_thread___enable_server_deprecate_eof;
 __thread bool mysql_thread___log_mysql_warnings_enabled;
+__thread bool mysql_thread___enable_load_data_local_infile;
 
 /* variables used for Query Cache */
 __thread int mysql_thread___query_cache_size_MB;
@@ -949,6 +950,7 @@ extern __thread int mysql_thread___query_digests_grouping_limit;
 extern __thread bool mysql_thread___enable_client_deprecate_eof;
 extern __thread bool mysql_thread___enable_server_deprecate_eof;
 extern __thread bool mysql_thread___log_mysql_warnings_enabled;
+extern __thread bool mysql_thread___enable_load_data_local_infile;
 
 /* variables used for Query Cache */
 extern __thread int mysql_thread___query_cache_size_MB;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1333,9 +1333,8 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 		return true;
 	}
 	// 'LOAD DATA LOCAL INFILE' is unsupported. We report an specific error to inform clients about this fact. For more context see #833.
-
-	if (mysql_thread___enable_load_data_local_infile == false) {
-		if ( (pkt->size >= 22 + 5) && (strncasecmp((char *)"LOAD DATA LOCAL INFILE",(char *)pkt->ptr+5, 22)==0) ) {
+	if ( (pkt->size >= 22 + 5) && (strncasecmp((char *)"LOAD DATA LOCAL INFILE",(char *)pkt->ptr+5, 22)==0) ) {
+		if (mysql_thread___enable_load_data_local_infile == false) {
 			client_myds->DSS=STATE_QUERY_SENT_NET;
 			client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,1,1047,(char *)"HY000",(char *)"Unsupported 'LOAD DATA LOCAL INFILE' command",true);
 			client_myds->DSS=STATE_SLEEP;
@@ -1345,11 +1344,19 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 			}
 			l_free(pkt->size,pkt->ptr);
 			return true;
+		} else {
+			if (mysql_thread___verbose_query_error) {
+				proxy_warning(
+					"Command '%.*s' refers to file in ProxySQL instance, NOT on client side!\n",
+					pkt->size - sizeof(mysql_hdr) - 1,
+					static_cast<char*>(pkt->ptr) + 5
+				);
+			} else {
+				proxy_warning(
+					"Command 'LOAD DATA LOCAL INFILE' refers to file in ProxySQL instance, NOT on client side!\n"
+				);
+			}
 		}
-	} else {
-		proxy_warning(
-			"Command 'LOAD DATA LOCAL INFILE' refers to file in ProxySQL instance, NOT on client side!\n"
-		);
 	}
 
 	return false;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1333,16 +1333,23 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 		return true;
 	}
 	// 'LOAD DATA LOCAL INFILE' is unsupported. We report an specific error to inform clients about this fact. For more context see #833.
-	if ( (pkt->size >= 22 + 5) && (strncasecmp((char *)"LOAD DATA LOCAL INFILE",(char *)pkt->ptr+5, 22)==0) ) {
-		client_myds->DSS=STATE_QUERY_SENT_NET;
-		client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,1,1047,(char *)"HY000",(char *)"Unsupported 'LOAD DATA LOCAL INFILE' command",true);
-		client_myds->DSS=STATE_SLEEP;
-		status=WAITING_CLIENT_DATA;
-		if (mirror==false) {
-			RequestEnd(NULL);
+
+	if (mysql_thread___enable_load_data_local_infile == false) {
+		if ( (pkt->size >= 22 + 5) && (strncasecmp((char *)"LOAD DATA LOCAL INFILE",(char *)pkt->ptr+5, 22)==0) ) {
+			client_myds->DSS=STATE_QUERY_SENT_NET;
+			client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,1,1047,(char *)"HY000",(char *)"Unsupported 'LOAD DATA LOCAL INFILE' command",true);
+			client_myds->DSS=STATE_SLEEP;
+			status=WAITING_CLIENT_DATA;
+			if (mirror==false) {
+				RequestEnd(NULL);
+			}
+			l_free(pkt->size,pkt->ptr);
+			return true;
 		}
-		l_free(pkt->size,pkt->ptr);
-		return true;
+	} else {
+		proxy_warning(
+			"Command 'LOAD DATA LOCAL INFILE' refers to file in ProxySQL instance, NOT on client side!\n"
+		);
 	}
 
 	return false;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -421,6 +421,7 @@ static char * mysql_thread_variables_names[]= {
 	(char *)"connect_timeout_server_max",
 	(char *)"enable_client_deprecate_eof",
 	(char *)"enable_server_deprecate_eof",
+	(char *)"enable_load_data_local_infile",
 	(char *)"eventslog_filename",
 	(char *)"eventslog_filesize",
 	(char *)"eventslog_default_log",
@@ -1158,6 +1159,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.query_digests_grouping_limit = 3;
 	variables.enable_client_deprecate_eof=true;
 	variables.enable_server_deprecate_eof=true;
+	variables.enable_load_data_local_infile=false;
 	variables.log_mysql_warnings_enabled=false;
 	// status variables
 	status_variables.mirror_sessions_current=0;
@@ -1970,6 +1972,7 @@ char ** MySQL_Threads_Handler::get_variables_list() {
 		VariablesPointers_bool["default_reconnect"]               = make_tuple(&variables.default_reconnect,               false);
 		VariablesPointers_bool["enable_client_deprecate_eof"]     = make_tuple(&variables.enable_client_deprecate_eof,     false);
 		VariablesPointers_bool["enable_server_deprecate_eof"]     = make_tuple(&variables.enable_server_deprecate_eof,     false);
+		VariablesPointers_bool["enable_load_data_local_infile"]   = make_tuple(&variables.enable_load_data_local_infile,   false);
 		VariablesPointers_bool["enforce_autocommit_on_reads"]     = make_tuple(&variables.enforce_autocommit_on_reads,     false);
 		VariablesPointers_bool["firewall_whitelist_enabled"]      = make_tuple(&variables.firewall_whitelist_enabled,      false);
 		VariablesPointers_bool["kill_backend_connection_when_disconnect"] = make_tuple(&variables.kill_backend_connection_when_disconnect, false);
@@ -3655,6 +3658,7 @@ void MySQL_Thread::refresh_variables() {
 	mysql_thread___default_reconnect=(bool)GloMTH->get_variable_int((char *)"default_reconnect");
 	mysql_thread___enable_client_deprecate_eof=(bool)GloMTH->get_variable_int((char *)"enable_client_deprecate_eof");
 	mysql_thread___enable_server_deprecate_eof=(bool)GloMTH->get_variable_int((char *)"enable_server_deprecate_eof");
+	mysql_thread___enable_load_data_local_infile=(bool)GloMTH->get_variable_int((char *)"enable_load_data_local_infile");
 	mysql_thread___log_mysql_warnings_enabled=(bool)GloMTH->get_variable_int((char *)"log_mysql_warnings_enabled");
 #ifdef DEBUG
 	mysql_thread___session_debug=(bool)GloMTH->get_variable_int((char *)"session_debug");

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -424,3 +424,25 @@ int exec(const std::string& cmd, std::string& result) {
 	}
 	return err;
 }
+
+std::vector<mysql_res_row> extract_mysql_rows(MYSQL_RES* my_res) {
+	if (my_res == nullptr) { return {}; }
+
+	std::vector<mysql_res_row> result {};
+	MYSQL_ROW row = nullptr;
+	uint32_t num_fields = mysql_num_fields(my_res);
+
+	while ((row = mysql_fetch_row(my_res))) {
+		mysql_res_row row_values {};
+		uint64_t *lengths = mysql_fetch_lengths(my_res);
+
+		for (uint32_t i = 0; i < num_fields; i++) {
+			std::string field_val(row[i], lengths[i]);
+			row_values.push_back(field_val);
+		}
+
+		result.push_back(row_values);
+	}
+
+	return result;
+};

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -66,4 +66,15 @@ int execvp(const std::string& file, const std::vector<const char*>& argv, std::s
  */
 int exec(const std::string& cmd, std::string& result);
 
+using mysql_res_row = std::vector<std::string>;
+
+/**
+ * @brief Function that extracts the provided 'MYSQL_RES' into a vector of vector of
+ *   strings.
+ * @param my_res The 'MYSQL_RES' for which to extract the values. In case of
+ *   being NULL an empty vector is returned.
+ * @return The extracted values of all the rows present in the resultset.
+ */
+std::vector<mysql_res_row> extract_mysql_rows(MYSQL_RES* my_res);
+
 #endif // #define UTILS_H

--- a/test/tap/tests/load_data_local_datadir/insert_data.txt
+++ b/test/tap/tests/load_data_local_datadir/insert_data.txt
@@ -1,0 +1,4 @@
+"1","a string","100.20"
+"2","a string containing a , comma","102.20"
+"3","a string containing a \" quote","102.20"
+"4","a string containing a \", quote and comma","102.20"

--- a/test/tap/tests/load_data_local_datadir/insert_data.txt
+++ b/test/tap/tests/load_data_local_datadir/insert_data.txt
@@ -1,4 +1,4 @@
-"1","a string","100.20"
-"2","a string containing a , comma","102.20"
-"3","a string containing a \" quote","102.20"
-"4","a string containing a \", quote and comma","102.20"
+1,"a string","100.20"
+2,"a string containing a , comma","102.20"
+3,"a string containing a \" quote","102.20"
+4,"a string containing a \", quote and comma","102.20"

--- a/test/tap/tests/test_unsupported_queries-t.cpp
+++ b/test/tap/tests/test_unsupported_queries-t.cpp
@@ -1,9 +1,12 @@
 /**
  * @file test_unsupported_queries-t.cpp
- * @brief Simple test to check that unsupported queries by ProxySQL return the expected error codes.
+ * @brief Test to check that unsupported queries, and queries that can be
+ *   enabled or disabled via configuration variables, return the expected error
+ *   codes, and perform correctly when enabled.
  */
 
 #include <cstring>
+#include <functional>
 #include <vector>
 #include <tuple>
 #include <string>
@@ -14,6 +17,7 @@
 
 #include "tap.h"
 #include "command_line.h"
+#include "proxysql_utils.h"
 #include "utils.h"
 
 /**
@@ -21,16 +25,309 @@
  *   together with the error code that they should return.
  */
 std::vector<std::tuple<std::string, int, std::string>> unsupported_queries {
-	std::make_tuple<std::string, int, std::string>("LOAD DATA LOCAL INFILE", 1047, "Unsupported 'LOAD DATA LOCAL INFILE' command"),
-	std::make_tuple<std::string, int, std::string>("LOAD DATA LOCAL INFILE 'data.txt' INTO TABLE db.test_table", 1047, "Unsupported 'LOAD DATA LOCAL INFILE' command"),
-	std::make_tuple<std::string, int, std::string>("LOAD DATA LOCAL INFILE '/tmp/test.txt' INTO TABLE test IGNORE 1 LINES", 1047, "Unsupported 'LOAD DATA LOCAL INFILE' command"),
+	std::make_tuple<std::string, int, std::string>(
+		"LOAD DATA LOCAL INFILE",
+		1047,
+		"Unsupported 'LOAD DATA LOCAL INFILE' command"
+	),
+	std::make_tuple<std::string, int, std::string>(
+		"LOAD DATA LOCAL INFILE 'data.txt' INTO TABLE db.test_table",
+		1047,
+		"Unsupported 'LOAD DATA LOCAL INFILE' command"
+	),
+	std::make_tuple<std::string, int, std::string>(
+		"LOAD DATA LOCAL INFILE '/tmp/test.txt' INTO TABLE test IGNORE 1 LINES",
+		1047,
+		"Unsupported 'LOAD DATA LOCAL INFILE' command"
+	),
 };
+
+/**
+ * @brief Type holding the required information for identifying, enabling and
+ *   disabling a query which support can be enabled and disabled by ProxySQL.
+ */
+using query_test_info =
+	std::tuple<
+		// Query to be tested
+		std::string,
+		// Variable name enabling / disabling the query
+		std::string,
+		// Value for enabling the query
+		std::string,
+		// Value for diabling the query
+		std::string,
+		// Expected error code in case of failure
+		int,
+		// Function performing an internal 'ok' test checking that the
+		// enabled / disabled query responds as expected
+		std::function<void(const CommandLine&, MYSQL*, int, bool)>
+	>;
+
+// "SET mysql-enable_load_data_local_infile='true'",
+
+
+/**
+ * @brief Extract the current value for a given 'variable_name' from
+ *   ProxySQL current configuration, either MEMORY or RUNTIME.
+ * @param proxysql_admin An already opened connection to ProxySQL Admin.
+ * @param variable_name The name of the variable to be retrieved from ProxySQL
+ *   config.
+ * @param variable_value Reference to string acting as output parameter which
+ *   will content the value of the specified variable.
+ * @return EXIT_SUCCESS, or one of the following error codes:
+ *   - EINVAL if supplied 'proxysql_admin' is NULL.
+ *   - '-1' in case of ProxySQL returns an 'NULL' row for the query selecting
+ *     the variable 'sqliteserver-read_only'.
+ *   - EXIT_FAILURE in case other operation failed.
+ */
+int get_variable_value(
+	MYSQL* proxysql_admin, const std::string& variable_name,
+	std::string& variable_value, bool runtime=false
+) {
+	if (proxysql_admin == NULL) {
+		return EINVAL;
+	}
+
+	int res = EXIT_FAILURE;
+
+	const std::string t_select_var_query {
+		"SELECT * FROM %sglobal_variables WHERE Variable_name='%s'"
+	};
+	std::string select_var_query {};
+
+	if (runtime) {
+		string_format(t_select_var_query, select_var_query, "runtime_", variable_name.c_str());
+	} else {
+		string_format(t_select_var_query, select_var_query, "", variable_name.c_str());
+	}
+
+	MYSQL_QUERY(proxysql_admin, select_var_query.c_str());
+
+	MYSQL_RES* admin_res = mysql_store_result(proxysql_admin);
+	if (!admin_res) {
+		diag("'mysql_store_result' at line %d failed: %s", __LINE__, mysql_error(proxysql_admin));
+		goto cleanup;
+	}
+
+	{
+		MYSQL_ROW row = mysql_fetch_row(admin_res);
+		if (!row || row[0] == nullptr || row[1] == nullptr) {
+			diag("'mysql_fetch_row' at line %d returned 'NULL'", __LINE__);
+			res = -1;
+			goto cleanup;
+		}
+
+		// Extract the result
+		std::string _variable_value { row[1] };
+		variable_value = _variable_value;
+
+		res = EXIT_SUCCESS;
+	}
+
+cleanup:
+
+	return res;
+}
+
+/**
+ * @brief Enable the query based using the information supplied in the
+ *   'query_info' parameter, and verifies that the value of the query has properly
+ *   change at runtime.
+ *
+ * @param proxysql_admin An already oppened connection to ProxySQL Admin.
+ * @param query_info Information about the query to be enabled.
+ *
+ * @return True if the query was properly enabled, false if not.
+ */
+bool enable_query(MYSQL* proxysql_admin, const query_test_info& query_info, bool enable=true) {
+	std::string exp_var_value {};
+
+	// In case of false, we choose the value for disabling the variable
+	if (enable == true) {
+		exp_var_value =  std::get<2>(query_info);
+	} else {
+		exp_var_value =  std::get<3>(query_info);
+	}
+
+	std::vector<std::string> enabling_queries {
+		"SET " + std::get<1>(query_info) + " = " + exp_var_value,
+		"LOAD MYSQL VARIABLES TO RUNTIME"
+	};
+
+	bool query_enabling_succeed = true;
+
+	for (const auto& query : enabling_queries) {
+		int query_res = mysql_query(proxysql_admin, query.c_str());
+		if (query_res) {
+			diag(
+				"Query '%s' for enabling query '%s' enabling at line '%d', with error: '%s'",
+				query.c_str(), std::get<0>(query_info).c_str(), __LINE__,
+				mysql_error(proxysql_admin)
+			);
+			query_enabling_succeed = false;
+			goto exit;
+		}
+	}
+
+	{
+		std::string variable_value {};
+		int var_err = get_variable_value(
+			proxysql_admin, std::get<1>(query_info), variable_value, true
+		);
+
+		if (var_err) {
+			diag(
+				"Getting value for variable '%s', failed with error: '%d'",
+				std::get<1>(query_info).c_str(), var_err
+			);
+			query_enabling_succeed = false;
+			goto exit;
+		}
+
+		// perform a final conversion in case it's required for the exp value
+		std::string f_exp_var_value {};
+		if (exp_var_value == "'true'") {
+			f_exp_var_value = "true";
+		} else if (exp_var_value == "'false'") {
+			f_exp_var_value = "false";
+		} else {
+			f_exp_var_value = exp_var_value;
+		}
+
+		if (variable_value != f_exp_var_value) {
+			query_enabling_succeed = false;
+			diag(
+				"Variable value doesn't match expected: (Exp: '%s', Act: '%s')",
+				exp_var_value.c_str(), variable_value.c_str()
+			);
+			goto exit;
+		}
+	}
+
+exit:
+
+	return query_enabling_succeed;
+}
+
+// ******************* QUERIES TESTING FUNCTIONS ******************** //
+
+const std::vector<std::string> prepare_table_queries {
+	"CREATE DATABASE IF NOT EXISTS test",
+	"DROP TABLE IF EXISTS test.load_data_local",
+	"CREATE TABLE IF NOT EXISTS test.load_data_local ("
+		" c1 INT NOT NULL AUTO_INCREMENT PRIMARY KEY, c2 VARCHAR(100), c3 VARCHAR(100))",
+};
+
+/**
+ * @brief Test that the query 'LOAD DATA LOCAL INFILE' performs correctly when
+ *   enabled, and returns the proper error code when disabled. Performs one
+ *   'ok()' call in case everything went as expected, and several 'diag()' call
+ *   in case of errors.
+ *
+ * @param cl CommandLine parameters required for the test.
+ * @param proxysql An already oppened connection to ProxySQL.
+ * @param exp_err The expected error code in case we are testing for failure,
+ *   '0' by default.
+ * @param test_for_success Select the operation mode of the test, 'true' for
+ *   testing for success, 'false' for failure. It's 'true' by default.
+ */
+void test_load_data_local_infile(
+	const CommandLine& cl, MYSQL* proxysql, int exp_err=0, bool test_for_success=true
+) {
+	std::string datafile {
+		std::string { cl.workdir } + "load_data_local_datadir/insert_data.txt"
+	};
+
+	bool table_prep_success = true;
+
+	for (const auto& query : prepare_table_queries) {
+		int query_res = mysql_query(proxysql, query.c_str());
+		if (query_res) {
+			diag(
+				"Query '%s' for table preparation failed at line '%d', with error: '%s'",
+				query.c_str(), __LINE__, mysql_error(proxysql)
+			);
+			table_prep_success = false;
+			break;
+		}
+	}
+
+	if (table_prep_success) {
+		std::string t_load_data_command {
+			"LOAD DATA LOCAL INFILE \"%s\" INTO TABLE test.load_data_local"
+		};
+		std::string load_data_command {};
+		string_format(t_load_data_command, load_data_command, datafile.c_str());
+
+		int load_data_res =
+			mysql_query(proxysql, load_data_command.c_str());
+
+		if (test_for_success) {
+			if (load_data_res) {
+				diag(
+					load_data_command.c_str(), __LINE__, mysql_error(proxysql)
+				);
+			}
+
+			ok(
+				load_data_res == EXIT_SUCCESS,
+				"Query '%s' should succeed. Error was: '%s'",
+				load_data_command.c_str(), mysql_error(proxysql)
+			);
+		} else {
+			if (load_data_res) {
+				diag(
+					load_data_command.c_str(), __LINE__, mysql_error(proxysql)
+				);
+			}
+
+			int my_errno = mysql_errno(proxysql);
+			ok(
+				my_errno == exp_err,
+				"Query '%s' should fail. ErrCode: '%d', and error: '%s'",
+				load_data_command.c_str(), my_errno, mysql_error(proxysql)
+			);
+		}
+	}
+}
+
+// ****************************************************************** //
+
+
+// ********************* QUERIES TESTS INFO  ************************ //
+
+/**
+ * @brief List of queries which need to be check before performing the
+ *   'unsupported' checks.
+ */
+std::vector<query_test_info> queries_tests_info {
+	std::make_tuple<
+		std::string, std::string, std::string, std::string, int,
+		std::function<void(const CommandLine&, MYSQL*, int, bool)>
+	>(
+		// Query to be tested
+		"LOAD DATA LOCAL INFILE",
+		// Variable name enabling / disabling the query
+		"mysql-enable_load_data_local_infile",
+		// Value for enabling the query
+		"'true'",
+		// Value for diabling the query
+		"'false'",
+		// Expected error code in case of failure
+		1047,
+		// Function performing an internal 'ok' test checking that the
+		// enabled / disabled query responds as expected
+		test_load_data_local_infile
+	)
+};
+
+// ****************************************************************** //
 
 int main(int argc, char** argv) {
 	CommandLine cl;
 
 	// plan as many tests as queries
-	plan(unsupported_queries.size());
+	plan(unsupported_queries.size() + 4 * queries_tests_info.size());
 
 	if (cl.getEnv()) {
 		diag("Failed to get the required environmental variables.");
@@ -48,7 +345,7 @@ int main(int argc, char** argv) {
 
 		if (!mysql_real_connect(proxysql_mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
 			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_mysql));
-			return -1;
+			return EXIT_FAILURE;
 		}
 
 		int query_err = mysql_query(proxysql_mysql, query.c_str());
@@ -67,6 +364,57 @@ int main(int argc, char** argv) {
 
 		mysql_close(proxysql_mysql);
 	}
+
+	// Create required connection to ProxySQL admin required to perform the
+	// tests for conditionally enabled queries.
+	MYSQL* proxysql_admin = mysql_init(NULL);
+
+	if (
+		!mysql_real_connect(
+			proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0
+		)
+	) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return EXIT_FAILURE;
+	}
+
+	// Enable and test the queries that can be conditionally enabled
+	for (const auto& query_test_info : queries_tests_info) {
+		MYSQL* proxysql_mysql = mysql_init(NULL);
+
+		// extract the tuple elements
+		const std::string query = std::get<0>(query_test_info);
+		const std::string variable_name = std::get<1>(query_test_info);
+		int exp_err = std::get<4>(query_test_info);
+		const auto& testing_fn = std::get<5>(query_test_info);
+
+		if (!mysql_real_connect(proxysql_mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_mysql));
+			return EXIT_FAILURE;
+		}
+
+		bool query_enabling_succeed = enable_query(proxysql_admin, query_test_info, true);
+		ok(
+			query_enabling_succeed, "Enabling query '%s' should succeed.",
+			std::get<0>(query_test_info).c_str()
+		);
+
+		// Check that the query is now properly supported
+		testing_fn(cl, proxysql_mysql, 0, true);
+
+		bool query_disabling_succeed = enable_query(proxysql_admin, query_test_info, false);
+		ok(
+			query_disabling_succeed, "Disabling query '%s' should succeed.",
+			std::get<0>(query_test_info).c_str()
+		);
+
+		// Check that the query is now failing
+		testing_fn(cl, proxysql_mysql, exp_err, false);
+
+		mysql_close(proxysql_mysql);
+	}
+
+	mysql_close(proxysql_admin);
 
 	return exit_status();
 }


### PR DESCRIPTION
Closes #3500.

**NOTE:**

Multiple attempts where performed to replicate crash described in [this comment](https://github.com/sysown/proxysql/issues/833#issuecomment-528756861) as requested in issue #3500. But all the attempts where unsuccessful.

To probe that no memory issues were observed during testing a valgrind output is attached after multiple passes of the provided tap test exercising the added code.

[valgrind-log.txt](https://github.com/sysown/proxysql/files/6817852/valgrind-log.txt)

Valgrind output obtained via:

```
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-log.txt ./src/proxysql --sqlite3-server --idle-threads -f -c $JENKINS_SCRIPTS_PATH/proxysql_single_backend_tests/conf/proxysql/proxysql.cnf -D single_backend_datadir
```