### PR TITLE
fix NO_BACKSLASH_ESCAPE, was breaking Rails on proxysql-2.4.2

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -5672,7 +5672,7 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 					auto values = std::begin(it->second);
 					if (var == "sql_mode") {
 						std::string value1 = *values;
-						if (strcasecmp(value1.c_str(),"NO_BACKSLASH_ESCAPE") != 0) {
+						if (strcasecmp(value1.c_str(),"NO_BACKSLASH_ESCAPE") == 0) {
 							// client is setting NO_BACKSLASH_ESCAPE in sql_mode
 							// Because we will reply with an OK packet without
 							// first setting sql_mode to the backend (this is


### PR DESCRIPTION
Only `set_no_backslash_escapes(true)` when client actually wants to set the `NO_BACKSLASH_ESCAPE` flag in the sql-mode session variable - this probably was a typo initially. 

This erroneous behavior was detected when trying to run Rails with the latest proxysql 2.4.2 version - it returned this slightly misleading `ArgumentError: negative string size (or size too big)` error message during startup, that seems to have to do with libmysql's `escape` functionality. With proxysql 2.3.2 it works just fine.

BTW: Not sure why it is `NO_BACKSLASH_ESCAPE` instead of `NO_BACKSLASH_ESCAPES`, but I guess this doesn't really matter in this comparison.