### PR TITLE
Closes #3525: Memory leak induced by 'stmts' not being closed when failed to prepare

### DIFF
--- a/include/MySQL_Protocol.h
+++ b/include/MySQL_Protocol.h
@@ -64,6 +64,22 @@ class MySQL_Prepared_Stmt_info {
 
 uint8_t mysql_decode_length(unsigned char *ptr, uint64_t *len);
 
+/**
+ * @brief ProxySQL replacement function for 'mysql_stmt_close'. Closes a
+ *   MYSQL_STMT avoiding any blocking commands that are sent by default
+ *   'mysql_stmt_close'.
+ *
+ *   NOTE: This function is not safe, caller must check that the supplied
+ *   argument is not NULL.
+ *
+ * @param mysql_stmt An already initialized 'MYSQL_STMT'. Caller must ensure
+ *   that the supplied argument is not NULL.
+ *
+ * @return The result of calling 'mysql_stmt_close' function over the internally
+ *   modified 'MYSQL_STMT'.
+ */
+my_bool proxy_mysql_stmt_close(MYSQL_STMT* mysql_stmt);
+
 class MySQL_Protocol {
 	private:
 	MySQL_Connection_userinfo *userinfo;

--- a/include/gen_utils.h
+++ b/include/gen_utils.h
@@ -229,6 +229,23 @@ inline unsigned long long realtime_time() {
   clock_gettime(CLOCK_REALTIME, &ts);
   return (((unsigned long long) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
 }
+
+/**
+ * @brief ProxySQL replacement function for 'mysql_stmt_close'. Closes a
+ *   MYSQL_STMT avoiding any blocking commands that are sent by default
+ *   'mysql_stmt_close'.
+ *
+ *   NOTE: This function is not safe, caller must check that the supplied
+ *   argument is not NULL.
+ *
+ * @param mysql_stmt An already initialized 'MYSQL_STMT'. Caller must ensure
+ *   that the supplied argument is not NULL.
+ *
+ * @return The result of calling 'mysql_stmt_close' function over the internally
+ *   modified 'MYSQL_STMT'.
+ */
+my_bool proxy_mysql_stmt_close(MYSQL_STMT* mysql_stmt);
+
 #endif /* __GEN_FUNCTIONS */
 
 bool Proxy_file_exists(const char *);

--- a/include/gen_utils.h
+++ b/include/gen_utils.h
@@ -230,22 +230,6 @@ inline unsigned long long realtime_time() {
   return (((unsigned long long) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
 }
 
-/**
- * @brief ProxySQL replacement function for 'mysql_stmt_close'. Closes a
- *   MYSQL_STMT avoiding any blocking commands that are sent by default
- *   'mysql_stmt_close'.
- *
- *   NOTE: This function is not safe, caller must check that the supplied
- *   argument is not NULL.
- *
- * @param mysql_stmt An already initialized 'MYSQL_STMT'. Caller must ensure
- *   that the supplied argument is not NULL.
- *
- * @return The result of calling 'mysql_stmt_close' function over the internally
- *   modified 'MYSQL_STMT'.
- */
-my_bool proxy_mysql_stmt_close(MYSQL_STMT* mysql_stmt);
-
 #endif /* __GEN_FUNCTIONS */
 
 bool Proxy_file_exists(const char *);

--- a/lib/MySQL_PreparedStatement.cpp
+++ b/lib/MySQL_PreparedStatement.cpp
@@ -691,12 +691,7 @@ MySQL_STMTs_local_v14::~MySQL_STMTs_local_v14() {
 			it != global_stmt_to_backend_stmt.end(); ++it) {
 			uint64_t global_stmt_id = it->first;
 			MYSQL_STMT *stmt = it->second;
-			if (stmt->mysql) {
-				stmt->mysql->stmts =
-				    list_delete(stmt->mysql->stmts, &stmt->list);
-			}
-			stmt->mysql = NULL;
-			mysql_stmt_close(stmt);
+			proxy_mysql_stmt_close(stmt);
 			GloMyStmt->ref_count_server(global_stmt_id, -1);
 		}
 	}

--- a/lib/MySQL_PreparedStatement.cpp
+++ b/lib/MySQL_PreparedStatement.cpp
@@ -4,6 +4,7 @@
 #include "SpookyV2.h"
 
 #include "MySQL_PreparedStatement.h"
+#include "MySQL_Protocol.h"
 
 //extern MySQL_STMT_Manager *GloMyStmt;
 //static uint32_t add_prepared_statement_calls = 0;

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -2925,3 +2925,15 @@ unsigned long long MySQL_ResultSet::current_size() {
 	}
 	return intsize;
 }
+
+my_bool proxy_mysql_stmt_close(MYSQL_STMT* stmt) {
+	// Clean internal structures for 'stmt->mysql->stmts'.
+	if (stmt->mysql) {
+		stmt->mysql->stmts =
+			list_delete(stmt->mysql->stmts, &stmt->list);
+	}
+	// Nullify 'mysql' field to avoid sending a blocking command to the server.
+	stmt->mysql = NULL;
+	// Perform the regular close operation.
+	return mysql_stmt_close(stmt);
+}

--- a/lib/gen_utils.cpp
+++ b/lib/gen_utils.cpp
@@ -219,3 +219,15 @@ bool Proxy_file_regular(const char *path) {
 		if (sb.st_mode & S_IFREG) return true;
 	return false;
 }
+
+my_bool proxy_mysql_stmt_close(MYSQL_STMT* stmt) {
+	// Clean internal structures for 'stmt->mysql->stmts'.
+	if (stmt->mysql) {
+		stmt->mysql->stmts =
+			list_delete(stmt->mysql->stmts, &stmt->list);
+	}
+	// Nullify 'mysql' field to avoid sending a blocking command to the server.
+	stmt->mysql = NULL;
+	// Perform the regular close operation.
+	return mysql_stmt_close(stmt);
+}

--- a/lib/gen_utils.cpp
+++ b/lib/gen_utils.cpp
@@ -220,14 +220,3 @@ bool Proxy_file_regular(const char *path) {
 	return false;
 }
 
-my_bool proxy_mysql_stmt_close(MYSQL_STMT* stmt) {
-	// Clean internal structures for 'stmt->mysql->stmts'.
-	if (stmt->mysql) {
-		stmt->mysql->stmts =
-			list_delete(stmt->mysql->stmts, &stmt->list);
-	}
-	// Nullify 'mysql' field to avoid sending a blocking command to the server.
-	stmt->mysql = NULL;
-	// Perform the regular close operation.
-	return mysql_stmt_close(stmt);
-}

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -2151,7 +2151,7 @@ void MySQL_Connection::async_free_result() {
 			// initialized, it must be freed. For more context see #3525.
 			if (this->async_state_machine == ASYNC_STMT_PREPARE_FAILED) {
 				if (query.stmt != NULL) {
-					mysql_stmt_close(query.stmt);
+					proxy_mysql_stmt_close(query.stmt);
 				}
 			}
 			query.stmt=NULL;

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -2145,6 +2145,15 @@ void MySQL_Connection::async_free_result() {
 					mysql_stmt_free_result(query.stmt);
 				}
 			}
+			// If we reached here from 'ASYNC_STMT_PREPARE_FAILED', the
+			// prepared statement was never added to 'local_stmts', thus
+			// it will never be freed when 'local_stmts' are purged. If
+			// initialized, it must be freed. For more context see #3525.
+			if (this->async_state_machine == ASYNC_STMT_PREPARE_FAILED) {
+				if (query.stmt != NULL) {
+					mysql_stmt_close(query.stmt);
+				}
+			}
 			query.stmt=NULL;
 		}
 		if (mysql_result) {

--- a/test/tap/tests/repro_test_leak_3525.cpp
+++ b/test/tap/tests/repro_test_leak_3525.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file repro_test_leak_3525.cpp
+ * @brief Test to reproduce issue #3525.
+ * @details This test is not meant to be executed, it's just a left as DOC of how to
+ *   reproduce issue #3525.
+ * @date 2021-07-30
+ */
+
+#include <string>
+#include <mysql.h>
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if(cl.getEnv())
+		return exit_status();
+
+	plan(1);
+
+	MYSQL* mysql = mysql_init(NULL);
+	if (mysql == NULL) {
+		return exit_status();
+	}
+
+	if (
+		!mysql_real_connect(mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)
+	) {
+		fprintf(stderr, "Failed to connect to database: Error: %s\n", mysql_error(mysql));
+		return exit_status();
+	}
+
+	MYSQL_STMT *stmt = mysql_stmt_init(mysql);
+	if (stmt == NULL) {
+		ok(false, " mysql_stmt_init(), out of memory\n");
+		return exit_status();
+	}
+
+	// Invalid statement
+	bool failed = false;
+	std::string my_errmsg {};
+	int my_errno = 0;
+
+	std::string query { "BEGIN" };
+	if (mysql_stmt_prepare(stmt, query.c_str(), query.size())) {
+		my_errno = mysql_errno(mysql);
+		my_errmsg = mysql_error(mysql);
+
+		failed = true;
+	} else {
+		my_errmsg = "NOT A FAILURE!";
+	}
+
+	ok(
+		failed, "'mysql_stmt_prepare' should fail: ('err_code': %d, 'err_msg': '%s')\n",
+		my_errno, my_errmsg.c_str()
+	);
+
+	if (mysql_stmt_close(stmt)) {
+		ok(false, "mysql_stmt_close at line %d failed: %s\n", __LINE__ , mysql_error(mysql));
+		return exit_status();
+	}
+
+	mysql_stmt_close(stmt);
+	mysql_close(mysql);
+	mysql_library_end();
+
+	mysql_close(mysql);
+}
+


### PR DESCRIPTION
This PR may close #3525, but we cannot ensure it until we receive extra information requested to the user. I'm setting the PR as a draft for now.

As a proof of the leak resolution valgrind reports from 1/3/5 executions of the attached leak-reproduction test are attached, relevant sections from `1` and `3` are:

`valgrind-log-1_test_exec.txt`:
```
==3568711== 9,240 (920 direct, 8,320 indirect) bytes in 1 blocks are definitely lost in loss record 2,915 of 2,972
==3568711==    at 0x4840B65: calloc (vg_replace_malloc.c:760)
==3568711==    by 0xB020B4: mysql_stmt_init (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x816765: MySQL_Connection::stmt_prepare_start() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x817995: MySQL_Connection::handler(short) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x81A11B: MySQL_Connection::async_query(short, char*, unsigned long, st_mysql_stmt**, stmt_execute_metadata_t*) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x64A94A: MySQL_Session::RunQuery(MySQL_Data_Stream*, MySQL_Connection*) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x64BDA9: MySQL_Session::handler() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x61500A: MySQL_Thread::process_all_sessions() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x612F05: MySQL_Thread::run() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x54C98C: mysql_worker_thread_func(void*) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568711==    by 0x4A78298: start_thread (in /usr/lib/libpthread-2.33.so)
==3568711==    by 0x5042052: clone (in /usr/lib/libc-2.33.so)
```

`valgrind-log-5_test_exec.txt`:
```
==3568894== 46,200 (1,840 direct, 44,360 indirect) bytes in 2 blocks are definitely lost in loss record 2,924 of 2,939
==3568894==    at 0x4840B65: calloc (vg_replace_malloc.c:760)
==3568894==    by 0xB020B4: mysql_stmt_init (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x816765: MySQL_Connection::stmt_prepare_start() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x817995: MySQL_Connection::handler(short) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x81A11B: MySQL_Connection::async_query(short, char*, unsigned long, st_mysql_stmt**, stmt_execute_metadata_t*) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x64A94A: MySQL_Session::RunQuery(MySQL_Data_Stream*, MySQL_Connection*) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x64BDA9: MySQL_Session::handler() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x61500A: MySQL_Thread::process_all_sessions() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x612F05: MySQL_Thread::run() (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x54C98C: mysql_worker_thread_func(void*) (in /home/javjarfer/Projects/proxysql_v2.2.0/src/proxysql)
==3568894==    by 0x4A78298: start_thread (in /usr/lib/libpthread-2.33.so)
==3568894==    by 0x5042052: clone (in /usr/lib/libc-2.33.so)
```

Summary after the fix:
```
==3572414== LEAK SUMMARY:
==3572414==    definitely lost: 0 bytes in 0 blocks
==3572414==    indirectly lost: 0 bytes in 0 blocks
==3572414==      possibly lost: 1,313,928 bytes in 316 blocks
==3572414==    still reachable: 2,613,540 bytes in 15,724 blocks
==3572414==                       of which reachable via heuristic:
==3572414==                         length64           : 1,794,768 bytes in 6,271 blocks
==3572414==         suppressed: 0 bytes in 0 blocks
```

[valgrind-log-1_test_exec.txt](https://github.com/sysown/proxysql/files/6907307/valgrind-log-1_test_exec.txt)
[valgrind-log-3_test_exec.txt](https://github.com/sysown/proxysql/files/6907308/valgrind-log-3_test_exec.txt)
[valgrind-log-5_test_exec.txt](https://github.com/sysown/proxysql/files/6907309/valgrind-log-5_test_exec.txt)
[valgrind-log-fix_5_test_exec.txt](https://github.com/sysown/proxysql/files/6907310/valgrind-log-fix_5_test_exec.txt)
