### PR TITLE
Do not print version numbers longer than 32 chars

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,7 +150,8 @@ static char * main_check_latest_version() {
 
 void * main_check_latest_version_thread(void *arg) {
 	char * latest_version = main_check_latest_version();
-	if (latest_version) {
+	// we check for potential invalid data , see issue #4042 
+	if (latest_version != NULL && strlen(latest_version) < 32) {
 		if (
 			(know_latest_version == NULL) // first check
 			|| (strcmp(know_latest_version,latest_version)) // new version detected


### PR DESCRIPTION
If the returned version number during version check is longer than 32 bytes it means that probably the request failed.
In this case we suppress and ignore it.

Fixes #4042