### PR TITLE
Fix crash on RESTAPI script invocation - Closes #4001

### DIFF
--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -128,6 +128,7 @@ enum debug_module {
 	PROXY_DEBUG_IPC,
 	PROXY_DEBUG_QUERY_CACHE,
 	PROXY_DEBUG_QUERY_STATISTICS,
+	PROXY_DEBUG_RESTAPI,
 	PROXY_DEBUG_UNKNOWN // this module doesn't exist. It is used only to define the last possible module
 };
 

--- a/include/proxysql_utils.h
+++ b/include/proxysql_utils.h
@@ -128,27 +128,27 @@ cfmt_t cstr_format(char (&out_buf)[N], const char* fmt, ...) {
 /**
  * @brief Simple struct that holds the 'timeout options' for 'wexecvp'.
  */
-struct to_opts {
+struct to_opts_t {
 	/**
 	 * @brief Timeout for the script execution to be completed, in case of being
 	 *   exceeded, the script will be terminated.
 	 */
 	unsigned int timeout_us;
 	/**
-	 * @brief Timeout used for 'select()' non blocking calls.
+	 * @brief Timeout used for 'poll()' non blocking calls.
 	 */
-	suseconds_t select_to_us;
+	suseconds_t poll_to_us;
 	/**
 	 * @brief The duration of the sleeps between the checks being performed
 	 *   on the child process waiting it to exit after being signaled to terminate,
 	 *   before issuing 'SIGKILL'.
 	 */
-	unsigned int it_delay_us;
+	unsigned int waitpid_delay_us;
 	/**
 	 * @brief The timeout to be waited on the child process after being signaled
 	 *   with 'SIGTERM' before being forcely terminated by 'SIGKILL'.
 	 */
-	unsigned int sigkill_timeout_us;
+	unsigned int sigkill_to_us;
 };
 
 /**
@@ -165,17 +165,16 @@ struct to_opts {
  * @return 0 In case of success or one of the following error codes:
  *   - '-1' in case any 'pipe()' creation failed.
  *   - '-2' in case 'fork()' call failed.
- *   - '-3' in case 'fcntl()' call failed .
- *   - '-4' in case of resource exhaustion, file descriptors being used exceeds 'FD_SETSIZE'.
- *   - '-5' in case 'select()' call failed.
- *   - '-6' in case 'read()' from pipes failed with a non-expected error.
+ *   - '-3' in case 'fcntl()' call failed.
+ *   - '-4' in case 'poll()' call failed.
+ *   - '-5' in case 'read()' from pipes failed with a non-expected error.
  *   - 'ETIME' in case the executable has exceeded the timeout supplied in 'opts.timeout_us'.
  *  In all this cases 'errno' is set to the error reported by the failing 'system call'.
  */
 int wexecvp(
 	const std::string& file,
 	const std::vector<const char*>& argv,
-	const to_opts* opts,
+	const to_opts_t& opts,
 	std::string& s_stdout,
 	std::string& s_stderr
 );

--- a/lib/ProxySQL_RESTAPI_Server.cpp
+++ b/lib/ProxySQL_RESTAPI_Server.cpp
@@ -97,17 +97,17 @@ private:
 		if (nullptr!=result)
 			return result;
 
-		to_opts wexecvp_opts {};
+		to_opts_t wexecvp_opts {};
 		wexecvp_opts.timeout_us = (interval_ms * 1000);
-		wexecvp_opts.select_to_us = 100*1000;
-		wexecvp_opts.it_delay_us = 500*1000;
-		wexecvp_opts.sigkill_timeout_us = 3000 * 1000;
+		wexecvp_opts.poll_to_us = 100*1000;
+		wexecvp_opts.waitpid_delay_us = 500*1000;
+		wexecvp_opts.sigkill_to_us = 3000 * 1000;
 
 		std::string script_stdout {""};
 		std::string script_stderr {""};
 
 		const std::vector<const char*> args { const_cast<const char*>(params.c_str()), NULL};
-		int script_err = wexecvp(script.c_str(), args, &wexecvp_opts, script_stdout, script_stderr);
+		int script_err = wexecvp(script.c_str(), args, wexecvp_opts, script_stdout, script_stderr);
 		int script_errno = errno;
 
 		std::string str_response_err {};

--- a/lib/ProxySQL_RESTAPI_Server.cpp
+++ b/lib/ProxySQL_RESTAPI_Server.cpp
@@ -3,13 +3,9 @@
 #include "httpserver.hpp"
 
 #include <functional>
-#include <sstream>
 
 #include "ProxySQL_RESTAPI_Server.hpp"
 #include "proxysql_utils.h"
-
-using namespace httpserver;
-
 
 #ifdef DEBUG
 #define DEB "_DEBUG"
@@ -20,6 +16,9 @@ using namespace httpserver;
 
 extern ProxySQL_Admin *GloAdmin;
 
+using namespace httpserver;
+using nlohmann::json;
+
 class sync_resource : public http_resource {
 private:
 	void add_headers(std::shared_ptr<http_response> &response) {
@@ -29,61 +28,90 @@ private:
 
 	const std::shared_ptr<http_response> find_script(const http_request& req, std::string& script, int &interval_ms) {
 		char *error=NULL;
-		std::stringstream ss;
-		ss << "SELECT * FROM runtime_restapi_routes WHERE uri='" << req.get_path_piece(1) << "' and method='" << req.get_method() << "' and active=1";
-		std::unique_ptr<SQLite3_result> resultset = std::unique_ptr<SQLite3_result>(GloAdmin->admindb->execute_statement(ss.str().c_str(), &error));
+		const string req_uri { req.get_path_piece(1) };
+		const string req_path { req.get_path() };
+		const string select_query {
+			"SELECT * FROM runtime_restapi_routes WHERE uri='" + req_uri + "' and"
+				" method='" + req.get_method() + "' and active=1"
+		};
+
+		std::unique_ptr<SQLite3_result> resultset {
+			std::unique_ptr<SQLite3_result>(GloAdmin->admindb->execute_statement(select_query.c_str(), &error))
+		};
+
 		if (!resultset) {
-			proxy_error("Cannot query script for given method [%s] and uri [%s]\n", req.get_method().c_str(), req.get_path_piece(1).c_str());
-			std::stringstream ss;
+			proxy_error(
+				"Cannot query script for given method [%s] and uri [%s]\n", req.get_method().c_str(), req_uri.c_str()
+			);
+			const string not_found_err_msg {
+				"The script for method [" + req.get_method() + "] and route [" + req.get_path() + "] was not found."
+			};
+			json j_err_resp {};
+
 			if (error) {
-				ss << "{\"error\":\"The script for method [" << req.get_method() << "] and route [" << req.get_path() << "] was not found. Error: " << error << "Error: \"}";
-				proxy_error("Path %s, error %s\n", req.get_path().c_str(), error);
+				j_err_resp = json { { "error", not_found_err_msg + " Error:" + error } };
+				proxy_error("Path '%s', error '%s'\n", req_path.c_str(), error);
+			} else {
+				j_err_resp = json { { "error", not_found_err_msg } };
+				proxy_error("Path '%s', error 'Path failed to be found on 'runtime_restapi_routes'\n", req_path.c_str());
 			}
-			else {
-				ss << "{\"error\":\"The script for method [" << req.get_method() << "] and route [" << req.get_path() << "] was not found.\"}";
-				proxy_error("Path %s\n", req.get_path().c_str());
-			}
-			auto response = std::shared_ptr<http_response>(new string_response(ss.str(), http::http_utils::http_bad_request));
+
+			auto response =
+				std::shared_ptr<http_response>(new string_response(j_err_resp.dump(), http::http_utils::http_bad_request));
 			add_headers(response);
+
 			return response;
-		}
-		if (resultset && resultset->rows_count != 1) {
-			std::stringstream ss;
-			ss << "{\"error\":\"The script for method [" << req.get_method() << "] and route [" << req.get_path() << "] was not found. Rows count returned [" << resultset->rows_count << "]\" }";
-			proxy_error("Script for method [%s] and route [%s] was not found\n", req.get_method().c_str(), req.get_path().c_str());
-			auto response = std::shared_ptr<http_response>(new string_response(ss.str(), http::http_utils::http_bad_request));
+		} else if (resultset && resultset->rows_count != 1) {
+			const string not_found_err_msg {
+				"The script for method [" + req.get_method() + "] and route [" + req_path + "] was not found."
+					" Rows count returned [" + std::to_string(resultset->rows_count) + "]"
+			};
+			json j_err_resp { { "error", not_found_err_msg } };
+
+			proxy_error(
+				"Script for method [%s] and uri [%s] was not found\n", req.get_method().c_str(), req_uri.c_str()
+			);
+			auto response =
+				std::shared_ptr<http_response>(new string_response(j_err_resp.dump(), http::http_utils::http_bad_request));
 			add_headers(response);
+
 			return response;
+		} else {
+			script = resultset->rows[0]->fields[5];
+			interval_ms = atoi(resultset->rows[0]->fields[2]);
+
+			return std::shared_ptr<http_response>(nullptr);
 		}
-		script = resultset->rows[0]->fields[5];
-		interval_ms = atoi(resultset->rows[0]->fields[2]);
-		return std::shared_ptr<http_response>(nullptr);
 	}
 
     const std::shared_ptr<http_response> process_request(const http_request& req, const std::string& _params) {
 		std::string params = req.get_content();
+		const string req_path { req.get_path() };
+
 		if (params.empty())
 			params = _params;
 		if (params.empty()) {
-			proxy_error("Empty parameters\n");
-
+			proxy_error("Path '%s', error 'Supplied empty parameters'\n", req_path.c_str());
+			json j_err_resp { { "type", "in" }, { "error", "Empty parameters" } };
 			auto response = std::shared_ptr<http_response>(
-				new string_response("{\"error\":\"Empty parameters\"}", http::http_utils::http_bad_request)
+				new string_response(j_err_resp.dump(), http::http_utils::http_bad_request)
 			);
+
 			add_headers(response);
 			return response;
 		}
 
 		try {
 			nlohmann::json valid=nlohmann::json::parse(params);
-		}
-		catch(nlohmann::json::exception& e) {
-			std::stringstream ss;
-			ss << "{\"type\":\"in\", \"error\":\"" << e.what() << "\"}";
-			proxy_error("Error parsing input json parameters. %s\n", ss.str().c_str());
+		} catch(nlohmann::json::exception& e) {
+			const string p_err_msg {
+				"parsing input JSON parameters - params: `" + params + "`, error: '" + e.what() + "'"
+			};
+			json j_err_resp { { "type", "in" }, { "error", "Error " + p_err_msg } };
+			proxy_error("Path '%s', error %s\n", req_path.c_str(), p_err_msg.c_str());
 
 			auto response = std::shared_ptr<http_response>(
-				new string_response(ss.str(), http::http_utils::http_bad_request)
+				new string_response(j_err_resp.dump(), http::http_utils::http_bad_request)
 			);
 			add_headers(response);
 			return response;
@@ -107,7 +135,9 @@ private:
 		std::string script_stderr {""};
 
 		const std::vector<const char*> args { const_cast<const char*>(params.c_str()), NULL};
+		proxy_debug(PROXY_DEBUG_RESTAPI, 2, "Starting script exec - script: '%s', params: `%s`\n", script.c_str(), params.c_str());
 		int script_err = wexecvp(script.c_str(), args, wexecvp_opts, script_stdout, script_stderr);
+		proxy_debug(PROXY_DEBUG_RESTAPI, 2, "Finished script exec - script: '%s', params: `%s`\n", script.c_str(), params.c_str());
 		int script_errno = errno;
 
 		std::string str_response_err {};
@@ -115,10 +145,14 @@ private:
 
 		// 'execvp' failed to be executed, the error code comes directly from the child process
 		if (script_err > 255) {
-			str_response_err =
-				std::string { "{\"type\":\"out\", \"error\":\"Script failed to be executed.\", \"error_code\":\"" }
-				+ std::to_string(script_err / 256)
-				+ "\"}";
+			json j_err_resp {
+				{ "type", "out" },
+				{ "error", "Script failed to be executed" },
+				{ "error_code", std::to_string(script_err / 256) },
+				{ "script_stdout", script_stdout },
+				{ "script_stderr", script_stderr }
+			};
+			str_response_err = j_err_resp.dump();
 			proxy_error(
 				"Script '%s' exited with errcode '%d': \n- script_stdout:\n'''\n%s'''\n- script_stderr:\n'''\n%s'''\n",
 				script.c_str(),
@@ -130,11 +164,12 @@ private:
 		// there was an internal error while calling the executable, or request timedout.
 		else if (script_err < 256 && script_err != 0) {
 			if (script_err == ETIME) {
-				str_response_err =
-					std::string { "{\"type\":\"out\", \"error\":\"Script execution timed out.\", \"error_code\":\"" }
-					+ std::to_string(ETIME)
-					+ "\"}";
-
+				json j_err_resp {
+					{ "type", "out" },
+					{ "error", "Script execution timed out" },
+					{ "error_code", std::to_string(ETIME) }
+				};
+				str_response_err = j_err_resp.dump();
 				proxy_error("Request to execute script '%s' timed out.\n", script.c_str());
 			} else if (script_err < 0) {
 				// there was an internal error unrelated to script execution
@@ -159,12 +194,12 @@ private:
 						failed_syscall = "unknown"; break;
 				}
 
-				str_response_err =
-					std::string {
-						"{\"type\":\"out\"," } +
-							"\"error\":\"Internal error while executing script, '" + failed_syscall + "' syscall failed.\", " +
-							"\"error_code\":\"" + std::to_string(script_errno)
-						+ "\"}";
+				json j_err_resp {
+					{ "type", "out" },
+					{ "error", "Internal error while executing script, '" + failed_syscall + "' syscall failed" },
+					{ "error_code", std::to_string(script_errno) }
+				};
+				str_response_err = j_err_resp.dump();
 				proxy_error(
 					"Internal error while executing script '%s'. '%s' syscall failed with error code: '%d'.\n",
 					script.c_str(),
@@ -172,43 +207,41 @@ private:
 					script_errno
 				);
 			} else {
-				str_response_err =
-					"{\"type\":\"out\", \"error\":\"Terminated without exit code. Child exit status reported in"
-						" 'error_code'\", \"error_code\":\"" + std::to_string(script_err) + "\"}";
-				proxy_error(
-					"Error while executing script '%s'. Child exit status: '%d'.\n", script.c_str(), script_err
-				);
+				json j_err_resp {
+					{ "type", "out" },
+					{ "error", "Terminated without exit code. Child exit status reported in 'error_code'" },
+					{ "error_code", std::to_string(script_err) }
+				};
+				str_response_err = j_err_resp.dump();
+				proxy_error("Error while executing script '%s'. Child exit status: '%d'.\n", script.c_str(), script_err);
 			}
 		}
 		// script returned and empty output, invalid output, no need to parse it.
 		else if (script_stdout.empty()) {
-			str_response_err =
-				std::string {
-					"{\"type\":\"out\"," } +
-						"\"error\":\"Script response is empty, only valid JSONs are accepted.\", " +
-						"\"error_code\":\"" + std::to_string(0)
-					+ "\"}";
+			json j_err_resp {
+				{ "type", "out" },
+				{ "error", "Script response is empty, only valid JSONs are accepted" },
+				{ "error_code", std::to_string(0) }
+			};
+			str_response_err = j_err_resp.dump();
 			proxy_error("Invalid empty response from script: '%s'\n", script.c_str());
 		}
 		// execution completed successfully without timing out.
 		else {
 			try {
 				nlohmann::json j { nlohmann::json::parse(script_stdout.c_str()) };
-			}
-			catch(nlohmann::json::exception& e) {
-				std::string escaped_stdout { replace_str(script_stdout, std::string { '"' }, "\\\"") };
-
-				str_response_err =
-					std::string { "{" } +
-						std::string { "\"type\":\"out\", \"error\":\"" } + e.what() +
-						std::string { ", \"error_code\":\"" } + std::to_string(script_err / 256) + "\"" +
-						std::string { ", \"script_stdout\":\"" } + escaped_stdout + "\"" +
-						std::string { ", \"script_stderr\":\"" } + script_stderr + "\"" +
-					"}";
+			} catch(nlohmann::json::exception& e) {
+				json j_err_resp {
+					{ "type", "out" },
+					{ "error", e.what() },
+					{ "error_code", std::to_string(script_err / 256) },
+					{ "script_stdout", script_stdout },
+					{ "script_stderr", script_stderr }
+				};
+				str_response_err = j_err_resp.dump();
 				proxy_error(
 					"Error parsing script output from script: '%s'\n- script_stdout:\n'''\n%s'''\n",
-					script.c_str(),
-					script_stdout.c_str()
+					script.c_str(), script_stdout.c_str()
 				);
 			}
 		}
@@ -240,35 +273,37 @@ private:
 public:
 	const std::shared_ptr<http_response> render(const http_request& req) {
 		proxy_info("Render generic request with method %s for uri %s\n", req.get_method().c_str(), req.get_path().c_str());
-		std::stringstream ss;
-		ss << "{\"error\":\"HTTP method " << req.get_method().c_str() << " is not implemented\"}";
-
-        auto response = std::shared_ptr<http_response>(new string_response(ss.str().c_str()));
+		json j_err_resp {{ "error", "HTTP method " + req.get_method() + " is not implemented" }};
+        auto response = std::shared_ptr<http_response>(new string_response(j_err_resp.dump()));
         response->with_header("Content-Type", "application/json");
         response->with_header("Access-Control-Allow-Origin", "*");
+
         return response;
     }
 
 	const std::shared_ptr<http_response> render_GET(const http_request& req) {
-		auto args = req.get_args();
+		const auto args = req.get_args();
 
-		size_t last = 0;
-		std::stringstream params;
-		params << "{";
-		for (auto arg : args) {
-			params << "\"" << arg.first << "\":\"" << arg.second << "\"";
-			if (last < args.size()-1) {
-				params << ",";
-				last++;
-			}
+		// Explicit object creation, otherwise 'array' is initialized
+		json input_params = json::object();
+		for (const auto& arg : args) {
+			input_params.push_back({arg.first, arg.second});
 		}
-		params << "}";
 
-		return process_request(req, params.str());
+		const char* req_path { req.get_path().c_str() };
+		const string s_params { input_params.dump() };
+		const char* p_params { s_params.c_str() };
+		proxy_debug(PROXY_DEBUG_RESTAPI, 1, "Processing GET - req: '%s', params: `%s`\n", req_path, p_params);
+
+		return process_request(req, s_params);
 	}
 
 	const std::shared_ptr<http_response> render_POST(const http_request& req) {
 		std::string params=req.get_content();
+		const char* req_path { req.get_path().c_str() };
+		const char* p_params { params.c_str() };
+		proxy_debug(PROXY_DEBUG_RESTAPI, 1, "Processing POST - req: '%s', params: `%s`\n", req_path, p_params);
+
 		return process_request(req, params);
 	}
 

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -401,6 +401,7 @@ void init_debug_struct() {
 	GloVars.global.gdbg_lvl[PROXY_DEBUG_IPC].name=(char *)"debug_ipc";
 	GloVars.global.gdbg_lvl[PROXY_DEBUG_QUERY_CACHE].name=(char *)"debug_query_cache";
 	GloVars.global.gdbg_lvl[PROXY_DEBUG_QUERY_STATISTICS].name=(char *)"debug_query_statistics";
+	GloVars.global.gdbg_lvl[PROXY_DEBUG_RESTAPI].name=(char *)"debug_restapi";
 
 	for (i=0;i<PROXY_DEBUG_UNKNOWN;i++) {
 		// if this happen, the above table is not populated correctly

--- a/lib/proxysql_utils.cpp
+++ b/lib/proxysql_utils.cpp
@@ -4,11 +4,16 @@
 #include <sstream>
 
 #include <fcntl.h>
+#include <poll.h>
 #include <signal.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <string.h>
 #include <unistd.h>
+
+using std::string;
+using std::vector;
 
 __attribute__((__format__ (__printf__, 1, 2)))
 cfmt_t cstr_format(const char* fmt, ...) {
@@ -47,7 +52,7 @@ cfmt_t cstr_format(const char* fmt, ...) {
  *
  * @return The error returned by 'kill' in case of it failing.
  */
-int kill_child_proc(pid_t child_pid, const uint timeout_us, const uint it_sleep_us) {
+int kill_child_proc(pid_t child_pid, const uint timeout_us, const uint waitpid_sleep_us) {
 	uint err = 0;
 	uint waited = 0;
 	int child_status = 0;
@@ -59,10 +64,10 @@ int kill_child_proc(pid_t child_pid, const uint timeout_us, const uint it_sleep_
 			kill(child_pid, SIGKILL);
 			waited = 0;
 		} else {
-			waited += it_sleep_us;
+			waited += waitpid_sleep_us;
 		}
 
-		usleep(it_sleep_us);
+		usleep(waitpid_sleep_us);
 	}
 
 	return err;
@@ -86,7 +91,7 @@ int read_pipe(int pipe_fd, std::string& sbuffer) {
 	for (;;) {
 		count = read(pipe_fd, (void*)buffer, sizeof(buffer) - 1);
 		if (count > 0) {
-		buffer[count] = 0;
+			buffer[count] = 0;
 			sbuffer += buffer;
 		} else if (count == 0){
 			res = 0;
@@ -110,12 +115,80 @@ uint64_t get_timestamp_us() {
 	return start_timestamp;
 }
 
+/**
+ * @brief Verifies if the supplied process 'pid' exists within the supplied 'timeout'.
+ *
+ * @param pid The pid of the process to monitor.
+ * @param status A point to an int to be updated with the child status reported by 'waitpid'.
+ * @param timeout The maximum timeout to wait for the child to exit.
+ *
+ * @return 'True' in case the child exited before the timeout, 'false' otherwise.
+ */
+bool check_child_exit(pid_t pid, int* status, uint32_t timeout) {
+	uint32_t check_delay = 100;
+	uint32_t cur_waited = 0;
+
+	bool proc_exit = false;
+
+	while (cur_waited < timeout) {
+		pid_t w_res = waitpid(pid, status, WNOHANG);
+
+		if (w_res == -1 && errno == ECHILD) {
+			proc_exit = true;
+			break;
+		}
+
+		usleep(check_delay * 1000);
+		cur_waited += check_delay;
+	}
+
+	return proc_exit;
+}
+
+/**
+ * @brief Struct for holding an error code and current 'errno' after failed syscall.
+ */
+struct syserr_t {
+	int err;
+	int _errno;
+};
+
+/**
+ * @brief Struct holding information about the child status.
+ */
+struct child_status_t {
+	/* @brief Holds the state of the 'stdout' reading pipe */
+	bool stdout_eof;
+	/* @brief Holds the state of the 'stderr' reading pipe */
+	bool stderr_eof;
+	/* @brief Holds the error state from last syscall used to interact with child */
+	syserr_t syserr;
+};
+
+/**
+ * @brief Reads from 'pipe_fd' into 'buf' and updates the provided 'child_status_t'.
+ *
+ * @param pipe_fd The pipe fd from which to read.
+ * @param buf The buffer to be udpated with the read contents.
+ * @param st The child status to be updated with possible 'read' errors.
+ *
+ * @return 'True' in case 'read' returned '0', meaning pipe has been closed, 'false' otherwise.
+ */
+bool read_pipe(int pipe_fd, string& buf, child_status_t& st) {
+	int read_res = read_pipe(pipe_fd, buf);
+
+	// Unexpected error while reading pipe
+	if (read_res < 0) {
+		st.syserr = { -5, errno };
+	} else {
+		st.syserr = { 0, 0 };
+	}
+
+	return read_res == 0;
+}
+
 int wexecvp(
-	const std::string& file,
-	const std::vector<const char*>& argv,
-	const to_opts* opts,
-	std::string& s_stdout,
-	std::string& s_stderr
+	const string& file, const vector<const char*>& argv, const to_opts_t& opts, string& s_stdout, string& s_stderr
 ) {
 	// Pipes definition
 	constexpr uint8_t NUM_PIPES = 3;
@@ -135,15 +208,13 @@ int wexecvp(
 	const auto& CHILD_WRITE_FD  = pipes[PARENT_READ_PIPE][WRITE_FD];
 	const auto& CHILD_WRITE_ERR = pipes[PARENT_ERR_PIPE][WRITE_FD];
 
-	int err = 0;
-	to_opts to_opts { 0, 100*1000, 500*1000, 2000*1000 };
+	int child_err = 0;
+	to_opts_t to_opts { 0, 100*1000, 500*1000, 2000*1000 };
 
-	if (opts) {
-		to_opts.timeout_us = opts->timeout_us;
-		to_opts.it_delay_us = opts->it_delay_us;
-		to_opts.select_to_us = opts->select_to_us;
-		to_opts.sigkill_timeout_us = opts->sigkill_timeout_us;
-	}
+	if (opts.timeout_us != 0) to_opts.timeout_us = opts.timeout_us;
+	if (opts.poll_to_us != 0) to_opts.poll_to_us = opts.poll_to_us;
+	if (opts.waitpid_delay_us != 0) to_opts.waitpid_delay_us = opts.waitpid_delay_us;
+	if (opts.sigkill_to_us != 0) to_opts.sigkill_to_us = opts.sigkill_to_us;
 
 	// Pipes for parent to write and read
 	int read_p_err = pipe(pipes[PARENT_READ_PIPE]);
@@ -195,148 +266,100 @@ int wexecvp(
 			exit(0);
 		}
 	} else {
-		int errno_cpy = 0;
-		int pipe_err = 0;
-
-		std::string stdout_ = "";
-		std::string stderr_ = "";
+		std::string stdout_ {};
+		std::string stderr_ {};
 
 		// Close no longer needed pipes
 		close(CHILD_READ_FD);
 		close(CHILD_WRITE_FD);
 		close(CHILD_WRITE_ERR);
 
+		// Record the start timestamp
+		uint64_t start_timestamp = get_timestamp_us();
+
+		// Declare the two pollfd to be used for the pipes
+		struct pollfd read_fds[2] = { { 0 } };
+
 		// Set the pipes in non-blocking mode
 		int cntl_non_err = fcntl(PARENT_READ_FD, F_SETFL, fcntl(PARENT_READ_FD, F_GETFL) | O_NONBLOCK);
 		int cntl_err_err = fcntl(PARENT_READ_ERR, F_SETFL, fcntl(PARENT_READ_ERR, F_GETFL) | O_NONBLOCK);
 
-		fd_set read_fds;
-		int maxfd = PARENT_READ_FD > PARENT_READ_ERR ? PARENT_READ_FD : PARENT_READ_ERR;
+		child_status_t st { 0 };
 
-		bool stdout_eof = false;
-		bool stderr_eof = false;
-
-		// Record the start timestamp
-		uint64_t start_timestamp = get_timestamp_us();
-
-		if ((cntl_err_err || cntl_non_err) || maxfd >= FD_SETSIZE) {
-			close(PARENT_READ_FD);
-			close(PARENT_READ_ERR);
-			close(PARENT_WRITE_FD);
-
-			if (cntl_err_err || cntl_non_err) {
-				pipe_err = -3;
-			} else {
-				pipe_err = -4;
-			}
-
-			// Kill child and return error
-			kill_child_proc(child_pid, to_opts.sigkill_timeout_us, to_opts.it_delay_us);
-			// Recover errno before return
-			errno = errno_cpy;
-			// Avoid loop
-			goto loop_exit;
+		if (cntl_err_err || cntl_non_err) {
+			st.syserr = { -3, errno };
 		}
 
-		while (!stdout_eof || !stderr_eof) {
-			FD_ZERO(&read_fds);
-			FD_SET(PARENT_READ_FD, &read_fds);
-			FD_SET(PARENT_READ_ERR, &read_fds);
+		while ((!st.stdout_eof || !st.stderr_eof) && !st.syserr.err) {
+			memset(&read_fds, 0, sizeof(read_fds));
+
+			// Ignore the already closed FDs
+			read_fds[0].fd = st.stdout_eof == false ? PARENT_READ_FD : -1;
+			read_fds[0].events = POLLIN;
+			read_fds[1].fd = st.stderr_eof == false ? PARENT_READ_ERR : -1;
+			read_fds[1].events = POLLIN;
 
 			// Wait for the pipes to be ready
-			timeval select_to = { 0, to_opts.select_to_us };
-			int select_err = select(maxfd + 1, &read_fds, NULL, NULL, &select_to);
+			uint poll_to = to_opts.poll_to_us / 1000;
+			poll_to = poll_to == 0 ? 1 : poll_to;
+			int poll_err = poll(read_fds, sizeof(read_fds)/sizeof(pollfd), poll_to);
 
-			// Unexpected error while executing 'select'
-			if (select_err < 0 && errno != EINTR) {
-				pipe_err = -5;
-				// Backup read errno
-				errno_cpy = errno;
-				// Kill child and return error
-				kill_child_proc(child_pid, to_opts.sigkill_timeout_us, to_opts.it_delay_us);
-				// Recover errno before return
-				errno = errno_cpy;
-				// Exit the loop
-				break;
+			// Unexpected error while executing 'poll'
+			if (poll_err < 0 && errno != EINTR) {
+				st.syserr = { -4, errno };
+				continue;
 			}
 
-			if (FD_ISSET(PARENT_READ_FD, &read_fds) && stdout_eof == false) {
-				int read_res = read_pipe(PARENT_READ_FD, stdout_);
-
-				if (read_res == 0) {
-					stdout_eof = true;
-				}
-				// Unexpected error while reading pipe
-				if (read_res < 0) {
-					pipe_err = -6;
-					// Backup read errno
-					errno_cpy = errno;
-					// Kill child and return error
-					kill_child_proc(child_pid, to_opts.sigkill_timeout_us, to_opts.it_delay_us);
-					// Recover errno before return
-					errno = errno_cpy;
-					// Exit the loop
-					break;
-				}
+			if ((read_fds[0].revents & POLLIN) && st.stdout_eof == false) {
+				st.stdout_eof = read_pipe(PARENT_READ_FD, stdout_, st);
+				if (st.syserr.err) { continue; }
 			}
 
-			if(FD_ISSET(PARENT_READ_ERR, &read_fds) && stderr_eof == false) {
-				int read_res = read_pipe(PARENT_READ_ERR, stderr_);
-
-				if (read_res == 0) {
-					stderr_eof = true;
-				}
-				// Unexpected error while reading pipe
-				if (read_res < 0) {
-					pipe_err = -6;
-					// Backup read errno
-					errno_cpy = errno;
-					// Kill child and return error
-					kill_child_proc(child_pid, to_opts.sigkill_timeout_us, to_opts.it_delay_us);
-					// Recover errno before return
-					errno = errno_cpy;
-					// Exit the loop
-					break;
-				}
+			if ((read_fds[1].revents & POLLIN) && st.stderr_eof == false) {
+				st.stderr_eof = read_pipe(PARENT_READ_ERR, stderr_, st);
+				if (st.syserr.err) { continue; }
 			}
 
-			// Check that the execution hasn't execeed the specified timeout
+			// Update the closed state for the pipes
+			st.stdout_eof = st.stdout_eof == false ? read_fds[0].revents & POLLHUP : true;
+			st.stderr_eof = st.stderr_eof == false ? read_fds[1].revents & POLLHUP : true;
+
+			// Check that execution hasn't exceed the specified timeout
 			if (to_opts.timeout_us != 0) {
 				uint64_t current_timestamp = get_timestamp_us();
 				if ((start_timestamp + to_opts.timeout_us) < current_timestamp) {
-					// Backup read errno
-					errno_cpy = errno;
-					kill_child_proc(child_pid, to_opts.sigkill_timeout_us, to_opts.it_delay_us);
-					// Recover errno before return
-					errno = errno_cpy;
-					// Set 'pipe_err' to 'ETIME' to reflect timeout
-					pipe_err = ETIME;
-					// Exit the loop
-					break;
+					st.syserr = { ETIME, errno };
+					continue;
 				}
 			}
 		}
-
-loop_exit:
 
 		// Close no longer needed pipes
 		close(PARENT_READ_FD);
 		close(PARENT_READ_ERR);
 		close(PARENT_WRITE_FD);
 
-		if (pipe_err == 0) {
-			waitpid(child_pid, &err, 0);
-		} else {
-			err = pipe_err;
-		}
-
-		if (pipe_err == 0 || pipe_err == ETIME) {
+		// In a best effort, we return read data also for expired timeouts
+		if (st.syserr.err == 0 || st.syserr.err == ETIME) {
 			s_stdout = stdout_;
 			s_stderr = stderr_;
 		}
+
+		if (st.syserr.err == 0) {
+			bool child_exited = check_child_exit(child_pid, &child_err, 1000);
+
+			if (child_exited == false) {
+				kill_child_proc(child_pid, to_opts.sigkill_to_us, to_opts.waitpid_delay_us);
+			}
+		} else {
+			kill_child_proc(child_pid, to_opts.sigkill_to_us, to_opts.waitpid_delay_us);
+
+			child_err = st.syserr.err;
+			errno = st.syserr._errno;
+		}
 	}
 
-	return err;
+	return child_err;
 }
 
 std::string replace_str(const std::string& str, const std::string& match, const std::string& repl) {

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -105,8 +105,10 @@ OPT=-O2 $(WGCOV) -Wl,--no-as-needed
 debug: OPT=-O0 -DDEBUG -ggdb -Wl,--no-as-needed $(WGCOV) $(WASAN)
 debug: tests
 
-tests: $(patsubst %.cpp,%,$(wildcard *-t.cpp)) setparser_test reg_test_3504-change_user_libmariadb_helper reg_test_3504-change_user_libmysql_helper set_testing-240.csv test_clickhouse_server_libmysql clickhouse_php_conn-t \
-	reg_test_stmt_resultset_err_no_rows_libmysql prepare_statement_err3024_libmysql prepare_statement_err3024_async reg_test_mariadb_stmt_store_result_libmysql reg_test_mariadb_stmt_store_result_async
+tests: $(patsubst %.cpp,%,$(wildcard *-t.cpp)) setparser_test reg_test_3504-change_user_libmariadb_helper reg_test_3504-change_user_libmysql_helper \
+	set_testing-240.csv test_clickhouse_server_libmysql-t clickhouse_php_conn-t reg_test_stmt_resultset_err_no_rows_libmysql-t \
+	prepare_statement_err3024_libmysql-t prepare_statement_err3024_async-t reg_test_mariadb_stmt_store_result_libmysql-t \
+	reg_test_mariadb_stmt_store_result_async-t
 testgalera: galera_1_timeout_count galera_2_timeout_no_count
 testaurora: aurora
 
@@ -159,22 +161,22 @@ reg_test_3504-change_user_libmariadb_helper: reg_test_3504-change_user_helper.cp
 reg_test_3504-change_user_libmysql_helper: reg_test_3504-change_user_helper.cpp
 	$(CXX) -DLIBMYSQL_HELPER -DDEBUG reg_test_3504-change_user_helper.cpp -I/usr/include/mysql -I$(IDIR) -I$(JSON_IDIR) -I../tap -L$(TAP_LIBDIR) -lpthread -ldl -std=c++11 -ltap -lmysqlclient -o reg_test_3504-change_user_libmysql_helper -DGITVERSION=\"$(GIT_VERSION)\"
 
-test_clickhouse_server_libmysql: test_clickhouse_server-t.cpp
+test_clickhouse_server_libmysql-t: test_clickhouse_server-t.cpp
 	$(CXX) -DLIBMYSQL_HELPER -DDEBUG test_clickhouse_server-t.cpp -I/usr/include/mysql -I$(IDIR) -I$(JSON_IDIR) -I../tap -L$(TAP_LIBDIR) -lpthread -ldl -std=c++11 -ltap -lmysqlclient -o test_clickhouse_server_libmysql-t -DGITVERSION=\"$(GIT_VERSION)\"
 
-reg_test_stmt_resultset_err_no_rows_libmysql: reg_test_stmt_resultset_err_no_rows-t.cpp
+reg_test_stmt_resultset_err_no_rows_libmysql-t: reg_test_stmt_resultset_err_no_rows-t.cpp
 	$(CXX) -DLIBMYSQL_HELPER reg_test_stmt_resultset_err_no_rows-t.cpp -I/usr/include/mysql -I$(IDIR) -I$(JSON_IDIR) -I../tap $(OPT) -L$(TAP_LIBDIR) -lpthread -ldl -std=c++11 -ltap -lmysqlclient -o reg_test_stmt_resultset_err_no_rows_libmysql-t -DGITVERSION=\"$(GIT_VERSION)\"
 
-reg_test_mariadb_stmt_store_result_libmysql: reg_test_mariadb_stmt_store_result-t.cpp $(TAP_LIBDIR)/libtap.a
+reg_test_mariadb_stmt_store_result_libmysql-t: reg_test_mariadb_stmt_store_result-t.cpp $(TAP_LIBDIR)/libtap.a
 	$(CXX) -DLIBMYSQL_HELPER reg_test_mariadb_stmt_store_result-t.cpp -I/usr/include/mysql -I$(IDIR) -I$(JSON_IDIR) -I../tap $(OPT) -L$(TAP_LIBDIR) -lpthread -ldl -std=c++11 -ltap -lmysqlclient -o reg_test_mariadb_stmt_store_result_libmysql-t -DGITVERSION=\"$(GIT_VERSION)\"
 
-reg_test_mariadb_stmt_store_result_async: reg_test_mariadb_stmt_store_result-t.cpp $(TAP_LIBDIR)/libtap.a
+reg_test_mariadb_stmt_store_result_async-t: reg_test_mariadb_stmt_store_result-t.cpp $(TAP_LIBDIR)/libtap.a
 	$(CXX) -DASYNC_API reg_test_mariadb_stmt_store_result-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl -std=c++11 -ltap $(STATIC_LIBS) -o reg_test_mariadb_stmt_store_result_async-t -DGITVERSION=\"$(GIT_VERSION)\"
 
-prepare_statement_err3024_libmysql: prepare_statement_err3024-t.cpp $(TAP_LIBDIR)/libtap.a
+prepare_statement_err3024_libmysql-t: prepare_statement_err3024-t.cpp $(TAP_LIBDIR)/libtap.a
 	$(CXX) -DLIBMYSQL_HELPER prepare_statement_err3024-t.cpp -I/usr/include/mysql -I$(IDIR) -I$(JSON_IDIR) -I../tap $(OPT) -L$(TAP_LIBDIR) -lpthread -ldl -std=c++11 -ltap -lmysqlclient -o prepare_statement_err3024_libmysql-t -DGITVERSION=\"$(GIT_VERSION)\"
 
-prepare_statement_err3024_async: prepare_statement_err3024-t.cpp $(TAP_LIBDIR)/libtap.a
+prepare_statement_err3024_async-t: prepare_statement_err3024-t.cpp $(TAP_LIBDIR)/libtap.a
 	$(CXX) -DASYNC_API prepare_statement_err3024-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl -std=c++11 -ltap $(STATIC_LIBS) -o prepare_statement_err3024_async-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 test_wexecvp_syscall_failures-t: test_wexecvp_syscall_failures-t.cpp $(TAP_LIBDIR)/libtap.a

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -176,3 +176,6 @@ prepare_statement_err3024_libmysql: prepare_statement_err3024-t.cpp $(TAP_LIBDIR
 
 prepare_statement_err3024_async: prepare_statement_err3024-t.cpp $(TAP_LIBDIR)/libtap.a
 	$(CXX) -DASYNC_API prepare_statement_err3024-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl -std=c++11 -ltap $(STATIC_LIBS) -o prepare_statement_err3024_async-t -DGITVERSION=\"$(GIT_VERSION)\"
+
+test_wexecvp_syscall_failures-t: test_wexecvp_syscall_failures-t.cpp $(TAP_LIBDIR)/libtap.a
+	$(CXX) $^ $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -std=c++11 -Wl,--wrap=pipe,--wrap=fcntl,--wrap=read,--wrap=poll -lpthread -ldl -ltap $(STATIC_LIBS) -o $@

--- a/test/tap/tests/reg_test_3223-restapi_return_codes-t.cpp
+++ b/test/tap/tests/reg_test_3223-restapi_return_codes-t.cpp
@@ -6,199 +6,374 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <string>
 #include <stdio.h>
+#include <tuple>
 #include <unistd.h>
 #include <vector>
-#include <tuple>
 
-#include <curl/curl.h>
+#include <signal.h>
 
-#include <mysql.h>
-#include <mysql/mysqld_error.h>
+#include "curl/curl.h"
+#include "json.hpp"
+#include "mysql.h"
+#include "mysql/mysqld_error.h"
 
+#include "command_line.h"
 #include "proxysql_utils.h"
 #include "tap.h"
-#include "command_line.h"
 #include "utils.h"
 
 using std::string;
+using std::vector;
 
+using hrc = std::chrono::high_resolution_clock;
+using nlohmann::json;
 
-const std::string base_address { "http://localhost:6070/sync/" };
+const string base_address { "http://localhost:6070/sync/" };
 
-std::vector<std::tuple<std::string, std::string, long>> valid_endpoints {
-	std::make_tuple( "large_output_script", "{}", 200 ),
-	std::make_tuple( "partial_output_flush_script", "{}", 200 ),
-	std::make_tuple( "valid_output_script", "{}", 200 ),
-	// check scripts remain operational
-	// NOTE: Disable due to requiring python2 annotation in file
-	// std::make_tuple( "metrics", "{\"user\":\"admin\", \"password\":\"admin\", \"host\":\"127.0.0.1\", \"port\":\"6032\"}", 200 )
+const vector<honest_req_t> honest_requests {
+	{ { "valid_output_script", "%s.py", "POST", 1000 }, { "{}" } },
+	// Check that 'POST' correctly forwards supplied parameters:
+	//  1 - Target script performs a check on the supplied parameters and fails in case they are unexpected
+	{ { "valid_params_script", "%s.py", "POST", 1000 }, { "{\"param1\": \"value1\", \"param2\": \"value2\"}" } },
+	// On top of the previous check, also check that 'GET' allows:
+	//  1 - Empty parameters: We internally translate into an empty well-formed JSON '{}'
+	//  2 - Escaped values: As long as the JSON is correct, the RESTAPI forwarding should be able to handle it
+	{ { "valid_params_script", "%s.py", "GET", 1000 }, { "", "?param1='value1'&param2='\"value2\"'" } },
+	// Checks that RESTAPI behaves correctly with scripts with big outputs
+	{ { "large_output_script", "%s.py", "POST", 5000 }, { "{}" } },
+	// Checks that RESTAPI is being able to properly read scripts with partial output flushes
+	{ { "partial_output_flush_script", "%s.py", "POST", 10000 }, { "{}" } },
 };
 
-std::vector<std::tuple<std::string, std::string, long>> invalid_requests {
-	std::make_tuple( "invalid_output_script", "{}", 424 ),
-	std::make_tuple( "timeout_script", "{}", 424 ),
-	std::make_tuple( "invalid_script", "{}", 424 ),
-	std::make_tuple( "non_existing_script", "{}", 400 ),
-	// supplied with invalid params
-	std::make_tuple( "valid_output_script", "", 400 )
+const vector<faulty_req_t> invalid_requests {
+	// Checks that 'POST' fails for:
+	//   1 - Empty parameters.
+	//   2 - Invalid JSON input.
+	//   3 - Valid JSON input but unexpected (checking script correctness itself).
+	{
+		{ "valid_params_script", "%s.py", "POST", 1000 },
+		{
+			// Empty parameters is considered and invalid JSON input for a POST request:
+			//   - '400' error, 'Invalid Request'.
+			//   - Error code of '0', script was never executed.
+			{ "", 400, 0 },
+			// Invalid JSON input should result in:
+			//   - '400' error, 'Invalid Request'.
+			//   - Error code of '0', script was never executed.
+			{ "\"param1\": \"value1\", \"param2\": \"value2}", 400, 0 },
+			// Valid JSON input, that fails script check:
+			//   - '424' error, script was the one failing during execution.
+			//   - Error code of '1'. Script exit code for failed input validation.
+			{ "{\"foo\": \"bar\"}", 424, 1 },
+		}
+	},
+	// Check invalid output (non valid JSON) for 'POST' and 'GET'
+	{ { "invalid_output_script", "%s.py", "POST", 1000 }, { { "{}",  424, 0 } } },
+	{ { "invalid_output_script", "%s.py", "GET", 1000 }, { { "",  424, 0 } } },
+	// Check timeout script for 'POST' and 'GET'
+	{ { "timeout_script", "%s.py", "POST", 1000 }, { { "{}", 424, ETIME } } },
+	{ { "timeout_script", "%s.py", "GET", 1000 }, { { "", 424, ETIME } } },
+	// Check error code from script failing to execute (Python exit code)
+	{ { "invalid_script", "%s.py", "POST", 1000 }, { { "{}", 424, 1 } } },
+	// Check non being able to execute the target script - Invalid Path
+	{ { "non_existing_script", "%s", "POST", 1000 }, { { "{}", 424, ENOENT } } },
+	// Check non being able to execute the target script - Insufficient perms
+	{ { "script_no_permissions", "%s", "POST", 1000 }, { { "{}", 424, EACCES } } },
+	// Check error code from script killed by signal
+	{ { "bash_sigsev_script", "%s.bash", "POST", 1000 }, { { "{}", 424, 128 + SIGSEGV } } },
+	// Check killing of script that closes communication pipes with ProxySQL
+	{ { "close_stdout_script", "%s.py", "POST", 1000 }, { { "{}", 424, ETIME } } },
 };
+
+int count_exp_tests(const vector<honest_req_t>& v1, const vector<faulty_req_t>& v2) {
+	int exp_tests = 0;
+
+	for (const honest_req_t& req : v1) {
+		exp_tests += req.params.size() * 3;
+	}
+
+	for (const faulty_req_t& req : v2) {
+		for (const ept_pl_t& ept_pl : req.ept_pls) {
+			if (ept_pl.script_err != ETIME) {
+				exp_tests += 4;
+			} else {
+				exp_tests += 5;
+			}
+		}
+	}
+
+	return exp_tests;
+}
+
+/**
+ * @details
+ *  ProxySQL could give a total grace period of '4' seconds to a finishing script before issuing a SIGKILL.
+ *  This scenario takes place when something goes wrong during the script execution in ProxySQL side, or when
+ *  the script closes the communication PIPES without finishing.
+ *    - Initial wait of 1s second after communication is broken waiting for script to gracefully finish.
+ *    - A maximum 3s of waiting time after SIGTERM before issuing SIGKILL.
+ */
+const uint32_t PROXY_GRACE_PERIOD = 1000 + 3000;
 
 int main(int argc, char** argv) {
 	CommandLine cl;
 
 	if (cl.getEnv()) {
 		diag("Failed to get the required environmental variables.");
-		return -1;
+		return EXIT_FAILURE;
 	}
 
-	plan(valid_endpoints.size() + invalid_requests.size());
+	plan(count_exp_tests(honest_requests, invalid_requests));
 
-	MYSQL* proxysql_admin = mysql_init(NULL);
+	MYSQL* admin = mysql_init(NULL);
 
 	// Initialize connections
-	if (!proxysql_admin) {
-		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
-		return -1;
+	if (!admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return EXIT_FAILURE;
 	}
 
-	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
-		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
-		return -1;
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return EXIT_FAILURE;
 	}
 
 	// Enable 'RESTAPI'
-	MYSQL_QUERY(proxysql_admin, "SET admin-restapi_enabled='true'");
-	MYSQL_QUERY(proxysql_admin, "SET admin-restapi_port=6070");
+	MYSQL_QUERY(admin, "SET admin-restapi_enabled='true'");
+	MYSQL_QUERY(admin, "SET admin-restapi_port=6070");
 
-	MYSQL_QUERY(proxysql_admin, "LOAD ADMIN VARIABLES TO RUNTIME");
+	MYSQL_QUERY(admin, "LOAD ADMIN VARIABLES TO RUNTIME");
 
 	// Clean current 'restapi_routes' if any
-	MYSQL_QUERY(proxysql_admin, "DELETE FROM restapi_routes");
+	MYSQL_QUERY(admin, "DELETE FROM restapi_routes");
 
 	// Configure restapi_routes to be used
-	std::string test_script_base_path {
-		std::string { cl.workdir  } + "reg_test_3223_scripts"
-	};
+	string script_base_path { string { cl.workdir  } + "reg_test_3223_scripts" };
+	const ept_info_t dummy_ept { "dummy_ept_script", "%s.py", "POST", 1000 };
 
-	std::vector<std::string> t_valid_scripts_inserts {
-		"INSERT INTO restapi_routes (active, timeout_ms, method, uri, script, comment) "
-		"VALUES (1,5000,'POST','large_output_script','%s/large_output_script.py','comm')",
-		"INSERT INTO restapi_routes (active, timeout_ms, method, uri, script, comment) "
-		"VALUES (1,5000,'POST','partial_output_flush_script','%s/partial_output_flush_script.py','comm')",
-		"INSERT INTO restapi_routes (active, timeout_ms, method, uri, script, comment) "
-		"VALUES (1,1000,'POST','valid_output_script','%s/valid_output_script.py','comm')"
-	};
-	std::vector<std::string> valid_scripts_inserts {};
-
-	for (const auto& t_valid_script_insert : t_valid_scripts_inserts) {
-		std::string valid_script_insert {};
-		string_format(t_valid_script_insert, valid_script_insert, test_script_base_path.c_str());
-		valid_scripts_inserts.push_back(valid_script_insert);
-	}
-
-	// Configure routes for valid scripts
-	for (const auto& valid_script_insert : valid_scripts_inserts) {
-		MYSQL_QUERY(
-			proxysql_admin,
-			valid_script_insert.c_str()
-		);
-	}
-
-	// NOTE: Disable due to requiring python2 annotation in file
-	// MYSQL_QUERY(
-	// 	proxysql_admin,
-	// 	"INSERT INTO restapi_routes (active, timeout_ms, method, uri, script, comment) "
-	// 	"VALUES (1,1000,'POST','metrics','../scripts/metrics.py','comm')"
-	// );
-
-	std::vector<std::string> t_invalid_scripts_inserts {
-		"INSERT INTO restapi_routes (active, timeout_ms, method, uri, script, comment) "
-		"VALUES (1,1000,'POST','invalid_output_script','%s/invalid_output_script.py','comm')",
-		"INSERT INTO restapi_routes (active, timeout_ms, method, uri, script, comment) "
-		"VALUES (1,1000,'POST','timeout_script','%s/timeout_script.py','comm')",
-		"INSERT INTO restapi_routes (active, timeout_ms, method, uri, script, comment) "
-		"VALUES (1,1000,'POST','invalid_script','%s/invalid_script.py','comm')"
-	};
-	std::vector<std::string> invalid_scripts_inserts {};
-	
-	for (const auto& t_invalid_script_insert : t_invalid_scripts_inserts) {
-		std::string invalid_script_insert {};
-		string_format(t_invalid_script_insert, invalid_script_insert, test_script_base_path.c_str());
-		invalid_scripts_inserts.push_back(invalid_script_insert);
-	}
-
-	// Configure routes for invalid scripts
-	for (const auto& invalid_script_insert : invalid_scripts_inserts) {
-		MYSQL_QUERY(
-			proxysql_admin,
-			invalid_script_insert.c_str()
-		);
-	}
-
-	MYSQL_QUERY(proxysql_admin, "LOAD restapi TO RUNTIME");
-
-	// Sensible wait until the new configured enpoints are ready.
-	// Use the first enpoint for the check
-	const auto& first_request_tuple { valid_endpoints.front() };
-	const std::string full_endpoint {
-		base_address + std::get<0>(first_request_tuple) + "/"
-	};
-	int endpoint_timeout = wait_until_enpoint_ready(
-		full_endpoint, std::get<1>(first_request_tuple), 10, 500
+	// Configure the valid requests
+	vector<ept_info_t> v_epts_info {};
+	const auto ext_v_epts_info = [] (const honest_req_t& req) { return req.ept_info; };
+	std::transform(
+		honest_requests.begin(), honest_requests.end(), std::back_inserter(v_epts_info), ext_v_epts_info
 	);
 
-	if (endpoint_timeout) {
-		diag(
-			"Timeout while trying to reach first valid enpoint."
-			" Test failed, skipping endpoint testing..."
-		);
-		goto skip_endpoints_testing;
+	int ept_conf_res = configure_endpoints(admin, script_base_path, v_epts_info, dummy_ept, true);
+	if (ept_conf_res) {
+		diag("Endpoint configuration failed. Skipping endpoint testing...");
+		return EXIT_FAILURE;
 	}
 
-	for (const auto& valid_request_tuple : valid_endpoints) {
-		const std::string full_endpoint { base_address + std::get<0>(valid_request_tuple) + "/"};
-		std::string post_out_err { "" };
-		uint64_t curl_res_code = 0;
+	{
+		for (const auto& req : honest_requests) {
+			for (const string& params : req.params) {
+				const string ept { join_path(base_address, req.ept_info.name) };
+				diag(
+					"%s: Checking valid '%s' request - ept: '%s', params: '%s'", tap_curtime().c_str(),
+					req.ept_info.method.c_str(), ept.c_str(), params.c_str()
+				);
+				std::chrono::nanoseconds duration;
+				hrc::time_point start;
+				hrc::time_point end;
 
-		// perform the POST operation
-		CURLcode post_err = perform_simple_post(
-			full_endpoint, std::get<1>(valid_request_tuple), curl_res_code, post_out_err
-		);
+				string curl_res_data { "" };
+				uint64_t curl_res_code = 0;
 
-		ok(
-			post_err == CURLE_OK && curl_res_code == 200,
-			"Performing a POST over endpoint '%s' should result into a 200 response:"
-			" (curl_err: '%d', response_errcode: '%ld', curlerr: '%s')",
-			full_endpoint.c_str(),
-			post_err,
-			curl_res_code,
-			post_out_err.c_str()
-		);
+				CURLcode post_err = CURLE_AGAIN;
+
+				if (req.ept_info.method == "POST") {
+					start = hrc::now();
+					post_err = perform_simple_post(ept, params, curl_res_code, curl_res_data);
+					end = hrc::now();
+
+					duration = end - start;
+					double duration_ms = duration.count() / static_cast<double>(1000*1000);
+
+					ok(
+						duration_ms < (req.ept_info.timeout + PROXY_GRACE_PERIOD),
+						"Request duration should always be smaller than (timeout + grace period) -"
+							" timeout: '%ld', duration_ms: '%lf', grace_period: '%d'",
+						req.ept_info.timeout, duration_ms, PROXY_GRACE_PERIOD
+					);
+
+					bool json_parse_failure = false;
+
+					try {
+						json _ = json::parse(curl_res_data);
+					} catch (std::exception& e) {
+						diag("Failed to parse response JSON - '%s'", e.what());
+						json_parse_failure = true;
+					}
+
+					const char* out_res_data = "'skipped_due_to_size'";
+
+					if (curl_res_data.length() > 50) {
+						diag("Omit print of 'curl_res_data' due to big size '%ld'", curl_res_data.length());
+					} else {
+						out_res_data = curl_res_data.c_str();
+					}
+
+					ok(
+						json_parse_failure == false,
+						"Valid JSON received for VALID '%s' request - params: '%s', curl_err_resp: '%s'",
+						req.ept_info.method.c_str(), params.c_str(), out_res_data
+					);
+
+					ok(
+						post_err == CURLE_OK && curl_res_code == 200,
+						"'%s' over '%s' should result into a '200' res code:"
+						" (curl_err: '%d', curl_res_code: '%ld', curl_res_data: '%s')",
+						req.ept_info.method.c_str(), ept.c_str(), post_err, curl_res_code, out_res_data
+					);
+				} else {
+					const string get_ept { ept + params };
+					start = hrc::now();
+					post_err = perform_simple_get(get_ept, curl_res_code, curl_res_data);
+					end = hrc::now();
+					bool json_parse_failure = false;
+
+					duration = end - start;
+					double duration_ms = duration.count() / static_cast<double>(1000*1000);
+
+					ok(
+						duration_ms < (req.ept_info.timeout + PROXY_GRACE_PERIOD),
+						"Request duration should always be smaller than (timeout + grace period) -"
+							" timeout: '%ld', duration_ms: '%lf', grace_period: '%d'",
+						req.ept_info.timeout, duration_ms, PROXY_GRACE_PERIOD
+					);
+
+					try {
+						json _ = json::parse(curl_res_data);
+					} catch (std::exception& e) {
+						diag("Failed to parse response JSON - '%s'", e.what());
+						json_parse_failure = true;
+					}
+
+					const char* out_res_data = "'skipped_due_to_size'";
+
+					if (curl_res_data.length() > 50) {
+						diag("Omit print of 'curl_res_data' due to big size '%ld'", curl_res_data.length());
+					} else {
+						out_res_data = curl_res_data.c_str();
+					}
+
+					ok(
+						json_parse_failure == false,
+						"Valid JSON received for VALID '%s' request - params: '%s', curl_err_resp: '%s'",
+						req.ept_info.method.c_str(), params.c_str(), out_res_data
+					);
+
+					ok(
+						post_err == CURLE_OK && curl_res_code == 200,
+						"'%s' over '%s' should result into a '200' res code:"
+							" (curl_err: '%d', curl_res_code: '%ld', curl_res_data: '%s')",
+						req.ept_info.method.c_str(), ept.c_str(), post_err, curl_res_code, out_res_data
+					);
+				}
+			}
+		}
 	}
 
-	for (const auto& invalid_request_tuple : invalid_requests) {
-		const std::string full_endpoint { base_address + std::get<0>(invalid_request_tuple) + "/" };
-		std::string post_out_err { "" };
-		uint64_t curl_res_code = 0;
+	vector<ept_info_t> i_epts_info {};
+	const auto ext_i_epts_info = [] (const faulty_req_t& req) { return req.ept_info; };
+	std::transform(
+		invalid_requests.begin(), invalid_requests.end(), std::back_inserter(i_epts_info), ext_i_epts_info
+	);
 
-		// perform the POST operation
-		CURLcode post_err = perform_simple_post(
-			full_endpoint, std::get<1>(invalid_request_tuple), curl_res_code, post_out_err);
+	ept_conf_res = configure_endpoints(admin, script_base_path, i_epts_info, dummy_ept, true);
+	if (ept_conf_res) {
+		diag("Endpoint configuration failed. Skipping endpoint testing...");
+		return EXIT_FAILURE;
+	}
 
-		ok(
-			post_err == CURLE_OK && curl_res_code == std::get<2>(invalid_request_tuple),
-			"Performing a POST over endpoint '%s' shouldn't result into a 200 response:"
-			" (curl_err: '%d', response_errcode: '%ld', curlerr: '%s')",
-			full_endpoint.c_str(),
-			post_err,
-			curl_res_code,
-			post_out_err.c_str()
-		);
+	for (const auto& req : invalid_requests) {
+		for (const ept_pl_t& ept_pl : req.ept_pls) {
+			std::chrono::nanoseconds duration;
+			hrc::time_point start;
+			hrc::time_point end;
+
+			const string ept { join_path(base_address, req.ept_info.name) };
+			diag(
+				"%s: Checking valid '%s' request - ept: '%s', params: '%s'", tap_curtime().c_str(),
+				req.ept_info.method.c_str(), ept.c_str(), ept_pl.params.c_str()
+			);
+
+			// Get the target script full path
+			string f_exe_name {};
+			string_format(req.ept_info.file, f_exe_name, req.ept_info.name.c_str());
+			const string script_path { join_path(script_base_path, f_exe_name) };
+			const string sigterm_file_flag { script_path + "-RECV_SIGTERM" };
+
+			string curl_res_data {};
+			uint64_t curl_res_code = 0;
+
+			// Prepare target folder in case of expected ETIME error
+			if (ept_pl.script_err == ETIME) {
+				remove(sigterm_file_flag.c_str());
+			}
+
+			// Perform the POST operation
+			CURLcode curl_code = CURLE_AGAIN;
+
+			start = hrc::now();
+			if (req.ept_info.method == "POST") {
+				curl_code = perform_simple_post(ept, ept_pl.params, curl_res_code, curl_res_data);
+			} else {
+				const string get_ept { ept + ept_pl.params };
+				curl_code = perform_simple_get(get_ept, curl_res_code, curl_res_data);
+			}
+			end = hrc::now();
+
+			duration = end - start;
+			double duration_ms = duration.count() / static_cast<double>(1000*1000);
+
+			ok(
+				duration_ms < (req.ept_info.timeout + PROXY_GRACE_PERIOD),
+				"Request duration should always be smaller than (timeout + grace period) -"
+					" timeout: '%ld', duration_ms: '%lf', grace_period: '%d'",
+				req.ept_info.timeout, duration_ms, PROXY_GRACE_PERIOD
+			);
+
+			uint64_t script_err = 0;
+			string str_resp_err {};
+
+			try {
+				json curl_err_rsp = json::parse(curl_res_data);
+				str_resp_err = curl_err_rsp["error"];
+				script_err = std::stoi(curl_err_rsp["error_code"].get<string>());
+			} catch (std::exception&) {}
+
+			ok(
+				str_resp_err.empty() == false,
+				"Valid JSON received for INVALID request - params: '%s', curl_res_data: '%s'",
+				ept_pl.params.c_str(), curl_res_data.c_str()
+			);
+
+			ok(
+				curl_code == CURLE_OK && ept_pl.curl_rc == curl_res_code,
+				"'%s' sould have failed: (curl_err: '%d', exp_rc: '%ld', act_rc: '%ld')",
+				req.ept_info.method.c_str(), curl_code, ept_pl.curl_rc, curl_res_code
+			);
+
+			ok(
+				ept_pl.script_err == script_err,
+				"Script error code should match expected - Exp: '%ld', Act: '%ld'",
+				ept_pl.script_err, script_err
+			);
+
+			// A SIGTERM signal should have been issued before SIGKILL; script should acknowledge it
+			if (ept_pl.script_err == ETIME) {
+				int f_exists = access(sigterm_file_flag.c_str(), F_OK);
+				ok(f_exists == 0, "Script '%s' should receive a 'SIGTERM' signal", f_exe_name.c_str());
+			}
+		}
 	}
 
 skip_endpoints_testing:
+	mysql_close(admin);
 
 	return exit_status();
 }

--- a/test/tap/tests/reg_test_3223_scripts/bash_sigsev_script.bash
+++ b/test/tap/tests/reg_test_3223_scripts/bash_sigsev_script.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+kill -11 $$

--- a/test/tap/tests/reg_test_3223_scripts/close_stdout_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/close_stdout_script.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""Simple script returning a valid empty result for RESTAPI."""
+
+import json
+import time
+import os
+import signal
+import sys
+
+def print_inv_json():
+    print("invalid_json", file=sys.stdout, flush=False, end="")
+
+def print_random_dic():
+    random_dic = {}
+
+    for i in range(0, 4000000):
+        random_dic["id_" + str(i)] = "0000000000"
+
+    j_random_dic = json.dumps(random_dic)
+    print(j_random_dic, file=sys.stderr)
+
+def close_stdout():
+    sys.stdout.close()
+    os.close(1)
+
+def close_stderr():
+    sys.stdout.close()
+    os.close(0)
+
+def flush_stderr():
+    sys.stderr.flush()
+
+def simple_print_and_flush(stdout=True):
+    if stdout:
+        print("{}", file=sys.stdout, flush=True, end="")
+    else:
+        print("{}", file=sys.stderr, flush=True, end="")
+
+def signal_handler(signo, stack_frame):
+    cur_dir = os.path.dirname(os.path.abspath(__file__))
+    f_path = os.path.join(cur_dir, f"{__file__}-RECV_SIGTERM")
+
+    fh = open(f_path, 'w')
+    fh.close()
+
+    time.sleep(20)
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, signal_handler)
+    simple_print_and_flush(stdout=True)
+    close_stdout()
+    close_stderr()
+
+    time.sleep(10)

--- a/test/tap/tests/reg_test_3223_scripts/dummy_ept_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/dummy_ept_script.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-"""Simple script returning a valid empty result for RESTAPI."""
-
-random_dic = {}
+"""Dummy script to check RESTAPI is ready."""
 
 if __name__ == "__main__":
     # Return minimal JSON

--- a/test/tap/tests/reg_test_3223_scripts/invalid_output_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/invalid_output_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Simple script that should fail to execute to check RESTAPI result code."""
 

--- a/test/tap/tests/reg_test_3223_scripts/invalid_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/invalid_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Simple script that should fail to execute to check RESTAPI result code."""
 

--- a/test/tap/tests/reg_test_3223_scripts/large_output_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/large_output_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Simple script to produce a 1MB output to be processed by the RESTAPI."""
 

--- a/test/tap/tests/reg_test_3223_scripts/partial_output_flush_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/partial_output_flush_script.py
@@ -3,7 +3,9 @@
 """Simple script to produce a 1MB output flushed in two times to be processed by the RESTAPI."""
 
 import json
+import textwrap
 import time
+import sys
 
 random_dic = {}
 
@@ -13,11 +15,8 @@ if __name__ == "__main__":
         random_dic["id_" + str(i)] = "0000000000"
 
     j_random_dic = json.dumps(random_dic)
+    parts = textwrap.wrap(j_random_dic, len(j_random_dic)//10)
 
-    # Split the string in half
-    firstpart, secondpart = j_random_dic[:len(j_random_dic)//2], j_random_dic[len(j_random_dic)//2:]
-
-    # Partial flush script
-    print(firstpart, end='', flush=True)
-    time.sleep(1)
-    print(secondpart, end='', flush=True)
+    for part in parts:
+        print(part, file=sys.stdout, flush=True, end='')
+        time.sleep(0.5)

--- a/test/tap/tests/reg_test_3223_scripts/timeout_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/timeout_script.py
@@ -1,13 +1,27 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Simple script to force a timeout failure in RESTAPI."""
 
-import time
 import json
+import os
+import signal
+import time
 
 random_dic = {}
 
+def signal_handler(signo, stack_frame):
+    cur_dir = os.path.dirname(os.path.abspath(__file__))
+    f_path = os.path.join(cur_dir, f"{__file__}-RECV_SIGTERM")
+
+    fh = open(f_path, 'w')
+    fh.close()
+
+    time.sleep(20)
+
 if __name__ == "__main__":
+    # Register the handler to advice caller of received signal
+    signal.signal(signal.SIGTERM, signal_handler)
+
     # Forcing the timeout
     time.sleep(10)
 

--- a/test/tap/tests/reg_test_3223_scripts/valid_params_script.py
+++ b/test/tap/tests/reg_test_3223_scripts/valid_params_script.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+"""Simple script returning its params as result for the RESTAPI."""
+
+import json
+import sys
+
+if __name__ == "__main__":
+    param_num = len(sys.argv)
+
+    if param_num == 2:
+        exp_args = json.loads(sys.argv[1])
+        print(sys.argv[1])
+
+        if len(exp_args):
+            arg1 = exp_args["param1"]
+            arg2 = exp_args["param2"]
+
+            exp_arg1 = arg1 == "value1" or arg1 == "'value1'"
+            exp_arg2 = arg2 == "value2" or arg2 == "'value2'" or arg2 == "'\"value2\"'"
+
+            sys.exit(not (exp_arg1 and exp_arg2))
+        else:
+            sys.exit(0)
+    else:
+        print(json.dumps({"error": f"Invalid number of params - exp: '2', act: '{param_num}'"}))
+        sys.exit(1)

--- a/test/tap/tests/reg_test_3223_scripts/write_to_std_streams.py
+++ b/test/tap/tests/reg_test_3223_scripts/write_to_std_streams.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+"""Simple script that writes a dummy output to the specified standard stream."""
+
+import sys
+import time
+import os
+import signal
+
+def signal_handler(signo, stack_frame):
+    cur_dir = os.path.dirname(os.path.abspath(__file__))
+    f_path = os.path.join(cur_dir, f"{__file__}-RECV_SIGTERM")
+
+    fh = open(f_path, 'w')
+    fh.close()
+
+    time.sleep(20)
+
+if __name__ == "__main__":
+    param_num = len(sys.argv)
+
+    if param_num == 2:
+        # Register the handler to advice caller of received signal
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        if sys.argv[1] == "stdout":
+            print("dummy_stdout_output", file=sys.stdout, flush=True, end='')
+        elif sys.argv[1] == "stderr":
+            print("dummy_stderr_output", file=sys.stderr, flush=True, end='')
+        else:
+            pass
+
+        # Ensure that we are killed by timeout
+        time.sleep(20)
+    else:
+        sys.exit(1)

--- a/test/tap/tests/reg_test_3847_admin_lock-t.cpp
+++ b/test/tap/tests/reg_test_3847_admin_lock-t.cpp
@@ -53,13 +53,13 @@ int main(int argc, char** argv) {
 	int launch_res = -1;
 
 	std::thread launch_sec_proxy = std::thread([&WORKSPACE,&cl] (int& err_code) -> void {
-		to_opts wexecvp_opts {};
-		wexecvp_opts.select_to_us = 100*1000;
-		wexecvp_opts.it_delay_us = 500*1000;
+		to_opts_t wexecvp_opts {};
+		wexecvp_opts.poll_to_us = 100*1000;
+		wexecvp_opts.waitpid_delay_us = 500*1000;
 		// Stop launched process after 20s
 		wexecvp_opts.timeout_us = 20000 * 1000;
 		// Send sigkill 3s after timeout
-		wexecvp_opts.sigkill_timeout_us = 3000 * 1000;
+		wexecvp_opts.sigkill_to_us = 3000 * 1000;
 
 		const string sec_cfg_file = string { cl.workdir } + "reg_test_3847_node_datadir/proxysql_sec.cfg";
 		const string sec_log_file = string { cl.workdir } + "reg_test_3847_node_datadir/proxysql_sec.log";
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
 		string s_stdout {};
 		string s_stderr {};
 
-		int w_res = wexecvp(proxysql_path, proxy_args, &wexecvp_opts, s_stdout, s_stderr);
+		int w_res = wexecvp(proxysql_path, proxy_args, wexecvp_opts, s_stdout, s_stderr);
 		if (w_res != EXIT_SUCCESS) {
 			diag("'wexecvp' failed with error: %d", w_res);
 		}

--- a/test/tap/tests/reg_test_4001-restapi_scripts_num_fds-t.cpp
+++ b/test/tap/tests/reg_test_4001-restapi_scripts_num_fds-t.cpp
@@ -1,0 +1,227 @@
+/**
+ * @file reg_test_4001-restapi_scripts_num_fds-t.cpp
+ * @brief Regression test for checking that RESTAPI is able to execute scripts when ProxySQL is handling more
+ *   than 'FD_SETSIZE' file descriptors.
+ *
+ * @details The tests creates a higher number of connections than the default maximum number of file
+ *  descriptors determined by `FD_SETSIZE` (1024). After doing this, it tries to enable the 'RESTAPI' and
+ *  performs requests to different endpoints while constantly creating and destroying new client connections.
+ *  This covers two scenarios:
+ *     - The usage of the RESTAPI when ProxySQL is using more than `FD_SETSIZE` file descriptors.
+ *     - The reproduction of the scenario leading to crash reported in issue #4001.
+ */
+
+#include <cstring>
+#include <chrono>
+#include <vector>
+#include <thread>
+#include <string>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include <mysql.h>
+
+#include "command_line.h"
+#include "proxysql_utils.h"
+#include "json.hpp"
+#include "tap.h"
+#include "utils.h"
+
+using nlohmann::json;
+using std::string;
+using std::vector;
+
+const int NUM_CONNECTIONS = 1300;
+const string base_address { "http://localhost:6070/sync/" };
+
+const vector<honest_req_t> honest_requests {
+	{ { "valid_output_script", "%s.py", "POST", 1000 }, { "{}" } },
+	// Check that 'POST' correctly forwards supplied parameters:
+	//  1 - Target script performs a check on the supplied parameters and fails in case they are unexpected
+	{ { "valid_params_script", "%s.py", "POST", 1000 }, { "{\"param1\": \"value1\", \"param2\": \"value2\"}" } },
+	// On top of the previous check, also check that 'GET' allows:
+	//  1 - Empty parameters: We internally translate into an empty well-formed JSON '{}'
+	//  2 - Escaped values: As long as the JSON is correct, the RESTAPI forwarding should be able to handle it
+	{ { "valid_params_script", "%s.py", "GET", 1000 }, { "", "?param1='value1'&param2='\"value2\"'" } },
+};
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
+
+	diag("Setting new process limits beyond 'FD_SETSIZE'");
+	struct rlimit limits { 0, 0 };
+	getrlimit(RLIMIT_NOFILE, &limits);
+	diag("Old process limits: { %ld, %ld }", limits.rlim_cur, limits.rlim_max);
+	limits.rlim_cur = NUM_CONNECTIONS * 2 + 100;
+	setrlimit(RLIMIT_NOFILE, &limits);
+	diag("New process limits: { %ld, %ld }", limits.rlim_cur, limits.rlim_max);
+
+	MYSQL* admin = mysql_init(NULL);
+
+	// Initialize connections
+	if (!admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return EXIT_FAILURE;
+	}
+
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return EXIT_FAILURE;
+	}
+
+	string script_base_path { string { cl.workdir  } + "reg_test_3223_scripts" };
+	const ept_info_t dummy_ept { "dummy_ept_script", "%s.py", "POST", 1000 };
+
+	vector<ept_info_t> v_epts_info {};
+	const auto ext_v_epts_info = [] (const honest_req_t& req) { return req.ept_info; };
+	std::transform(
+		honest_requests.begin(), honest_requests.end(), std::back_inserter(v_epts_info), ext_v_epts_info
+	);
+
+	int ept_conf_res = configure_endpoints(admin, script_base_path, v_epts_info, dummy_ept, true);
+	if (ept_conf_res) {
+		diag("Endpoint configuration failed. Skipping endpoint testing...");
+		return EXIT_FAILURE;
+	}
+
+	std::vector<MYSQL*> mysql_connections {};
+
+	for (int i = 0; i < NUM_CONNECTIONS; i++) {
+		MYSQL* proxy = mysql_init(NULL);
+		if (!mysql_real_connect(proxy, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy));
+			return EXIT_FAILURE;
+		}
+		mysql_connections.push_back(proxy);
+	}
+
+	typedef std::chrono::high_resolution_clock hrc;
+	const uint64_t test_duration = 10000;
+
+	const uint32_t FAILURE_RATE = 10;
+	int conn_creation_res = EXIT_FAILURE;
+	uint64_t conn_count = 0;
+	uint64_t mysql_fails = 0;
+
+	{
+		std::thread create_conns([&]() -> int {
+			std::chrono::nanoseconds duration;
+			hrc::time_point start;
+			hrc::time_point end;
+
+			start = hrc::now();
+
+			while (true) {
+				if (mysql_fails > (conn_count * FAILURE_RATE) / 100) {
+					diag("Too many mysql failures in connection creation, considering test as failed...");
+					conn_creation_res = EXIT_FAILURE;
+					return EXIT_FAILURE;
+				}
+
+				MYSQL* proxy = mysql_init(NULL);
+
+				if (!mysql_real_connect(proxy, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+					fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy));
+					mysql_fails += 1;
+				}
+
+				int rc = mysql_query(proxy, "DO 1");
+				if (rc) {
+					diag("mysql_errno: '%d', mysql_error: '%s'", mysql_errno(proxy), mysql_error(proxy));
+					mysql_fails += 1;
+				}
+
+				mysql_close(proxy);
+				end = hrc::now();
+				duration = end - start;
+
+				if (duration.count() >= (test_duration*1000*1000)) {
+					break;
+				}
+
+				conn_count += 1;
+			}
+
+			conn_creation_res = EXIT_SUCCESS;
+			return EXIT_SUCCESS;
+		});
+
+		std::chrono::nanoseconds duration;
+		hrc::time_point start;
+		hrc::time_point end;
+
+		start = hrc::now();
+
+		while (true) {
+			int rc = 0;
+
+			for (const honest_req_t& req : honest_requests) {
+				for (const string& params : req.params) {
+					const string ept { join_path(base_address, req.ept_info.name) };
+					std::string curl_res_data {};
+					uint64_t curl_res_code = 0;
+
+					CURLcode curl_err = CURLE_COULDNT_CONNECT;
+
+					if (req.ept_info.method == "POST") {
+						curl_err = perform_simple_post(ept, params, curl_res_code, curl_res_data);
+
+						ok(
+							curl_err == CURLE_OK && curl_res_code == 200,
+							"'%s' over '%s' should result into a '200' res code: (curl_err: '%d', curl_res_code: '%ld')",
+							req.ept_info.method.c_str(), ept.c_str(), curl_err, curl_res_code
+						);
+					} else {
+						const string get_ept { ept + params };
+						curl_err = perform_simple_get(get_ept, curl_res_code, curl_res_data);
+
+						ok(
+							curl_err == CURLE_OK && curl_res_code == 200,
+							"'%s' over '%s' should result into a '200' res code: (curl_err: '%d', curl_res_code: '%ld')",
+							req.ept_info.method.c_str(), ept.c_str(), curl_err, curl_res_code
+						);
+					}
+
+					if (curl_err == 7) {
+						diag("Operation over endpoint failed with 'CURLE_COULDNT_CONNECT'. Aborting...");
+						break;
+					}
+				}
+			}
+
+			end = hrc::now();
+			duration = end - start;
+
+			if (duration.count() >= test_duration*1000*1000 || rc) {
+				break;
+			}
+		}
+
+		create_conns.join();
+
+		ok(
+			conn_creation_res == EXIT_SUCCESS,
+			"MySQL conns operations shouldn't had more than a '%d'%% failure rate - conn_count: %ld, failures: %ld",
+			FAILURE_RATE, conn_count, mysql_fails
+		);
+	}
+skip_endpoints_testing:
+
+	for (MYSQL* conn : mysql_connections) {
+		mysql_close(conn);
+	}
+
+	mysql_close(admin);
+
+	curl_global_cleanup();
+
+	return exit_status();
+}

--- a/test/tap/tests/reg_test_stmt_resultset_err_no_rows_php-t.cpp
+++ b/test/tap/tests/reg_test_stmt_resultset_err_no_rows_php-t.cpp
@@ -32,8 +32,8 @@ int main(int argc, char** argv) {
 	string php_stderr {};
 	const string php_path { string{ cl.workdir } + "./reg_test_stmt_resultset_err_no_rows.php" };
 
-	to_opts opts {2 * 1000 * 1000, 0, 0, 0};
-	int exec_res = wexecvp(php_path, {}, &opts, php_stdout, php_stderr);
+	to_opts_t opts {2 * 1000 * 1000, 0, 0, 0};
+	int exec_res = wexecvp(php_path, {}, opts, php_stdout, php_stderr);
 
 	diag("Output from executed test: '%s'", php_path.c_str());
 	diag("========================================================================");

--- a/test/tap/tests/test_clickhouse_server-t.cpp
+++ b/test/tap/tests/test_clickhouse_server-t.cpp
@@ -497,7 +497,8 @@ int main(int argc, char** argv) {
 		// NOTE: Wait for ProxySQL to reconfigure, changing Clickhous interface.
 		// Trying to perform a connection immediately after changing the
 		// interface could lead to 'EADDRINUSE' in ProxySQL side.
-		sleep(1);
+		// UPDATE: Timeout increased to '5' seconds to avoid previously described issue.
+		sleep(5);
 
 		// Connect to the new interface
 		std::pair<std::string, int> new_host_port {};

--- a/test/tap/tests/test_cluster_sync-t.cpp
+++ b/test/tap/tests/test_cluster_sync-t.cpp
@@ -470,7 +470,7 @@ int main(int, char**) {
 		std::string proxy_stdout {};
 		std::string proxy_stderr {};
 		int exec_res = wexecvp(
-			std::string(cl.workdir) + "../../../src/proxysql", { "-f", "-M", "-c", fmt_config_file.c_str() }, NULL,
+			std::string(cl.workdir) + "../../../src/proxysql", { "-f", "-M", "-c", fmt_config_file.c_str() }, {},
 			proxy_stdout, proxy_stderr
 		);
 

--- a/test/tap/tests/test_sqlite3_server-t.cpp
+++ b/test/tap/tests/test_sqlite3_server-t.cpp
@@ -348,7 +348,8 @@ int main(int argc, char** argv) {
 		// NOTE: Wait for ProxySQL to reconfigure, changing SQLite3 interface.
 		// Trying to perform a connection immediately after changing the
 		// interface could lead to 'EADDRINUSE' in ProxySQL side.
-		sleep(1);
+		// UPDATE: Timeout increased to '5' seconds to avoid previously described issue.
+		sleep(5);
 
 		// Connect to the new interface
 		std::pair<std::string, int> new_host_port {};

--- a/test/tap/tests/test_wexecvp_syscall_failures-t.cpp
+++ b/test/tap/tests/test_wexecvp_syscall_failures-t.cpp
@@ -1,0 +1,189 @@
+/**
+ * @file test_wexecvp_syscall_failures.cpp
+ * @brief Makes use of GCC wrap option for testing 'wexecvp' over different syscall failures.
+ * @date 2022-12-08
+ */
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <poll.h>
+#include <unistd.h>
+
+#include "proxysql_utils.h"
+#include "tap.h"
+#include "utils.h"
+
+using std::string;
+using std::vector;
+using std::pair;
+
+bool g_read_use_real = false;
+int g_read_ret = -1;
+int g_read_errno = EINVAL;
+
+extern "C" ssize_t __real_read(int __fd, void *__buf, size_t __nbytes);
+extern "C" ssize_t __wrap_read(int fd, void* buf, size_t nbytes);
+
+ssize_t __wrap_read(int fd, void* buf, size_t nbytes) {
+	if (g_read_use_real) {
+		return __real_read(fd, buf, nbytes);
+	}
+
+	errno = g_read_errno;
+	return g_read_ret;
+}
+
+bool g_pipe_use_real = true;
+int g_pipe_ret = -1;
+int g_pipe_errno = EINVAL;
+
+extern "C" int __real_pipe(int __pipedes[2]);
+extern "C" int __wrap_pipe(int __pipedes[2]);
+
+int __wrap_pipe(int __pipedes[2]) {
+	if (g_pipe_use_real) {
+		return __real_pipe(__pipedes);
+	}
+
+	errno = g_pipe_errno;
+	return g_pipe_ret;
+}
+
+bool g_fcntl_use_real = false;
+int g_fcntl_ret = -1;
+int g_fcntl_errno = EINVAL;
+
+extern "C" int __real_fcntl(int __fd, int __cmd, ...);
+extern "C" int __wrap_fcntl(int __fd, int __cmd, ...);
+
+int __wrap_fcntl(int __fd, int __cmd, ...) {
+	if (g_fcntl_use_real) {
+		va_list args;
+		va_start(args, __cmd);
+		int res =  __real_fcntl(__fd, __cmd, args);
+		va_end(args);
+
+		return res;
+	}
+
+	usleep(500 * 1000);
+
+	errno = g_fcntl_errno;
+	return g_fcntl_ret;
+}
+
+bool g_poll_use_real = false;
+int g_poll_ret = -1;
+int g_poll_errno = EINVAL;
+
+extern "C" int __real_poll(struct pollfd *__fds, nfds_t __nfds, int __timeout);
+extern "C" int __wrap_poll(struct pollfd *__fds, nfds_t __nfds, int __timeout);
+
+int __wrap_poll(struct pollfd *__fds, nfds_t __nfds, int __timeout) {
+	if (g_poll_use_real) {
+		return __real_poll(__fds, __nfds, __timeout);
+	}
+
+	usleep(500 * 1000);
+
+	errno = g_poll_errno;
+	return g_poll_ret;
+}
+
+using errno_t = int;
+using test_pl_t = pair<bool&,errno_t>;
+
+void enable_reals(const vector<test_pl_t>& test_pls) {
+	for (const test_pl_t& test_pl : test_pls) {
+		test_pl.first = true;
+	}
+}
+
+int main(int argc, char** argv) {
+	const char* workdir = getenv("TAP_WORKDIR");
+
+	if (!workdir) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
+
+	const string base_path { join_path(workdir, "reg_test_3223_scripts") };
+	const auto check_read_failure =
+		[] (const string& base_path, const test_pl_t& pl, const string& std_stream) -> void {
+			const string exe_path { join_path(base_path, "write_to_std_streams.py") };
+
+			string o_stdout {};
+			string o_stderr {};
+
+			to_opts_t wexecvp_opts {};
+			wexecvp_opts.timeout_us = 1*1000*1000;
+			wexecvp_opts.waitpid_delay_us = 100*1000;
+			wexecvp_opts.sigkill_to_us = 500*1000;
+
+			const string sigterm_file_flag { exe_path + "-RECV_SIGTERM" };
+			diag("Removing previous SIGTERM flag file - '%s'", sigterm_file_flag.c_str());
+			remove(sigterm_file_flag.c_str());
+
+			diag("Launching executable '%s' with params '%s'", exe_path.c_str(), std_stream.c_str());
+			int err = wexecvp(exe_path, { std_stream.c_str() }, wexecvp_opts, o_stdout, o_stderr);
+
+			int exp_err = 0;
+			int exp_errno = 0;
+			int _errno = errno;
+
+			// From function spec itself, 'read' failure implies '-6'
+			if ((std_stream == "stdout" || std_stream == "stderr" ) || pl.second != -5) {
+				exp_err = pl.second;
+				exp_errno = EINVAL;
+			} else {
+				// If no output is performed by the target script, no 'read' should be call by ProxySQL. No read
+				// calls should imply no failure.
+				exp_err = ETIME;
+				exp_errno = 0;
+				_errno = 0;
+			}
+
+			ok(
+				exp_err == err && _errno == exp_errno,
+				"'wexecvp' should return exp err - { exp_err: %d, act_err:%d }, { exp_errno: %d, act_errno: %d }",
+				exp_err, err, _errno, exp_errno
+			);
+
+			if (pl.second <= -3) {
+				int f_exists = access(sigterm_file_flag.c_str(), F_OK);
+				ok(f_exists == 0, "Script '%s' should receive a 'SIGTERM' signal", exe_path.c_str());
+			}
+		};
+
+	const vector<test_pl_t> test_pls {
+		{ g_pipe_use_real, -1 },
+		{ g_fcntl_use_real, -3 },
+		{ g_poll_use_real, -4 },
+		{ g_read_use_real, -5 }
+	};
+
+	uint32_t planned_tests = 0;
+	for (const test_pl_t& pl : test_pls) {
+		if (pl.second <= -3) {
+			planned_tests += 3 * 2;
+		} else {
+			planned_tests += 3;
+		}
+	}
+
+	plan(planned_tests);
+
+	for (const test_pl_t& pl : test_pls) {
+		enable_reals(test_pls);
+
+		pl.first = false;
+
+		check_read_failure(base_path, pl, "stdout");
+		check_read_failure(base_path, pl, "stderr");
+		check_read_failure(base_path, pl, "");
+	}
+
+	return exit_status();
+}

--- a/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
+++ b/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
@@ -148,14 +148,14 @@ int main(int argc, char** argv) {
 		std::string select_query {};
 		string_format(t_select_query, select_query, id);
 
-		to_opts opts { 10000*1000, 100*1000, 500*1000, 2000*1000 };
+		to_opts_t opts { 10000*1000, 100*1000, 500*1000, 2000*1000 };
 
 		// Query *without* support for EOF deprecation
 		auto eof_query = [&] (std::string& query_res, std::string& eof_query_err) -> int {
 			int exec_res = wexecvp(
 				std::string(cl.workdir) + "fwd_eof_query",
 				{ select_query.c_str() },
-				&opts,
+				opts,
 				query_res,
 				eof_query_err
 			);
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
 			int exec_res = wexecvp(
 				std::string(cl.workdir) + "fwd_eof_ok_query",
 				{ select_query.c_str() },
-				&opts,
+				opts,
 				query_res,
 				ok_query_err
 			);


### PR DESCRIPTION
This PR addresses several issues:

- Crash reported in issue #4001 due to invalid double call to `close` on file descritor.
- Replace of the use of `select` in favor of `poll` to address the `FD_SETSIZE` limitation.
- Enforce proper JSON formatting for each response of the RESTAPI endpoints, and for the formatting of input parameters in `GET` requests.
- General improvement in testing of the RESTAPI.