### PR TITLE
Fix compilation for 'GCC 12.1.0'

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -10,6 +10,7 @@
 #include "cpp.h"
 #include <tuple>
 #include <vector>
+#include <array>
 
 #include "ProxySQL_RESTAPI_Server.hpp"
 

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -75,12 +75,6 @@ using mysql_res_row = std::vector<std::string>;
 std::vector<mysql_res_row> extract_mysql_rows(MYSQL_RES* my_res);
 
 /**
- * @brief Dummy write function to avoid CURL to write received output to stdout.
- * @return Returns the size presented.
- */
-size_t my_dummy_write(char*, size_t size, size_t nmemb, void*);
-
-/**
  * @brief Waits until the provided endpoint is ready to be used or the
  *   timeout period expired. For this checks the return code of
  *   'perform_simple_post' which only fails in case the 'CURL' request couldn't


### PR DESCRIPTION
Compilation currently fails under 'GCC 12.1.0':

```
../include/proxysql_admin.h:208:75: error: field ‘p_counter_array’ has incomplete type ‘std::array<prometheus::Counter*, 2>’
  208 |                 std::array<prometheus::Counter*, p_admin_counter::__size> p_counter_array {};
      |
```