### PR TITLE
Don't intercept SELECT CONNECTION_ID() as COM_STMT_PREPARE

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6200,7 +6200,8 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 	}
 
 	// handle case #1797
-	if ((pkt->size==SELECT_CONNECTION_ID_LEN+5 && strncasecmp((char *)SELECT_CONNECTION_ID,(char *)pkt->ptr+5,pkt->size-5)==0)) {
+	// handle case #2564
+       if ((pkt->size==SELECT_CONNECTION_ID_LEN+5 && *(char *)(pkt->ptr+4)!=(char)0x16 && strncasecmp((char *)SELECT_CONNECTION_ID,(char *)pkt->ptr+5,pkt->size-5)==0)) {
 		char buf[32];
 		char buf2[32];
 		sprintf(buf,"%u",thread_session_id);

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1201,7 +1201,8 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 		}
 	}
 
-	if (pkt->size==SELECT_VERSION_COMMENT_LEN+5 && strncmp((char *)SELECT_VERSION_COMMENT,(char *)pkt->ptr+5,pkt->size-5)==0) {
+	//handle 2564
+	if (pkt->size==SELECT_VERSION_COMMENT_LEN+5 && *(char *)(pkt->ptr+4)==(char)0x03 && strncmp((char *)SELECT_VERSION_COMMENT,(char *)pkt->ptr+5,pkt->size-5)==0) {
 		// FIXME: this doesn't return AUTOCOMMIT or IN_TRANS
 		PtrSize_t pkt_2;
 		if (deprecate_eof_active) {
@@ -6201,7 +6202,7 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 
 	// handle case #1797
 	// handle case #2564
-       if ((pkt->size==SELECT_CONNECTION_ID_LEN+5 && *(char *)(pkt->ptr+4)!=(char)0x16 && strncasecmp((char *)SELECT_CONNECTION_ID,(char *)pkt->ptr+5,pkt->size-5)==0)) {
+       if ((pkt->size==SELECT_CONNECTION_ID_LEN+5 && *(char *)(pkt->ptr+4)==(char)0x03 && strncasecmp((char *)SELECT_CONNECTION_ID,(char *)pkt->ptr+5,pkt->size-5)==0)) {
 		char buf[32];
 		char buf2[32];
 		sprintf(buf,"%u",thread_session_id);
@@ -6268,15 +6269,15 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 			// if we reached here, we don't know the right backend
 			// we try to determine if it is a simple "SELECT LAST_INSERT_ID()" or "SELECT @@IDENTITY" and we return mysql->last_insert_id
 
-
+			//handle 2564
 			if (
-				(pkt->size==SELECT_LAST_INSERT_ID_LEN+5 && strncasecmp((char *)SELECT_LAST_INSERT_ID,(char *)pkt->ptr+5,pkt->size-5)==0)
+				(pkt->size==SELECT_LAST_INSERT_ID_LEN+5 && *(char *)(pkt->ptr+4)==(char)0x03 && strncasecmp((char *)SELECT_LAST_INSERT_ID,(char *)pkt->ptr+5,pkt->size-5)==0)
 				||
-				(pkt->size==SELECT_LAST_INSERT_ID_LIMIT1_LEN+5 && strncasecmp((char *)SELECT_LAST_INSERT_ID_LIMIT1,(char *)pkt->ptr+5,pkt->size-5)==0)
+				(pkt->size==SELECT_LAST_INSERT_ID_LIMIT1_LEN+5 && *(char *)(pkt->ptr+4)==(char)0x03 && strncasecmp((char *)SELECT_LAST_INSERT_ID_LIMIT1,(char *)pkt->ptr+5,pkt->size-5)==0)
                 ||
-                (pkt->size==SELECT_VARIABLE_IDENTITY_LEN+5 && strncasecmp((char *)SELECT_VARIABLE_IDENTITY,(char *)pkt->ptr+5,pkt->size-5)==0)
+                (pkt->size==SELECT_VARIABLE_IDENTITY_LEN+5 && *(char *)(pkt->ptr+4)==(char)0x03 && strncasecmp((char *)SELECT_VARIABLE_IDENTITY,(char *)pkt->ptr+5,pkt->size-5)==0)
                 ||
-                (pkt->size==SELECT_VARIABLE_IDENTITY_LIMIT1_LEN+5 && strncasecmp((char *)SELECT_VARIABLE_IDENTITY_LIMIT1,(char *)pkt->ptr+5,pkt->size-5)==0)
+                (pkt->size==SELECT_VARIABLE_IDENTITY_LIMIT1_LEN+5 && *(char *)(pkt->ptr+4)==(char)0x03 && strncasecmp((char *)SELECT_VARIABLE_IDENTITY_LIMIT1,(char *)pkt->ptr+5,pkt->size-5)==0)
 			) {
 				char buf[32];
 				sprintf(buf,"%llu",last_insert_id);


### PR DESCRIPTION
As mentioned in issue #2564, back in 2018, proxysql added an "intercept" for the query `SELECT CONNECTION_ID()` to return the proxy connection id, not the backend server id for later use with `KILL` commands.  The if statement in 2018 didn't consider the query type, but only checked for specific length and a strcmp() of the SQL in question.  If the query matches the if statement then a hard-coded response packet is sent(with presumably a usable connection id) that appears to be the response packet for a `COM_QUERY` request.

The problem comes up because there is only a 1 byte difference in packets depending if the client makes that query as a query or a prepared statement.  At offset 4, a value of 0x3 is `COM_QUERY` and 0x16 is `COM_STMT_PREPARE`.  when a client sends `COM_STMT_PREPARE`, it's expecting a different response than what's coded in the intercept.  When the client receives the malformed(from it's perspective) response, it closes the connection.

I don't know if the returned client id in a prepared statement is useful, but at least in my case I can't control the SQL being used.  I'd argue this is no more incorrect than changing the SQL to `SELECT  CONNECTION_ID()`(with 2 spaces), which would cause the same behavior.  Below is some trivial ruby code to demonstrate the problem:

```ruby
require 'mysql2'

client=Mysql2::Client.new(proxysql_connect_info)
client.query('SELECT CONNECTION_ID()') #works as expected with intercept

#what tableau does
stmt=client.prepare('SELECT CONNECTION_ID()') # connection bombs here because of the intercept
stmt.execute #never get here
```