### PR TITLE
Curl include for tap build

### DIFF
--- a/test/tap/tap/Makefile
+++ b/test/tap/tap/Makefile
@@ -21,5 +21,5 @@ debug: OPT = -O0 -DDEBUG -ggdb
 debug: libtap.a
 
 libtap.a: tap.cpp tap.h command_line.cpp command_line.h utils.cpp utils.h
-	g++ -c tap.cpp command_line.cpp utils.cpp -std=c++11 -I$(JSON_IDIR) -I$(MARIADB_IDIR) $(OPT)
+	g++ -c tap.cpp command_line.cpp utils.cpp -std=c++11 -I$(JSON_IDIR) -I${CURL_IDIR} -I$(MARIADB_IDIR) $(OPT)
 	ar rcs libtap.a tap.o command_line.o utils.o


### PR DESCRIPTION
Fixes issue: #3711

Added the include directive to the proxysql/test/tap/tap/Makefile to include curl dependency to fix compilation error on Ubuntu 20.04