### PR TITLE
Solve bug #3749 and improve testing

### DIFF
--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -311,7 +311,7 @@ class MySQL_Session
 	unsigned int NumActiveTransactions(bool check_savpoint=false);
 	bool HasOfflineBackends();
 	bool SetEventInOfflineBackends();
-	int FindOneActiveTransaction();
+	int FindOneActiveTransaction(bool check_savepoint=false);
 	unsigned long long IdleTime();
 
 	void reset_all_backends();

--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -308,7 +308,7 @@ class MySQL_Session
 	void SQLite3_to_MySQL(SQLite3_result *, char *, int , MySQL_Protocol *, bool in_transaction=false, bool deprecate_eof_active=false);
 	void MySQL_Result_to_MySQL_wire(MYSQL *mysql, MySQL_ResultSet *MyRS, MySQL_Data_Stream *_myds=NULL);
 	void MySQL_Stmt_Result_to_MySQL_wire(MYSQL_STMT *stmt, MySQL_Connection *myconn);
-	unsigned int NumActiveTransactions();
+	unsigned int NumActiveTransactions(bool check_savpoint=false);
 	bool HasOfflineBackends();
 	bool SetEventInOfflineBackends();
 	int FindOneActiveTransaction();

--- a/include/mysql_connection.h
+++ b/include/mysql_connection.h
@@ -216,6 +216,7 @@ class MySQL_Connection {
 	} */
 	bool IsServerOffline();
 	bool IsAutoCommit();
+	bool AutocommitFalse_AndSavepoint();
 	bool MultiplexDisabled();
 	bool IsKeepMultiplexEnabledVariables(char *query_digest_text);
 	void ProcessQueryAndSetStatusFlags(char *query_digest_text);

--- a/test/tap/tests/savepoint-948-t.cpp
+++ b/test/tap/tests/savepoint-948-t.cpp
@@ -19,37 +19,19 @@
 #include "utils.h"
 #include "command_line.h"
 
+#include "json.hpp"
+using nlohmann::json;
 
-unsigned long long monotonic_time() {
-	struct timespec ts;
-	//clock_gettime(CLOCK_MONOTONIC_COARSE, &ts); // this is faster, but not precise
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (((unsigned long long) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
-}
-
-struct cpu_timer
-{
-	cpu_timer() {
-		begin = monotonic_time();
-	}
-	~cpu_timer()
-	{
-		unsigned long long end = monotonic_time();
-		std::cerr << double( end - begin ) / 1000000 << " secs.\n" ;
-		begin=end-begin;
-	};
-	unsigned long long begin;
-};
 
 bool debug_diag=true;
-/*
 unsigned int num_threads=4;
 int count=10;
 int transactions=200;
-*/
+/*
 unsigned int num_threads=1;
 int count=1;
-int transactions=200;
+int transactions=5;
+*/
 char *username=NULL;
 char *password=NULL;
 char *host=(char *)"localhost";
@@ -97,6 +79,7 @@ void * my_conn_thread(void *arg) {
 	unsigned int select_ERR=0;
 	int i, j;
 	MYSQL **mysqlconns=(MYSQL **)malloc(sizeof(MYSQL *)*count);
+	bool ac[count];
 
 	if (mysqlconns==NULL) {
 		exit(EXIT_FAILURE);
@@ -118,6 +101,7 @@ void * my_conn_thread(void *arg) {
 		}
 		mysqlconns[i]=mysql;
 		__sync_add_and_fetch(&status_connections,1);
+		ac[i]=true;
 	}
 	__sync_fetch_and_add(&connect_phase_completed,1);
 
@@ -135,6 +119,11 @@ void * my_conn_thread(void *arg) {
 		int sleepDelay;
 		for (int i=0; i<fr%3; i++) {
 			std::string q = "SET autocommit=" + std::to_string(fr%2);
+			if (fr%2 == 0) {
+				ac[r1]=false;
+			} else {
+				ac[r1]=true;
+			}
 			if (debug_diag==true)
 				diag("Thread %lu , connection %p , query: %s", pthread_self(), mysql, q.c_str());
 			if (mysql_query(mysql, q.c_str())) {
@@ -153,6 +142,7 @@ void * my_conn_thread(void *arg) {
 					diag("Thread %lu , connection %p , query: %s", pthread_self(), mysql, q.c_str());
 			} else {
 				q = "SET AUTOCOMMIT=0";
+				ac[r1]=false;
 				if (debug_diag==true)
 					diag("Thread %lu , connection %p , query: %s", pthread_self(), mysql, q.c_str());
 			}
@@ -169,7 +159,7 @@ void * my_conn_thread(void *arg) {
 				fprintf(stderr,"Error running query: %s. Error: %s\n", sel1.c_str(), mysql_error(mysql));
 			} else {
 				if (debug_diag==true)
-					diag("Thread %lu , connection %p , query: %s", pthread_self(), mysql, sel1.c_str());
+					diag("Thread %lu , connection %p , query: %s. QOT: %s", pthread_self(), mysql, sel1.c_str(), (explicit_transaction==false ? "true" : "false"));
 				MYSQL_RES *result = mysql_store_result(mysql);
 				mysql_free_result(result);
 				select_OK++;
@@ -250,10 +240,26 @@ void * my_conn_thread(void *arg) {
 		{
 			std::string q;
 			int f = fr%3;
+			switch (f) {
+				case 0:
+					q = "COMMIT";
+					break;
+				case 1:
+					q = "ROLLBACK";
+					break;
+				case 2:
+					if (ac[r1] == false) {
+						q = "SET autocommit=1";
+					} else {
+						q = "COMMIT";
+					}
+					break;
+/*
 			if (f==0) {
 				q = "COMMIT";
 			} else {
 				q = "ROLLBACK";
+*/
 /*
 				// FIXME: this code is currently commented because of another bug
 				if (explicit_transaction==false) {
@@ -263,6 +269,8 @@ void * my_conn_thread(void *arg) {
 				}
 */
 			}
+			if (debug_diag==true)
+				diag("Thread %lu , connection %p , query: %s, TrxEnd", pthread_self(), mysql, q.c_str());
 			if (mysql_query(mysql, q.c_str())) {
 				fprintf(stderr,"Error running query: %s. Error: %s\n", q.c_str(), mysql_error(mysql));
 				exit(EXIT_FAILURE);
@@ -450,6 +458,9 @@ int main(int argc, char *argv[]) {
 	// FIXME: until we fix the autocommit bug, we may have some minor mismatch
 	//ok((MyHGM_myconnpoll_get <= cnt_transactions+cnt_SELECT_outside_transactions && MyHGM_myconnpoll_get >= cnt_transactions+cnt_SELECT_outside_transactions-10) , "Number of transactions [%d] , Queries outside transaction [%d] , total connections returned [%d]", cnt_transactions.load(std::memory_order_relaxed), cnt_SELECT_outside_transactions.load(std::memory_order_relaxed), MyHGM_myconnpoll_get);
 	ok((MyHGM_myconnpoll_get == cnt_transactions+cnt_SELECT_outside_transactions) , "Number of transactions [%d] , Queries outside transaction [%d] , total connections returned [%d]", cnt_transactions.load(std::memory_order_relaxed), cnt_SELECT_outside_transactions.load(std::memory_order_relaxed), MyHGM_myconnpoll_get);
+
+
+
 	MYSQL_QUERY(mysqladmin, "DELETE FROM mysql_query_rules");
 	MYSQL_QUERY(mysqladmin, "INSERT INTO mysql_query_rules SELECT * FROM mysql_query_rules_948");
 	MYSQL_QUERY(mysqladmin, "LOAD MYSQL QUERY RULES TO RUNTIME");

--- a/test/tap/tests/test_session_status_flags-t.cpp
+++ b/test/tap/tests/test_session_status_flags-t.cpp
@@ -62,6 +62,13 @@ int main(int argc, char *argv[]) {
 			return -1;
 		}
 
+		diag("Preparing table test.test_savepoint");
+		MYSQL_QUERY(proxysql_mysql, "CREATE DATABASE IF NOT EXISTS test");
+		MYSQL_QUERY(proxysql_mysql, "CREATE TABLE IF NOT EXISTS test.test_savepoint(id INT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=INNODB");
+		MYSQL_QUERY(proxysql_mysql, "DELETE FROM test.test_savepoint");
+		MYSQL_QUERY(proxysql_mysql, "INSERT INTO test.test_savepoint VALUES (1), (2)");
+		sleep(1);
+
 		// Check that transaction state is reflected when actively in a transaction
 		const std::vector<std::string> transaction_queries { "START TRANSACTION", "SELECT 1", "PROXYSQL INTERNAL SESSION", "COMMIT" };
 		json j_status;

--- a/test/tap/tests/test_session_status_flags-t.cpp
+++ b/test/tap/tests/test_session_status_flags-t.cpp
@@ -38,6 +38,8 @@ int main(int argc, char *argv[]) {
 		return exit_status();
 	}
 
+	plan(23);
+
 	MYSQL* proxysql_admin = mysql_init(NULL);
 	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
@@ -50,7 +52,7 @@ int main(int argc, char *argv[]) {
 	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL SERVERS TO RUNTIME");
 
 	// Wait for ProxySQL to detect replication issues
-	sleep(10);
+	//sleep(10);
 
 	{
 		MYSQL* proxysql_mysql = mysql_init(NULL);
@@ -718,6 +720,7 @@ int main(int argc, char *argv[]) {
 
 		const std::vector<std::string> savepoint_queries {
 			"SET AUTOCOMMIT=0",
+			"SELECT * FROM test.test_savepoint LIMIT 1 FOR UPDATE",
 			"SAVEPOINT test_session_variables_savepoint",
 			"PROXYSQL INTERNAL SESSION",
 			"COMMIT",
@@ -770,7 +773,6 @@ int main(int argc, char *argv[]) {
 		} else {
 			ok(false, "No backends detected for the current connection.");
 		}
-
 		mysql_close(proxysql_mysql);
 	}
 


### PR DESCRIPTION
In MySQL_Connection::IsActiveTransaction:
in the past we were incorrectly checking STATUS_MYSQL_CONNECTION_HAS_SAVEPOINT
and returning true in case there were any savepoint.
Although flag STATUS_MYSQL_CONNECTION_HAS_SAVEPOINT was not reset in
case of no transaction, thus the check was incorrect.
We can ignore STATUS_MYSQL_CONNECTION_HAS_SAVEPOINT for multiplexing
purpose in IsActiveTransaction() because it is also checked
in MultiplexDisabled()