### PR TITLE
Fix incorrect minimum values ​​of two parameters

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -2029,8 +2029,8 @@ char ** MySQL_Threads_Handler::get_variables_list() {
 		VariablesPointers_int["monitor_replication_lag_timeout"]     = make_tuple(&variables.monitor_replication_lag_timeout,   100,       600*1000, false);
 		VariablesPointers_int["monitor_replication_lag_count"]       = make_tuple(&variables.monitor_replication_lag_count,       1,             10, false);
 
-		VariablesPointers_int["monitor_groupreplication_healthcheck_interval"]          = make_tuple(&variables.monitor_groupreplication_healthcheck_interval,          100, 7*24*3600*1000, false);
-		VariablesPointers_int["monitor_groupreplication_healthcheck_timeout"]           = make_tuple(&variables.monitor_groupreplication_healthcheck_timeout,           100,       600*1000, false);
+		VariablesPointers_int["monitor_groupreplication_healthcheck_interval"]          = make_tuple(&variables.monitor_groupreplication_healthcheck_interval,          50, 7*24*3600*1000, false);
+		VariablesPointers_int["monitor_groupreplication_healthcheck_timeout"]           = make_tuple(&variables.monitor_groupreplication_healthcheck_timeout,           50,       600*1000, false);
 		VariablesPointers_int["monitor_groupreplication_healthcheck_max_timeout_count"] = make_tuple(&variables.monitor_groupreplication_healthcheck_max_timeout_count,   1,             10, false);
 		VariablesPointers_int["monitor_groupreplication_max_transactions_behind_count"] = make_tuple(&variables.monitor_groupreplication_max_transactions_behind_count,   1,             10, false);
 


### PR DESCRIPTION
**Closes #3542**

Correct the minimum value of the two parameters. 
monitor_groupreplication_healthcheck_interval :   Minimum  50
monitor_groupreplication_healthcheck_timeout:   Minimum  50

**Reference documents：**

(1) monitor_groupreplication_healthcheck_interval -- https://proxysql.com/documentation/global-variables/mysql-monitor-variables/#mysql-monitor_groupreplication_healthcheck_interval

(2) monitor_groupreplication_healthcheck_timeout -- https://proxysql.com/documentation/global-variables/mysql-monitor-variables/#mysql-monitor_groupreplication_healthcheck_timeout