### PR TITLE
Remove final query delimiter ';' from query digests

### DIFF
--- a/lib/c_tokenizer.cpp
+++ b/lib/c_tokenizer.cpp
@@ -2498,27 +2498,29 @@ void final_stage(shared_st* shared_st, stage_1_st* stage_1_st, const options* op
 		}
 	}
 
-	// remove all trailing whitespaces
-	// ===============================
+	// Remove all trailing whitespaces and semicolons
+	// ==============================================
 	//
-	// Final spaces left by comments which are never collapsed, ex:
+	// - Final spaces left by comments which are never collapsed, ex:
 	//
 	// ```
 	// Q: `select 1.1   -- final_comment  \n`
 	// D: `select ?  `
 	//              ^ never collapsed
 	// ```
+	//
+	// - Semicolons (';') marking the end of the query are also removed.
 	{
 		// v1_crashing_payload_06
-		char* wspace = shared_st->res_cur_pos - 1;
-		while (wspace > shared_st->res_init_pos && (*wspace == ' ' || *wspace == ';')) {
-			wspace--;
+		char* f_char = shared_st->res_cur_pos - 1;
+		while (f_char > shared_st->res_init_pos && (*f_char == ' ' || *f_char == ';')) {
+			f_char--;
 		}
-		wspace++;
-		*wspace = '\0';
+		f_char++;
+		*f_char = '\0';
 		// NOTE: Since this is the last operation this isn't really required. But it's left in case this block
 		// is moved in the future.
-		shared_st->res_cur_pos = wspace;
+		shared_st->res_cur_pos = f_char;
 	}
 }
 

--- a/lib/c_tokenizer.cpp
+++ b/lib/c_tokenizer.cpp
@@ -2511,7 +2511,7 @@ void final_stage(shared_st* shared_st, stage_1_st* stage_1_st, const options* op
 	{
 		// v1_crashing_payload_06
 		char* wspace = shared_st->res_cur_pos - 1;
-		while (wspace > shared_st->res_init_pos && *wspace == ' ') {
+		while (wspace > shared_st->res_init_pos && (*wspace == ' ' || *wspace == ';')) {
 			wspace--;
 		}
 		wspace++;

--- a/test/tap/tests/tokenizer_payloads/regular_tokenizer_digests.hjson
+++ b/test/tap/tests/tokenizer_payloads/regular_tokenizer_digests.hjson
@@ -31,6 +31,45 @@
 		"s3": "select ?",
 		"s4": "select ?"
 	},
+	// Final spaces and ending query delimiters (';')
+	{
+		"q": [
+			"  /* comment */SELECT * FROM test.select_for_update_foo FOR UPDATE           ;",
+			"/* comment */ SELECT * FROM test.select_for_update_foo FOR UPDATE;       ",
+			"SELECT * FROM test.select_for_update_foo FOR UPDATE  ;  /* comment */",
+			"-- random_comment\n SELECT * FROM test.select_for_update_foo FOR UPDATE; -- final_comment\n   "
+		],
+		"s1": "SELECT * FROM test.select_for_update_foo FOR UPDATE",
+		"s2": "SELECT * FROM test.select_for_update_foo FOR UPDATE",
+		"s3": "SELECT * FROM test.select_for_update_foo FOR UPDATE",
+		"s4": "SELECT * FROM test.select_for_update_foo FOR UPDATE"
+	},
+	// Final spaces and ending and middle query delimiters (';'). Just one space preserved before and after (';').
+	{
+		"q": [
+			"  /* comment */SELECT * FROM test.select_for_update_foo FOR UPDATE  ; SELECT 1         ;",
+			"/* comment */ SELECT * FROM test.select_for_update_foo FOR UPDATE ;  SELECT 1;     ",
+			"SELECT * FROM test.select_for_update_foo FOR UPDATE  ;  /* comment */ SELECT 1     ;",
+			"-- random_comment\n SELECT * FROM test.select_for_update_foo FOR UPDATE ; -- final_comment\n SELECT 1;  -- final_comment\n  "
+		],
+		"s1": "SELECT * FROM test.select_for_update_foo FOR UPDATE ; SELECT ?",
+		"s2": "SELECT * FROM test.select_for_update_foo FOR UPDATE ; SELECT ?",
+		"s3": "SELECT * FROM test.select_for_update_foo FOR UPDATE ; SELECT ?",
+		"s4": "SELECT * FROM test.select_for_update_foo FOR UPDATE ; SELECT ?"
+	},
+	// Final spaces and ending and middle query delimiters (';'). No extra spaces before (';')
+	{
+		"q": [
+			"  /* comment */SELECT * FROM test.select_for_update_foo FOR UPDATE; SELECT 1         ;",
+			"/* comment */ SELECT * FROM test.select_for_update_foo FOR UPDATE;  SELECT 1;     ",
+			"SELECT * FROM test.select_for_update_foo FOR UPDATE;  /* comment */ SELECT 1     ;",
+			"-- random_comment\n SELECT * FROM test.select_for_update_foo FOR UPDATE; -- final_comment\n SELECT 1;  -- final_comment\n  "
+		],
+		"s1": "SELECT * FROM test.select_for_update_foo FOR UPDATE; SELECT ?",
+		"s2": "SELECT * FROM test.select_for_update_foo FOR UPDATE; SELECT ?",
+		"s3": "SELECT * FROM test.select_for_update_foo FOR UPDATE; SELECT ?",
+		"s4": "SELECT * FROM test.select_for_update_foo FOR UPDATE; SELECT ?"
+	},
 	// Floats
 	{
 		"q": [


### PR DESCRIPTION
Only the delimiter present at the end of the digest will be removed. Delimiters found in the middle of the full digest, like in the case of multi-statements should be preserved.