### PR TITLE
SSL: Add support for certificate revocation list (CRL) and multiple certificate authorities (CA)

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -522,9 +522,12 @@ class MySQL_Threads_Handler
 		int auditlog_filesize;
 		// SSL related, proxy to server
 		char * ssl_p2s_ca;
+		char * ssl_p2s_capath;
 		char * ssl_p2s_cert;
 		char * ssl_p2s_key;
 		char * ssl_p2s_cipher;
+		char * ssl_p2s_crl;
+		char * ssl_p2s_crlpath;
 		int query_cache_size_MB;
 		int min_num_servers_lantency_awareness;
 		int aurora_max_lag_ms_only_read_from_replicas;

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -805,9 +805,12 @@ __thread int mysql_thread___query_cache_size_MB;
 
 /* variables used for SSL , from proxy to server (p2s) */
 __thread char * mysql_thread___ssl_p2s_ca;
+__thread char * mysql_thread___ssl_p2s_capath;
 __thread char * mysql_thread___ssl_p2s_cert;
 __thread char * mysql_thread___ssl_p2s_key;
 __thread char * mysql_thread___ssl_p2s_cipher;
+__thread char * mysql_thread___ssl_p2s_crl;
+__thread char * mysql_thread___ssl_p2s_crlpath;
 
 /* variables used by events log */
 __thread char * mysql_thread___eventslog_filename;
@@ -957,9 +960,12 @@ extern __thread int mysql_thread___query_cache_size_MB;
 
 /* variables used for SSL , from proxy to server (p2s) */
 extern __thread char * mysql_thread___ssl_p2s_ca;
+extern __thread char * mysql_thread___ssl_p2s_capath;
 extern __thread char * mysql_thread___ssl_p2s_cert;
 extern __thread char * mysql_thread___ssl_p2s_key;
 extern __thread char * mysql_thread___ssl_p2s_cipher;
+extern __thread char * mysql_thread___ssl_p2s_crl;
+extern __thread char * mysql_thread___ssl_p2s_crlpath;
 
 /* variables used by events log */
 extern __thread char * mysql_thread___eventslog_filename;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1084,7 +1084,14 @@ bool MySQL_Monitor_State_Data::create_new_connection() {
 		mysql=mysql_init(NULL);
 		assert(mysql);
 		if (use_ssl) {
-			mysql_ssl_set(mysql, mysql_thread___ssl_p2s_key, mysql_thread___ssl_p2s_cert, mysql_thread___ssl_p2s_ca, NULL, mysql_thread___ssl_p2s_cipher);
+			mysql_ssl_set(mysql,
+					mysql_thread___ssl_p2s_key,
+					mysql_thread___ssl_p2s_cert,
+					mysql_thread___ssl_p2s_ca,
+					mysql_thread___ssl_p2s_capath,
+					mysql_thread___ssl_p2s_cipher);
+			mysql_options(mysql, MYSQL_OPT_SSL_CRL, mysql_thread___ssl_p2s_crl);
+			mysql_options(mysql, MYSQL_OPT_SSL_CRLPATH, mysql_thread___ssl_p2s_crlpath);
 		}
 		unsigned int timeout=mysql_thread___monitor_connect_timeout/1000;
 		if (timeout==0) timeout=1;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1282,11 +1282,11 @@ char * MySQL_Threads_Handler::get_variable_string(char *name) {
 				return strdup(variables.ssl_p2s_cert);
 			}
 		}
-		if (!strcmp(name,"ssl_p2_capath")) {
-			if (variables.ssl_p2_capath==NULL || strlen(variables.ssl_p2_capath)==0) {
+		if (!strcmp(name,"ssl_p2s_capath")) {
+			if (variables.ssl_p2s_capath==NULL || strlen(variables.ssl_p2s_capath)==0) {
 				return NULL;
 			} else {
-				return strdup(variables.ssl_p2_capath);
+				return strdup(variables.ssl_p2s_capath);
 			}
 		}
 		if (!strcmp(name,"ssl_p2s_key")) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -539,9 +539,12 @@ static char * mysql_thread_variables_names[]= {
 	(char *)"session_debug",
 #endif /* DEBUG */
 	(char *)"ssl_p2s_ca",
+	(char *)"ssl_p2s_capath",
 	(char *)"ssl_p2s_cert",
 	(char *)"ssl_p2s_key",
 	(char *)"ssl_p2s_cipher",
+	(char *)"ssl_p2s_crl",
+	(char *)"ssl_p2s_crlpath",
 	(char *)"stacksize",
 	(char *)"threads",
 	(char *)"init_connect",
@@ -1151,9 +1154,12 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.servers_stats=true;
 	variables.default_reconnect=true;
 	variables.ssl_p2s_ca=NULL;
+	variables.ssl_p2s_capath=NULL;
 	variables.ssl_p2s_cert=NULL;
 	variables.ssl_p2s_key=NULL;
 	variables.ssl_p2s_cipher=NULL;
+	variables.ssl_p2s_crl=NULL;
+	variables.ssl_p2s_crlpath=NULL;
 	variables.keep_multiplexing_variables=strdup((char *)"tx_isolation,version");
 #ifdef DEBUG
 	variables.session_debug=true;
@@ -1276,6 +1282,13 @@ char * MySQL_Threads_Handler::get_variable_string(char *name) {
 				return strdup(variables.ssl_p2s_cert);
 			}
 		}
+		if (!strcmp(name,"ssl_p2_capath")) {
+			if (variables.ssl_p2_capath==NULL || strlen(variables.ssl_p2_capath)==0) {
+				return NULL;
+			} else {
+				return strdup(variables.ssl_p2_capath);
+			}
+		}
 		if (!strcmp(name,"ssl_p2s_key")) {
 			if (variables.ssl_p2s_key==NULL || strlen(variables.ssl_p2s_key)==0) {
 				return NULL;
@@ -1288,6 +1301,20 @@ char * MySQL_Threads_Handler::get_variable_string(char *name) {
 				return NULL;
 			} else {
 				return strdup(variables.ssl_p2s_cipher);
+			}
+		}
+		if (!strcmp(name,"ssl_p2s_crl")) {
+			if (variables.ssl_p2s_crl==NULL || strlen(variables.ssl_p2s_crl)==0) {
+				return NULL;
+			} else {
+				return strdup(variables.ssl_p2s_crl);
+			}
+		}
+		if (!strcmp(name,"ssl_p2s_crlpath")) {
+			if (variables.ssl_p2s_crlpath==NULL || strlen(variables.ssl_p2s_crlpath)==0) {
+				return NULL;
+			} else {
+				return strdup(variables.ssl_p2s_crlpath);
 			}
 		}
 	}
@@ -1500,6 +1527,13 @@ char * MySQL_Threads_Handler::get_variable(char *name) {	// this is the public f
 				return strdup(variables.ssl_p2s_ca);
 			}
 		}
+		if (!strcasecmp(name,"ssl_p2s_capath")) {
+			if (variables.ssl_p2s_capath==NULL || strlen(variables.ssl_p2s_capath)==0) {
+				return NULL;
+			} else {
+				return strdup(variables.ssl_p2s_capath);
+			}
+		}
 		if (!strcasecmp(name,"ssl_p2s_cert")) {
 			if (variables.ssl_p2s_cert==NULL || strlen(variables.ssl_p2s_cert)==0) {
 				return NULL;
@@ -1519,6 +1553,20 @@ char * MySQL_Threads_Handler::get_variable(char *name) {	// this is the public f
 				return NULL;
 			} else {
 				return strdup(variables.ssl_p2s_cipher);
+			}
+		}
+		if (!strcasecmp(name,"ssl_p2s_crl")) {
+			if (variables.ssl_p2s_crl==NULL || strlen(variables.ssl_p2s_crl)==0) {
+				return NULL;
+			} else {
+				return strdup(variables.ssl_p2s_crl);
+			}
+		}
+		if (!strcasecmp(name,"ssl_p2s_crlpath")) {
+			if (variables.ssl_p2s_crlpath==NULL || strlen(variables.ssl_p2s_crlpath)==0) {
+				return NULL;
+			} else {
+				return strdup(variables.ssl_p2s_crlpath);
 			}
 		}
 	}
@@ -1821,6 +1869,15 @@ bool MySQL_Threads_Handler::set_variable(char *name, const char *value) {	// thi
 		}
 		return true;
 	}
+	if (!strcasecmp(name,"ssl_p2s_capath")) {
+		if (variables.ssl_p2s_capath) free(variables.ssl_p2s_capath);
+		variables.ssl_p2s_capath=NULL;
+		if (vallen) {
+			if (strcmp(value,"(null)"))
+				variables.ssl_p2s_capath=strdup(value);
+		}
+		return true;
+	}
 	if (!strcasecmp(name,"ssl_p2s_cert")) {
 		if (variables.ssl_p2s_cert) free(variables.ssl_p2s_cert);
 		variables.ssl_p2s_cert=NULL;
@@ -1845,6 +1902,24 @@ bool MySQL_Threads_Handler::set_variable(char *name, const char *value) {	// thi
 		if (vallen) {
 			if (strcmp(value,"(null)"))
 				variables.ssl_p2s_cipher=strdup(value);
+		}
+		return true;
+	}
+	if (!strcasecmp(name,"ssl_p2s_crl")) {
+		if (variables.ssl_p2s_crl) free(variables.ssl_p2s_crl);
+		variables.ssl_p2s_crl=NULL;
+		if (vallen) {
+			if (strcmp(value,"(null)"))
+				variables.ssl_p2s_crl=strdup(value);
+		}
+		return true;
+	}
+	if (!strcasecmp(name,"ssl_p2s_crlpath")) {
+		if (variables.ssl_p2s_crlpath) free(variables.ssl_p2s_crlpath);
+		variables.ssl_p2s_crlpath=NULL;
+		if (vallen) {
+			if (strcmp(value,"(null)"))
+				variables.ssl_p2s_crlpath=strdup(value);
 		}
 		return true;
 	}
@@ -2317,9 +2392,12 @@ MySQL_Threads_Handler::~MySQL_Threads_Handler() {
 	if (variables.eventslog_filename) free(variables.eventslog_filename);
 	if (variables.auditlog_filename) free(variables.auditlog_filename);
 	if (variables.ssl_p2s_ca) free(variables.ssl_p2s_ca);
+	if (variables.ssl_p2s_capath) free(variables.ssl_p2s_capath);
 	if (variables.ssl_p2s_cert) free(variables.ssl_p2s_cert);
 	if (variables.ssl_p2s_key) free(variables.ssl_p2s_key);
 	if (variables.ssl_p2s_cipher) free(variables.ssl_p2s_cipher);
+	if (variables.ssl_p2s_crl) free(variables.ssl_p2s_crl);
+	if (variables.ssl_p2s_crlpath) free(variables.ssl_p2s_crlpath);
 	for (int i=0; i<SQL_NAME_LAST; i++) {
 		if (variables.default_variables[i]) {
 			free(variables.default_variables[i]);
@@ -2452,9 +2530,12 @@ MySQL_Thread::~MySQL_Thread() {
 	if (mysql_thread___eventslog_filename) { free(mysql_thread___eventslog_filename); mysql_thread___eventslog_filename=NULL; }
 	if (mysql_thread___auditlog_filename) { free(mysql_thread___auditlog_filename); mysql_thread___auditlog_filename=NULL; }
 	if (mysql_thread___ssl_p2s_ca) { free(mysql_thread___ssl_p2s_ca); mysql_thread___ssl_p2s_ca=NULL; }
+	if (mysql_thread___ssl_p2s_capath) { free(mysql_thread___ssl_p2s_capath); mysql_thread___ssl_p2s_capath=NULL; }
 	if (mysql_thread___ssl_p2s_cert) { free(mysql_thread___ssl_p2s_cert); mysql_thread___ssl_p2s_cert=NULL; }
 	if (mysql_thread___ssl_p2s_key) { free(mysql_thread___ssl_p2s_key); mysql_thread___ssl_p2s_key=NULL; }
 	if (mysql_thread___ssl_p2s_cipher) { free(mysql_thread___ssl_p2s_cipher); mysql_thread___ssl_p2s_cipher=NULL; }
+	if (mysql_thread___ssl_p2s_crl) { free(mysql_thread___ssl_p2s_crl); mysql_thread___ssl_p2s_crl=NULL; }
+	if (mysql_thread___ssl_p2s_crlpath) { free(mysql_thread___ssl_p2s_crlpath); mysql_thread___ssl_p2s_crlpath=NULL; }
 
 
 	if (match_regexes) {
@@ -3556,12 +3637,18 @@ void MySQL_Thread::refresh_variables() {
 	// SSL proxy to server
 	if (mysql_thread___ssl_p2s_ca) free(mysql_thread___ssl_p2s_ca);
 	mysql_thread___ssl_p2s_ca=GloMTH->get_variable_string((char *)"ssl_p2s_ca");
+	if (mysql_thread___ssl_p2s_capath) free(mysql_thread___ssl_p2s_capath);
+	mysql_thread___ssl_p2s_capath=GloMTH->get_variable_string((char *)"ssl_p2s_ca");
 	if (mysql_thread___ssl_p2s_cert) free(mysql_thread___ssl_p2s_cert);
 	mysql_thread___ssl_p2s_cert=GloMTH->get_variable_string((char *)"ssl_p2s_cert");
 	if (mysql_thread___ssl_p2s_key) free(mysql_thread___ssl_p2s_key);
 	mysql_thread___ssl_p2s_key=GloMTH->get_variable_string((char *)"ssl_p2s_key");
 	if (mysql_thread___ssl_p2s_cipher) free(mysql_thread___ssl_p2s_cipher);
 	mysql_thread___ssl_p2s_cipher=GloMTH->get_variable_string((char *)"ssl_p2s_cipher");
+	if (mysql_thread___ssl_p2s_crl) free(mysql_thread___ssl_p2s_crl);
+	mysql_thread___ssl_p2s_crl=GloMTH->get_variable_string((char *)"ssl_p2s_crl");
+	if (mysql_thread___ssl_p2s_crlpath) free(mysql_thread___ssl_p2s_crlpath);
+	mysql_thread___ssl_p2s_crlpath=GloMTH->get_variable_string((char *)"ssl_p2s_crlpath");
 
 	mysql_thread___monitor_wait_timeout=(bool)GloMTH->get_variable_int((char *)"monitor_wait_timeout");
 	mysql_thread___monitor_writer_is_also_reader=(bool)GloMTH->get_variable_int((char *)"monitor_writer_is_also_reader");
@@ -3709,9 +3796,12 @@ MySQL_Thread::MySQL_Thread() {
 
 	// SSL proxy to server
 	mysql_thread___ssl_p2s_ca=NULL;
+	mysql_thread___ssl_p2s_capath=NULL;
 	mysql_thread___ssl_p2s_cert=NULL;
 	mysql_thread___ssl_p2s_key=NULL;
 	mysql_thread___ssl_p2s_cipher=NULL;
+	mysql_thread___ssl_p2s_crl=NULL;
+	mysql_thread___ssl_p2s_crlpath=NULL;
 
 	last_maintenance_time=0;
 	maintenance_loop=true;

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -659,7 +659,14 @@ void MySQL_Connection::connect_start() {
 		mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "mysql_bug_102266", "Avoid MySQL bug https://bugs.mysql.com/bug.php?id=102266 , https://github.com/sysown/proxysql/issues/3276");
 	}
 	if (parent->use_ssl) {
-		mysql_ssl_set(mysql, mysql_thread___ssl_p2s_key, mysql_thread___ssl_p2s_cert, mysql_thread___ssl_p2s_ca, NULL, mysql_thread___ssl_p2s_cipher);
+		mysql_ssl_set(mysql,
+				mysql_thread___ssl_p2s_key,
+				mysql_thread___ssl_p2s_cert,
+				mysql_thread___ssl_p2s_ca,
+				mysql_thread___ssl_p2s_capath,
+				mysql_thread___ssl_p2s_cipher);
+		mysql_options(mysql, MYSQL_OPT_SSL_CRL, mysql_thread___ssl_p2s_crl);
+		mysql_options(mysql, MYSQL_OPT_SSL_CRLPATH, mysql_thread___ssl_p2s_crlpath);
 	}
 	unsigned int timeout= 1;
 	const char *csname = NULL;


### PR DESCRIPTION
This PR adds two SSL options to the proxy<->server (`p2s`) connections. This is a change we are running in our production environment at Shopify.

In a self-managed SSL architecture, particularly in a large-scale infrastructure intranet in our case, CRLs allow explicitly revoking certificates before their expiration date, while specifying multiple CAs would allow us to rotate our certificates without having to rebuild all our infrastructure from scratch.

The actual changes here are fairly trivial as they use the currently-existing options on the MySQL client library. For a reference to review against, please see the MySQL C API section on [Support for Encrypted Connections](https://dev.mysql.com/doc/c-api/5.7/en/c-api-encrypted-connections.html), where the functions `mysql_options()` and `mysql_set_ssl()` functions are well-described.

Below are helpful descriptions of the feature from the [mariadb documentation](https://mariadb.com/kb/en/secure-connections-overview/#certificate-authorities-cas).

* **`ssl_capath`**

> The **ssl_capath** option defines a path to a directory that contains one or more PEM files that should each contain one X509 certificate for a trusted Certificate Authority (CA). This option requires that you use the absolute path, not a relative path. The ssl_capath option is only supported if the server or client was built with OpenSSL, wolfSSL, or yaSSL. If the client was built with GnuTLS or Schannel, then the ssl_capath option is not supported.

* **`ssl_{crl,crlpath}`**

> Certificate Revocation Lists (CRLs) are lists of certificates that have been revoked by the Certificate Authority (CA) before they were due to expire.
>CRLs are specified on the server and client by using the ssl_crl and ssl_crlpath options.

> The **ssl_crl** option defines a path to a PEM file that should contain one or more X509 revoked certificates. This option requires that you use the absolute path, not a relative path. For servers, the ssl_crl option is only valid if the server was built with OpenSSL. If the server was built with wolfSSL or yaSSL, then the ssl_crl option is not supported. For clients, the ssl_crl option is only valid if the client was built with OpenSSL or Schannel. Likewise, if the client was built with GnuTLS, wolfSSL or yaSSL, then the ssl_crl option is not supported.

> The **ssl_crlpath** option defines a path to a directory that contains one or more PEM files that should each contain one revoked X509 certificate. This option requires that you use the absolute path, not a relative path. The ssl_crlpath option is only supported if the server or client was built with OpenSSL. If the server was built with wolfSSL or yaSSL, then the ssl_crlpath option is not supported. Likewise, if the client was built with GnuTLS, Schannel, wolfSSL, or yaSSL, then the ssl_crlpath option is not supported.