### PR TITLE
Add regex support for 'spiffe_id' user attribute

### DIFF
--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -2233,7 +2233,13 @@ bool MySQL_Protocol::verify_user_attributes(int calling_line, const char *callin
 				ret = false;
 				std::string spiffe_val = j["spiffe_id"].get<std::string>();
 				if ((*myds)->x509_subject_alt_name) {
-					if (strncmp(spiffe_val.c_str(), "spiffe://", strlen("spiffe://"))==0) {
+					if (spiffe_val.rfind("!", 0) == 0 && spiffe_val.size() > 1) {
+						string str_spiffe_regex { spiffe_val.substr(1) };
+						re2::RE2::Options opts = re2::RE2::Options(RE2::Quiet);
+						re2::RE2 subject_alt_regex(str_spiffe_regex, opts);
+
+						ret = re2::RE2::FullMatch((*myds)->x509_subject_alt_name, subject_alt_regex);
+					} else if (strncmp(spiffe_val.c_str(), "spiffe://", strlen("spiffe://"))==0) {
 						if (strcmp(spiffe_val.c_str(), (*myds)->x509_subject_alt_name)==0) {
 							ret = true;
 						}

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -1,6 +1,8 @@
 #include <openssl/rand.h>
 #include "proxysql.h"
 #include "cpp.h"
+#include "re2/re2.h"
+#include "re2/regexp.h"
 
 #include "MySQL_PreparedStatement.h"
 #include "MySQL_Data_Stream.h"


### PR DESCRIPTION
### Feature description

This PR adds the possibility to specify regexes as the 'spiffe_id' user attribute. This attribute is used to match against the `subject_alt_name` supplied by the client certificate. For more information see: https://proxysql.com/documentation/SSL-Support/

### Usage

To enable a regex matching for SPIFFE, it's enough to supply a user attribute 'spiffe_id' starting with the symbol `!`. Eg:

```
INSERT INTO mysql_users (username,password,active,use_ssl,attributes) values ('test_mysql_services', '', 1, 1, '{"spiffe_id": "!spiffe:\/\/example\\.org\/workload-proxysql\/.*"}');
```

The rest of the expression after the `!` mark will be handled as a regular expression. Once this user is enabled, connections that supply certificates that can be verified against `proxysql-ca.pem` and that supply a `X509v3 Subject Alternative` that matches the regex will be accepted.