### PR TITLE
TAP test_sqlite3_server-t

### DIFF
--- a/test/tap/tests/test_sqlite3_server-t.cpp
+++ b/test/tap/tests/test_sqlite3_server-t.cpp
@@ -231,7 +231,7 @@ int main(int argc, char** argv) {
 	// plan as many tests as queries
 	plan(
 		2 /* Fail to connect with wrong username and password */ + successful_queries.size()
-		+ unsuccessful_queries.size() + admin_queries.size() // + sqlite_intf_queries.size()
+		+ unsuccessful_queries.size() + admin_queries.size() + sqlite_intf_queries.size()
 		+ 1 /* Connect to new setup interface */
 	);
 
@@ -335,7 +335,7 @@ int main(int argc, char** argv) {
 		// Reinitialize MYSQL handle
 		mysql_close(proxysql_sqlite3);
 		proxysql_sqlite3 = mysql_init(NULL);
-/*
+
 		// Change SQLite interface and connect to new port
 		for (const auto& admin_query : sqlite_intf_queries) {
 			int query_err = mysql_query(proxysql_admin, admin_query.c_str());
@@ -344,7 +344,7 @@ int main(int argc, char** argv) {
 				admin_query.c_str(), __LINE__, mysql_error(proxysql_admin)
 			);
 		}
-*/
+
 		// NOTE: Wait for ProxySQL to reconfigure, changing SQLite3 interface.
 		// Trying to perform a connection immediately after changing the
 		// interface could lead to 'EADDRINUSE' in ProxySQL side.


### PR DESCRIPTION
test_sqlite3_server-t keeps failing randomly on port change
the port change was disabled in v2.x by commit
https://github.com/sysown/proxysql/commit/9d2cf44b7717328b697afcb98578b86dd11d3f98
and reintroduced here for further testing and fixing