### PR TITLE
Closes #3756: Conflict between `deprecate_eof` and `fast_forward`

### DIFF
--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -1223,6 +1223,11 @@ bool MySQL_Protocol::generate_pkt_initial_handshake(bool send, void **ptr, unsig
 	}
 	mysql_thread___server_capabilities |= CLIENT_LONG_FLAG;
 	mysql_thread___server_capabilities |= CLIENT_MYSQL | CLIENT_PLUGIN_AUTH | CLIENT_RESERVED;
+	if (mysql_thread___enable_client_deprecate_eof) {
+		mysql_thread___server_capabilities |= CLIENT_DEPRECATE_EOF;
+	} else {
+		mysql_thread___server_capabilities &= ~CLIENT_DEPRECATE_EOF;
+	}
 	(*myds)->myconn->options.server_capabilities=mysql_thread___server_capabilities;
   memcpy(_ptr+l,&mysql_thread___server_capabilities, sizeof(mysql_thread___server_capabilities)/2); l+=sizeof(mysql_thread___server_capabilities)/2;
   const MARIADB_CHARSET_INFO *ci = NULL;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6509,7 +6509,7 @@ void MySQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 				}
 			}
 		}
-		if (session_fast_forward == false || qpo->create_new_conn == false) {
+		if (session_fast_forward == false && qpo->create_new_conn == false) {
 			if (qpo->min_gtid) {
 				gtid_uuid = qpo->min_gtid;
 				with_gtid = true;


### PR DESCRIPTION
This PR also fixes a issue found during development regarding `create_new_connection` query annotation.

### Query annotation issue description

When query annotation 'create_new_connection` is used, the request may fail if the connection is requested from the thread local cache instead of the connection pool.