### PR TITLE
WIP Fix invalid resultset

### DIFF
--- a/lib/Query_Cache.cpp
+++ b/lib/Query_Cache.cpp
@@ -519,6 +519,18 @@ unsigned char* eof_to_ok_packet(QC_entry_t* entry) {
 	memcpy(vp, it, 4);
 	// =======================================
 
+	// Decrement ids after the first EOF
+	unsigned char* dp = result + entry->column_eof_pkt_offset;
+	mysql_hdr decrement_hdr;
+	for (;;) {
+		memcpy(&decrement_hdr, dp, sizeof(mysql_hdr));
+		decrement_hdr.pkt_id--;
+		memcpy(dp, &decrement_hdr, sizeof(mysql_hdr));
+		dp += sizeof(mysql_hdr) + decrement_hdr.pkt_length;
+		if (dp >= vp)
+			break;
+	}
+
 	return result;
 }
 


### PR DESCRIPTION
Fix invalid resultset when using query cache and mixing clients using and not using CLIENT_DEPRECATE_EOF.

Otherwise, if a client connects to ProxySQL not using CLIENT_DEPRECATE_EOF and it caches a resultset, when a client using CLIENT_DEPRECATE_EOF executes the same query it will get an invalid resultset and the client will disconnect. The data in the resultset is correct, but proxysql skips a sequence id thus the client assumes it is corrupted.

More info in issue #3698