### PR TITLE
Fixed several issues discovered while testing ASAN CI run

### DIFF
--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -2309,8 +2309,9 @@ bool MySQL_Connection::IsKeepMultiplexEnabledVariables(char *query_digest_text) 
 
 	std::vector<char*>query_digest_text_filter_select_v;
 	char* query_digest_text_filter_select_tok = NULL;
+	char* save_query_digest_text_ptr = NULL;
 	if (query_digest_text_filter_select) {
-	query_digest_text_filter_select_tok = strtok(query_digest_text_filter_select, ",");
+		query_digest_text_filter_select_tok = strtok_r(query_digest_text_filter_select, ",", &save_query_digest_text_ptr);
 	}
 	while(query_digest_text_filter_select_tok){
 		//filter "as"/space/alias,such as select @@version as a, @@version b
@@ -2329,19 +2330,20 @@ bool MySQL_Connection::IsKeepMultiplexEnabledVariables(char *query_digest_text) 
 		}else{
 			query_digest_text_filter_select_v.push_back(query_digest_text_filter_select_tok);
 		}
-		query_digest_text_filter_select_tok=strtok(NULL, ",");
+		query_digest_text_filter_select_tok=strtok_r(NULL, ",", &save_query_digest_text_ptr);
 	}
 
 	std::vector<char*>keep_multiplexing_variables_v;
 	char* keep_multiplexing_variables_tmp;
+	char* save_keep_multiplexing_variables_ptr = NULL;
 	unsigned long keep_multiplexing_variables_len=strlen(mysql_thread___keep_multiplexing_variables);
 	keep_multiplexing_variables_tmp=(char*)malloc(keep_multiplexing_variables_len+1);
 	memcpy(keep_multiplexing_variables_tmp, mysql_thread___keep_multiplexing_variables, keep_multiplexing_variables_len);
 	keep_multiplexing_variables_tmp[keep_multiplexing_variables_len]='\0';
-	char* keep_multiplexing_variables_tok=strtok(keep_multiplexing_variables_tmp, " ,");
+	char* keep_multiplexing_variables_tok=strtok_r(keep_multiplexing_variables_tmp, " ,", &save_keep_multiplexing_variables_ptr);
 	while (keep_multiplexing_variables_tok){
 		keep_multiplexing_variables_v.push_back(keep_multiplexing_variables_tok);
-		keep_multiplexing_variables_tok=strtok(NULL, " ,");
+		keep_multiplexing_variables_tok=strtok_r(NULL, " ,", &save_keep_multiplexing_variables_ptr);
 	}
 
 	for (std::vector<char*>::iterator it=query_digest_text_filter_select_v.begin();it!=query_digest_text_filter_select_v.end();it++){

--- a/test/tap/tests/admin_various_commands2-t.cpp
+++ b/test/tap/tests/admin_various_commands2-t.cpp
@@ -166,7 +166,7 @@ int main() {
 
 
 	for (std::vector<std::string>::iterator it2 = queries.begin(); it2 != queries.end(); it2++) {
-		proxysql_admin = mysql_init(NULL); // local scope
+		MYSQL* proxysql_admin = mysql_init(NULL); // local scope
 		if (!proxysql_admin) {
 			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
 			return -1;

--- a/test/tap/tests/firewall_commands1-t.cpp
+++ b/test/tap/tests/firewall_commands1-t.cpp
@@ -85,7 +85,7 @@ int main() {
 	plan(queries.size());
 
 	for (std::vector<std::string>::iterator it2 = queries.begin(); it2 != queries.end(); it2++) {
-		proxysql_admin = mysql_init(NULL); // local scope . We intentionally create new connections
+		MYSQL* proxysql_admin = mysql_init(NULL); // local scope . We intentionally create new connections
 		if (!proxysql_admin) {
 			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
 			return -1;

--- a/test/tap/tests/mysql-mirror1-t.cpp
+++ b/test/tap/tests/mysql-mirror1-t.cpp
@@ -127,6 +127,8 @@ int main(int argc, char** argv) {
 	}
 	int rows_read = 0;
 
+	sleep(1); // some INSERT may still be running
+
 	// at this point the table sbtest should have 600 rows:
 	// 300 rows from normal insert, and 100 rows from mirror
 	rc = run_q(conns[0], "SELECT * FROM test.sbtest1");

--- a/test/tap/tests/reg_test_3427-stmt_first_comment1-t.cpp
+++ b/test/tap/tests/reg_test_3427-stmt_first_comment1-t.cpp
@@ -77,7 +77,6 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	MYSQL_STMT* stmt = nullptr;
 	MYSQL* proxysql_mysql = mysql_init(NULL);
 	MYSQL* proxysql_admin = mysql_init(NULL);
 
@@ -89,13 +88,6 @@ int main(int argc, char** argv) {
 	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
 		return -1;
-	}
-
-	stmt = mysql_stmt_init(proxysql_mysql);
-	if (!stmt) {
-		diag("mysql_stmt_init(), out of memory");
-		res = EXIT_FAILURE;
-		goto exit;
 	}
 
 	// Insert data in the table to be queried
@@ -163,6 +155,13 @@ int main(int argc, char** argv) {
 
 			std::string query {};
 			string_format(query_t, query, query_id);
+
+			MYSQL_STMT* stmt = mysql_stmt_init(proxysql_mysql);
+			if (!stmt) {
+				diag("mysql_stmt_init(), out of memory");
+				res = EXIT_FAILURE;
+				goto exit;
+			}
 
 			if (mysql_stmt_prepare(stmt, query.c_str(), strlen(query.c_str()))) {
 				diag("mysql_stmt_prepare at line %d failed: %s", __LINE__ , mysql_error(proxysql_mysql));
@@ -261,11 +260,12 @@ int main(int argc, char** argv) {
 				res = EXIT_FAILURE;
 				goto exit;
 			}
+
+			mysql_stmt_close(stmt);
 		}
 	}
 
 exit:
-	if (stmt) { mysql_stmt_close(stmt); }
 	mysql_close(proxysql_mysql);
 	mysql_close(proxysql_admin);
 

--- a/test/tap/tests/reg_test_3546-stmt_empty_params-t.cpp
+++ b/test/tap/tests/reg_test_3546-stmt_empty_params-t.cpp
@@ -89,7 +89,6 @@ int main(int argc, char** argv) {
 		return -1;
 	}
 
-	MYSQL_STMT* stmt_param = nullptr;
 	MYSQL* proxysql_mysql = mysql_init(NULL);
 	MYSQL* proxysql_admin = mysql_init(NULL);
 
@@ -101,12 +100,6 @@ int main(int argc, char** argv) {
 	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
 		return -1;
-	}
-
-	stmt_param = mysql_stmt_init(proxysql_mysql);
-	if (!stmt_param) {
-		diag("mysql_stmt_init(), out of memory");
-		goto exit;
 	}
 
 	// Insert the row to be queried with the prepared statement.
@@ -132,6 +125,13 @@ int main(int argc, char** argv) {
 	}
 
 	{
+		MYSQL_STMT* stmt_param = nullptr;
+		stmt_param = mysql_stmt_init(proxysql_mysql);
+		if (!stmt_param) {
+			diag("mysql_stmt_init(), out of memory");
+			goto exit;
+		}
+
 		// Set the number of maximum connections for servers in the writer hostgroup
 		std::string t_update_mysql_servers {
 			"UPDATE mysql_servers SET max_connections=1 WHERE hostgroup_id=%d"
@@ -246,10 +246,11 @@ int main(int argc, char** argv) {
 				);
 			}
 		}
+
+		mysql_stmt_close(stmt_param);
 	}
 
 exit:
-	if (stmt_param) { mysql_stmt_close(stmt_param); }
 	mysql_close(proxysql_mysql);
 	mysql_close(proxysql_admin);
 

--- a/test/tap/tests/reg_test_fast_forward_split_packet-t.cpp
+++ b/test/tap/tests/reg_test_fast_forward_split_packet-t.cpp
@@ -1,0 +1,126 @@
+/**
+ * @file reg_test_fast_forward_split_packet-t.cpp
+ * @brief This is a simple regression test for checking that 'FAST_FORWARD' is able to handle split packets
+ *   received in a connection that is yet in 'CONNECTING_SERVER' state.
+ * @details In order to achieve this behavior consistently, the test performs the following operations:
+ *  1. Enables 'fast_forward' for 'mysql_users'.
+ *  2. Creates a number of connections.
+ *  3. Performs a unique 'INSERT' query of increasing size in each of the connections.
+ *
+ *  If the issue is present and ProxySQL cannot handle this situation, the test can fail before reaching
+ *  'QUEUE_T_DEFAULT_SIZE', but will for sure fail after this threshold is reached. Since the input buffer
+ *  is filled by the query, there won't be other option that processing the received packet in two different
+ *  iterations of 'MySQL_Session::handler', which will force the 'CONNECTING_SERVER' situation.
+ */
+
+#include <vector>
+#include <string>
+#include <stdio.h>
+#include <cstring>
+#include <unistd.h>
+#include <mysql.h>
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+const int NUM_CONNS = 35;
+
+MYSQL* conns[NUM_CONNS];
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	// One query that should succeed per-connection
+	plan(NUM_CONNS);
+
+	MYSQL* proxysql_admin = mysql_init(NULL);
+	if (!proxysql_admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return -1;
+	}
+
+	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return -1;
+	}
+
+	MYSQL_QUERY(proxysql_admin, "UPDATE mysql_users SET fast_forward=1");
+	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL USERS TO RUNTIME");
+
+	std::random_device rd {};
+	std::mt19937 mt(rd());
+	std::uniform_int_distribution<int> dist(0.0, 9.0);
+
+	for (int i = 0; i < NUM_CONNS ; i++) {
+		MYSQL * mysql = mysql_init(NULL);
+		if (!mysql) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(mysql));
+			return EXIT_FAILURE;
+		}
+
+		if (!mysql_real_connect(mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(mysql));
+			return EXIT_FAILURE;
+		}
+		conns[i] = mysql;
+	}
+
+	MYSQL_QUERY(conns[0], "DROP TABLE IF EXISTS test.reg_test_fast_forward_split");
+	MYSQL_QUERY(
+		conns[0],
+		"CREATE TABLE IF NOT EXISTS test.reg_test_fast_forward_split ("
+			" `id` int(10) unsigned NOT NULL AUTO_INCREMENT, `k` int(10) unsigned NOT NULL DEFAULT '0',"
+			" `c` char(120) NOT NULL DEFAULT '', `pad` char(60) NOT NULL DEFAULT '',"
+			"  PRIMARY KEY (`id`), KEY `k_1` (`k`) "
+		")"
+	);
+
+	int query_num = 10;
+	std::string q { "INSERT INTO test.reg_test_fast_forward_split (k, c, pad) values " };
+	bool put_comma=false;
+
+	for (int j = 0; j < NUM_CONNS; j++) {
+		MYSQL* proxysql_mysql = conns[j];
+
+		for (int i=0; i< query_num; ++i) {
+			int k = dist(mt);
+			std::string c;
+			for (int j=0; j<10; j++) {
+				for (int k=0; k<11; k++) {
+					c += std::to_string(dist(mt));
+				}
+				if (j<9)
+					c += "-";
+			}
+			std::string pad;
+			for (int j=0; j<5; j++) {
+				for (int k=0; k<11; k++) {
+					pad += std::to_string(dist(mt));
+				}
+				if (j<4)
+					pad += "-";
+			}
+			if (put_comma) q += ",";
+			if (!put_comma) put_comma=true;
+
+			q += "(" + std::to_string(k) + ",'" + c + "','" + pad + "')";
+		}
+
+		int q_err = mysql_query(proxysql_mysql, q.c_str());
+		ok(q_err == EXIT_SUCCESS, "Executing query of size: '%ld', should succeed", q.size());
+	}
+
+	for (int j = 0; j < NUM_CONNS; j++) {
+		mysql_close(conns[j]);
+	}
+
+	mysql_close(proxysql_admin);
+
+	return exit_status();
+}

--- a/test/tap/tests/test_cluster_sync-t.cpp
+++ b/test/tap/tests/test_cluster_sync-t.cpp
@@ -169,7 +169,7 @@ int main(int, char**) {
 
 		const std::string docker_command =
 			std::string("docker run -p 16032:6032 ") + "-v " + std::string(cl.workdir) + "../../../:/tmp/proxysql"
-			" ubuntu:19.10 sh -c \"./tmp/proxysql/src/proxysql -f -M -c /tmp/proxysql/test/tap/tests/test_cluster_sync_config/test_cluster_sync.cnf\" " +
+			" ubuntu:20.04 sh -c \"./tmp/proxysql/src/proxysql -f -M -c /tmp/proxysql/test/tap/tests/test_cluster_sync_config/test_cluster_sync.cnf\" " +
 			std::string("> ") + cluster_sync_node_stderr + " 2>&1";
 
 		int exec_res = system(docker_command.c_str());

--- a/test/tap/tests/test_mysqlsh-t.cpp
+++ b/test/tap/tests/test_mysqlsh-t.cpp
@@ -89,8 +89,6 @@ int main(int argc, char** argv) {
 			} else {
 				ok(false, "Invalid resulset. Expected 'num_fields' = 1, not %d", concat_num_fields);
 			}
-
-			mysql_free_result(concat_res);
 		}
 
 		mysql_free_result(concat_res);


### PR DESCRIPTION
- Fixed multiplexing disabling and buffer overflow in 'IsKeepMultiplexEnabledVariables' under high concurrency.
- Fixed handling of split packets during 'CONNECTING_SERVER' state for 'FAST_FORWARD'
- Several memory error fixes for tests files to allow a full ASAN run in the CI.