### PR TITLE
Add new QPS limits rules feature

### DIFF
--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -8,6 +8,7 @@
 using json = nlohmann::json;
 
 extern class MySQL_Variables mysql_variables;
+struct QPS_Limit_Bucket;
 
 enum proxysql_session_type {
 	PROXYSQL_SESSION_MYSQL,
@@ -217,6 +218,7 @@ class MySQL_Session
 	MySQL_Data_Stream *server_myds;
 	char * default_schema;
 	char * user_attributes;
+	std::shared_ptr<QPS_Limit_Bucket> qps_queue;
 
 	//this pointer is always initialized inside handler().
 	// it is an attempt to start simplifying the complexing of handler()

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -195,6 +195,12 @@ class MySQL_Thread
 
 	bool epoll_thread;
 	bool poll_timeout_bool;
+	/**
+	 * @brief Flag that indicates if there are sessions being processed that have been delayed.
+	 * @details Flag set after sessions processing, whenever a imposed delay is found after processing a
+	 *  session. When 'true', we can't assume that it's safe not to check for sessions that have timed out.
+	 */
+	bool handling_delayed_sessions;
 
 	// status variables are per thread only
 	// in this way, there is no need for atomic operation and there is no cache miss

--- a/include/TokenBucket.h
+++ b/include/TokenBucket.h
@@ -1,0 +1,109 @@
+/*
+Original work Copyright (c) 2017 Erik Rigtorp <erik@rigtorp.se>
+Modified work Copyright 2021 Javier Jaramago Fernández <javier@sysown.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+
+class TokenBucket {
+public:
+	TokenBucket() {}
+
+	TokenBucket(const uint64_t rate, const uint64_t burstSize) {
+		timePerToken_ = 1000000 / rate;
+		timePerBurst_ = burstSize * timePerToken_;
+	}
+
+	TokenBucket(const TokenBucket &other) {
+		timePerToken_ = other.timePerToken_.load();
+		timePerBurst_ = other.timePerBurst_.load();
+		disabled_ = other.disabled_.load();
+	}
+
+	TokenBucket &operator=(const TokenBucket &other) {
+		timePerToken_ = other.timePerToken_.load();
+		timePerBurst_ = other.timePerBurst_.load();
+		disabled_ = other.disabled_.load();
+		return *this;
+	}
+
+	bool consume(const uint64_t tokens) {
+		if (disabled_.load(std::memory_order_relaxed) == true) {
+			return true;
+		}
+
+		const uint64_t now =
+				std::chrono::duration_cast<std::chrono::microseconds>(
+					std::chrono::steady_clock::now().time_since_epoch()
+				).count();
+		const uint64_t timeNeeded =
+				tokens * timePerToken_.load(std::memory_order_relaxed);
+		const uint64_t minTime =
+				now - timePerBurst_.load(std::memory_order_relaxed);
+		uint64_t oldTime = time_.load(std::memory_order_relaxed);
+		uint64_t newTime = oldTime;
+
+		if (minTime > oldTime) {
+			newTime = minTime;
+		}
+
+		for (;;) {
+			newTime += timeNeeded;
+			if (newTime > now) {
+				return false;
+			}
+			if (time_.compare_exchange_weak(oldTime, newTime,
+											std::memory_order_relaxed,
+											std::memory_order_relaxed)) {
+				return true;
+			}
+			newTime = oldTime;
+		}
+
+		return false;
+	}
+
+	void disable() {
+		disabled_ = true;
+	}
+
+	void enable() {
+		disabled_ = false;
+	}
+
+	void update(const uint64_t rate, const uint64_t burstSize) {
+		timePerToken_ = 1000000 / rate;
+		timePerBurst_ = burstSize;
+	}
+
+	bool is_disabled() {
+		return disabled_.load(std::memory_order_relaxed);
+	}
+
+private:
+	std::atomic<bool> disabled_ = {false};
+	std::atomic<uint64_t> time_ = {0};
+	std::atomic<uint64_t> timePerToken_ = {0};
+	std::atomic<uint64_t> timePerBurst_ = {0};
+};

--- a/include/khash.h
+++ b/include/khash.h
@@ -286,7 +286,7 @@ static const double __ac_HASH_UPPER = 0.77;
 							__ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */ \
 						} else { /* write the element and jump out of the loop */ \
 							h->keys[i] = key;							\
-							if (kh_is_map) h->vals[i] = val;			\
+							if (kh_is_map) new (&h->vals[i]) khval_t(val); \
 							break;										\
 						}												\
 					}													\

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -432,6 +432,7 @@ class ProxySQL_Admin {
 
 	unsigned int ProxySQL_Test___GenerateRandom_mysql_query_rules_fast_routing(unsigned int, bool);
 	bool ProxySQL_Test___Verify_mysql_query_rules_fast_routing(int *ret1, int *ret2, int cnt, int dual);
+	void save_mysql_qps_limit_rules_from_runtime(bool _runtime);
 	void ProxySQL_Test___MySQL_HostGroups_Manager_generate_many_clusters();
 	unsigned long long ProxySQL_Test___MySQL_HostGroups_Manager_read_only_action();
 #ifdef DEBUG

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -117,9 +117,15 @@ typedef struct _Query_Processor_rule_t QP_rule_t;
 struct QPS_Limit_Bucket {
 	TokenBucket token_bucket;
 	uint64_t session_queue;
+	int64_t qps_limit;
 
-	QPS_Limit_Bucket(const uint64_t rate, const uint64_t burst_size) :
-		token_bucket(rate, burst_size), session_queue(0) {}
+	QPS_Limit_Bucket(const int64_t qps_limit, const uint64_t burst_size) :
+		token_bucket(qps_limit, burst_size), session_queue(0), qps_limit(qps_limit) {}
+
+	void update(const int64_t qps_limit, const uint64_t burst_size) {
+		this->token_bucket.update(qps_limit, burst_size);
+		this->qps_limit = qps_limit;
+	}
 };
 
 KHASH_MAP_INIT_STR(khQPSLimitBucket, std::shared_ptr<QPS_Limit_Bucket>);

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -119,6 +119,8 @@ struct QPS_Limit_Bucket {
 	uint64_t session_queue;
 	int64_t qps_limit;
 
+	QPS_Limit_Bucket() = delete;
+
 	QPS_Limit_Bucket(const int64_t qps_limit, const uint64_t burst_size) :
 		token_bucket(qps_limit, burst_size), session_queue(0), qps_limit(qps_limit) {}
 

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -577,6 +577,13 @@ void MySQL_Session::reset() {
 			client_myds->myconn->reset();
 		}
 	}
+
+	if (this->qps_queue != NULL) {
+		__sync_fetch_and_sub(&this->qps_queue->session_queue, 1);
+
+		this->qps_queue.reset();
+		this->qps_queue = nullptr;
+	}
 }
 
 MySQL_Session::~MySQL_Session() {
@@ -2962,6 +2969,7 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 			clock_gettime(CLOCK_THREAD_CPUTIME_ID,&begint);
 		}
 		qpo=GloQPro->process_mysql_query(this,pkt.ptr,pkt.size,&CurrentQuery);
+		if (qpo->qps_queue != nullptr) this->qps_queue = qpo->qps_queue;
 		if (thread->variables.stats_time_query_processor) {
 			clock_gettime(CLOCK_THREAD_CPUTIME_ID,&endt);
 			thread->status_variables.stvar[st_var_query_processor_time] = thread->status_variables.stvar[st_var_query_processor_time] +
@@ -3099,6 +3107,7 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 			clock_gettime(CLOCK_THREAD_CPUTIME_ID,&begint);
 		}
 		qpo=GloQPro->process_mysql_query(this,NULL,0,&CurrentQuery);
+		if (qpo->qps_queue != nullptr) this->qps_queue = qpo->qps_queue;
 		if (qpo->max_lag_ms >= 0) {
 			thread->status_variables.stvar[st_var_queries_with_max_lag_ms]++;
 		}
@@ -3556,6 +3565,7 @@ __get_pkts_from_client:
 										clock_gettime(CLOCK_THREAD_CPUTIME_ID,&begint);
 									}
 									qpo=GloQPro->process_mysql_query(this,pkt.ptr,pkt.size,&CurrentQuery);
+									if (qpo->qps_queue != nullptr) this->qps_queue = qpo->qps_queue;
 									// This block was moved from 'handler_special_queries' to support
 									// handling of 'USE' statements which are preceded by a comment.
 									// For more context check issue: #3493.
@@ -4353,17 +4363,23 @@ handler_again:
 				handler_ret = 0;
 				return handler_ret;
 			}
-			if (qpo->qps_queue != NULL) {
-				bool got_token = qpo->qps_queue->token_bucket.consume(1);
-				if (got_token == false) {
+			if (this->qps_queue != NULL) {
+				const int64_t qps_limit = __sync_fetch_and_add(&this->qps_queue->qps_limit, 0);
+
+				if (qps_limit != -1 && this->qps_queue->token_bucket.consume(1) == false) {
 					// TODO: Fixed value now, should depend on 'qpo->qps_queue->session_queue'
+					// uint64_t cur_queue = __sync_fetch_and_add(&this->qps_queue->session_queue, 0);
+					// uint64_t time_per_token = 1000000 / tg_qps;
+					// this->pause_until = thread->curtime + cur_queue*time_per_token;
+
 					this->pause_until = thread->curtime + 10*1000;
 					handler_ret = 0;
 					return handler_ret;
 				} else {
-					__sync_fetch_and_sub(&qpo->qps_queue->session_queue, 1);
-					qpo->qps_queue.reset();
-					qpo->qps_queue = nullptr;
+					__sync_fetch_and_sub(&this->qps_queue->session_queue, 1);
+
+					this->qps_queue.reset();
+					this->qps_queue = nullptr;
 				}
 			}
 			if (mysql_thread___connect_timeout_server_max) {

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -4367,12 +4367,14 @@ handler_again:
 				const int64_t qps_limit = __sync_fetch_and_add(&this->qps_queue->qps_limit, 0);
 
 				if (qps_limit != -1 && this->qps_queue->token_bucket.consume(1) == false) {
-					// TODO: Fixed value now, should depend on 'qpo->qps_queue->session_queue'
-					// uint64_t cur_queue = __sync_fetch_and_add(&this->qps_queue->session_queue, 0);
-					// uint64_t time_per_token = 1000000 / tg_qps;
-					// this->pause_until = thread->curtime + cur_queue*time_per_token;
+					uint64_t cur_queue = __sync_fetch_and_add(&this->qps_queue->session_queue, 0);
+					uint64_t time_per_token = 0;
 
-					this->pause_until = thread->curtime + 10*1000;
+					if (qps_limit != 0) {
+						time_per_token = 1000000 / qps_limit;
+						this->pause_until = thread->curtime + cur_queue*time_per_token;
+					}
+
 					handler_ret = 0;
 					return handler_ret;
 				} else {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3141,7 +3141,8 @@ __run_skip_1a:
 		GloMyLogger->flush();
 
 		pre_poll_time=curtime;
-		int ttw = ( mypolls.poll_timeout ? ( mypolls.poll_timeout/1000 < (unsigned int) mysql_thread___poll_timeout ? mypolls.poll_timeout/1000 : mysql_thread___poll_timeout ) : mysql_thread___poll_timeout );
+		uint64_t new_poll_timeout = ceil(mypolls.poll_timeout/1000.0);
+		int ttw = ( mypolls.poll_timeout ? ( new_poll_timeout < (unsigned int) mysql_thread___poll_timeout ? new_poll_timeout : mysql_thread___poll_timeout ) : mysql_thread___poll_timeout );
 #ifdef IDLE_THREADS
 		if (GloVars.global.idle_threads && idle_maintenance_thread) {
 			memset(events,0,sizeof(struct epoll_event)*MY_EPOLL_THREAD_MAXEVENTS); // let's make valgrind happy. It also seems that needs to be zeroed anyway

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -5555,9 +5555,9 @@ void MySQL_Thread::tune_timeout_for_myds_needs_pause(MySQL_Data_Stream *myds) {
 void MySQL_Thread::tune_timeout_for_session_needs_pause(MySQL_Data_Stream *myds) {
 	// Verify that pause until is actually bigger that current time as for 'wait_until', otherwise
 	// we could be unnecessarily setting 'poll_timeout' to a negative value (two complement),
-	// for later imposing the max_vale of 'mysql_thread___poll_timeout'. Or even worse, if 'poll_timeout'
-	// was already set, and 'pause_until' matches 'curtime', we could be resetting the already set
-	// 'poll_timeout' to '0', causing to be later defaulted to 'mysql_thread___poll_timeout'.
+	// for later imposing 'mysql_thread___poll_timeout'. Or even worse, if 'poll_timeout' was already set, and
+	// 'pause_until' matches 'curtime', we could be resetting the already set 'poll_timeout' to '0', causing
+	// to be later defaulted to 'mysql_thread___poll_timeout'.
 	if (myds->sess->pause_until > curtime) {
 		if (mypolls.poll_timeout==0 || (myds->sess->pause_until - curtime < mypolls.poll_timeout)) {
 			// In case of 'poll_timeout' already set, pick the lowest value

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -5561,7 +5561,7 @@ void MySQL_Thread::tune_timeout_for_session_needs_pause(MySQL_Data_Stream *myds)
 	if (myds->sess->pause_until > curtime) {
 		if (mypolls.poll_timeout==0 || (myds->sess->pause_until - curtime < mypolls.poll_timeout)) {
 			// In case of 'poll_timeout' already set, pick the lowest value
-			uint32_t new_poll_timeout = myds->sess->pause_until - curtime;
+			uint64_t new_poll_timeout = myds->sess->pause_until - curtime;
 			if (mypolls.poll_timeout != 0) {
 				 if (new_poll_timeout < mypolls.poll_timeout) {
 					 mypolls.poll_timeout = new_poll_timeout;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3472,12 +3472,12 @@ bool MySQL_Thread::process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned
 					assert(myds->sess->status!=session_status___NONE);
 				} else {
 					// no events
-					if (myds->wait_until && curtime > myds->wait_until) {
+					if (myds->wait_until && curtime >= myds->wait_until) {
 						// timeout
 						myds->sess->to_process=1;
 						assert(myds->sess->status!=session_status___NONE);
 					} else {
-						if (myds->sess->pause_until && curtime > myds->sess->pause_until) {
+						if (myds->sess->pause_until && curtime >= myds->sess->pause_until) {
 							// timeout
 							myds->sess->to_process=1;
 						}
@@ -5477,11 +5477,11 @@ void MySQL_Thread::check_timing_out_session(unsigned int n) {
 	// no events. This section is copied from process_data_on_data_stream()
 	MySQL_Data_Stream *_myds=mypolls.myds[n];
 	if (_myds && _myds->sess) {
-		if (_myds->wait_until && curtime > _myds->wait_until) {
+		if (_myds->wait_until && curtime >= _myds->wait_until) {
 			// timeout
 			_myds->sess->to_process=1;
 		} else {
-			if (_myds->sess->pause_until && curtime > _myds->sess->pause_until) {
+			if (_myds->sess->pause_until && curtime >= _myds->sess->pause_until) {
 				// timeout
 				_myds->sess->to_process=1;
 			}
@@ -5537,8 +5537,7 @@ void MySQL_Thread::tune_timeout_for_myds_needs_pause(MySQL_Data_Stream *myds) {
 
 void MySQL_Thread::tune_timeout_for_session_needs_pause(MySQL_Data_Stream *myds) {
 	if (mypolls.poll_timeout==0 || (myds->sess->pause_until - curtime < mypolls.poll_timeout) ) {
-		uint64_t new_poll_timeout = myds->sess->pause_until - curtime;
-		mypolls.poll_timeout= new_poll_timeout == 0 ? 1 : new_poll_timeout;
+		mypolls.poll_timeout= myds->sess->pause_until - curtime;
 		proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 7, "Session=%p , poll_timeout=%llu , pause_until=%llu , curtime=%llu\n", mypolls.poll_timeout, myds->sess->pause_until, curtime);
 	}
 }

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -5537,7 +5537,8 @@ void MySQL_Thread::tune_timeout_for_myds_needs_pause(MySQL_Data_Stream *myds) {
 
 void MySQL_Thread::tune_timeout_for_session_needs_pause(MySQL_Data_Stream *myds) {
 	if (mypolls.poll_timeout==0 || (myds->sess->pause_until - curtime < mypolls.poll_timeout) ) {
-		mypolls.poll_timeout= myds->sess->pause_until - curtime;
+		uint64_t new_poll_timeout = myds->sess->pause_until - curtime;
+		mypolls.poll_timeout= new_poll_timeout == 0 ? 1 : new_poll_timeout;
 		proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 7, "Session=%p , poll_timeout=%llu , pause_until=%llu , curtime=%llu\n", mypolls.poll_timeout, myds->sess->pause_until, curtime);
 	}
 }

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -396,7 +396,7 @@ static int http_handler(void *cls, struct MHD_Connection *connection, const char
 
 #define ADMIN_SQLITE_TABLE_MYSQL_QUERY_RULES_FAST_ROUTING  "CREATE TABLE mysql_query_rules_fast_routing (username VARCHAR NOT NULL , schemaname VARCHAR NOT NULL , flagIN INT NOT NULL DEFAULT 0 , destination_hostgroup INT CHECK (destination_hostgroup >= 0) NOT NULL , comment VARCHAR NOT NULL , PRIMARY KEY (username, schemaname, flagIN) )"
 
-#define ADMIN_SQLITE_TABLE_MYSQL_QPS_LIMIT_RULES "CREATE TABLE mysql_qps_limit_rules (username VARCHAR NOT NULL, schemaname VARCHAR NOT NULL, flagIN INT NOT NULL DEFAULT 0, qps_limit INT NOT NULL DEFAULT 0, bucket_size INT NOT NULL DEFAULT 0, PRIMARY KEY (username, schemaname, flagIN) )"
+#define ADMIN_SQLITE_TABLE_MYSQL_QPS_LIMIT_RULES "CREATE TABLE mysql_qps_limit_rules (username VARCHAR NOT NULL , schemaname VARCHAR NOT NULL , flagIN INT NOT NULL DEFAULT 0 , qps_limit INT NOT NULL DEFAULT 0 , bucket_size INT NOT NULL DEFAULT 0 , PRIMARY KEY (username, schemaname, flagIN) )"
 
 #define ADMIN_SQLITE_TABLE_GLOBAL_VARIABLES "CREATE TABLE global_variables (variable_name VARCHAR NOT NULL PRIMARY KEY , variable_value VARCHAR NOT NULL)"
 
@@ -469,7 +469,7 @@ static int http_handler(void *cls, struct MHD_Connection *connection, const char
 
 #define ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QUERY_RULES_FAST_ROUTING  "CREATE TABLE runtime_mysql_query_rules_fast_routing (username VARCHAR NOT NULL , schemaname VARCHAR NOT NULL , flagIN INT NOT NULL DEFAULT 0 , destination_hostgroup INT CHECK (destination_hostgroup >= 0) NOT NULL , comment VARCHAR NOT NULL , PRIMARY KEY (username, schemaname, flagIN) )"
 
-#define ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QPS_LIMIT_RULES "CREATE TABLE runtime_mysql_qps_limit_rules (username VARCHAR NOT NULL, schemaname VARCHAR NOT NULL, flagIN INT NOT NULL DEFAULT 0, qps_limit INT NOT NULL DEFAULT 0, bucket_size INT NOT NULL DEFAULT 0, PRIMARY KEY (username, schemaname, flagIN) )"
+#define ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QPS_LIMIT_RULES "CREATE TABLE runtime_mysql_qps_limit_rules (username VARCHAR NOT NULL , schemaname VARCHAR NOT NULL , flagIN INT NOT NULL DEFAULT 0 , qps_limit INT NOT NULL DEFAULT 0 , bucket_size INT NOT NULL DEFAULT 0 , PRIMARY KEY (username, schemaname, flagIN) )"
 
 #define ADMIN_SQLITE_TABLE_RUNTIME_SCHEDULER "CREATE TABLE runtime_scheduler (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL , active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 1 , interval_ms INTEGER CHECK (interval_ms>=100 AND interval_ms<=100000000) NOT NULL , filename VARCHAR NOT NULL , arg1 VARCHAR , arg2 VARCHAR , arg3 VARCHAR , arg4 VARCHAR , arg5 VARCHAR , comment VARCHAR NOT NULL DEFAULT '')" 
 
@@ -9730,6 +9730,7 @@ void ProxySQL_Admin::__insert_or_replace_maintable_select_disktable() {
 	admindb->execute("INSERT OR REPLACE INTO main.mysql_users SELECT * FROM disk.mysql_users");
 	admindb->execute("INSERT OR REPLACE INTO main.mysql_query_rules SELECT * FROM disk.mysql_query_rules");
 	admindb->execute("INSERT OR REPLACE INTO main.mysql_query_rules_fast_routing SELECT * FROM disk.mysql_query_rules_fast_routing");
+	admindb->execute("INSERT OR REPLACE INTO main.mysql_qps_limit_rules SELECT * FROM disk.mysql_qps_limit_rules");
 	admindb->execute("INSERT OR REPLACE INTO main.mysql_firewall_whitelist_users SELECT * FROM disk.mysql_firewall_whitelist_users");
 	admindb->execute("INSERT OR REPLACE INTO main.mysql_firewall_whitelist_rules SELECT * FROM disk.mysql_firewall_whitelist_rules");
 	admindb->execute("INSERT OR REPLACE INTO main.mysql_firewall_whitelist_sqli_fingerprints SELECT * FROM disk.mysql_firewall_whitelist_sqli_fingerprints");

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -396,6 +396,8 @@ static int http_handler(void *cls, struct MHD_Connection *connection, const char
 
 #define ADMIN_SQLITE_TABLE_MYSQL_QUERY_RULES_FAST_ROUTING  "CREATE TABLE mysql_query_rules_fast_routing (username VARCHAR NOT NULL , schemaname VARCHAR NOT NULL , flagIN INT NOT NULL DEFAULT 0 , destination_hostgroup INT CHECK (destination_hostgroup >= 0) NOT NULL , comment VARCHAR NOT NULL , PRIMARY KEY (username, schemaname, flagIN) )"
 
+#define ADMIN_SQLITE_TABLE_MYSQL_QPS_LIMIT_RULES "CREATE TABLE mysql_qps_limit_rules (username VARCHAR NOT NULL, schemaname VARCHAR NOT NULL, flagIN INT NOT NULL DEFAULT 0, qps_limit INT NOT NULL DEFAULT 0, bucket_size INT NOT NULL DEFAULT 0, PRIMARY KEY (username, schemaname, flagIN) )"
+
 #define ADMIN_SQLITE_TABLE_GLOBAL_VARIABLES "CREATE TABLE global_variables (variable_name VARCHAR NOT NULL PRIMARY KEY , variable_value VARCHAR NOT NULL)"
 
 #define ADMIN_SQLITE_RUNTIME_GLOBAL_VARIABLES "CREATE TABLE runtime_global_variables (variable_name VARCHAR NOT NULL PRIMARY KEY , variable_value VARCHAR NOT NULL)"
@@ -466,6 +468,8 @@ static int http_handler(void *cls, struct MHD_Connection *connection, const char
 #define ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QUERY_RULES "CREATE TABLE runtime_mysql_query_rules (rule_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL , active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 0 , username VARCHAR , schemaname VARCHAR , flagIN INT CHECK (flagIN >= 0) NOT NULL DEFAULT 0 , client_addr VARCHAR , proxy_addr VARCHAR , proxy_port INT CHECK (proxy_port >= 0 AND proxy_port <= 65535), digest VARCHAR , match_digest VARCHAR , match_pattern VARCHAR , negate_match_pattern INT CHECK (negate_match_pattern IN (0,1)) NOT NULL DEFAULT 0 , re_modifiers VARCHAR DEFAULT 'CASELESS' , flagOUT INT CHECK (flagOUT >= 0), replace_pattern VARCHAR CHECK(CASE WHEN replace_pattern IS NULL THEN 1 WHEN replace_pattern IS NOT NULL AND match_pattern IS NOT NULL THEN 1 ELSE 0 END) , destination_hostgroup INT DEFAULT NULL , cache_ttl INT CHECK(cache_ttl > 0) , cache_empty_result INT CHECK (cache_empty_result IN (0,1)) DEFAULT NULL , cache_timeout INT CHECK(cache_timeout >= 0) , reconnect INT CHECK (reconnect IN (0,1)) DEFAULT NULL , timeout INT UNSIGNED CHECK (timeout >= 0) , retries INT CHECK (retries>=0 AND retries <=1000) , delay INT UNSIGNED CHECK (delay >=0) , next_query_flagIN INT UNSIGNED , mirror_flagOUT INT UNSIGNED , mirror_hostgroup INT UNSIGNED , error_msg VARCHAR , OK_msg VARCHAR , sticky_conn INT CHECK (sticky_conn IN (0,1)) , multiplex INT CHECK (multiplex IN (0,1,2)) , gtid_from_hostgroup INT UNSIGNED , log INT CHECK (log IN (0,1)) , apply INT CHECK(apply IN (0,1)) NOT NULL DEFAULT 0 , attributes VARCHAR CHECK (JSON_VALID(attributes) OR attributes = '') NOT NULL DEFAULT '' , comment VARCHAR)"
 
 #define ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QUERY_RULES_FAST_ROUTING  "CREATE TABLE runtime_mysql_query_rules_fast_routing (username VARCHAR NOT NULL , schemaname VARCHAR NOT NULL , flagIN INT NOT NULL DEFAULT 0 , destination_hostgroup INT CHECK (destination_hostgroup >= 0) NOT NULL , comment VARCHAR NOT NULL , PRIMARY KEY (username, schemaname, flagIN) )"
+
+#define ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QPS_LIMIT_RULES "CREATE TABLE runtime_mysql_qps_limit_rules (username VARCHAR NOT NULL, schemaname VARCHAR NOT NULL, flagIN INT NOT NULL DEFAULT 0, qps_limit INT NOT NULL DEFAULT 0, bucket_size INT NOT NULL DEFAULT 0, PRIMARY KEY (username, schemaname, flagIN) )"
 
 #define ADMIN_SQLITE_TABLE_RUNTIME_SCHEDULER "CREATE TABLE runtime_scheduler (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL , active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 1 , interval_ms INTEGER CHECK (interval_ms>=100 AND interval_ms<=100000000) NOT NULL , filename VARCHAR NOT NULL , arg1 VARCHAR , arg2 VARCHAR , arg3 VARCHAR , arg4 VARCHAR , arg5 VARCHAR , comment VARCHAR NOT NULL DEFAULT '')" 
 
@@ -2792,6 +2796,7 @@ bool admin_handler_command_load_or_save(char *query_no_space, unsigned int query
 			ProxySQL_Admin *SPA=(ProxySQL_Admin *)pa;
 			SPA->save_mysql_query_rules_from_runtime(false);
 			SPA->save_mysql_query_rules_fast_routing_from_runtime(false);
+			SPA->save_mysql_qps_limit_rules_from_runtime(false);
 			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Saved mysql query rules from RUNTIME\n");
 			SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL);
 			return false;
@@ -2957,6 +2962,7 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 	bool runtime_mysql_servers=false;
 	bool runtime_mysql_query_rules=false;
 	bool runtime_mysql_query_rules_fast_routing=false;
+	bool runtime_mysql_qps_limit_rules=false;
 
 	bool runtime_proxysql_servers=false;
 	bool runtime_checksums_values=false;
@@ -3090,6 +3096,9 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 			}
 			if (strstr(query_no_space,"runtime_mysql_query_rules_fast_routing")) {
 				runtime_mysql_query_rules_fast_routing=true; refresh=true;
+			}
+			if (strstr(query_no_space,"runtime_mysql_qps_limit_rules")) {
+				runtime_mysql_qps_limit_rules=true; refresh=true;
 			}
 			if (strstr(query_no_space,"runtime_scheduler")) {
 				runtime_scheduler=true; refresh=true;
@@ -3225,6 +3234,9 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 			}
 			if (runtime_mysql_query_rules_fast_routing) {
 				save_mysql_query_rules_fast_routing_from_runtime(true);
+			}
+			if (runtime_mysql_qps_limit_rules) {
+				save_mysql_qps_limit_rules_from_runtime(true);
 			}
 			if (runtime_scheduler) {
 				save_scheduler_runtime_to_database(true);
@@ -5597,6 +5609,8 @@ bool ProxySQL_Admin::init() {
 	insert_into_tables_defs(tables_defs_admin,"runtime_mysql_aws_aurora_hostgroups", ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_AWS_AURORA_HOSTGROUPS);
 	insert_into_tables_defs(tables_defs_admin,"mysql_query_rules", ADMIN_SQLITE_TABLE_MYSQL_QUERY_RULES);
 	insert_into_tables_defs(tables_defs_admin,"mysql_query_rules_fast_routing", ADMIN_SQLITE_TABLE_MYSQL_QUERY_RULES_FAST_ROUTING);
+	insert_into_tables_defs(tables_defs_admin,"mysql_qps_limit_rules", ADMIN_SQLITE_TABLE_MYSQL_QPS_LIMIT_RULES);
+	insert_into_tables_defs(tables_defs_admin,"runtime_mysql_qps_limit_rules", ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QPS_LIMIT_RULES);
 	insert_into_tables_defs(tables_defs_admin,"runtime_mysql_query_rules", ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QUERY_RULES);
 	insert_into_tables_defs(tables_defs_admin,"runtime_mysql_query_rules_fast_routing", ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_QUERY_RULES_FAST_ROUTING);
 	insert_into_tables_defs(tables_defs_admin,"global_variables", ADMIN_SQLITE_TABLE_GLOBAL_VARIABLES);
@@ -5632,6 +5646,7 @@ bool ProxySQL_Admin::init() {
 	insert_into_tables_defs(tables_defs_config,"mysql_aws_aurora_hostgroups", ADMIN_SQLITE_TABLE_MYSQL_AWS_AURORA_HOSTGROUPS);
 	insert_into_tables_defs(tables_defs_config,"mysql_query_rules", ADMIN_SQLITE_TABLE_MYSQL_QUERY_RULES);
 	insert_into_tables_defs(tables_defs_config,"mysql_query_rules_fast_routing", ADMIN_SQLITE_TABLE_MYSQL_QUERY_RULES_FAST_ROUTING);
+	insert_into_tables_defs(tables_defs_config,"mysql_qps_limit_rules", ADMIN_SQLITE_TABLE_MYSQL_QPS_LIMIT_RULES);
 	insert_into_tables_defs(tables_defs_config,"global_variables", ADMIN_SQLITE_TABLE_GLOBAL_VARIABLES);
 	// the table is not required to be present on disk. Removing it due to #1055
 	insert_into_tables_defs(tables_defs_config,"mysql_collations", ADMIN_SQLITE_TABLE_MYSQL_COLLATIONS);
@@ -9147,6 +9162,50 @@ void ProxySQL_Admin::save_mysql_query_rules_fast_routing_from_runtime(bool _runt
 	resultset = NULL;
 }
 
+void ProxySQL_Admin::save_mysql_qps_limit_rules_from_runtime(bool _runtime) {
+	if (_runtime) {
+		admindb->execute("DELETE FROM runtime_mysql_qps_limit_rules");
+	} else {
+		admindb->execute("DELETE FROM mysql_qps_limit_rules");
+	}
+
+	SQLite3_result * resultset=GloQPro->get_current_qps_limit_rules();
+	if (resultset) {
+		int rc = 0;
+		sqlite3_stmt* statement = NULL;
+		char* query = NULL;
+
+		if (_runtime) {
+			query = (char*)"INSERT INTO runtime_mysql_qps_limit_rules VALUES (?1, ?2, ?3, ?4, ?5)";
+		} else {
+			query = (char*)"INSERT INTO mysql_qps_limit_rules VALUES (?1, ?2, ?3, ?4, ?5)";
+		}
+
+		rc = admindb->prepare_v2(query, &statement);
+		ASSERT_SQLITE_OK(rc, admindb);
+
+		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
+			SQLite3_row *r1=*it;
+
+			rc=(*proxy_sqlite3_bind_text)(statement, 1, r1->fields[0], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb); // username
+			rc=(*proxy_sqlite3_bind_text)(statement, 2, r1->fields[1], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb); // schemaname
+			rc=(*proxy_sqlite3_bind_int64)(statement, 3, atoi(r1->fields[2])); ASSERT_SQLITE_OK(rc, admindb); // flagIn
+			rc=(*proxy_sqlite3_bind_int64)(statement, 4, atoi(r1->fields[3])); ASSERT_SQLITE_OK(rc, admindb); // QPS
+			rc=(*proxy_sqlite3_bind_int64)(statement, 5, atoi(r1->fields[4])); ASSERT_SQLITE_OK(rc, admindb); // (Burst) Bucket Size
+
+			SAFE_SQLITE3_STEP2(statement);
+			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, admindb);
+			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
+		}
+
+		(*proxy_sqlite3_finalize)(statement);
+	}
+
+	if(resultset) delete resultset;
+
+	resultset = NULL;
+}
+
 void ProxySQL_Admin::save_mysql_query_rules_from_runtime(bool _runtime) {
 	if (_runtime) {
 		admindb->execute("DELETE FROM runtime_mysql_query_rules");
@@ -9905,6 +9964,8 @@ void ProxySQL_Admin::flush_mysql_query_rules__from_disk_to_memory() {
 	admindb->execute("INSERT INTO main.mysql_query_rules SELECT * FROM disk.mysql_query_rules");
 	admindb->execute("DELETE FROM main.mysql_query_rules_fast_routing");
 	admindb->execute("INSERT INTO main.mysql_query_rules_fast_routing SELECT * FROM disk.mysql_query_rules_fast_routing");
+	admindb->execute("DELETE FROM main.mysql_qps_limit_rules");
+	admindb->execute("INSERT INTO main.mysql_qps_limit_rules SELECT * FROM disk.mysql_qps_limit_rules");
 	admindb->execute("PRAGMA foreign_keys = ON");
 	admindb->wrunlock();
 }
@@ -9916,6 +9977,8 @@ void ProxySQL_Admin::flush_mysql_query_rules__from_memory_to_disk() {
 	admindb->execute("INSERT INTO disk.mysql_query_rules SELECT * FROM main.mysql_query_rules");
 	admindb->execute("DELETE FROM disk.mysql_query_rules_fast_routing");
 	admindb->execute("INSERT INTO disk.mysql_query_rules_fast_routing SELECT * FROM main.mysql_query_rules_fast_routing");
+	admindb->execute("DELETE FROM disk.mysql_qps_limit_rules");
+	admindb->execute("INSERT INTO disk.mysql_qps_limit_rules SELECT * FROM main.mysql_qps_limit_rules");
 	admindb->execute("PRAGMA foreign_keys = ON");
 	admindb->wrunlock();
 }
@@ -11420,10 +11483,18 @@ char * ProxySQL_Admin::load_mysql_query_rules_to_runtime() {
 	SQLite3_result *resultset2 = NULL;
 	char *query2=(char *)"SELECT username, schemaname, flagIN, destination_hostgroup, comment FROM main.mysql_query_rules_fast_routing ORDER BY username, schemaname, flagIN";
 	admindb->execute_statement(query2, &error2 , &cols2 , &affected_rows2 , &resultset2);
+	char* error_qps_limit = NULL;
+	int cols_qps_limit = 0;
+	int affected_rows_qps_limit = 0;
+	SQLite3_result *resultset_qps_limit = NULL;
+	char* query_qps_limit = (char *)"SELECT username, schemaname, flagIN, qps_limit, bucket_size FROM main.mysql_qps_limit_rules ORDER BY username, schemaname, flagIN";
+	admindb->execute_statement(query_qps_limit, &error_qps_limit , &cols_qps_limit , &affected_rows_qps_limit , &resultset_qps_limit);
 	if (error) {
 		proxy_error("Error on %s : %s\n", query, error);
 	} else if (error2) {
 		proxy_error("Error on %s : %s\n", query2, error2);
+	} else if (error_qps_limit) {
+		proxy_error("Error on %s : %s\n", query_qps_limit, error_qps_limit);
 	} else {
 		GloQPro->wrlock();
 		if (checksum_variables.checksum_mysql_query_rules) {
@@ -11505,6 +11576,7 @@ char * ProxySQL_Admin::load_mysql_query_rules_to_runtime() {
 		}
 		GloQPro->sort(false);
 		GloQPro->load_fast_routing(resultset2);
+		GloQPro->load_qps_limits(resultset_qps_limit);
 		GloQPro->wrunlock();
 		GloQPro->commit();
 	}

--- a/test/tap/tests/test_qps_limit_rules-t.cpp
+++ b/test/tap/tests/test_qps_limit_rules-t.cpp
@@ -2,13 +2,26 @@
  * @file test_qps_limit_rules-t.cpp
  * @brief This test verifies the implementation of 'qps_limit_rules'.
  * @details The following checks are performed:
- *   - Test 1: Open several connections to ProxySQL using the same user, perform multiple queries per
- *     connections checking that:
- *       1. The rate is stable and matches the target value.
- *       2. It's evenly distributed between connections.
- *   - Test 2: Test that different sets of rules are updated and matched as expected. WIP
+ *   - Test 1: Checks that QPS limitation holds for a single connection.
+ *   - Test 2: Checks that:
+ *       1. For multiple connections the rate is stable and matches the target value.
+ *       2. It's evenly distributed between multiple connections.
+ *       3. The target global value of QPS matches the expected one, taking into account initial burst.
+ *       4. Completion of all queries is performed within the expected time interval, no query stalling took
+ *          place.
+ *   - Test 3: Checks that the QPS converge to the stablished limit within the expected time period after changing
+ *     the QPS limit and number of connections doesn't affect the outcome. Connections creation and query limits
+ *     are changed while serving traffic.
+ *   - Test 4: Checks that the different QPS limit configurations work as expected.
+ *       1. Creates three different rules for three different users.
+ *       2. Checks in different connections that the imposed rules are holding.
+ *       3. Populates 'mysql_qps_limit_rules' table with unused rules to force hashmap resizing. This tests
+ *       the changes performed to 'khash' value initialization for smart pointers.
+ *   - Test 5: Checks that '0' is a valid QPS value, and that when set connections matching the rules stall
+ *     until limit is changed, or removed.
  */
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <future>
@@ -30,44 +43,11 @@
 #include "command_line.h"
 #include "utils.h"
 
-using std::map;
 using std::string;
 using std::vector;
 using std::tuple;
 
 using hrc = std::chrono::high_resolution_clock;
-
-map<string,vector<string>> fetch_row_values_(MYSQL_RES* res) {
-	map<string, vector<string>> row_map {};
-
-	if (res == NULL) {
-		return row_map;
-	}
-
-	std::vector<std::string> field_names {};
-
-	MYSQL_ROW row = nullptr;
-	int num_fields = mysql_num_fields(res);
-	MYSQL_FIELD* fields = mysql_fetch_fields(res);
-
-	for(int i = 0; i < num_fields; i++) {
-		row_map.insert({string { fields[i].name }, vector<string> {}});
-	}
-
-	while ((row = mysql_fetch_row(res))) {
-		for(int i = 0; i < num_fields; i++) {
-			string field_name { fields[i].name };
-
-			if (row[i]) {
-				row_map[field_name].push_back(row[i]);
-			} else {
-				row_map[field_name].push_back("");
-			}
-		}
-	}
-
-	return row_map;
-}
 
 struct conn_opts {
 	string host;
@@ -104,12 +84,16 @@ const string t_qps_limit_rule {
 	" VALUES ('%s', '%s', %d, %d, %d)"
 };
 
+const string t_update_qps_limit_rule {
+	"UPDATE mysql_qps_limit_rules SET qps_limit=%d, bucket_size=%d WHERE username='%s' AND schemaname='%s' AND flagIN='%d'"
+};
+
 int conn_query_executor(
-	MYSQL* proxysql, const string query, const uint64_t delay_ms, uint64_t* query_count, bool* stop
+	MYSQL* proxysql, const string query, const uint64_t delay_ms, uint64_t* query_count, char* stop
 ) {
 	usleep(delay_ms * 1000);
 
-	while(__sync_fetch_and_add((char*)stop, 0) == 0) {
+	while(__sync_fetch_and_add(stop, 0) == 0) {
 		MYSQL_QUERY(proxysql, query.c_str());
 		MYSQL_RES* myres = mysql_use_result(proxysql);
 		if (myres != nullptr) { mysql_free_result(myres); }
@@ -124,17 +108,79 @@ double ret_expected_qps(const int64_t qps_limit, const uint64_t burst_size, doub
 	return ((qps_limit + burst_size) + (qps_limit * (time - 1))) / time;
 }
 
-int check_single_conn_qps_limits_count(MYSQL* proxysql, const int64_t qps_limit, const uint64_t burst_size) {
+int stop_workers(
+	vector<MYSQL*>& cur_conns, vector<std::future<int>>& workers, vector<uint64_t>& query_counts,
+	vector<char>& stop_flags, uint32_t workers_num
+) {
+	if (query_counts.size() != stop_flags.size()) { return EXIT_FAILURE; }
+
+	uint32_t cur_worker_num = workers.size() - 1;
+	uint32_t rc_code = 0;
+
+	for (uint32_t i = 0; i < workers_num; i++) {
+		std::future<int>& worker = workers[cur_worker_num - i];
+		MYSQL* conn = cur_conns[cur_worker_num - i];
+		stop_flags[cur_worker_num - i] = 1;
+		query_counts[cur_worker_num - i] = 0;
+
+		rc_code |= worker.get();
+		mysql_close(conn);
+		cur_conns.pop_back();
+		workers.pop_back();
+
+		if (rc_code != EXIT_SUCCESS) {
+			break;
+		}
+	}
+
+	return rc_code;
+}
+
+int add_workers(
+	const conn_opts& conn_opts, const string& query, vector<MYSQL*>& cur_conns, vector<std::future<int>>& workers,
+	vector<uint64_t>& query_counts, vector<char>& stop_flags, uint32_t workers_num
+) {
+	if (query_counts.size() != stop_flags.size()) { return EXIT_FAILURE; }
+
+	uint32_t worker_num = 0;
+	uint32_t rc_code = 0;
+
+	vector<MYSQL*> conns {};
+	rc_code = create_connections(conn_opts, workers_num, conns);
+	if (rc_code != EXIT_SUCCESS) { return rc_code; }
+
+	for (MYSQL* conn : conns) {
+		worker_num = workers.size();
+		if (worker_num > query_counts.size()) {
+			rc_code = 2;
+			break;
+		} else {
+			workers.push_back(
+				std::async(
+					conn_query_executor, conn, query, 0, &query_counts[worker_num], &stop_flags[worker_num]
+				)
+			);
+		}
+	}
+
+	cur_conns.insert(cur_conns.end(), conns.begin(), conns.end());
+
+	return rc_code;
+}
+
+int check_single_conn_qps_limits_count(
+	MYSQL* proxysql, const string query, const int64_t qps_limit, const uint64_t burst_size
+) {
 	double CONN_TIME = 2.0;
 	double WAIT_TIME_US = CONN_TIME*pow(10, 6);
 
 	uint64_t query_count = 0;
-	bool stop = 0;
+	char stop = 0;
 
 	std::chrono::nanoseconds duration;
 	hrc::time_point start = hrc::now();
 
-	auto future = std::async(conn_query_executor, proxysql, "SELECT 1", 0, &query_count, &stop);
+	auto future = std::async(conn_query_executor, proxysql, query, 0, &query_count, &stop);
 
 	usleep(WAIT_TIME_US);
 	__sync_fetch_and_add((char*)&stop, 1);
@@ -172,12 +218,12 @@ int check_single_conn_qps_limits_count(MYSQL* proxysql, const int64_t qps_limit,
 
 int check_multi_conn_qps_limits_count(vector<MYSQL*> conns, const int64_t qps_limit, const uint64_t burst_size) {
 	uint32_t init_delay = 500;
-	double CONN_TIME = 10.0;
+	double CONN_TIME = 5.0;
 	double WAIT_TIME_US = CONN_TIME*pow(10, 6) + init_delay*1000;
 
 	vector<std::future<int>> conns_ths {};
 	vector<uint64_t> conns_count(conns.size(), { 0 });
-	bool stop = 0;
+	char stop = 0;
 	size_t conn_pos = 0;
 
 	std::chrono::nanoseconds duration;
@@ -192,7 +238,7 @@ int check_multi_conn_qps_limits_count(vector<MYSQL*> conns, const int64_t qps_li
 	}
 
 	usleep(WAIT_TIME_US);
-	__sync_fetch_and_add((char*)&stop, 1);
+	__sync_fetch_and_add(&stop, 1);
 
 	int conns_res = EXIT_SUCCESS;
 	for (std::future<int>& conn_th : conns_ths) {
@@ -221,43 +267,176 @@ int check_multi_conn_qps_limits_count(vector<MYSQL*> conns, const int64_t qps_li
 	size_t conn_num = 0;
 	uint64_t total_query_count = 0;
 	for (uint64_t query_count : conns_count) {
-		double expected_qps = ret_expected_qps(qps_limit, burst_size, CONN_TIME) / conns.size();
-		uint32_t EPSILON = (expected_qps * 15) / 100;
+		double exp_conn_qps = ret_expected_qps(qps_limit, burst_size, CONN_TIME) / conns.size();
+		uint32_t conn_epsilon = (exp_conn_qps * 25) / 100;
 
 		bool condition =
 			conns_res == EXIT_SUCCESS &&
-			(query_count / CONN_TIME) > expected_qps - EPSILON && (query_count / CONN_TIME) < expected_qps + EPSILON;
+			(query_count / CONN_TIME) > exp_conn_qps - conn_epsilon && (query_count / CONN_TIME) < exp_conn_qps + conn_epsilon;
 
 		ok(
 			condition,
 			"Expected QPS for conn_num '%ld':"
 			" { err: '%d', burst_size: '%ld', QPS_Limit: '%ld', Exp_QPS: '%lf', QPS: '%lf', EPSILON: '%d' }",
-			conn_num, conns_res, burst_size, qps_limit, expected_qps, query_count / CONN_TIME, EPSILON
+			conn_num, conns_res, burst_size, qps_limit, exp_conn_qps, query_count / CONN_TIME, conn_epsilon
 		);
 
 		conn_num += 1;
 		total_query_count += query_count;
 	}
-	diag("Total query count: '%d'\n", total_query_count);
+
+	double exp_qps = ret_expected_qps(qps_limit, burst_size, CONN_TIME);
+	double total_qps = total_query_count / CONN_TIME;
+	double total_qps_epsilon = (qps_limit * 10) / 100.0;
+
+	ok(
+		total_qps > exp_qps - total_qps_epsilon && total_qps < exp_qps + total_qps_epsilon,
+		"Averall QPS: { Total_Queries: '%ld', Exp_QPS: '%lf', QPS: '%lf', Epsilon: '%lf' }",
+		total_query_count, exp_qps, total_qps, total_qps_epsilon
+	);
 	diag("");
 
 	return EXIT_SUCCESS;
+}
+
+int check_multi_conn_qps_limits_conv(vector<MYSQL*> conns, const int64_t qps_limit, const uint64_t burst_size) {
+	uint32_t init_delay = 500;
+	double CONN_TIME = 5.0;
+	double WAIT_TIME_US = CONN_TIME*pow(10, 6) + init_delay*1000;
+
+	vector<std::future<int>> conns_ths {};
+	vector<uint64_t> conns_count(conns.size(), { 0 });
+	char stop = 0;
+	size_t conn_pos = 0;
+
+	std::chrono::nanoseconds duration;
+	hrc::time_point start = hrc::now();
+
+	for (MYSQL* conn : conns) {
+		conns_ths.push_back(std::async(
+			conn_query_executor, conn, "SELECT 1", init_delay, &conns_count[conn_pos], &stop
+		));
+
+		conn_pos += 1;
+	}
+
+	hrc::time_point end = hrc::now();
+	duration = end - start;
+
+	double duration_s = duration.count() / pow(10,9);
+	double duration_epsilon = (duration_s * 10) / 100;
+	double wait_time_s = WAIT_TIME_US / pow(10, 6);
+
+	usleep(WAIT_TIME_US);
+	__sync_fetch_and_add(&stop, 1);
+
+	return EXIT_SUCCESS;
+}
+
+double check_target_qps(
+	vector<uint64_t>& query_counts, uint64_t qps_limit, uint32_t epsilon, double timeout_s, uint32_t* cur_qps
+) {
+	bool qps_limit_reached = false;
+	bool timeout = false;
+
+	uint32_t current_qps = 0;
+	uint32_t time_waited = 0;
+	uint64_t prev_query_count = 0;
+
+	std::chrono::nanoseconds duration;
+	hrc::time_point start = hrc::now();
+
+	while(qps_limit_reached == false && timeout == false) {
+		sleep(1);
+
+		uint64_t cur_query_count = 0;
+		for (size_t i = 0; i < query_counts.size(); i++) {
+			cur_query_count += __sync_fetch_and_add(&query_counts[i], 0);
+		}
+
+		current_qps = cur_query_count - prev_query_count;
+
+		if (qps_limit != 0 && current_qps > (qps_limit - epsilon) && current_qps < (qps_limit + epsilon)) {
+			qps_limit_reached = true;
+		} else {
+			prev_query_count = cur_query_count;
+			if (time_waited >= timeout_s) {
+				timeout = true;
+			}
+		}
+
+		time_waited += 1;
+	}
+
+	hrc::time_point end = hrc::now();
+	duration = end - start;
+	double duration_s = duration.count() / pow(10,9);
+
+	*cur_qps = current_qps;
+
+	if (qps_limit_reached == true) {
+		return duration_s;
+	} else {
+		return 0;
+	}
+}
+
+void stop_all_workers(vector<std::future<int>>& workers, vector<char>& stop_flags) {
+	for (uint32_t i = 0; i < workers.size(); i++) {
+		stop_flags[i] = 1;
+	}
+	for (std::future<int>& worker : workers) {
+		worker.get();
+	}
 }
 
 using qps_limit = uint64_t;
 using burst_size = uint64_t;
 using std::pair;
 
+using user = string;
+using pass = string;
+using schema = string;
+using flagIN = uint32_t;
+
 const vector<pair<qps_limit,burst_size>> tests_payloads {
-	// { 1000, 20 }, { 1000, 50 }, { 1000, 100 },
-	// { 1000, 150 }, { 1000, 500 }, { 1000, 500 },
-	{ 1500, 1600 }, { 2000, 2000 }, { 2000, 3000 },
+	{ 1000, 20 }, { 1000, 50 },  { 500, 100 }, { 1000, 1500 }, { 1000, 150 },
+	{ 1000, 500 }, { 1000, 500 }, { 1500, 1600 }, { 2000, 2000 }, { 2000, 3000 }
 };
+
+const uint32_t test_2_max_conns = 35;
+const uint32_t test_2_min_conns = 5;
+const uint32_t test_2_its = (test_2_max_conns - test_2_min_conns) / 10;
+
+using test_config = tuple<user,pass,schema,flagIN,string>;
+
+vector<test_config> test_4_configs {
+	std::make_tuple("sbtest1", "sbtest1", "", 0, "SELECT 1"),
+	std::make_tuple("sbtest2", "sbtest2", "qps_limit_db", 0, "SELECT 1"),
+	std::make_tuple("sbtest3", "sbtest3", "qps_limit_db", 3, "DO 1")
+};
+const vector<pair<qps_limit,burst_size>> test_4_payloads { { 1000, 20 }, { 2000, 20 } };
+const vector<pair<qps_limit,burst_size>> test_5_payloads { { 200, 1000 }, { 1000, 500 } };
+
+vector<int32_t> test_2_target_conns { 10, 20, 10, 5, 40, 9 };
+vector<int32_t> test_3_target_conns { 10, 20, 10, 5, 40, 9 };
+vector<int32_t> test_5_target_conns { 1, 20, 5, 10, 35 };
 
 int main(int argc, char** argv) {
 	CommandLine cl;
 
-	plan(tests_payloads.size() * 5);
+	plan(
+		// Test 1: Expected tests
+		tests_payloads.size()*2 +
+		// Test 2: Expected tests
+		10*tests_payloads.size()*((test_2_its + 1)*test_2_its/2) + test_2_its*tests_payloads.size()*2 - test_2_its*5*tests_payloads.size() +
+		// Test 3: Expected tests
+		tests_payloads.size() * test_3_target_conns.size() +
+		// Test 4: Expected tests
+		test_4_payloads.size() * test_4_configs.size() * 4 +
+		// Test 5: Expected tests
+		test_5_payloads.size() * test_5_target_conns.size() * 2
+	);
 
 	if (cl.getEnv()) {
 		diag("Failed to get the required environmental variables.");
@@ -270,8 +449,7 @@ int main(int argc, char** argv) {
 		return EXIT_FAILURE;
 	}
 
-	// Test 1: a) Check QPS limitation holds for a single connection
-	/*
+	// Test 1: See description on top
 	{
 		const string TEST_USER { "sbtest1" };
 		const string TEST_PASS { "sbtest1" };
@@ -294,10 +472,10 @@ int main(int argc, char** argv) {
 			MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
 			MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
 
-			// Give at least 1s between executions
-			usleep(1000 * 1000);
+			// Wait for the QPS counting to stabilize after the previous value
+			usleep(qps_limit*1000 + 500*1000);
 
-			int test_rc = check_single_conn_qps_limits_count(proxysql, qps_limit, burst_size);
+			int test_rc = check_single_conn_qps_limits_count(proxysql, "SELECT 1", qps_limit, burst_size);
 			if (test_rc != EXIT_SUCCESS) { return EXIT_FAILURE; }
 		}
 
@@ -306,17 +484,14 @@ int main(int argc, char** argv) {
 		// Give some time for the update
 		usleep(500 * 1000);
 	}
-	*/
 
-	// Test 1: b) Check that:
-	//   1. For multiple connections the rate is stable and matches the target value.
-	//   2. It's evenly distributed between multiple connections.
+	// Test 2: See description on top
 	{
 		const string TEST_USER { "sbtest1" };
 		const string TEST_PASS { "sbtest1" };
 
 		conn_opts conn_opts { cl.host, TEST_USER, TEST_PASS, cl.port };
-		for (int i = 9; i < 10; i++) {
+		for (int i = 5; i < test_2_max_conns; i += 10) {
 			vector<MYSQL*> conns {};
 			int conns_err = create_connections(conn_opts, i, conns);
 			if (conns_err != EXIT_SUCCESS) { return EXIT_FAILURE; }
@@ -333,8 +508,8 @@ int main(int argc, char** argv) {
 				MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
 				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
 
-				// Give at least 1s between executions
-				usleep(1000 * 1000);
+				// Wait for the QPS counting to stabilize after the previous value
+				usleep(qps_limit*1000 + 500*1000);
 
 				int test_rc = check_multi_conn_qps_limits_count(conns, qps_limit, burst_size);
 				if (test_rc != EXIT_SUCCESS) { return EXIT_FAILURE; }
@@ -346,7 +521,264 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// Test 2: WIP
+	// Test 3: See description on top
+	{
+		const string TEST_USER { "sbtest1" };
+		const string TEST_PASS { "sbtest1" };
+
+		uint64_t max_conn_num = static_cast<uint64_t>(*std::max_element(test_3_target_conns.begin(), test_3_target_conns.end()));
+		conn_opts conn_opts { cl.host, TEST_USER, TEST_PASS, cl.port };
+
+		int32_t cur_conns = 0;
+		vector<MYSQL*> conns {};
+		vector<std::future<int>> workers {};
+		vector<uint64_t> query_counts(max_conn_num, { 0 });
+		vector<char> stop_flags(max_conn_num, { 0 });
+
+		for (int tg_conns : test_3_target_conns) {
+			int32_t conns_diff = tg_conns - cur_conns;
+
+			if (conns_diff < 0) {
+				diag("Removing '%d' worker threads...", std::abs(conns_diff));
+				int stop_res = stop_workers(conns, workers, query_counts, stop_flags, std::abs(conns_diff));
+				if (stop_res != EXIT_SUCCESS) {
+					diag("Failed to stop workers with error: '%d'", stop_res);
+					return EXIT_FAILURE;
+				}
+			} else {
+				diag("Adding '%d' worker threads...", conns_diff);
+				int add_res = add_workers(
+						conn_opts, "SELECT 1", conns, workers, query_counts, stop_flags, std::abs(conns_diff)
+					);
+				if (add_res != EXIT_SUCCESS) {
+					diag("Failed to add workers with error: '%d'", add_res);
+					return EXIT_FAILURE;
+				}
+			}
+			cur_conns = conns.size();
+
+			diag("Started checking test payloads...");
+			for (const auto& test_payload : tests_payloads) {
+				uint32_t qps_limit = test_payload.first;
+				uint32_t burst_size = test_payload.second;
+
+				// Setup 'qps_limit_rules'
+				string user_limit_rule {};
+				string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), "", 0, qps_limit, burst_size);
+
+				MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+				MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+				double timeout_s = (qps_limit*1000 + 500*1000) / pow(10, 6);
+				timeout_s = timeout_s < 1 ? 1 : timeout_s;
+				uint32_t epsilon = qps_limit * 10 / 100;
+				uint32_t current_qps = 0;
+
+				double duration_s = check_target_qps(query_counts, qps_limit, epsilon, timeout_s, &current_qps);
+
+				ok(
+					static_cast<uint32_t>(duration_s) != 0,
+					"Target QPS limit reached before timeout: { qps_limit: '%d', qps: '%d', epsilon: '%d', duration: '%lf' }",
+					qps_limit, current_qps, epsilon, duration_s
+				);
+			}
+		}
+
+		stop_all_workers(workers, stop_flags);
+		for (MYSQL* conn : conns) {
+			mysql_close(conn);
+		}
+	}
+
+	// Test 4: See description on top
+	{
+		vector<MYSQL*> tests_conns {};
+
+		for (const test_config& test_config : test_4_configs) {
+			const string& TEST_USER = std::get<0>(test_config);
+			const string& TEST_PASS = std::get<1>(test_config);
+
+			MYSQL* conn = mysql_init(NULL);
+			if (!mysql_real_connect(conn, cl.host, TEST_USER.c_str(), TEST_PASS.c_str(), NULL, cl.port, NULL, 0)) {
+				fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(conn));
+				return EXIT_FAILURE;
+			}
+
+			tests_conns.push_back(conn);
+		}
+
+		// Cleanup and prepare
+		MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+		MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_query_rules WHERE rule_id=3");
+		MYSQL_QUERY(
+			proxysql_admin,
+			"INSERT INTO mysql_query_rules (rule_id,active,flagOUT,match_digest,destination_hostgroup,apply)"
+			" VALUES (3,1,3,'^DO',1,1)"
+		);
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+		// Second connection
+		MYSQL_QUERY(tests_conns[1], "DROP DATABASE IF EXISTS qps_limit_db");
+		MYSQL_QUERY(tests_conns[1], "CREATE DATABASE qps_limit_db");
+
+		MYSQL_QUERY(tests_conns[1], "USE qps_limit_db");
+		MYSQL_QUERY(tests_conns[2], "USE qps_limit_db");
+
+		for (const auto& test_payload : test_4_payloads) {
+			uint32_t config_num = 0;
+			uint32_t qps_limit = test_payload.first;
+			uint32_t burst_size = test_payload.second;
+
+			MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+			for (const test_config& test_config : test_4_configs) {
+				const string& TEST_USER = std::get<0>(test_config);
+				const string& schema = std::get<2>(test_config);
+				const uint32_t flagIN = std::get<3>(test_config);
+
+				string user_limit_rule {};
+				string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), schema.c_str(), flagIN, qps_limit, burst_size);
+
+				MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+			}
+
+			for (MYSQL* conn : tests_conns) {
+				const string& TEST_USER = std::get<0>(test_4_configs[config_num]);
+				const string& schemaname = std::get<2>(test_4_configs[config_num]);
+				const uint32_t flagIN = std::get<3>(test_4_configs[config_num]);
+				const string& query = std::get<4>(test_4_configs[config_num]);
+
+				// Setup 'qps_limit_rules'
+				string user_limit_rule {};
+				string_format(
+					t_update_qps_limit_rule, user_limit_rule, qps_limit, burst_size, TEST_USER.c_str(),
+					schemaname.c_str(), flagIN
+				);
+
+				MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+				// Wait for the QPS counting to stabilize after the previous value
+				usleep(qps_limit*1000 + 500*1000);
+
+				int test_rc = check_single_conn_qps_limits_count(conn, query.c_str(), qps_limit, burst_size);
+				if (test_rc != EXIT_SUCCESS) { return EXIT_FAILURE; }
+
+				MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules WHERE username NOT IN ('sbtest1', 'sbtest2', 'sbtest3')");
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+				// Fill the map with random unused keys
+				for (uint32_t i = 4; i < 1024; i++) {
+					const string TEST_USER { "sbtest" + std::to_string(i) };
+					string user_limit_rule {};
+					string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), "qps_limit_db", i, 0, 0);
+
+					MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+				}
+
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+				test_rc = check_single_conn_qps_limits_count(conn, query.c_str(), qps_limit, burst_size);
+				if (test_rc != EXIT_SUCCESS) { return EXIT_FAILURE; }
+
+				config_num += 1;
+			}
+		}
+
+		for (MYSQL* conn : tests_conns) {
+			mysql_close(conn);
+		}
+	}
+
+	// Test 5: See description on top
+	{
+		const string TEST_USER { "sbtest1" };
+		const string TEST_PASS { "sbtest1" };
+
+		uint64_t max_conn_num = static_cast<uint64_t>(*std::max_element(test_5_target_conns.begin(), test_5_target_conns.end()));
+		conn_opts conn_opts { cl.host, TEST_USER, TEST_PASS, cl.port };
+
+		int32_t cur_conns = 0;
+		vector<MYSQL*> conns {};
+		vector<std::future<int>> workers {};
+		vector<uint64_t> query_counts(max_conn_num, { 0 });
+		vector<char> stop_flags(max_conn_num, { 0 });
+
+		for (int target_conns : test_5_target_conns) {
+			int32_t conns_diff = target_conns - cur_conns;
+
+			if (conns_diff < 0) {
+				diag("Removing '%d' worker threads...", std::abs(conns_diff));
+				int stop_res = stop_workers(conns, workers, query_counts, stop_flags, std::abs(conns_diff));
+				if (stop_res != EXIT_SUCCESS) {
+					diag("Failed to stop workers with error: '%d'", stop_res);
+					return EXIT_FAILURE;
+				}
+			} else {
+				diag("Adding '%d' worker threads...", conns_diff);
+				int add_res = add_workers(
+						conn_opts, "SELECT 1", conns, workers, query_counts, stop_flags, std::abs(conns_diff)
+					);
+				if (add_res != EXIT_SUCCESS) {
+					diag("Failed to add workers with error: '%d'", add_res);
+					return EXIT_FAILURE;
+				}
+			}
+			cur_conns = conns.size();
+
+			diag("Started checking test payloads...");
+			for (const auto& test_payload : test_5_payloads) {
+				uint32_t qps_limit = test_payload.first;
+				uint32_t burst_size = test_payload.second;
+
+				// Setup 'qps_limit_rules'
+				string user_limit_rule {};
+				string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), "", 0, qps_limit, burst_size);
+
+				MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+				MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+				double timeout_s = (qps_limit*1000 + 500*1000) / pow(10, 6);
+				timeout_s = timeout_s < 1 ? 1 : timeout_s;
+				uint32_t epsilon = qps_limit * 10 / 100;
+				uint32_t current_qps = 0;
+				uint32_t zero_qps_timeout = 2;
+
+				double duration_s = check_target_qps(query_counts, qps_limit, epsilon, timeout_s, &current_qps);
+
+				ok(
+					duration_s != 0,
+					"Target QPS limit reached before timeout: { qps_limit: '%d', qps: '%d', epsilon: '%d', duration: '%lf' }",
+					qps_limit, current_qps, epsilon, duration_s
+				);
+
+				string update_user_limit_rule {};
+				string_format(t_update_qps_limit_rule, update_user_limit_rule, 0, 0, TEST_USER.c_str(), "", 0);
+				MYSQL_QUERY(proxysql_admin, update_user_limit_rule.c_str());
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+				duration_s = check_target_qps(query_counts, 0, epsilon, zero_qps_timeout, &current_qps);
+
+				ok(
+					static_cast<uint32_t>(duration_s) == 0 && current_qps == 0,
+					"Zero QPS during specified time: { qps_limit: '%d', qps: '%d', epsilon: '%d', duration: '%d' }",
+					qps_limit, current_qps, 0, zero_qps_timeout
+				);
+
+				// Unblock the connections
+				MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+			}
+		}
+
+		stop_all_workers(workers, stop_flags);
+		for (MYSQL* conn : conns) {
+			mysql_close(conn);
+		}
+
+		MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+	}
 
 	mysql_close(proxysql_admin);
 

--- a/test/tap/tests/test_qps_limit_rules-t.cpp
+++ b/test/tap/tests/test_qps_limit_rules-t.cpp
@@ -4,19 +4,22 @@
  * @details The following checks are performed:
  *   - Test 1: Open several connections to ProxySQL using the same user, perform multiple queries per
  *     connections checking that:
- *       1. The rate is stable and matches the target value. WIP
- *       2. It's evenly distributed between connections. WIP
- *   - Test 2: WIP
- *   - Test 3: WIP
+ *       1. The rate is stable and matches the target value.
+ *       2. It's evenly distributed between connections.
+ *   - Test 2: Test that different sets of rules are updated and matched as expected. WIP
  */
 
 #include <chrono>
 #include <cstring>
+#include <future>
 #include <iostream>
 #include <map>
 #include <vector>
 #include <string>
 #include <stdio.h>
+#include <tuple>
+#include <thread>
+#include <mutex>
 #include <unistd.h>
 
 #include <mysql.h>
@@ -27,14 +30,234 @@
 #include "command_line.h"
 #include "utils.h"
 
+using std::map;
 using std::string;
+using std::vector;
+using std::tuple;
 
 using hrc = std::chrono::high_resolution_clock;
+
+map<string,vector<string>> fetch_row_values_(MYSQL_RES* res) {
+	map<string, vector<string>> row_map {};
+
+	if (res == NULL) {
+		return row_map;
+	}
+
+	std::vector<std::string> field_names {};
+
+	MYSQL_ROW row = nullptr;
+	int num_fields = mysql_num_fields(res);
+	MYSQL_FIELD* fields = mysql_fetch_fields(res);
+
+	for(int i = 0; i < num_fields; i++) {
+		row_map.insert({string { fields[i].name }, vector<string> {}});
+	}
+
+	while ((row = mysql_fetch_row(res))) {
+		for(int i = 0; i < num_fields; i++) {
+			string field_name { fields[i].name };
+
+			if (row[i]) {
+				row_map[field_name].push_back(row[i]);
+			} else {
+				row_map[field_name].push_back("");
+			}
+		}
+	}
+
+	return row_map;
+}
+
+struct conn_opts {
+	string host;
+	string user;
+	string pass;
+	int port;
+};
+
+int create_connections(const conn_opts& conn_opts, uint32_t cons_num, std::vector<MYSQL*>& proxy_conns) {
+	std::vector<MYSQL*> result {};
+
+	for (uint32_t i = 0; i < cons_num; i++) {
+		MYSQL* proxysql_mysql = mysql_init(NULL);
+
+		if (
+			!mysql_real_connect(
+				proxysql_mysql, conn_opts.host.c_str(), conn_opts.user.c_str(), conn_opts.pass.c_str(),
+				NULL, conn_opts.port, NULL, 0
+			)
+		) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_mysql));
+			return EXIT_FAILURE;
+		} else {
+			result.push_back(proxysql_mysql);
+		}
+	}
+
+	proxy_conns = result;
+	return EXIT_SUCCESS;
+}
+
+const string t_qps_limit_rule {
+	"INSERT INTO mysql_qps_limit_rules (username, schemaname, flagIN, qps_limit, bucket_size)"
+	" VALUES ('%s', '%s', %d, %d, %d)"
+};
+
+int conn_query_executor(
+	MYSQL* proxysql, const string query, const uint64_t delay_ms, uint64_t* query_count, bool* stop
+) {
+	usleep(delay_ms * 1000);
+
+	while(__sync_fetch_and_add((char*)stop, 0) == 0) {
+		MYSQL_QUERY(proxysql, query.c_str());
+		MYSQL_RES* myres = mysql_use_result(proxysql);
+		if (myres != nullptr) { mysql_free_result(myres); }
+		__sync_fetch_and_add(query_count, 1);
+	}
+
+	return EXIT_SUCCESS;
+}
+
+double ret_expected_qps(const int64_t qps_limit, const uint64_t burst_size, double time) {
+	if (time == 0) { return 0; }
+	return ((qps_limit + burst_size) + (qps_limit * (time - 1))) / time;
+}
+
+int check_single_conn_qps_limits_count(MYSQL* proxysql, const int64_t qps_limit, const uint64_t burst_size) {
+	double CONN_TIME = 2.0;
+	double WAIT_TIME_US = CONN_TIME*pow(10, 6);
+
+	uint64_t query_count = 0;
+	bool stop = 0;
+
+	std::chrono::nanoseconds duration;
+	hrc::time_point start = hrc::now();
+
+	auto future = std::async(conn_query_executor, proxysql, "SELECT 1", 0, &query_count, &stop);
+
+	usleep(WAIT_TIME_US);
+	__sync_fetch_and_add((char*)&stop, 1);
+	int conn_res = future.get();
+
+	hrc::time_point end = hrc::now();
+	duration = end - start;
+
+	double duration_s = duration.count() / pow(10,9);
+	double duration_epsilon = (duration_s * 10) / 100;
+	double wait_time_s = WAIT_TIME_US / pow(10, 6);
+
+	diag("Global duration check for stalling detection: { duration: '%lf' }", duration_s);
+	ok(
+		conn_res == EXIT_SUCCESS &&
+		duration_s > (wait_time_s - duration_epsilon) && duration_s < (wait_time_s + duration_epsilon),
+		"Queries execution duration: { exp_duration: '%lf', act_duration: '%lf', epsilon: '%lf' }",
+		wait_time_s, duration_s, duration_epsilon
+	);
+
+	double expected_qps = ret_expected_qps(qps_limit, burst_size, CONN_TIME);
+	uint32_t EPSILON = (expected_qps * 15) / 100;
+
+	ok(
+		conn_res == EXIT_SUCCESS &&
+		(query_count / CONN_TIME) > expected_qps - EPSILON && (query_count / CONN_TIME) < expected_qps + EPSILON,
+		"Expected QPS for single conn:"
+		" { err: '%d', burst_size: '%ld', QPS_Limit: '%ld', Exp_QPS: '%lf', QPS: '%lf', EPSILON: '%d' }",
+		conn_res, burst_size, qps_limit, expected_qps, query_count / CONN_TIME, EPSILON
+	);
+	diag("");
+
+	return EXIT_SUCCESS;
+}
+
+int check_multi_conn_qps_limits_count(vector<MYSQL*> conns, const int64_t qps_limit, const uint64_t burst_size) {
+	uint32_t init_delay = 500;
+	double CONN_TIME = 10.0;
+	double WAIT_TIME_US = CONN_TIME*pow(10, 6) + init_delay*1000;
+
+	vector<std::future<int>> conns_ths {};
+	vector<uint64_t> conns_count(conns.size(), { 0 });
+	bool stop = 0;
+	size_t conn_pos = 0;
+
+	std::chrono::nanoseconds duration;
+	hrc::time_point start = hrc::now();
+
+	for (MYSQL* conn : conns) {
+		conns_ths.push_back(std::async(
+			conn_query_executor, conn, "SELECT 1", init_delay, &conns_count[conn_pos], &stop
+		));
+
+		conn_pos += 1;
+	}
+
+	usleep(WAIT_TIME_US);
+	__sync_fetch_and_add((char*)&stop, 1);
+
+	int conns_res = EXIT_SUCCESS;
+	for (std::future<int>& conn_th : conns_ths) {
+		if (conn_th.valid()) {
+			conns_res |= conn_th.get();
+		} else {
+			conns_res |= EXIT_FAILURE;
+		}
+	}
+
+	hrc::time_point end = hrc::now();
+	duration = end - start;
+
+	double duration_s = duration.count() / pow(10,9);
+	double duration_epsilon = (duration_s * 10) / 100;
+	double wait_time_s = WAIT_TIME_US / pow(10, 6);
+
+	diag("Global duration check for stalling detection: { duration: '%lf' }", duration_s);
+	ok(
+		conns_res == EXIT_SUCCESS &&
+		duration_s > (wait_time_s - duration_epsilon) && duration_s < (wait_time_s + duration_epsilon),
+		"Queries execution duration: { exp_duration: '%lf', act_duration: '%lf', epsilon: '%lf' }",
+		wait_time_s, duration_s, duration_epsilon
+	);
+
+	size_t conn_num = 0;
+	uint64_t total_query_count = 0;
+	for (uint64_t query_count : conns_count) {
+		double expected_qps = ret_expected_qps(qps_limit, burst_size, CONN_TIME) / conns.size();
+		uint32_t EPSILON = (expected_qps * 15) / 100;
+
+		bool condition =
+			conns_res == EXIT_SUCCESS &&
+			(query_count / CONN_TIME) > expected_qps - EPSILON && (query_count / CONN_TIME) < expected_qps + EPSILON;
+
+		ok(
+			condition,
+			"Expected QPS for conn_num '%ld':"
+			" { err: '%d', burst_size: '%ld', QPS_Limit: '%ld', Exp_QPS: '%lf', QPS: '%lf', EPSILON: '%d' }",
+			conn_num, conns_res, burst_size, qps_limit, expected_qps, query_count / CONN_TIME, EPSILON
+		);
+
+		conn_num += 1;
+		total_query_count += query_count;
+	}
+	diag("Total query count: '%d'\n", total_query_count);
+	diag("");
+
+	return EXIT_SUCCESS;
+}
+
+using qps_limit = uint64_t;
+using burst_size = uint64_t;
+using std::pair;
+
+const vector<pair<qps_limit,burst_size>> tests_payloads {
+	// { 1000, 20 }, { 1000, 50 }, { 1000, 100 },
+	// { 1000, 150 }, { 1000, 500 }, { 1000, 500 },
+	{ 1500, 1600 }, { 2000, 2000 }, { 2000, 3000 },
+};
 
 int main(int argc, char** argv) {
 	CommandLine cl;
 
-	plan(1);
+	plan(tests_payloads.size() * 5);
 
 	if (cl.getEnv()) {
 		diag("Failed to get the required environmental variables.");
@@ -47,57 +270,83 @@ int main(int argc, char** argv) {
 		return EXIT_FAILURE;
 	}
 
-	const string t_qps_limit_rule {
-		"INSERT INTO mysql_qps_limit_rules (username, schemaname, flagIN, qps_limit, bucket_size)"
-		" VALUES ('%s', '%s', %d, %d, %d)"
-	};
-
-	MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
-	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
-
-	// Test 1
+	// Test 1: a) Check QPS limitation holds for a single connection
+	/*
 	{
 		const string TEST_USER { "sbtest1" };
 		const string TEST_PASS { "sbtest1" };
 
-		const uint64_t qps_limit = 100;
-		const uint64_t burst_size = 100;
-		const uint64_t qps_factor = 6;
-		const double EPSILON = 0.1;
-
-		// Setup 'qps_limit_rules'
-		string user_limit_rule {};
-		string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), "", 0, qps_limit, burst_size);
-		MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
-		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
-
-		MYSQL* sbtest1_conn = mysql_init(NULL);
-		if (!mysql_real_connect(sbtest1_conn, cl.host, TEST_USER.c_str(), TEST_PASS.c_str(), NULL, cl.port, NULL, 0)) {
-			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(sbtest1_conn));
+		MYSQL* proxysql = mysql_init(NULL);
+		if (!mysql_real_connect(proxysql, cl.host, TEST_USER.c_str(), TEST_PASS.c_str(), NULL, cl.port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql));
 			return EXIT_FAILURE;
 		}
 
-		// Check that queries takes the expected ammount of time to be exectued
-		std::chrono::nanoseconds duration;
-		hrc::time_point start = hrc::now();
+		for (const auto& test_payload : tests_payloads) {
+			uint32_t qps_limit = test_payload.first;
+			uint32_t burst_size = test_payload.second;
 
-		for (uint64_t i = 0; i < qps_limit*6; i++) {
-			MYSQL_QUERY(sbtest1_conn, "/* hostgroup=0 */ SELECT 1");
-			mysql_free_result(mysql_store_result(sbtest1_conn));
+			// Setup 'qps_limit_rules'
+			string user_limit_rule {};
+			string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), "", 0, qps_limit, burst_size);
+
+			MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+			MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+			MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+			// Give at least 1s between executions
+			usleep(1000 * 1000);
+
+			int test_rc = check_single_conn_qps_limits_count(proxysql, qps_limit, burst_size);
+			if (test_rc != EXIT_SUCCESS) { return EXIT_FAILURE; }
 		}
 
-		hrc::time_point end = hrc::now();
-		duration = end - start;
-		double s_duration = duration.count() / pow(10,9);
+		mysql_close(proxysql);
 
-		ok(
-			(s_duration > (qps_factor - 1) - EPSILON) && (s_duration < (qps_factor - 1) + EPSILON),
-			"Waited time should match the QPS limit times factor minus one: { Exp: '%ld', Act: '%lf' }",
-			qps_factor - 1, s_duration
-		);
-
-		mysql_close(sbtest1_conn);
+		// Give some time for the update
+		usleep(500 * 1000);
 	}
+	*/
+
+	// Test 1: b) Check that:
+	//   1. For multiple connections the rate is stable and matches the target value.
+	//   2. It's evenly distributed between multiple connections.
+	{
+		const string TEST_USER { "sbtest1" };
+		const string TEST_PASS { "sbtest1" };
+
+		conn_opts conn_opts { cl.host, TEST_USER, TEST_PASS, cl.port };
+		for (int i = 9; i < 10; i++) {
+			vector<MYSQL*> conns {};
+			int conns_err = create_connections(conn_opts, i, conns);
+			if (conns_err != EXIT_SUCCESS) { return EXIT_FAILURE; }
+
+			for (const auto& test_payload : tests_payloads) {
+				uint32_t qps_limit = test_payload.first;
+				uint32_t burst_size = test_payload.second;
+
+				// Setup 'qps_limit_rules'
+				string user_limit_rule {};
+				string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), "", 0, qps_limit, burst_size);
+
+				MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+				MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+				MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+				// Give at least 1s between executions
+				usleep(1000 * 1000);
+
+				int test_rc = check_multi_conn_qps_limits_count(conns, qps_limit, burst_size);
+				if (test_rc != EXIT_SUCCESS) { return EXIT_FAILURE; }
+			}
+
+			for (MYSQL* conn : conns) {
+				mysql_close(conn);
+			}
+		}
+	}
+
+	// Test 2: WIP
 
 	mysql_close(proxysql_admin);
 

--- a/test/tap/tests/test_qps_limit_rules-t.cpp
+++ b/test/tap/tests/test_qps_limit_rules-t.cpp
@@ -1,0 +1,105 @@
+/**
+ * @file test_qps_limit_rules-t.cpp
+ * @brief This test verifies the implementation of 'qps_limit_rules'.
+ * @details The following checks are performed:
+ *   - Test 1: Open several connections to ProxySQL using the same user, perform multiple queries per
+ *     connections checking that:
+ *       1. The rate is stable and matches the target value. WIP
+ *       2. It's evenly distributed between connections. WIP
+ *   - Test 2: WIP
+ *   - Test 3: WIP
+ */
+
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <vector>
+#include <string>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <mysql.h>
+#include <mysql/mysqld_error.h>
+
+#include "tap.h"
+#include "proxysql_utils.h"
+#include "command_line.h"
+#include "utils.h"
+
+using std::string;
+
+using hrc = std::chrono::high_resolution_clock;
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	plan(1);
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
+
+	MYSQL* proxysql_admin = mysql_init(NULL);
+	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return EXIT_FAILURE;
+	}
+
+	const string t_qps_limit_rule {
+		"INSERT INTO mysql_qps_limit_rules (username, schemaname, flagIN, qps_limit, bucket_size)"
+		" VALUES ('%s', '%s', %d, %d, %d)"
+	};
+
+	MYSQL_QUERY(proxysql_admin, "DELETE FROM mysql_qps_limit_rules");
+	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+	// Test 1
+	{
+		const string TEST_USER { "sbtest1" };
+		const string TEST_PASS { "sbtest1" };
+
+		const uint64_t qps_limit = 100;
+		const uint64_t burst_size = 100;
+		const uint64_t qps_factor = 6;
+		const double EPSILON = 0.1;
+
+		// Setup 'qps_limit_rules'
+		string user_limit_rule {};
+		string_format(t_qps_limit_rule, user_limit_rule, TEST_USER.c_str(), "", 0, qps_limit, burst_size);
+		MYSQL_QUERY(proxysql_admin, user_limit_rule.c_str());
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
+
+		MYSQL* sbtest1_conn = mysql_init(NULL);
+		if (!mysql_real_connect(sbtest1_conn, cl.host, TEST_USER.c_str(), TEST_PASS.c_str(), NULL, cl.port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(sbtest1_conn));
+			return EXIT_FAILURE;
+		}
+
+		// Check that queries takes the expected ammount of time to be exectued
+		std::chrono::nanoseconds duration;
+		hrc::time_point start = hrc::now();
+
+		for (uint64_t i = 0; i < qps_limit*6; i++) {
+			MYSQL_QUERY(sbtest1_conn, "/* hostgroup=0 */ SELECT 1");
+			mysql_free_result(mysql_store_result(sbtest1_conn));
+		}
+
+		hrc::time_point end = hrc::now();
+		duration = end - start;
+		double s_duration = duration.count() / pow(10,9);
+
+		ok(
+			(s_duration > (qps_factor - 1) - EPSILON) && (s_duration < (qps_factor - 1) + EPSILON),
+			"Waited time should match the QPS limit times factor minus one: { Exp: '%ld', Act: '%lf' }",
+			qps_factor - 1, s_duration
+		);
+
+		mysql_close(sbtest1_conn);
+	}
+
+	mysql_close(proxysql_admin);
+
+	return exit_status();
+}


### PR DESCRIPTION
This PR adds a new feature allowing to impose QPS limits for queries based on three different criteria:

- username: Username to which the QPS limitation will be imposed.
- schemaname: Schema to which the QPS limitation will be imposed.
- flagIN: Evaluated in the same way as flagIN is in mysql_query_rules and correlates to the flagout / apply specified in the `mysql_query_rules` table. Allows limiting based on a  particular 'mysql_query_rule' match.

The added new table definition is the following:

```
mysql> show create table mysql_qps_limit_rules\G
*************************** 1. row ***************************
       table: mysql_qps_limit_rules
Create Table: CREATE TABLE mysql_qps_limit_rules (
    username VARCHAR NOT NULL,
    schemaname VARCHAR NOT NULL,
    flagIN INT NOT NULL DEFAULT 0,
    qps_limit INT NOT NULL DEFAULT 0,
    bucket_size INT NOT NULL DEFAULT 0,
    PRIMARY KEY (username, schemaname, flagIN) )
```

The rules allow to impose `qps_limit` and `bucket_size` values:

- `qps_limit`: Allows to control the desired QPS that queries matching the rule.
- `bucket_size`: Allows to control the burstiness or variations allowed for the QPS limit imposed (depth of the token bucket). For more information see: https://en.wikipedia.org/wiki/Token_bucket

The value `0` is considered a valid value for `qps_limit`. When imposed, all the queries matching the rule will stall, until the `qps_limit` is either changed, or removed.