### PR TITLE
Upgrade OpenSSL from 3.0.2 to 3.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ deps/libev/libev-4.24/
 
 #libssl
 deps/libssl/openssl-openssl-*/
+deps/libssl/openssl-3*/
 
 #google coredumper
 deps/google-coredumper/google-coredumper/

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -75,7 +75,7 @@ endif
 libinjection: libinjection/libinjection/src/libinjection.a
 
 libssl/openssl/libssl.a:
-	cd libssl && rm -rf openssl-openssl-*/ || true
+	cd libssl && rm -rf openssl-openssl-*/ openssl-3*/ || true
 	cd libssl && tar -zxf openssl-*.tar.gz
 	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
 	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
@@ -314,7 +314,7 @@ cleanall:
 	cd libmicrohttpd && rm -f libmicrohttpd || true
 	cd curl && rm -rf curl-*/ || true
 	cd libev && rm -rf libev-*/ || true
-	cd libssl && rm -rf openssl-openssl-*/ || true
+	cd libssl && rm -rf openssl-openssl-*/ openssl-3*/ || true
 	cd libconfig && rm -rf libconfig-*/ || true
 	cd prometheus-cpp && rm -rf prometheus-cpp-*/ || true
 	cd cityhash && rm -rf cityhash/ || true

--- a/deps/libssl/README.md
+++ b/deps/libssl/README.md
@@ -2,4 +2,10 @@ In ProxySQL 2.0.4 , libssl was upgrade from 1.1.0h to 1.1.1b .
 
 In ProxySQL 2.0.7 , libssl was downgraded back to 1.1.0h . See [bug 2244](https://github.com/sysown/proxysql/issues/2244) .
 
+In ProxySQL 2.1.1 , libssl was upgraded to version 1.1.1j
+
+In ProxySQL 2.4.0 , libssl was upgraded from version 1.1.1j to 3.0.2
+
 Do not upgrade without extensive testing.
+
+See note about `struct bio_st` in MySQL_Data_Stream.cpp .

--- a/deps/libssl/openssl
+++ b/deps/libssl/openssl
@@ -1,1 +1,1 @@
-openssl-openssl-3.0.2
+openssl-3.0.5


### PR DESCRIPTION
Severe performance degradation identified in OpenSSL 3.0.2

See https://github.com/sysown/proxysql/pull/3937 for reference.

Thanks to @davisp and @huozhe