### PR TITLE
Add last_insert_id to query logs

### DIFF
--- a/include/MySQL_Logger.hpp
+++ b/include/MySQL_Logger.hpp
@@ -30,6 +30,7 @@ class MySQL_Event {
 	bool have_rows_sent;
 	uint64_t affected_rows;
 	uint64_t rows_sent;
+	uint64_t last_insert_id;
 	public:
 	MySQL_Event(log_event_type _et, uint32_t _thread_id, char * _username, char * _schemaname , uint64_t _start_time , uint64_t _end_time , uint64_t _query_digest, char *_client, size_t _client_len);
 	uint64_t write(std::fstream *f, MySQL_Session *sess);
@@ -41,6 +42,7 @@ class MySQL_Event {
 	void set_extra_info(char *);
 	void set_affected_rows(uint64_t ar);
 	void set_rows_sent(uint64_t rs);
+	void set_last_insert_id(uint64_t li_id);
 };
 
 class MySQL_Logger {

--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -60,6 +60,7 @@ class Query_Info {
 	bool have_affected_rows;
 	uint64_t affected_rows;
 	uint64_t rows_sent;
+	uint64_t last_insert_id;
 	uint64_t waiting_since;
 
 	Query_Info();

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -526,6 +526,7 @@ bool MySQL_Protocol::generate_pkt_OK(bool send, void **ptr, unsigned int *len, u
 		if (sess->session_type == PROXYSQL_SESSION_MYSQL) {
 			sess->CurrentQuery.have_affected_rows = true;
 			sess->CurrentQuery.affected_rows = affected_rows;
+			sess->CurrentQuery.last_insert_id = last_insert_id;
 		}
 	}
 	if (*myds && (*myds)->myconn) {

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -275,6 +275,7 @@ Query_Info::Query_Info() {
 	have_affected_rows=false;
 	waiting_since = 0;
 	affected_rows=0;
+	last_insert_id=0;
 	rows_sent=0;
 	start_time=0;
 	end_time=0;
@@ -308,6 +309,7 @@ void Query_Info::begin(unsigned char *_p, int len, bool mysql_header) {
 	waiting_since = 0;
 	affected_rows=0;
 	rows_sent=0;
+	last_insert_id=0;
 	sess->gtid_hid=-1;
 }
 

--- a/tools/eventslog_reader_sample.cpp
+++ b/tools/eventslog_reader_sample.cpp
@@ -109,6 +109,7 @@ class MySQL_Event {
 	uint64_t hid;
 	uint64_t affected_rows;
 	uint64_t rows_sent;
+	uint64_t last_insert_id;
 	log_event_type et;
 	public:
 	MySQL_Event() {
@@ -163,6 +164,7 @@ class MySQL_Event {
 		read_encoded_length((uint64_t *)&end_time,f);
 		read_encoded_length((uint64_t *)&affected_rows,f);
 		read_encoded_length((uint64_t *)&rows_sent,f);
+		read_encoded_length((uint64_t *)&last_insert_id,f);
 		read_encoded_length((uint64_t *)&query_digest,f);
 		char digest_hex[20];
 		sprintf(digest_hex,"0x%016llX", (long long unsigned int)query_digest);
@@ -185,6 +187,7 @@ class MySQL_Event {
 		cout << " duration=" << (end_time-start_time) << "us";
 		cout << " rows_affected=" << affected_rows;
 		cout << " rows_sent=" << rows_sent;
+		cout << " last_insert_id=" << last_insert_id;
 		cout << " digest=\"" << digest_hex << "\"" << endl << query_ptr << endl;
 	}
 	~MySQL_Event() {


### PR DESCRIPTION
This change includes the last_insert_id into the query event logs. Example output can be found [here](https://gist.github.com/davisp/15da377befcc4f4b073461c27032a577).