### PR TITLE
v2.x-ldap_fixes-2

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -5914,10 +5914,6 @@ void ProxySQL_Admin::init_ldap() {
 		insert_into_tables_defs(tables_defs_admin,"mysql_ldap_mapping", ADMIN_SQLITE_TABLE_MYSQL_LDAP_MAPPING);
 		insert_into_tables_defs(tables_defs_admin,"runtime_mysql_ldap_mapping", ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_LDAP_MAPPING);
 		insert_into_tables_defs(tables_defs_config,"mysql_ldap_mapping", ADMIN_SQLITE_TABLE_MYSQL_LDAP_MAPPING);
-		if (variables.hash_passwords==true) {
-			proxy_info("Impossible to set admin-hash_passwords=true when LDAP is enabled. Reverting to false\n");
-			variables.hash_passwords=false;
-		}
 	}
 }
 
@@ -6094,6 +6090,9 @@ bool ProxySQL_Admin::init() {
 	insert_into_tables_defs(tables_defs_stats,"stats_proxysql_message_metrics", STATS_SQLITE_TABLE_PROXYSQL_MESSAGE_METRICS);
 	insert_into_tables_defs(tables_defs_stats,"stats_proxysql_message_metrics_reset", STATS_SQLITE_TABLE_PROXYSQL_MESSAGE_METRICS_RESET);
 
+	// init ldap here
+	init_ldap();
+
 	// upgrade mysql_servers if needed (upgrade from previous version)
 	disk_upgrade_mysql_servers();
 
@@ -6229,6 +6228,10 @@ void ProxySQL_Admin::init_sqliteserver_variables() {
 }
 
 void ProxySQL_Admin::init_ldap_variables() {
+	if (variables.hash_passwords==true) {
+		proxy_info("Impossible to set admin-hash_passwords=true when LDAP is enabled. Reverting to false\n");
+		variables.hash_passwords=false;
+	}
 	flush_ldap_variables___runtime_to_database(configdb, false, false, false);
 	flush_ldap_variables___runtime_to_database(admindb, false, true, false);
 	flush_ldap_variables___database_to_runtime(admindb,true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1027,7 +1027,6 @@ void ProxySQL_Main_init_phase2___not_started() {
 	}
 
 	if (GloMyLdapAuth) {
-		GloAdmin->init_ldap();
 		GloAdmin->load_ldap_variables_to_runtime();
 	}
 


### PR DESCRIPTION
Make sure LDAP tables are existing and commited to disk before use

```
2022-09-02 10:34:17 ProxySQL_Admin.cpp:6301:load_or_update_global_settings(): [INFO] Using UUID: 9588556d-fc2d-48ac-9c48-201abab06768 . Writing it to database

Thread 1 "proxysql" hit Breakpoint 1, ProxySQL_Admin::__insert_or_replace_maintable_select_disktable (this=0x7ffff7061c00) at ProxySQL_Admin.cpp:10125
10125			admindb->execute("INSERT OR REPLACE INTO main.mysql_ldap_mapping SELECT * FROM disk.mysql_ldap_mapping");
(gdb) bt
#0  ProxySQL_Admin::__insert_or_replace_maintable_select_disktable (this=0x7ffff7061c00) at ProxySQL_Admin.cpp:10125
#1  0x0000555555baaec3 in ProxySQL_Admin::init (this=0x7ffff7061c00) at ProxySQL_Admin.cpp:5957
#2  0x0000555555a51b0c in ProxySQL_Main_init_Admin_module () at main.cpp:681
#3  0x0000555555a52a44 in ProxySQL_Main_init_phase2___not_started () at main.cpp:1008
#4  0x0000555555a544a2 in main (argc=8, argv=0x7fffffffde58) at main.cpp:1494
(gdb) c
Continuing.
2022-09-02 10:34:37 sqlite3db.cpp:166:execute(): [ERROR] SQLITE error: no such table: main.mysql_ldap_mapping --- INSERT OR REPLACE INTO main.mysql_ldap_mapping SELECT * FROM disk.mysql_ldap_mapping
2022-09-02 10:34:37 sqlite3db.cpp:166:execute(): [ERROR] SQLITE error: no such table: disk.mysql_ldap_mapping --- INSERT OR REPLACE INTO disk.mysql_ldap_mapping SELECT * FROM main.mysql_ldap_mapping
2022-09-02 10:34:37 ProxySQL_Admin.cpp:7988:set_variable(): [INFO] Impossible to set admin-hash_passwords=true when LDAP is enabled. Reverting to false
```