### PR TITLE
Tap makefile curl include

### DIFF
--- a/test/tap/tap/Makefile
+++ b/test/tap/tap/Makefile
@@ -8,15 +8,11 @@ CURL_DIR=$(DEPS_PATH)/curl/curl
 CURL_IDIR=$(CURL_DIR)/include
 CURL_LDIR=$(CURL_DIR)/lib/.libs
 
-CURL_DIR=$(DEPS_PATH)/curl/curl
-CURL_IDIR=$(CURL_DIR)/include
-CURL_LDIR=$(CURL_DIR)/lib/.libs
-
 IDIR=../../../include
 LDIR=../../../lib
 
 LIBPROXYSQLAR=$(LDIR)/libproxysql.a
-INCLUDEDIRS=-I$(IDIR) -I$(JSON_IDIR) -I$(MARIADB_IDIR)
+INCLUDEDIRS=-I$(IDIR) -I$(JSON_IDIR) -I$(MARIADB_IDIR) -I${CURL_IDIR}
 
 .PHONY: all
 all: libtap.a


### PR DESCRIPTION
Fixes issue: https://github.com/sysown/proxysql/issues/3711

* Added the include directive to the proxysql/test/tap/tap/Makefile to include curl dependency to fix compilation error on Ubuntu 20.04

* Removed duplicate curl definitions