### PR TITLE
Resolves #3371 Error handling if statement global id not found

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -3135,12 +3135,13 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 		memcpy(&client_stmt_id,(char *)pkt.ptr+5,sizeof(uint32_t));
 		stmt_global_id=client_myds->myconn->local_stmts->find_global_stmt_id_from_client(client_stmt_id);
 		if (stmt_global_id == 0) {
-			proxy_error("Could not execute statement, global id not found. Client statement id is %d", client_stmt_id);
+			proxy_error("Could not execute statement, global id not found. Client statement id is %d. Client will be disconnected.", client_stmt_id);
 			l_free(pkt.size,pkt.ptr);
 			client_myds->setDSS_STATE_QUERY_SENT_NET();
 			client_myds->myprot.generate_pkt_ERR(true, nullptr, nullptr, 1, 1243, (char*)"28000", (char*)"Prepared statement not found", true);
 			client_myds->DSS=STATE_SLEEP;
 			status=WAITING_CLIENT_DATA;
+			client_myds->destroy_MySQL_Connection_From_Pool(true);
 			return;
 		}
 		CurrentQuery.stmt_global_id=stmt_global_id;

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -3135,10 +3135,13 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 		memcpy(&client_stmt_id,(char *)pkt.ptr+5,sizeof(uint32_t));
 		stmt_global_id=client_myds->myconn->local_stmts->find_global_stmt_id_from_client(client_stmt_id);
 		if (stmt_global_id == 0) {
-			// FIXME: add error handling
-			// LCOV_EXCL_START
-			assert(0);
-			// LCOV_EXCL_STOP
+			proxy_error("Could not execute statement, global id not found. Client statement id is %d", client_stmt_id);
+			l_free(pkt.size,pkt.ptr);
+			client_myds->setDSS_STATE_QUERY_SENT_NET();
+			client_myds->myprot.generate_pkt_ERR(true, nullptr, nullptr, 1, 1243, (char*)"28000", (char*)"Prepared statement not found", true);
+			client_myds->DSS=STATE_SLEEP;
+			status=WAITING_CLIENT_DATA;
+			return;
 		}
 		CurrentQuery.stmt_global_id=stmt_global_id;
 		// now we get the statement information


### PR DESCRIPTION
Resolves [Issue 3371](https://github.com/sysown/proxysql/issues/3371)

* Added error log output instead of assert failure if the global id for the statement is not found

* Returns an error packet to the client if this occurs