### PR TITLE
Fix POST processing of final keys without values for libhttpserver

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -87,6 +87,7 @@ ifeq ($(REQUIRE_PATCH), true)
 	cd libhttpserver/libhttpserver && patch src/httpserver/http_response.hpp < ../http_response.hpp.patch
 	cd libhttpserver/libhttpserver && patch src/httpserver/string_response.hpp < ../string_response.hpp.patch
 	cd libhttpserver/libhttpserver && patch -p0 < ../re2_regex.patch
+	cd libhttpserver/libhttpserver && patch -p0 < ../final_val_post_process.patch
 endif
 ifeq ($(UNAME_S),FreeBSD)
 	sed -i -e 's/\/bin\/bash/\/usr\/local\/bin\/bash/' libhttpserver/libhttpserver/bootstrap

--- a/deps/libhttpserver/final_val_post_process.patch
+++ b/deps/libhttpserver/final_val_post_process.patch
@@ -1,0 +1,19 @@
+diff --git src/webserver.cpp src/webserver.cpp
+index a3104e9..5ae7381 100644
+--- src/webserver.cpp
++++ src/webserver.cpp
+@@ -676,6 +676,14 @@ int webserver::finalize_answer(
+         {
+             if(hrm->is_allowed(method))
+             {
++                // NOTE: Here 'MHD_destroy_post_processor' is required for performing a final 'post_process'
++                // of the 'URL Encode'. This ensures ensures the processing of final key without value left
++                // at the end of the buffer. See function internal doc at 'postprocessor.c'.
++                if (mr->pp != NULL) {
++                    MHD_destroy_post_processor(mr->pp);
++                    mr->pp = NULL;
++                }
++
+                 mr->dhrs = ((hrm)->*(mr->callback))(*mr->dhr); //copy in memory (move in case)
+                 if (mr->dhrs->get_response_code() == -1)
+                 {


### PR DESCRIPTION
This patch for 'libhttpserver' fixes the losing of final keys that doesn't have values for content type 'application/x-www-form-urlencoded', thus making POST params processing conforming with https://url.spec.whatwg.org/#application/x-www-form-urlencoded.