### PR TITLE
Add transaction_isolation to the list of hardcoded session variables that do not disable ProxySQL multiplexing Fixes sysown/proxysql#3663

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1175,7 +1175,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.ssl_p2s_cipher=NULL;
 	variables.ssl_p2s_crl=NULL;
 	variables.ssl_p2s_crlpath=NULL;
-	variables.keep_multiplexing_variables=strdup((char *)"tx_isolation,version");
+	variables.keep_multiplexing_variables=strdup((char *)"tx_isolation,transaction_isolation,version");
 #ifdef DEBUG
 	variables.session_debug=true;
 #endif /*debug */


### PR DESCRIPTION
MySQL 8 has the session variable @@tx_isolation deprecated and only supports the synonym @@transaction_isolation

While upgrading our MySQL servers from MySQL 5.7.23 to MySQL 8.0.21, we chose to change the usage to the new session variable in our internal library built on top of SQLAlchemy.

However, this has effectively disabled ProxySQL multiplexing

proxysql/lib/MySQL_Thread.cpp

https://github.com/sysown/proxysql/blob/9829c6d37b2c3946073d879d4d35aee0dbf1f2d0/lib/MySQL_Thread.cpp#L1178

and resulted in significantly higher backend connections while the frontend connections remained the same 

<img width="1343" alt="Screen Shot 2021-10-18 at 12 20 59 PM" src="https://user-images.githubusercontent.com/29114965/137798571-9407c4df-e6f8-4153-ba96-9e8b76d7a4e0.png">
<img width="1336" alt="Screen Shot 2021-10-18 at 12 21 07 PM" src="https://user-images.githubusercontent.com/29114965/137798589-4dc8055a-a62c-41a5-955d-36c7e01e6c58.png">

And eventually resulting in very high number of threads connected to the MySQL primary.

It would be good to include the new session variable to the list of hardcoded session variables that do not disable ProxySQL multiplexing

Additional details:
ProxySQL version used: 2.2.0
OS version: ProxySQL on Ubuntu Bionic (18.04) and MySQL on Ubuntu Xenial (16.04)

Fixes sysown/proxysql#3663