### PR TITLE
Proxysql elf sha1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,6 +596,7 @@ cleanall:
 	cd test/tap && ${MAKE} clean
 	rm binaries/*deb || true
 	rm binaries/*rpm || true
+	rm binaries/*id-hash || true
 
 .PHONY: cleanbuild
 cleanbuild:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ endif
 USERCHECK := $(shell getent passwd proxysql)
 GROUPCHECK := $(shell getent group proxysql)
 
+
+
 .PHONY: default
 default: build_deps build_lib build_src
 
@@ -81,6 +83,7 @@ clickhouse: build_deps_clickhouse build_lib_clickhouse build_src_clickhouse
 
 .PHONY: debug_clickhouse
 debug_clickhouse: build_deps_debug_clickhouse build_lib_debug_clickhouse build_src_debug_clickhouse
+
 
 
 .PHONY: build_deps
@@ -172,20 +175,24 @@ build_src_debug_clickhouse: build_deps build_lib_debug_clickhouse
 	cd src && OPTZ="${O0} -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} ${MAKE}
 
 
+
 .PHONY: clean
 clean:
 	cd lib && ${MAKE} clean
 	cd src && ${MAKE} clean
 	cd test/tap && ${MAKE} clean
 
+
+
 packages: amd64-packages arm64-packages
 .PHONY: packages
 
-amd64-packages: centos6 centos6.7 centos6.7-dbg centos7 centos7-dbg centos8 centos8-dbg ubuntu14 ubuntu14-dbg ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-dbg debian8 debian8-dbg debian9 debian9-dbg debian10 debian10-dbg debian11 debian11-dbg fedora24 fedora24-dbg fedora27 fedora27-dbg fedora28 fedora28-dbg fedora33 fedora33-dbg fedora34 fedora34-dbg
+amd64-packages: centos6 centos6-dbg centos6.7 centos6.7-dbg centos7 centos7-dbg centos8 centos8-dbg ubuntu14 ubuntu14-dbg ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-dbg debian8 debian8-dbg debian9 debian9-dbg debian10 debian10-dbg debian11 debian11-dbg fedora24 fedora24-dbg fedora27 fedora27-dbg fedora28 fedora28-dbg fedora33 fedora33-dbg fedora34 fedora34-dbg
 .PHONY: amd64-packages
 
 arm64-packages: centos7-arm64 centos8-arm64 debian9-arm64 debian10-arm64 debian11-arm64 ubuntu18-arm64 ubuntu20-arm64 fedora32-arm64 fedora33-arm64
 .PHONY: arm64-packages
+
 
 centos5: binaries/proxysql-${CURVER}-1-centos5.x86_64.rpm
 .PHONY: centos5
@@ -193,11 +200,20 @@ centos5: binaries/proxysql-${CURVER}-1-centos5.x86_64.rpm
 centos5-dbg: binaries/proxysql-${CURVER}-1-dbg-centos5.x86_64.rpm
 .PHONY: centos5-dbg
 
+
 centos6: binaries/proxysql-${CURVER}-1-centos6.x86_64.rpm
 .PHONY: centos6
 
+centos6-dbg: binaries/proxysql-${CURVER}-1-dbg-centos6.x86_64.rpm
+.PHONY: centos6-dbg
+
+
 centos6.7: binaries/proxysql-${CURVER}-1-centos67.x86_64.rpm
 .PHONY: centos6.7
+
+centos6.7-dbg: binaries/proxysql-${CURVER}-1-dbg-centos67.x86_64.rpm
+.PHONY: centos6.7-dbg
+
 
 centos7: binaries/proxysql-${CURVER}-1-centos7.x86_64.rpm
 .PHONY: centos7
@@ -205,20 +221,19 @@ centos7: binaries/proxysql-${CURVER}-1-centos7.x86_64.rpm
 centos7-arm64: binaries/proxysql-${CURVER}-1-centos7.aarch64.rpm
 .PHONY: centos7-arm64
 
+centos7-dbg: binaries/proxysql-${CURVER}-1-dbg-centos7.x86_64.rpm
+.PHONY: centos7-dbg
+
+
 centos8: binaries/proxysql-${CURVER}-1-centos8.x86_64.rpm
 .PHONY: centos8
 
 centos8-arm64: binaries/proxysql-${CURVER}-1-centos8.aarch64.rpm
 .PHONY: centos8-arm64
 
-centos6.7-dbg: binaries/proxysql-${CURVER}-1-dbg-centos67.x86_64.rpm
-.PHONY: centos6.7-dbg
-
-centos7-dbg: binaries/proxysql-${CURVER}-1-dbg-centos7.x86_64.rpm
-.PHONY: centos7-dbg
-
 centos8-dbg: binaries/proxysql-${CURVER}-1-dbg-centos8.x86_64.rpm
 .PHONY: centos8-dbg
+
 
 fedora24: binaries/proxysql-${CURVER}-1-fedora24.x86_64.rpm
 .PHONY: fedora24
@@ -226,11 +241,13 @@ fedora24: binaries/proxysql-${CURVER}-1-fedora24.x86_64.rpm
 fedora24-dbg: binaries/proxysql-${CURVER}-1-dbg-fedora24.x86_64.rpm
 .PHONY: fedora24-dbg
 
+
 fedora27: binaries/proxysql-${CURVER}-1-fedora27.x86_64.rpm
 .PHONY: fedora27
 
 fedora27-dbg: binaries/proxysql-${CURVER}-1-dbg-fedora27.x86_64.rpm
 .PHONY: fedora27-dbg
+
 
 fedora28: binaries/proxysql-${CURVER}-1-fedora28.x86_64.rpm
 .PHONY: fedora28
@@ -238,11 +255,20 @@ fedora28: binaries/proxysql-${CURVER}-1-fedora28.x86_64.rpm
 fedora28-dbg: binaries/proxysql-${CURVER}-1-dbg-fedora28.x86_64.rpm
 .PHONY: fedora28-dbg
 
+
+fedora32-arm64: binaries/proxysql-${CURVER}-1-fedora32.aarch64.rpm
+.PHONY: fedora32-arm64
+
+
 fedora33: binaries/proxysql-${CURVER}-1-fedora33.x86_64.rpm
 .PHONY: fedora33
 
+fedora33-arm64: binaries/proxysql-${CURVER}-1-fedora33.aarch64.rpm
+.PHONY: fedora33-arm64
+
 fedora33-dbg: binaries/proxysql-${CURVER}-1-dbg-fedora33.x86_64.rpm
 .PHONY: fedora33-dbg
+
 
 fedora34: binaries/proxysql-${CURVER}-1-fedora34.x86_64.rpm
 .PHONY: fedora34
@@ -250,74 +276,64 @@ fedora34: binaries/proxysql-${CURVER}-1-fedora34.x86_64.rpm
 fedora34-dbg: binaries/proxysql-${CURVER}-1-dbg-fedora34.x86_64.rpm
 .PHONY: fedora34-dbg
 
-fedora32-arm64: binaries/proxysql-${CURVER}-1-fedora32.aarch64.rpm
-.PHONY: fedora32-arm64
-
-fedora33-arm64: binaries/proxysql-${CURVER}-1-fedora33.aarch64.rpm
-.PHONY: fedora33-arm64
 
 ubuntu14: binaries/proxysql_${CURVER}-ubuntu14_amd64.deb
 .PHONY: ubuntu14
 
-ubuntu16: binaries/proxysql_${CURVER}-ubuntu16_amd64.deb
-.PHONY: ubuntu16
-
-ubuntu18: binaries/proxysql_${CURVER}-ubuntu18_amd64.deb
-.PHONY: ubuntu18
-
-ubuntu20: binaries/proxysql_${CURVER}-ubuntu20_amd64.deb
-.PHONY: ubuntu20
-
-ubuntu18-arm64: binaries/proxysql_${CURVER}-ubuntu18_aarch64.deb
-.PHONY: ubuntu18-arm64
-
-ubuntu20-arm64: binaries/proxysql_${CURVER}-ubuntu20_aarch64.deb
-.PHONY: ubuntu20-arm64
-
-debian7: binaries/proxysql_${CURVER}-debian7_amd64.deb
-.PHONY: debian7
-
-debian8: binaries/proxysql_${CURVER}-debian8_amd64.deb
-.PHONY: debian8
-
-debian9: binaries/proxysql_${CURVER}-debian9_amd64.deb
-.PHONY: debian9
-
-debian10: binaries/proxysql_${CURVER}-debian10_amd64.deb
-.PHONY: debian10
-
-debian11: binaries/proxysql_${CURVER}-debian11_amd64.deb
-.PHONY: debian11
-
-debian9-arm64: binaries/proxysql_${CURVER}-debian9_aarch64.deb
-.PHONY: debian9-arm64
-
-debian10-arm64: binaries/proxysql_${CURVER}-debian10_aarch64.deb
-.PHONY: debian10-arm64
-
-debian11-arm64: binaries/proxysql_${CURVER}-debian11_aarch64.deb
-.PHONY: debian11-arm64
-
 ubuntu14-dbg: binaries/proxysql_${CURVER}-dbg-ubuntu14_amd64.deb
 .PHONY: ubuntu14-dbg
+
+
+ubuntu16: binaries/proxysql_${CURVER}-ubuntu16_amd64.deb
+.PHONY: ubuntu16
 
 ubuntu16-dbg: binaries/proxysql_${CURVER}-dbg-ubuntu16_amd64.deb
 .PHONY: ubuntu16-dbg
 
+
+ubuntu18: binaries/proxysql_${CURVER}-ubuntu18_amd64.deb
+.PHONY: ubuntu18
+
+ubuntu18-arm64: binaries/proxysql_${CURVER}-ubuntu18_aarch64.deb
+.PHONY: ubuntu18-arm64
+
 ubuntu18-dbg: binaries/proxysql_${CURVER}-dbg-ubuntu18_amd64.deb
 .PHONY: ubuntu18-dbg
+
+
+ubuntu20: binaries/proxysql_${CURVER}-ubuntu20_amd64.deb
+.PHONY: ubuntu20
+
+ubuntu20-arm64: binaries/proxysql_${CURVER}-ubuntu20_aarch64.deb
+.PHONY: ubuntu20-arm64
 
 ubuntu20-dbg: binaries/proxysql_${CURVER}-dbg-ubuntu20_amd64.deb
 .PHONY: ubuntu20-dbg
 
+
+debian7: binaries/proxysql_${CURVER}-debian7_amd64.deb
+.PHONY: debian7
+
 debian7-dbg: binaries/proxysql_${CURVER}-dbg-debian7_amd64.deb
 .PHONY: debian7-dbg
+
+
+debian8: binaries/proxysql_${CURVER}-debian8_amd64.deb
+.PHONY: debian8
 
 debian8-dbg: binaries/proxysql_${CURVER}-dbg-debian8_amd64.deb
 .PHONY: debian8-dbg
 
+
+debian9: binaries/proxysql_${CURVER}-debian9_amd64.deb
+.PHONY: debian9
+
+debian9-arm64: binaries/proxysql_${CURVER}-debian9_aarch64.deb
+.PHONY: debian9-arm64
+
 debian9-dbg: binaries/proxysql_${CURVER}-dbg-debian9_amd64.deb
 .PHONY: debian9-dbg
+
 
 debian9.4: binaries/proxysql_${CURVER}-debian9.4_amd64.deb
 .PHONY: debian9.4
@@ -325,11 +341,27 @@ debian9.4: binaries/proxysql_${CURVER}-debian9.4_amd64.deb
 debian9.4-dbg: binaries/proxysql_${CURVER}-dbg-debian9.4_amd64.deb
 .PHONY: debian9.4-dbg
 
+
+debian10: binaries/proxysql_${CURVER}-debian10_amd64.deb
+.PHONY: debian10
+
+debian10-arm64: binaries/proxysql_${CURVER}-debian10_aarch64.deb
+.PHONY: debian10-arm64
+
 debian10-dbg: binaries/proxysql_${CURVER}-dbg-debian10_amd64.deb
 .PHONY: debian10-dbg
 
+
+debian11: binaries/proxysql_${CURVER}-debian11_amd64.deb
+.PHONY: debian11
+
+debian11-arm64: binaries/proxysql_${CURVER}-debian11_aarch64.deb
+.PHONY: debian11-arm64
+
 debian11-dbg: binaries/proxysql_${CURVER}-dbg-debian11_amd64.deb
 .PHONY: debian11-dbg
+
+
 
 binaries/proxysql-${CURVER}-1-centos5.x86_64.rpm:
 	docker-compose up centos5_build
@@ -339,9 +371,15 @@ binaries/proxysql-${CURVER}-1-dbg-centos5.x86_64.rpm:
 	docker-compose up centos5_dbg_build
 	docker-compose rm -f
 
+
 binaries/proxysql-${CURVER}-1-centos6.x86_64.rpm:
 	docker-compose up centos6_build
 	docker-compose rm -f
+
+binaries/proxysql-${CURVER}-1-dbg-centos6.x86_64.rpm:
+	docker-compose up centos6_dbg_build
+	docker-compose rm -f
+
 
 binaries/proxysql-${CURVER}-1-centos67.x86_64.rpm:
 	docker-compose up centos67_build
@@ -350,6 +388,7 @@ binaries/proxysql-${CURVER}-1-centos67.x86_64.rpm:
 binaries/proxysql-${CURVER}-1-dbg-centos67.x86_64.rpm:
 	docker-compose up centos67_dbg_build
 	docker-compose rm -f
+
 
 binaries/proxysql-${CURVER}-1-centos7.x86_64.rpm:
 	docker-compose up centos7_build
@@ -363,17 +402,19 @@ binaries/proxysql-${CURVER}-1-dbg-centos7.x86_64.rpm:
 	docker-compose up centos7_dbg_build
 	docker-compose rm -f
 
+
 binaries/proxysql-${CURVER}-1-centos8.x86_64.rpm:
 	docker-compose up centos8_build
+	docker-compose rm -f
+
+binaries/proxysql-${CURVER}-1-centos8.aarch64.rpm:
+	docker-compose up centos8_arm64_build
 	docker-compose rm -f
 
 binaries/proxysql-${CURVER}-1-dbg-centos8.x86_64.rpm:
 	docker-compose up centos8_dbg_build
 	docker-compose rm -f
 
-binaries/proxysql-${CURVER}-1-centos8.aarch64.rpm:
-	docker-compose up centos8_arm64_build
-	docker-compose rm -f
 
 binaries/proxysql-${CURVER}-1-fedora24.x86_64.rpm:
 	docker-compose up fedora24_build
@@ -383,13 +424,6 @@ binaries/proxysql-${CURVER}-1-dbg-fedora24.x86_64.rpm:
 	docker-compose up fedora24_dbg_build
 	docker-compose rm -f
 
-binaries/proxysql-${CURVER}-1-fedora32.aarch64.rpm:
-	docker-compose up fedora32_arm64_build
-	docker-compose rm -f
-
-binaries/proxysql-${CURVER}-1-fedora33.aarch64.rpm:
-	docker-compose up fedora33_arm64_build
-	docker-compose rm -f
 
 binaries/proxysql-${CURVER}-1-dbg-fedora27.x86_64.rpm:
 	docker-compose up fedora27_dbg_build
@@ -399,6 +433,7 @@ binaries/proxysql-${CURVER}-1-fedora27.x86_64.rpm:
 	docker-compose up fedora27_build
 	docker-compose rm -f
 
+
 binaries/proxysql-${CURVER}-1-fedora28.x86_64.rpm:
 	docker-compose up fedora28_build
 	docker-compose rm -f
@@ -406,6 +441,12 @@ binaries/proxysql-${CURVER}-1-fedora28.x86_64.rpm:
 binaries/proxysql-${CURVER}-1-dbg-fedora28.x86_64.rpm:
 	docker-compose up fedora28_dbg_build
 	docker-compose rm -f
+
+
+binaries/proxysql-${CURVER}-1-fedora32.aarch64.rpm:
+	docker-compose up fedora32_arm64_build
+	docker-compose rm -f
+
 
 binaries/proxysql-${CURVER}-1-fedora33.x86_64.rpm:
 	docker-compose up fedora33_build
@@ -415,6 +456,12 @@ binaries/proxysql-${CURVER}-1-dbg-fedora33.x86_64.rpm:
 	docker-compose up fedora33_dbg_build
 	docker-compose rm -f
 
+
+binaries/proxysql-${CURVER}-1-fedora33.aarch64.rpm:
+	docker-compose up fedora33_arm64_build
+	docker-compose rm -f
+
+
 binaries/proxysql-${CURVER}-1-fedora34.x86_64.rpm:
 	docker-compose up fedora34_build
 	docker-compose rm -f
@@ -423,53 +470,96 @@ binaries/proxysql-${CURVER}-1-dbg-fedora34.x86_64.rpm:
 	docker-compose up fedora34_dbg_build
 	docker-compose rm -f
 
+
 binaries/proxysql_${CURVER}-ubuntu12_amd64.deb:
 	docker-compose up ubuntu12_build
 	docker-compose rm -f
+
 
 binaries/proxysql_${CURVER}-ubuntu14_amd64.deb:
 	docker-compose up ubuntu14_build
 	docker-compose rm -f
 
+binaries/proxysql_${CURVER}-dbg-ubuntu14_amd64.deb:
+	docker-compose up ubuntu14_dbg_build
+	docker-compose rm -f
+
+
 binaries/proxysql_${CURVER}-ubuntu16_amd64.deb:
 	docker-compose up ubuntu16_build
 	docker-compose rm -f
+
+binaries/proxysql_${CURVER}-dbg-ubuntu16_amd64.deb:
+	docker-compose up ubuntu16_dbg_build
+	docker-compose rm -f
+
 
 binaries/proxysql_${CURVER}-ubuntu18_amd64.deb:
 	docker-compose up ubuntu18_build
 	docker-compose rm -f
 
-binaries/proxysql_${CURVER}-ubuntu20_amd64.deb:
-	docker-compose up ubuntu20_build
+binaries/proxysql_${CURVER}-dbg-ubuntu18_amd64.deb:
+	docker-compose up ubuntu18_dbg_build
 	docker-compose rm -f
+
 
 binaries/proxysql_${CURVER}-ubuntu18_aarch64.deb:
 	docker-compose up ubuntu18_arm64_build
+	docker-compose rm -f
+
+binaries/proxysql_${CURVER}-dbg-ubuntu20_amd64.deb:
+	docker-compose up ubuntu20_dbg_build
+	docker-compose rm -f
+
+
+binaries/proxysql_${CURVER}-ubuntu20_amd64.deb:
+	docker-compose up ubuntu20_build
 	docker-compose rm -f
 
 binaries/proxysql_${CURVER}-ubuntu20_aarch64.deb:
 	docker-compose up ubuntu20_arm64_build
 	docker-compose rm -f
 
+
 binaries/proxysql_${CURVER}-debian7_amd64.deb:
 	docker-compose up debian7_build
 	#docker-compose rm -f
+
+binaries/proxysql_${CURVER}-dbg-debian7_amd64.deb:
+	docker-compose up debian7_dbg_build
+	docker-compose rm -f
+
 
 binaries/proxysql_${CURVER}-debian8_amd64.deb:
 	docker-compose up debian8_build
 	docker-compose rm -f
 
+binaries/proxysql_${CURVER}-dbg-debian8_amd64.deb:
+	docker-compose up debian8_dbg_build
+	docker-compose rm -f
+
+
 binaries/proxysql_${CURVER}-debian9_amd64.deb:
 	docker-compose up debian9_build
+	docker-compose rm -f
+
+binaries/proxysql_${CURVER}-dbg-debian9_amd64.deb:
+	docker-compose up debian9_dbg_build
 	docker-compose rm -f
 
 binaries/proxysql_${CURVER}-debian9_aarch64.deb:
 	docker-compose up debian9_arm64_build
 	docker-compose rm -f
 
+
 binaries/proxysql_${CURVER}-debian9.4_amd64.deb:
 	docker-compose up debian9_build
 	docker-compose rm -f
+
+binaries/proxysql_${CURVER}-dbg-debian9.4_amd64.deb:
+	docker-compose up debian9_dbg_build
+	docker-compose rm -f
+
 
 binaries/proxysql_${CURVER}-debian10_amd64.deb:
 	docker-compose up debian10_build
@@ -479,6 +569,11 @@ binaries/proxysql_${CURVER}-debian10_aarch64.deb:
 	docker-compose up debian10_arm64_build
 	docker-compose rm -f
 
+binaries/proxysql_${CURVER}-dbg-debian10_amd64.deb:
+	docker-compose up debian10_dbg_build
+	docker-compose rm -f
+
+
 binaries/proxysql_${CURVER}-debian11_amd64.deb:
 	docker-compose up debian11_build
 	docker-compose rm -f
@@ -487,45 +582,11 @@ binaries/proxysql_${CURVER}-debian11_aarch64.deb:
 	docker-compose up debian11_arm64_build
 	docker-compose rm -f
 
-binaries/proxysql_${CURVER}-dbg-ubuntu14_amd64.deb:
-	docker-compose up ubuntu14_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-ubuntu16_amd64.deb:
-	docker-compose up ubuntu16_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-ubuntu18_amd64.deb:
-	docker-compose up ubuntu18_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-ubuntu20_amd64.deb:
-	docker-compose up ubuntu20_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-debian7_amd64.deb:
-	docker-compose up debian7_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-debian8_amd64.deb:
-	docker-compose up debian8_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-debian9_amd64.deb:
-	docker-compose up debian9_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-debian9.4_amd64.deb:
-	docker-compose up debian9_dbg_build
-	docker-compose rm -f
-
-binaries/proxysql_${CURVER}-dbg-debian10_amd64.deb:
-	docker-compose up debian10_dbg_build
-	docker-compose rm -f
-
 binaries/proxysql_${CURVER}-dbg-debian11_amd64.deb:
 	docker-compose up debian11_dbg_build
 	docker-compose rm -f
+
+
 
 .PHONY: cleanall
 cleanall:

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ clean:
 packages: amd64-packages arm64-packages
 .PHONY: packages
 
-amd64-packages: centos6.7 centos6.7-dbg centos7 centos7-dbg centos8 centos8-dbg ubuntu14 ubuntu14-dbg ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-dbg debian8 debian8-dbg debian9 debian9-dbg debian10 debian10-dbg debian11 debian11-dbg fedora24 fedora24-dbg fedora27 fedora27-dbg fedora28 fedora28-dbg fedora33 fedora33-dbg fedora34 fedora34-dbg
+amd64-packages: centos6 centos6.7 centos6.7-dbg centos7 centos7-dbg centos8 centos8-dbg ubuntu14 ubuntu14-dbg ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-dbg debian8 debian8-dbg debian9 debian9-dbg debian10 debian10-dbg debian11 debian11-dbg fedora24 fedora24-dbg fedora27 fedora27-dbg fedora28 fedora28-dbg fedora33 fedora33-dbg fedora34 fedora34-dbg
 .PHONY: amd64-packages
 
 arm64-packages: centos7-arm64 centos8-arm64 debian9-arm64 debian10-arm64 debian11-arm64 ubuntu18-arm64 ubuntu20-arm64 fedora32-arm64 fedora33-arm64
@@ -192,6 +192,9 @@ centos5: binaries/proxysql-${CURVER}-1-centos5.x86_64.rpm
 
 centos5-dbg: binaries/proxysql-${CURVER}-1-dbg-centos5.x86_64.rpm
 .PHONY: centos5-dbg
+
+centos6: binaries/proxysql-${CURVER}-1-centos6.x86_64.rpm
+.PHONY: centos6
 
 centos6.7: binaries/proxysql-${CURVER}-1-centos67.x86_64.rpm
 .PHONY: centos6.7
@@ -334,6 +337,10 @@ binaries/proxysql-${CURVER}-1-centos5.x86_64.rpm:
 
 binaries/proxysql-${CURVER}-1-dbg-centos5.x86_64.rpm:
 	docker-compose up centos5_dbg_build
+	docker-compose rm -f
+
+binaries/proxysql-${CURVER}-1-centos6.x86_64.rpm:
+	docker-compose up centos6_build
 	docker-compose rm -f
 
 binaries/proxysql-${CURVER}-1-centos67.x86_64.rpm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,23 @@ services:
       - MAKE
       - MAKEOPT
       - CURVER
-      - PKG_RELEASE=centos67
+      - PKG_RELEASE=centos6
+      - PROXYSQL_BUILD_ARCH=x86_64
+    command:
+      - /opt/entrypoint/entrypoint.bash
+  centos6_dbg_build:
+    image: proxysql/packaging:build-centos6
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
+      - ./docker/images/proxysql/rhel-compliant/rhel6/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - APPLY_PATCH=rhel6
+      - MAKE
+      - MAKEOPT
+      - CURVER
+      - PKG_RELEASE=dbg-centos6
+      - PROXYSQL_BUILD_TYPE=debug
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: "2.0"
 services:
+
   centos6_build:
     image: proxysql/packaging:build-centos6
     volumes:
@@ -15,6 +16,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos6_dbg_build:
     image: proxysql/packaging:build-centos6
     volumes:
@@ -31,6 +33,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos67_build:
     image: proxysql/packaging:build-centos6.7v2
     volumes:
@@ -46,6 +49,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos67_dbg_build:
     image: proxysql/packaging:build-centos6.7v2
     volumes:
@@ -62,6 +66,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos7_build:
     image: proxysql/packaging:build-centos7
     volumes:
@@ -77,6 +82,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos7_arm64_build:
     image: proxysql/packaging-arm64:build-centos7
     volumes:
@@ -92,6 +98,7 @@ services:
       - PROXYSQL_BUILD_ARCH=aarch64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos7_dbg_build:
     image: proxysql/packaging:build-centos7
     volumes:
@@ -107,6 +114,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos8_build:
     image: proxysql/packaging:build-centos8
     volumes:
@@ -122,6 +130,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos8_arm64_build:
     image: proxysql/packaging-arm64:build-centos8
     volumes:
@@ -137,6 +146,7 @@ services:
       - PROXYSQL_BUILD_ARCH=aarch64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   centos8_dbg_build:
     image: proxysql/packaging:build-centos8
     volumes:
@@ -152,6 +162,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   fedora24_build:
     image: proxysql/packaging:build-fedora24
     volumes:
@@ -167,6 +178,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   fedora24_dbg_build:
     image: proxysql/packaging:build-fedora24
     volumes:
@@ -182,6 +194,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   fedora27_build:
     image: proxysql/packaging:build-fedora27
     volumes:
@@ -197,6 +210,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   fedora27_dbg_build:
     image: proxysql/packaging:build-fedora27
     volumes:
@@ -212,6 +226,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   fedora28_build:
     image: proxysql/packaging:build-fedora28
     volumes:
@@ -227,6 +242,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   fedora28_dbg_build:
     image: proxysql/packaging:build-fedora28
     volumes:
@@ -242,6 +258,23 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
+  fedora32_arm64_build:
+    image: proxysql/packaging-arm64:build-fedora32
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
+      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - MAKE
+      - MAKEOPT
+      - CURVER
+      - PKG_RELEASE=fedora32
+      - PROXYSQL_BUILD_TYPE=clickhouse
+      - PROXYSQL_BUILD_ARCH=aarch64
+    command:
+      - /opt/entrypoint/entrypoint.bash
+
   fedora33_build:
     image: proxysql/packaging:build-fedora33
     volumes:
@@ -257,6 +290,23 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
+  fedora33_arm64_build:
+    image: proxysql/packaging-arm64:build-fedora33
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
+      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - MAKE
+      - MAKEOPT
+      - CURVER
+      - PKG_RELEASE=fedora33
+      - PROXYSQL_BUILD_TYPE=clickhouse
+      - PROXYSQL_BUILD_ARCH=aarch64
+    command:
+      - /opt/entrypoint/entrypoint.bash
+
   fedora33_dbg_build:
     image: proxysql/packaging:build-fedora33
     volumes:
@@ -288,6 +338,7 @@ services:
       - PROXYSQL_BUILD_ARCH=x86_64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   fedora34_dbg_build:
     image: proxysql/packaging:build-fedora34
     volumes:
@@ -304,36 +355,6 @@ services:
     command:
       - /opt/entrypoint/entrypoint.bash
 
-  fedora32_arm64_build:
-    image: proxysql/packaging-arm64:build-fedora32
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
-      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=fedora32
-      - PROXYSQL_BUILD_TYPE=clickhouse
-      - PROXYSQL_BUILD_ARCH=aarch64
-    command:
-      - /opt/entrypoint/entrypoint.bash
-  fedora33_arm64_build:
-    image: proxysql/packaging-arm64:build-fedora33
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
-      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - MAKE
-      - MAKEOPT
-      - CURVER
-      - PKG_RELEASE=fedora33
-      - PROXYSQL_BUILD_TYPE=clickhouse
-      - PROXYSQL_BUILD_ARCH=aarch64
-    command:
-      - /opt/entrypoint/entrypoint.bash
   debian8_build:
     image: proxysql/packaging:build-debian8
     volumes:
@@ -348,6 +369,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian8_dbg_build:
     image: proxysql/packaging:build-debian8
     volumes:
@@ -363,6 +385,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian9_build:
     image: proxysql/packaging:build-debian9
     volumes:
@@ -378,6 +401,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian9_arm64_build:
     image: proxysql/packaging-arm64:build-debian9
     volumes:
@@ -393,6 +417,7 @@ services:
       - PROXYSQL_BUILD_ARCH=arm64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian9_dbg_build:
     image: proxysql/packaging:build-debian9
     volumes:
@@ -408,6 +433,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian9.4_build:
     image: proxysql/packaging:build-debian9.4
     volumes:
@@ -423,6 +449,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian9.4_dbg_build:
     image: proxysql/packaging:build-debian9.4
     volumes:
@@ -438,6 +465,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian10_build:
     image: proxysql/packaging:build-debian10
     volumes:
@@ -453,6 +481,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian10_arm64_build:
     image: proxysql/packaging-arm64:build-debian10
     volumes:
@@ -468,6 +497,7 @@ services:
       - PROXYSQL_BUILD_ARCH=arm64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian10_dbg_build:
     image: proxysql/packaging:build-debian10
     volumes:
@@ -483,6 +513,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian11_build:
     image: proxysql/packaging:build-debian11
     volumes:
@@ -498,6 +529,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian11_arm64_build:
     image: proxysql/packaging-arm64:build-debian11
     volumes:
@@ -513,6 +545,7 @@ services:
       - PROXYSQL_BUILD_ARCH=arm64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   debian11_dbg_build:
     image: proxysql/packaging:build-debian11
     volumes:
@@ -528,6 +561,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu14_build:
     image: proxysql/packaging:build-ubuntu14
     volumes:
@@ -542,6 +576,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu14_dbg_build:
     image: proxysql/packaging:build-ubuntu14
     volumes:
@@ -557,6 +592,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu16_build:
     image: proxysql/packaging:build-ubuntu16
     volumes:
@@ -572,6 +608,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu16_dbg_build:
     image: proxysql/packaging:build-ubuntu16
     volumes:
@@ -587,6 +624,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu18_build:
     image: proxysql/packaging:build-ubuntu18
     volumes:
@@ -602,6 +640,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu18_arm64_build:
     image: proxysql/packaging-arm64:build-ubuntu18
     volumes:
@@ -617,6 +656,7 @@ services:
       - PROXYSQL_BUILD_ARCH=arm64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu18_dbg_build:
     image: proxysql/packaging:build-ubuntu18
     volumes:
@@ -632,6 +672,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu20_build:
     image: proxysql/packaging:build-ubuntu20
     volumes:
@@ -647,6 +688,7 @@ services:
       - PROXYSQL_BUILD_ARCH=amd64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu20_arm64_build:
     image: proxysql/packaging-arm64:build-ubuntu20
     volumes:
@@ -662,6 +704,7 @@ services:
       - PROXYSQL_BUILD_ARCH=arm64
     command:
       - /opt/entrypoint/entrypoint.bash
+
   ubuntu20_dbg_build:
     image: proxysql/packaging:build-ubuntu20
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,20 @@
 version: "2.0"
 services:
+  centos6_build:
+    image: proxysql/packaging:build-centos6
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/:/root/
+      - ./docker/images/proxysql/rhel-compliant/rhel6/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - APPLY_PATCH=rhel6
+      - MAKE
+      - MAKEOPT
+      - CURVER
+      - PKG_RELEASE=centos67
+      - PROXYSQL_BUILD_ARCH=x86_64
+    command:
+      - /opt/entrypoint/entrypoint.bash
   centos67_build:
     image: proxysql/packaging:build-centos6.7v2
     volumes:

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -41,5 +41,6 @@ sed -i "s/PKG_ARCH/${ARCH}/g" /opt/proxysql/proxysql.ctl
 cp /opt/proxysql/src/proxysql /opt/proxysql/
 equivs-build proxysql.ctl
 mv "/opt/proxysql/proxysql_${CURVER}_$ARCH.deb" "./binaries/proxysql_${CURVER}-${PKG_RELEASE}_$ARCH.deb"
+cp "/opt/proxysql/src/proxysql.sha1" "/opt/proxysql/binaries/proxysql-${CURVER}-${PKG_RELEASE}.$ARCH.id-hash"
 # Cleanup current build
 rm -f /opt/proxysql/proxysql.ctl /opt/proxysql/proxysql

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -1,45 +1,40 @@
 #!/bin/bash
-
 set -eu
 
+echo "==> Build environment:"
+env
 
 ARCH=$PROXYSQL_BUILD_ARCH
-
 echo "==> $ARCH architecture detected for package"
 
+echo "==> Cleaning"
 # Delete package if exists
-rm -f "/opt/proxysql/binaries/proxysql_${CURVER}-${PKG_RELEASE}_$ARCH.deb" || true
+rm -f /opt/proxysql/binaries/proxysql_${CURVER}-${PKG_RELEASE}_$ARCH.deb || true
 # Cleanup relic directories from a previously failed build
 rm -f /opt/proxysql/proxysql.ctl /opt/proxysql/proxysql || true
+
 # Clean and build dependancies and source
+echo "==> Building"
 cd /opt/proxysql
-# Patch for Ubuntu 12
-if [ "`grep Ubuntu /etc/issue | awk '{print $2}' | cut -d. -f1`" == "12" ]; then
-	sed -i -e 's/c++11/c++0x/' lib/Makefile
-	sed -i -e 's/c++11/c++0x/' src/Makefile
-        cd /opt/proxysql/deps/re2/
-	mv re2.tar.gz /tmp/
-	wget -O re2.tar.gz https://github.com/sysown/proxysql/raw/v1.3.9/deps/re2/re2-20140304.tgz
-        cd /opt/proxysql
-fi
 if [[ -z ${PROXYSQL_BUILD_TYPE:-} ]] ; then
-  deps_target="build_deps"
-  build_target=""
+	deps_target="build_deps"
+	build_target=""
 else
-  deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
-  build_target="$PROXYSQL_BUILD_TYPE"
+	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
+	build_target="$PROXYSQL_BUILD_TYPE"
 fi
 ${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 
 if [[ -z ${build_target} ]] ; then
-  ${MAKE} ${MAKEOPT}
+	${MAKE} ${MAKEOPT}
 else
-  ${MAKE} ${MAKEOPT} "${build_target}"
+	${MAKE} ${MAKEOPT} "${build_target}"
 fi
-
 touch /opt/proxysql/src/proxysql
-# Prepare package files and build RPM
+
+# Prepare package files and build DEB
+echo "==> Packaging"
 cp /root/ctl/proxysql.ctl /opt/proxysql/proxysql.ctl
 sed -i "s/PKG_VERSION_CURVER/${CURVER}/g" /opt/proxysql/proxysql.ctl
 sed -i "s/PKG_ARCH/${ARCH}/g" /opt/proxysql/proxysql.ctl
@@ -47,10 +42,4 @@ cp /opt/proxysql/src/proxysql /opt/proxysql/
 equivs-build proxysql.ctl
 mv "/opt/proxysql/proxysql_${CURVER}_$ARCH.deb" "./binaries/proxysql_${CURVER}-${PKG_RELEASE}_$ARCH.deb"
 # Cleanup current build
-# Unpatch Ubuntu 12
-if [ "`grep Ubuntu /etc/issue | awk '{print $2}' | cut -d. -f1`" == "12" ]; then
-        sed -i -e 's/c++0x/c++11/' lib/Makefile
-        sed -i -e 's/c++0x/c++11/' src/Makefile
-        mv /tmp/re2.tar.gz /opt/proxysql/deps/re2/
-fi
 rm -f /opt/proxysql/proxysql.ctl /opt/proxysql/proxysql

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -41,6 +41,6 @@ sed -i "s/PKG_ARCH/${ARCH}/g" /opt/proxysql/proxysql.ctl
 cp /opt/proxysql/src/proxysql /opt/proxysql/
 equivs-build proxysql.ctl
 mv "/opt/proxysql/proxysql_${CURVER}_$ARCH.deb" "./binaries/proxysql_${CURVER}-${PKG_RELEASE}_$ARCH.deb"
-cp "/opt/proxysql/src/proxysql.sha1" "/opt/proxysql/binaries/proxysql-${CURVER}-${PKG_RELEASE}.$ARCH.id-hash"
+cp "/opt/proxysql/src/proxysql.sha1" "/opt/proxysql/binaries/proxysql-${CURVER}-${PKG_RELEASE}_$ARCH.id-hash"
 # Cleanup current build
 rm -f /opt/proxysql/proxysql.ctl /opt/proxysql/proxysql

--- a/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
@@ -17,20 +17,21 @@ rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/p
 echo "==> Building"
 cd /opt/proxysql
 if [[ -z ${PROXYSQL_BUILD_TYPE:-} ]] ; then
-  deps_target="build_deps"
-  build_target=""
+	deps_target="build_deps"
+	build_target=""
 else
-  deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
-  build_target="$PROXYSQL_BUILD_TYPE"
+	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
+	build_target="$PROXYSQL_BUILD_TYPE"
 fi
 ${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 
 if [[ -z ${build_target} ]] ; then
-  ${MAKE} ${MAKEOPT}
+	${MAKE} ${MAKEOPT}
 else
-  ${MAKE} ${MAKEOPT} "${build_target}"
+	${MAKE} ${MAKEOPT} "${build_target}"
 fi
+touch /opt/proxysql/src/proxysql
 
 # Prepare package files and build RPM
 echo "==> Packaging"

--- a/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
@@ -46,5 +46,6 @@ mkdir -p /root/rpmbuild/{RPMS,SRPMS,BUILD,SOURCES,SPECS,tmp}
 mv "/opt/proxysql/proxysql-${CURVER}.tar.gz" /root/rpmbuild/SOURCES
 cd /root/rpmbuild && rpmbuild -ba SPECS/proxysql.spec --define "version ${CURVER}"
 mv "/root/rpmbuild/RPMS/$ARCH/proxysql-${CURVER}-1.$ARCH.rpm" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.rpm"
+cp "/opt/proxysql/src/proxysql.sha1" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.id-hash"
 # Cleanup current build
 rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/proxysql/proxysql "/opt/proxysql/proxysql-${CURVER}"

--- a/docker/images/proxysql/rhel-compliant/rhel6/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/rhel6/entrypoint/entrypoint.bash
@@ -4,9 +4,12 @@ set -eu
 echo "==> Build environment:"
 env
 
+ARCH=$PROXYSQL_BUILD_ARCH
+echo "==> $ARCH architecture detected for package"
+
 echo "==> Cleaning"
 # Delete package if exists
-rm -f /opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.x86_64.rpm || true
+rm -f /opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.rpm || true
 # Cleanup relic directories from a previously failed build
 rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/proxysql/proxysql /opt/proxysql/proxysql-${CURVER} || true
 
@@ -14,20 +17,21 @@ rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/p
 echo "==> Building"
 cd /opt/proxysql
 if [[ -z ${PROXYSQL_BUILD_TYPE:-} ]] ; then
-  deps_target="build_deps"
-  build_target=""
+	deps_target="build_deps"
+	build_target=""
 else
-  deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
-  build_target="$PROXYSQL_BUILD_TYPE"
+	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
+	build_target="$PROXYSQL_BUILD_TYPE"
 fi
 ${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 
 if [[ -z ${build_target} ]] ; then
-  ${MAKE} ${MAKEOPT}
+	${MAKE} ${MAKEOPT}
 else
-  ${MAKE} ${MAKEOPT} "${build_target}"
+	${MAKE} ${MAKEOPT} "${build_target}"
 fi
+touch /opt/proxysql/src/proxysql
 
 # Prepare package files and build RPM
 echo "==> Packaging"
@@ -41,6 +45,6 @@ tar czvf "proxysql-${CURVER}.tar.gz" proxysql-${CURVER}
 mkdir -p /root/rpmbuild/{RPMS,SRPMS,BUILD,SOURCES,SPECS,tmp}
 mv "/opt/proxysql/proxysql-${CURVER}.tar.gz" /root/rpmbuild/SOURCES
 cd /root/rpmbuild && rpmbuild -ba SPECS/proxysql.spec --define "version ${CURVER}"
-mv "/root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.x86_64.rpm"
+mv "/root/rpmbuild/RPMS/$ARCH/proxysql-${CURVER}-1.$ARCH.rpm" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.rpm"
 # Cleanup current build
 rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/proxysql/proxysql "/opt/proxysql/proxysql-${CURVER}"

--- a/docker/images/proxysql/rhel-compliant/rhel6/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/rhel6/entrypoint/entrypoint.bash
@@ -46,5 +46,6 @@ mkdir -p /root/rpmbuild/{RPMS,SRPMS,BUILD,SOURCES,SPECS,tmp}
 mv "/opt/proxysql/proxysql-${CURVER}.tar.gz" /root/rpmbuild/SOURCES
 cd /root/rpmbuild && rpmbuild -ba SPECS/proxysql.spec --define "version ${CURVER}"
 mv "/root/rpmbuild/RPMS/$ARCH/proxysql-${CURVER}-1.$ARCH.rpm" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.rpm"
+cp "/opt/proxysql/src/proxysql.sha1" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.id-hash"
 # Cleanup current build
 rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/proxysql/proxysql "/opt/proxysql/proxysql-${CURVER}"

--- a/docker/images/proxysql/rhel-compliant/rhel7/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/rhel7/entrypoint/entrypoint.bash
@@ -1,26 +1,11 @@
 #!/bin/bash
 set -eu
 
-# For troubleshooting...
-# while true; do echo hello; sleep 2; done
-
 echo "==> Build environment:"
 env
 
 ARCH=$PROXYSQL_BUILD_ARCH
 echo "==> $ARCH architecture detected for package"
-
-echo "==> Dirty patching to ensure OS deps are installed"
-
-if [[ -f "/usr/bin/python" ]]  || [[ -h "/usr/bin/python" ]];
-then 
-    echo "==> Installing dependancies for RHEL compliant version 7"
-    yum -y install gnutls-devel libtool || true
-else
-    echo "==> Installing dependancies for RHEL compliant version 8"
-    yum -y install python2 gnutls-devel libtool || true
-    ln -s /usr/bin/python2.7 /usr/bin/python || true
-fi
 
 echo "==> Cleaning"
 # Delete package if exists
@@ -32,20 +17,21 @@ rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/p
 echo "==> Building"
 cd /opt/proxysql
 if [[ -z ${PROXYSQL_BUILD_TYPE:-} ]] ; then
-  deps_target="build_deps"
-  build_target=""
+	deps_target="build_deps"
+	build_target=""
 else
-  deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
-  build_target="$PROXYSQL_BUILD_TYPE"
+	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
+	build_target="$PROXYSQL_BUILD_TYPE"
 fi
 ${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 
 if [[ -z ${build_target} ]] ; then
-  ${MAKE} ${MAKEOPT}
+	${MAKE} ${MAKEOPT}
 else
-  ${MAKE} ${MAKEOPT} "${build_target}"
+	${MAKE} ${MAKEOPT} "${build_target}"
 fi
+touch /opt/proxysql/src/proxysql
 
 # Prepare package files and build RPM
 echo "==> Packaging"

--- a/docker/images/proxysql/rhel-compliant/rhel7/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/rhel7/entrypoint/entrypoint.bash
@@ -48,5 +48,6 @@ mkdir -p /root/rpmbuild/{RPMS,SRPMS,BUILD,SOURCES,SPECS,tmp}
 mv "/opt/proxysql/proxysql-${CURVER}.tar.gz" /root/rpmbuild/SOURCES
 cd /root/rpmbuild && rpmbuild -ba SPECS/proxysql.spec --define "version ${CURVER}"
 mv "/root/rpmbuild/RPMS/$ARCH/proxysql-${CURVER}-1.$ARCH.rpm" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.rpm"
+cp "/opt/proxysql/src/proxysql.sha1" "/opt/proxysql/binaries/proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.id-hash"
 # Cleanup current build
 rm -fr /root/.pki /root/rpmbuild/{BUILDROOT,RPMS,SRPMS,BUILD,SOURCES,tmp} /opt/proxysql/proxysql "/opt/proxysql/proxysql-${CURVER}"

--- a/src/Makefile
+++ b/src/Makefile
@@ -159,12 +159,13 @@ OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 $(ODIR)/%.o: %.cpp
 	$(CXX) -c -o $@ $< $(MYCXXFLAGS) $(CXXFLAGS) -Wall
 
-proxysql: $(ODIR) $(OBJ) $(LIBPROXYSQLAR)
+$(EXECUTABLE): $(ODIR) $(OBJ) $(LIBPROXYSQLAR)
 ifeq ($(PROXYSQLCLICKHOUSE),1)
 	$(CXX) -o $@ $(OBJ) $(LIBPROXYSQLAR) $(CLICKHOUSE_CPP_DIR)/clickhouse/libclickhouse-cpp-lib.a $(CITYHASH_DIR)/libcityhash.a $(LZ4_DIR)/liblz4.a $(MYCXXFLAGS) $(CXXFLAGS) $(LDIRS) $(LIBS) $(LDFLAGS) $(MYLIBS)
 else
 	$(CXX) -o $@ $(OBJ) $(LIBPROXYSQLAR) $(MYCXXFLAGS) $(CXXFLAGS) $(LDIRS) $(LIBS) $(LDFLAGS) $(MYLIBS)
 endif
+	sha1sum $(EXECUTABLE) > $(EXECUTABLE).sha1
 
 $(ODIR):
 	mkdir $(ODIR)
@@ -175,5 +176,5 @@ $(LIBPROXYSQLAR):
 default: $(EXECUTABLE)
 
 clean:
-	rm -f *.pid $(ODIR)/*.o $(ODIR)/*.gcno $(ODIR)/*.gcda *~ core perf.data* heaptrack.proxysql.* $(EXECUTABLE)
+	rm -f *.pid $(ODIR)/*.o $(ODIR)/*.gcno $(ODIR)/*.gcda *~ core perf.data* heaptrack.proxysql.* $(EXECUTABLE) $(EXECUTABLE).sha1
 


### PR DESCRIPTION
after proxysql elf is built, proxysql.sha1 file is created in ./src
after packages are built, copy proxysql.sha1 as proxysql-${CURVER}-1-${PKG_RELEASE}.$ARCH.id-hash into ./binaries

content is output of 'sha1sum proxysql'