### PR TITLE
Fix malformed packet when connected with MariaDB server with fast_forward flag ON

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -222,6 +222,7 @@ endif
 #	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_secure.c < ../ma_secure.c.patch
 	cd mariadb-client-library/mariadb_client && patch include/mysql.h < ../mysql.h.patch
 	cd mariadb-client-library/mariadb_client && patch include/mariadb_com.h < ../mariadb_com.h.patch
+	cd mariadb-client-library/mariadb_client && patch include/ma_priv.h < ../ma_priv.h.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_alloc.c < ../ma_alloc.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_charset.c < ../ma_charset.c.patch
 #	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_pvio.c < ../ma_pvio.c.patch

--- a/deps/mariadb-client-library/ma_priv.h.patch
+++ b/deps/mariadb-client-library/ma_priv.h.patch
@@ -1,0 +1,10 @@
+@@ -30,8 +30,7 @@
+ 
+ static inline my_bool ma_has_extended_type_info(const MYSQL *mysql)
+ {
+-  return ((mysql->extension->mariadb_server_capabilities) &
+-          (MARIADB_CLIENT_EXTENDED_METADATA >> 32)) != 0;
++  return 0;
+ }
+ 
+ static inline uint ma_extended_type_info_rows(const MYSQL *mysql)

--- a/deps/mariadb-client-library/mariadb_com.h.patch
+++ b/deps/mariadb-client-library/mariadb_com.h.patch
@@ -1,3 +1,14 @@
+@@ -178,8 +178,8 @@
+ 
+ #define MARIADB_CLIENT_SUPPORTED_FLAGS (MARIADB_CLIENT_PROGRESS |\
+                                        MARIADB_CLIENT_COM_MULTI |\
+-                                       MARIADB_CLIENT_STMT_BULK_OPERATIONS|\
+-                                       MARIADB_CLIENT_EXTENDED_METADATA)
++                                       MARIADB_CLIENT_STMT_BULK_OPERATIONS\
++                                       )
+ 
+ #define CLIENT_SUPPORTED_FLAGS  (CLIENT_MYSQL |\
+                                  CLIENT_FOUND_ROWS |\
 @@ -210,8 +210,6 @@
                                   CLIENT_LONG_FLAG |\
                                   CLIENT_TRANSACTIONS |\

--- a/test/tap/tests/reg_test_3992_fast_forward_malformed_packet-mysqlsh-t.cpp
+++ b/test/tap/tests/reg_test_3992_fast_forward_malformed_packet-mysqlsh-t.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file reg_test_3992-fast_forward_malformed_packet-t.cpp
+ * @brief This is a regression test for issue #3992. Test checks if queries are executed successfully with MariaDB  
+ *  server via mysql client having fast forward flag set to true and false.
+ * @details The test executes basic queries to check execution in MariaDB via mysql client with Fast Forward flags on/off
+ *   
+ */
+
+#include <vector>
+#include <string>
+#include <stdio.h>
+#include <cstring>
+#include <unistd.h>
+#include <mysql.h>
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+	
+	const std::vector<std::pair<std::string, std::string>> users { {"mariadbuserff", "mariadbuserff"},
+											   {"mariadbuser", "mariadbuser"} };
+
+	for (const auto& user : users)
+	{
+		// Test that mysqlsh is able to connect and execute a query
+		const char* mysqlsh_client = "mysqlsh";
+		const std::string mysql_user = std::string("-u") + user.first + " ";
+		const std::string mysql_pass = std::string("-p") + user.second + " ";
+		const std::string mysql_port = std::string("-P") + std::to_string(cl.port) + " ";
+		const std::string host = std::string("-h ") + std::string(cl.host) + " ";
+
+		int mysqlsh_res = system((std::string("mysqlsh ") + std::string("--sql ") + mysql_user + mysql_pass + mysql_port + host + "-e \"SHOW DATABASES\"").c_str());
+		ok(mysqlsh_res == 0, "'mysqlsh' empty select command should be correctly executed. Err code was: %d", mysqlsh_res);
+
+		mysqlsh_res = system((std::string("mysqlsh ") + std::string("--sql ") + mysql_user + mysql_pass + mysql_port + host + "-e \"SELECT 1\"").c_str());
+		ok(mysqlsh_res == 0, "'mysqlsh' empty select command should be correctly executed. Err code was: %d", mysqlsh_res);
+	}
+
+	return exit_status();
+}

--- a/test/tap/tests/reg_test_3992_fast_forward_malformed_packet-t.cpp
+++ b/test/tap/tests/reg_test_3992_fast_forward_malformed_packet-t.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file reg_test_3992-fast_forward_malformed_packet-t.cpp
+ * @brief This is a regression test for issue #3992. Test checks if queries are executed successfully with MariaDB  
+ *  server having fast forward flag set to true and false.
+ * @details The test executes basic queries to check execution in MariaDB with Fast Forward flags on/off
+ *   
+ */
+
+#include <vector>
+#include <string>
+#include <stdio.h>
+#include <cstring>
+#include <unistd.h>
+#include <mysql.h>
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+	
+	std::vector<MYSQL*> conns;
+	
+	const std::vector<std::pair<std::string, std::string>> users { {"mariadbuserff", "mariadbuserff"},
+											   {"mariadbuser", "mariadbuser"} };
+
+	const std::vector<std::string> queries {"SHOW DATABASES", "SELECT 1"};
+
+	plan(users.size() * queries.size());
+
+	for (const auto& user : users)
+	{
+		MYSQL* mysql = mysql_init(NULL);
+		
+		if (!mysql) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(mysql));
+			return EXIT_FAILURE;
+		}
+
+		if (!mysql_real_connect(mysql, cl.host, user.first.c_str(), user.second.c_str(), NULL, cl.port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(mysql));
+			return EXIT_FAILURE;
+		}
+
+		conns.push_back(mysql);
+	}
+
+	for (MYSQL* conn : conns)
+	{
+		for (const std::string& query : queries)
+		{
+			const int q_err = mysql_query(conn, query.c_str());
+
+			if (q_err == EXIT_SUCCESS)
+			{
+				MYSQL_RES *result = mysql_store_result(conn);
+				mysql_free_result(result);
+
+				ok(true, "Executing query of size: '%ld', should succeed", query.size());
+			}
+			else
+				ok(false, "Executing query of size: '%ld', should succeed", query.size());
+		}
+		
+		mysql_close(conn);
+	}
+
+	return exit_status();
+}


### PR DESCRIPTION
Resolves [Issue 3992](https://github.com/sysown/proxysql/issues/3992)
* Removed MARIADB_CLIENT_EXTENDED_METADATA flag