### PR TITLE
Fix duplicate counting of MySQL errors for client conns

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6727,7 +6727,6 @@ void MySQL_Session::MySQL_Stmt_Result_to_MySQL_wire(MYSQL_STMT *stmt, MySQL_Conn
 		MYSQL *mysql=stmt->mysql;
 		// no result set
 		int myerrno=mysql_stmt_errno(stmt);
-		MyHGM->p_update_mysql_error_counter(p_mysql_error_type::mysql, myconn->parent->myhgc->hid, myconn->parent->address, myconn->parent->port, myerrno);
 		if (myerrno==0) {
 			unsigned int num_rows = mysql_affected_rows(stmt->mysql);
 			unsigned int nTrx=NumActiveTransactions();
@@ -6810,11 +6809,6 @@ void MySQL_Session::MySQL_Result_to_MySQL_wire(MYSQL *mysql, MySQL_ResultSet *My
 			//client_myds->pkt_sid++;
 		} else {
 			// error
-			if (_myds) {
-				if (_myds->myconn) {
-					MyHGM->p_update_mysql_error_counter(p_mysql_error_type::mysql, _myds->myconn->parent->myhgc->hid, _myds->myconn->parent->address, _myds->myconn->parent->port, myerrno);
-				}
-			}
 			char sqlstate[10];
 			sprintf(sqlstate,"%s",mysql_sqlstate(mysql));
 			if (_myds && _myds->killed_at) { // see case #750

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -274,7 +274,6 @@ void MySQL_Connection::compute_unknown_transaction_status() {
 			unknown_transaction_status = false; // no error
 			return;
 		}
-		MyHGM->p_update_mysql_error_counter(p_mysql_error_type::mysql, parent->myhgc->hid, parent->address, parent->port, _myerrno);
 		if (_myerrno >= 2000 && _myerrno < 3000) { // client error
 			// do not change it
 			return;


### PR DESCRIPTION
Invalid query errors are currently being duplicated in counters. The only proper place for counting query errors currently is in 'MySQL_Session::handler' in PROCESSING_QUERY stage, after the query failure have been detected.