### PR TITLE
Removed unnecessary `+` mark from query annotations in tap tests

### DIFF
--- a/test/tap/tests/reg_test_1574-stmt_metadata-t.cpp
+++ b/test/tap/tests/reg_test_1574-stmt_metadata-t.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
 	}
 
 	// Force the 'hostgroup' for the 'SELECT' query to avoid replication issues
-	std::string query_t = "SELECT /*+ ;hostgroup=0,%s */ * FROM test.reg_test_1574";
+	std::string query_t = "SELECT /* ;hostgroup=0,%s */ * FROM test.reg_test_1574";
 	std::string query (static_cast<std::size_t>(query_t.size() + 20), '\0');
 
 	std::string rnd_str(static_cast<std::size_t>(20), '\0');

--- a/test/tap/tests/reg_test_3317-lock_hostgroup_special_queries-t.cpp
+++ b/test/tap/tests/reg_test_3317-lock_hostgroup_special_queries-t.cpp
@@ -33,7 +33,7 @@ void check_set_names(MYSQL* proxysql_mysql) {
 		return;
 	}
 
-	query_res = mysql_query(proxysql_mysql, "SELECT /*+ ;hostgroup=0 */ @@character_set_client, @@character_set_results, @@character_set_connection");
+	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@character_set_client, @@character_set_results, @@character_set_connection");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -77,7 +77,7 @@ void check_set_names(MYSQL* proxysql_mysql) {
  * @param proxysql_mysql A MYSQL handle to an already stablished MySQL connection.
  */
 void check_autocommit(MYSQL* proxysql_mysql) {
-	int query_res = mysql_query(proxysql_mysql, "SELECT /*+ ;hostgroup=0 */ @@autocommit");
+	int query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@autocommit");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -104,7 +104,7 @@ void check_autocommit(MYSQL* proxysql_mysql) {
 	}
 
 	// Check new status on @@autocommit
-	query_res = mysql_query(proxysql_mysql, "SELECT /*+ ;hostgroup=0 */ @@autocommit");
+	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@autocommit");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -139,7 +139,7 @@ void check_session_character_set_server(MYSQL* proxysql_mysql) {
 		return;
 	}
 
-	query_res = mysql_query(proxysql_mysql, "SELECT /*+ ;hostgroup=0 */ @@character_set_server");
+	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@character_set_server");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -178,7 +178,7 @@ void check_session_character_set_results(MYSQL* proxysql_mysql) {
 		return;
 	}
 
-	query_res = mysql_query(proxysql_mysql, "SELECT /*+ ;hostgroup=0 */ @@character_set_results");
+	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@character_set_results");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;

--- a/test/tap/tests/reg_test_3427-stmt_first_comment1-t.cpp
+++ b/test/tap/tests/reg_test_3427-stmt_first_comment1-t.cpp
@@ -148,9 +148,9 @@ int main(int argc, char** argv) {
 			std::string query_t {};
 
 			if (param) {
-				query_t = "SELECT /*+ ;hostgroup=0;%d */ * FROM test.reg_test_3427 WHERE id IN (?)";
+				query_t = "SELECT /* ;hostgroup=0;%d */ * FROM test.reg_test_3427 WHERE id IN (?)";
 			} else {
-				query_t = "SELECT /*+ ;hostgroup=0;%d */ * FROM test.reg_test_3427";
+				query_t = "SELECT /* ;hostgroup=0;%d */ * FROM test.reg_test_3427";
 			}
 
 			std::string query {};

--- a/test/tap/tests/reg_test_3434-text_stmt_mix-t.cpp
+++ b/test/tap/tests/reg_test_3434-text_stmt_mix-t.cpp
@@ -221,7 +221,7 @@ std::string build_random_select_query(
 ) {
 	// Force the 'hostgroup' for the 'SELECT' query
 	std::string t_query {
-		"SELECT /*+ ;hostgroup=%d,%s */ * FROM %s WHERE id IN ("
+		"SELECT /* ;hostgroup=%d,%s */ * FROM %s WHERE id IN ("
 	};
 
 	for (uint32_t i = 0; i < num_params; i++) {

--- a/test/tap/tests/reg_test_3493-USE_with_comment-t.cpp
+++ b/test/tap/tests/reg_test_3493-USE_with_comment-t.cpp
@@ -50,19 +50,19 @@ int main(int argc, char** argv) {
 
 	MYSQL* proxysql_mysql = mysql_init(NULL);
 
-	db_query.push_back(std::make_pair("reg_test_3493_use_comment", "/*+ placeholder_comment */ USE reg_test_3493_use_comment"));
-	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-a1`", "USE /*+ placeholder_comment */ `reg_test_3493_use_comment-a1`"));
-	db_query.push_back(std::make_pair("reg_test_3493_use_comment_1", "  USE /*+ placeholder_comment */   `reg_test_3493_use_comment_1`"));
-	db_query.push_back(std::make_pair("reg_test_3493_use_comment_2", "USE/*+ placeholder_comment */ `reg_test_3493_use_comment_2`"));
-	db_query.push_back(std::make_pair("reg_test_3493_use_comment_3", "USE /*+ placeholder_comment */`reg_test_3493_use_comment_3`"));
-	db_query.push_back(std::make_pair("reg_test_3493_use_comment_4", "  USE /*+ placeholder_comment */   reg_test_3493_use_comment_4"));
-	db_query.push_back(std::make_pair("reg_test_3493_use_comment_5", "USE/*+ placeholder_comment */ reg_test_3493_use_comment_5"));
-	db_query.push_back(std::make_pair("reg_test_3493_use_comment_6", "USE /*+ placeholder_comment */reg_test_3493_use_comment_6"));
-	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-1`", "  USE /*+ placeholder_comment */   `reg_test_3493_use_comment-1`"));
-	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-2`", "USE/*+ placeholder_comment */ `reg_test_3493_use_comment-2`"));
-	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-3`", "USE /*+ placeholder_comment */`reg_test_3493_use_comment-3`"));
-	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-4`", "/*+ placeholder_comment */USE          `reg_test_3493_use_comment-4`"));
-	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-5`", "USE/*+ placeholder_comment */`reg_test_3493_use_comment-5`"));
+	db_query.push_back(std::make_pair("reg_test_3493_use_comment", "/* placeholder_comment */ USE reg_test_3493_use_comment"));
+	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-a1`", "USE /* placeholder_comment */ `reg_test_3493_use_comment-a1`"));
+	db_query.push_back(std::make_pair("reg_test_3493_use_comment_1", "  USE /* placeholder_comment */   `reg_test_3493_use_comment_1`"));
+	db_query.push_back(std::make_pair("reg_test_3493_use_comment_2", "USE/* placeholder_comment */ `reg_test_3493_use_comment_2`"));
+	db_query.push_back(std::make_pair("reg_test_3493_use_comment_3", "USE /* placeholder_comment */`reg_test_3493_use_comment_3`"));
+	db_query.push_back(std::make_pair("reg_test_3493_use_comment_4", "  USE /* placeholder_comment */   reg_test_3493_use_comment_4"));
+	db_query.push_back(std::make_pair("reg_test_3493_use_comment_5", "USE/* placeholder_comment */ reg_test_3493_use_comment_5"));
+	db_query.push_back(std::make_pair("reg_test_3493_use_comment_6", "USE /* placeholder_comment */reg_test_3493_use_comment_6"));
+	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-1`", "  USE /* placeholder_comment */   `reg_test_3493_use_comment-1`"));
+	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-2`", "USE/* placeholder_comment */ `reg_test_3493_use_comment-2`"));
+	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-3`", "USE /* placeholder_comment */`reg_test_3493_use_comment-3`"));
+	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-4`", "/* placeholder_comment */USE          `reg_test_3493_use_comment-4`"));
+	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-5`", "USE/* placeholder_comment */`reg_test_3493_use_comment-5`"));
 	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-6`", "/* comment */USE`reg_test_3493_use_comment-6`"));
 	db_query.push_back(std::make_pair("`reg_test_3493_use_comment-7`", "USE`reg_test_3493_use_comment-7`"));
 
@@ -107,19 +107,19 @@ int main(int argc, char** argv) {
 		// statement.
 		switch (i%5) {
 			case 0:
-				MYSQL_QUERY(proxysql_mysql, "/*+ ;create_new_connection=1 */ SELECT DATABASE()");
+				MYSQL_QUERY(proxysql_mysql, "/* ;create_new_connection=1 */ SELECT DATABASE()");
 				break;
 			case 1:
-				MYSQL_QUERY(proxysql_mysql, "/*+ ;create_new_connection=1 */SELECT DATABASE()");
+				MYSQL_QUERY(proxysql_mysql, "/* ;create_new_connection=1 */SELECT DATABASE()");
 				break;
 			case 2:
-				MYSQL_QUERY(proxysql_mysql, "SELECT /*+ ;create_new_connection=1 */ DATABASE()");
+				MYSQL_QUERY(proxysql_mysql, "SELECT /* ;create_new_connection=1 */ DATABASE()");
 				break;
 			case 3:
-				MYSQL_QUERY(proxysql_mysql, "SELECT/*+ ;create_new_connection=1 */ DATABASE()");
+				MYSQL_QUERY(proxysql_mysql, "SELECT/* ;create_new_connection=1 */ DATABASE()");
 				break;
 			case 4:
-				MYSQL_QUERY(proxysql_mysql, "SELECT /*+ ;create_new_connection=1 */DATABASE()");
+				MYSQL_QUERY(proxysql_mysql, "SELECT /* ;create_new_connection=1 */DATABASE()");
 				break;
 			default:
 				assert(0);

--- a/test/tap/tests/reg_test_3546-stmt_empty_params-t.cpp
+++ b/test/tap/tests/reg_test_3546-stmt_empty_params-t.cpp
@@ -47,7 +47,7 @@ int prepare_stmt(
 ) {
 	int res = EXIT_SUCCESS;
 	std::string query {
-		"SELECT /*+ ;hostgroup=0 */ id,c1,c2 FROM test.reg_test_3546 WHERE date IN (?)"
+		"SELECT /* ;hostgroup=0 */ id,c1,c2 FROM test.reg_test_3546 WHERE date IN (?)"
 	};
 
 	if (mysql_stmt_prepare(stmt, query.c_str(), strlen(query.c_str()))) {

--- a/test/tap/tests/reg_test_3549-autocommit_tracking-t.cpp
+++ b/test/tap/tests/reg_test_3549-autocommit_tracking-t.cpp
@@ -138,19 +138,19 @@ std::vector<std::pair<std::string, test_spec>> test_definitions {
 		"simple_set_autocommit_no_lock",
 		{
 			{ "SET autocommit=1",             1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 1 },
+			{ "SELECT /* ;hostgroup=0 */ 1",  1 },
 			{ "SET autocommit=0",             0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 0 }
+			{ "SELECT /* ;hostgroup=0 */ 1",  0 }
 		}
 	},
 	{
 		"simple_set_autocommit_no_lock_2",
 		{
 			{ "SET autocommit=0",             0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",  0 },
 			{ "COMMIT",                       0 },
 			{ "SET autocommit=1",             1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 1 }
+			{ "SELECT /* ;hostgroup=0 */ 1", 1 }
 		}
 	},
 	{
@@ -158,9 +158,9 @@ std::vector<std::pair<std::string, test_spec>> test_definitions {
 		{
 			{ "SET @session_var=1",           1 },
 			{ "SET autocommit=1",             1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 1 },
+			{ "SELECT /* ;hostgroup=0 */ 1",  1 },
 			{ "SET autocommit=0",             0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 0 }
+			{ "SELECT /* ;hostgroup=0 */ 1",  0 }
 		}
 	},
 	{
@@ -168,10 +168,10 @@ std::vector<std::pair<std::string, test_spec>> test_definitions {
 		{
 			{ "SET @session_var=1",           1 },
 			{ "SET autocommit=0",             0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",  0 },
 			{ "COMMIT",                       0 },
 			{ "SET autocommit=1",             1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1", 1 }
+			{ "SELECT /* ;hostgroup=0 */ 1",  1 }
 		}
 	},
 	{
@@ -181,19 +181,19 @@ std::vector<std::pair<std::string, test_spec>> test_definitions {
 		"complex_set_autocommit_no_lock_1",
 		{
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=1", 1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             1 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              1 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=0", 0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 }
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 }
 		}
 	},
 	{
 		"complex_set_autocommit_no_lock_2",
 		{
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=0", 0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 },
 			{ "COMMIT",                                                                                   0 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=1", 1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             1 }
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              1 }
 		}
 	},
 	{
@@ -201,9 +201,9 @@ std::vector<std::pair<std::string, test_spec>> test_definitions {
 		{
 			{ "SET @session_var=1",                                                                       1 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=1", 1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             1 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              1 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=0", 0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 }
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 }
 		}
 	},
 	{
@@ -211,26 +211,26 @@ std::vector<std::pair<std::string, test_spec>> test_definitions {
 		{
 			{ "SET @session_var=1",                                                                       1 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=0", 0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 },
 			{ "COMMIT",                                                                                   0 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=1", 1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             1 }
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              1 }
 		}
 	},
 	{
 		"mix_set_autocommit_1",
 		{
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=0", 0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 },
 			{ "COMMIT",                                                                                   0 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=1", 1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             1 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              1 },
 			{ "SET autocommit=0",                                                                         0 },
 			{ "COMMIT",                                                                                   0 },
 			{ "SET autocommit=1",                                                                         1 },
 			{ "BEGIN",                                                                                    1 },
 			{ "SET @session_var=1",                                                                       1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             1 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              1 },
 			{ "COMMIT",                                                                                   1 },
 		}
 	},
@@ -238,16 +238,16 @@ std::vector<std::pair<std::string, test_spec>> test_definitions {
 		"mix_set_autocommit_2",
 		{
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=0", 0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 },
 			{ "COMMIT",                                                                                   0 },
 			{ "SET time_zone='+04:00', character_set_client='latin1', max_join_size=10000, autocommit=1", 1 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             1 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              1 },
 			{ "SET autocommit=0",                                                                         0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 },
 			{ "COMMIT",                                                                                   0 },
 			{ "BEGIN",                                                                                    0 },
 			{ "SET @session_var=1",                                                                       0 },
-			{ "SELECT /*+ ;hostgroup=0 */ 1",                                                             0 },
+			{ "SELECT /* ;hostgroup=0 */ 1",                                                              0 },
 			{ "COMMIT",                                                                                   0 },
 		}
 	},

--- a/test/tap/tests/reg_test_3585-stmt_metadata-t.cpp
+++ b/test/tap/tests/reg_test_3585-stmt_metadata-t.cpp
@@ -348,7 +348,7 @@ int main(int argc, char** argv) {
 	int rc;
 	std::string query_i = "INSERT INTO test.reg_test_3585 VALUES (? , ? , ? , ? , ? , ? , ?)";
 	// Force the 'hostgroup' for the 'SELECT' query to avoid replication issues
-	std::string query_s = "SELECT /*+ ;hostgroup=0 */ * FROM test.reg_test_3585 WHERE id=?";
+	std::string query_s = "SELECT /* ;hostgroup=0 */ * FROM test.reg_test_3585 WHERE id=?";
 
 	// init and prepare INSERT
 	MYSQL_STMT *stmti = mysql_stmt_init(proxysql_mysql);

--- a/test/tap/tests/reg_test_3603-stmt_metadata-t.cpp
+++ b/test/tap/tests/reg_test_3603-stmt_metadata-t.cpp
@@ -555,7 +555,7 @@ int main(int argc, char** argv) {
 			"start_time=?,trck_num=? where id=?";
 
 	// Force the 'hostgroup' for the 'SELECT' query to avoid replication issues
-	std::string query_s = "SELECT /*+ ;hostgroup=0 */ * FROM test.reg_test_3603 WHERE id=?";
+	std::string query_s = "SELECT /* ;hostgroup=0 */ * FROM test.reg_test_3603 WHERE id=?";
 
 	// init and prepare INSERT
 	MYSQL_STMT *stmti = mysql_stmt_init(proxysql_mysql);

--- a/test/tap/tests/test_connection_annotation-t.cpp
+++ b/test/tap/tests/test_connection_annotation-t.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 	srand(time(NULL));
 	int rand_conn = rand() % 100;
 	for (int i = 0; i < rand_conn; i++) {
-		MYSQL_QUERY(proxysql_mysql, "SELECT /*+ ;create_new_connection=1 */ 1");
+		MYSQL_QUERY(proxysql_mysql, "SELECT /* ;create_new_connection=1 */ 1");
 		proxy_res = mysql_store_result(proxysql_mysql);
 		mysql_free_result(proxy_res);
 	}

--- a/test/tap/tests/test_query_rules_routing-t.cpp
+++ b/test/tap/tests/test_query_rules_routing-t.cpp
@@ -80,31 +80,31 @@ std::vector<dst_hostgroup_test> dst_hostgroup_tests {
 		},
 		{
 			{
-				"SELECT /*+ ;%s */ 1",
+				"SELECT /* ;%s */ 1",
 				1
 			},
 			{
-				"SELECT /*+ ;%s */ c FROM test.reg_test_3427_0 WHERE id=1",
+				"SELECT /* ;%s */ c FROM test.reg_test_3427_0 WHERE id=1",
 				1
 			},
 			{
-				"SELECT /*+ ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 20",
+				"SELECT /* ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 20",
 				1
 			},
 			{
-				"SELECT /*+ ;%s */ SUM(k) c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10",
+				"SELECT /* ;%s */ SUM(k) c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10",
 				1
 			},
 			{
-				"INSERT /*+ ;%s */ INTO test.reg_test_3427_0 (k) VALUES (2)",
+				"INSERT /* ;%s */ INTO test.reg_test_3427_0 (k) VALUES (2)",
 				0
 			},
 			{
-				"UPDATE /*+ ;%s */ test.reg_test_3427_0 SET pad=\"random\" WHERE id=2",
+				"UPDATE /* ;%s */ test.reg_test_3427_0 SET pad=\"random\" WHERE id=2",
 				0
 			},
 			{
-				"SELECT DISTINCT /*+ ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10 ORDER BY c",
+				"SELECT DISTINCT /* ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10 ORDER BY c",
 				1
 			}
 		}
@@ -118,23 +118,23 @@ std::vector<dst_hostgroup_test> dst_hostgroup_tests {
 		},
 		{
 			{
-				"UPDATE /*+ ;%s */ test.reg_test_3427_0 SET pad=\"random\" WHERE id=2",
+				"UPDATE /* ;%s */ test.reg_test_3427_0 SET pad=\"random\" WHERE id=2",
 				0
 			},
 			{
-				"SELECT DISTINCT /*+ ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10 ORDER BY c",
+				"SELECT DISTINCT /* ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10 ORDER BY c",
 				1
 			},
 			{
-				"SELECT /*+ ;%s */ c FROM test.reg_test_3427_1 WHERE id BETWEEN 1 AND 10 ORDER BY c",
+				"SELECT /* ;%s */ c FROM test.reg_test_3427_1 WHERE id BETWEEN 1 AND 10 ORDER BY c",
 				0
 			},
 			{
-				"INSERT /*+ ;%s */ INTO test.reg_test_3427_0 (k) VALUES (2)",
+				"INSERT /* ;%s */ INTO test.reg_test_3427_0 (k) VALUES (2)",
 				0
 			},
 			{
-				"SELECT DISTINCT /*+ ;hostgroup=0;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10 ORDER BY c",
+				"SELECT DISTINCT /* ;hostgroup=0;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10 ORDER BY c",
 				0
 			},
 		}
@@ -148,31 +148,31 @@ std::vector<dst_hostgroup_test> dst_hostgroup_tests {
 		},
 		{
 			{
-				"UPDATE /*+ ;%s */ test.reg_test_3427_0 SET pad=\"random\" WHERE id=2",
+				"UPDATE /* ;%s */ test.reg_test_3427_0 SET pad=\"random\" WHERE id=2",
 				0
 			},
 			{
-				"SELECT /*+ ;hostgroup=0;%s */ c FROM test.reg_test_3427_0 WHERE id=1",
+				"SELECT /* ;hostgroup=0;%s */ c FROM test.reg_test_3427_0 WHERE id=1",
 				0
 			},
 			{
-				"SELECT /*+ ;hostgroup=0;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 20",
+				"SELECT /* ;hostgroup=0;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 20",
 				0
 			},
 			{
-				"SELECT /*+ ;hostgroup=0;%s */ SUM(k) c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10",
+				"SELECT /* ;hostgroup=0;%s */ SUM(k) c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10",
 				0
 			},
 			{
-				"SELECT /*+ ;%s */ c FROM test.reg_test_3427_0 WHERE id=1",
+				"SELECT /* ;%s */ c FROM test.reg_test_3427_0 WHERE id=1",
 				1
 			},
 			{
-				"SELECT /*+ ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 20",
+				"SELECT /* ;%s */ c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 20",
 				1
 			},
 			{
-				"SELECT /*+ ;%s */ SUM(k) c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10",
+				"SELECT /* ;%s */ SUM(k) c FROM test.reg_test_3427_0 WHERE id BETWEEN 1 AND 10",
 				1
 			}
 		}

--- a/test/tap/tests/test_set_collation-t.cpp
+++ b/test/tap/tests/test_set_collation-t.cpp
@@ -102,7 +102,7 @@ int query_and_check_session_variables(MYSQL *mysql, std::string collation, int i
 	MYSQL_RES* proxy_res = nullptr;
 	std::string query = "";
 	if (new_connection)
-		query += "/*+ ;create_new_connection=1 */ ";
+		query += "/* ;create_new_connection=1 */ ";
 	query += "SELECT lower(variable_name), variable_value FROM performance_schema.session_variables WHERE";
 	query +=" Variable_name IN ('character_set_client', 'character_set_connection', 'character_set_results', 'collation_connection') ORDER BY Variable_name";
 

--- a/test/tap/tests/test_unsupported_queries-t.cpp
+++ b/test/tap/tests/test_unsupported_queries-t.cpp
@@ -284,7 +284,7 @@ void helper_test_load_data_local_infile(
 
 			// Check that the data has actually been loaded to the database
 			// NOTE: Specifically target 'hostgroup=0' to avoid replication lag.
-			int myerr = mysql_query(proxysql, "SELECT * /*+ ;hostgroup=0 */ FROM test.load_data_local");
+			int myerr = mysql_query(proxysql, "SELECT * /* ;hostgroup=0 */ FROM test.load_data_local");
 			if (myerr) {
 				diag(
 					"Query 'SELECT * FROM test.load_data_local' for table preparation failed"


### PR DESCRIPTION
Multiple tap tests use the unnecessary mark `+` for query annotations, since this mark is also used for [Query Optimizer Hints](https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html), and could be misleading it should be removed.