### PR TITLE
Add PyMySQL test for malformed packet when using MariaDB with fast_forward

### DIFF
--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -85,7 +85,7 @@ all: tests
 
 .PHONY: clean
 clean:
-	rm -f *-t galera_1_timeout_count galera_2_timeout_no_count aurora generate_set_session_csv set_testing-240.csv clickhouse_php_conn-t || true
+	rm -f *-t galera_1_timeout_count galera_2_timeout_no_count aurora generate_set_session_csv set_testing-240.csv clickhouse_php_conn-t reg_test_3992_fast_forward_malformed_packet-pymysql-t || true
 
 WITHGCOVVAR := $(shell echo $(WITHGCOV))
 ifeq ($(WITHGCOVVAR),1)
@@ -118,6 +118,10 @@ set_testing-240.csv: generate_set_session_csv
 clickhouse_php_conn-t: clickhouse_php_conn-t.php
 	cp clickhouse_php_conn-t.php clickhouse_php_conn-t
 	chmod +x clickhouse_php_conn-t
+
+reg_test_3992_fast_forward_malformed_packet-pymysql-t: reg_test_3992_fast_forward_malformed_packet-pymysql-t.py
+	cp reg_test_3992_fast_forward_malformed_packet-pymysql-t.py reg_test_3992_fast_forward_malformed_packet-pymysql-t
+	chmod +x reg_test_3992_fast_forward_malformed_packet-pymysql-t
 
 %-t:%-t.cpp $(TAP_LIBDIR)/libtap.a
 	$(CXX) $^ $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl -std=c++11 -ltap $(STATIC_LIBS) -o $@

--- a/test/tap/tests/reg_test_3992_fast_forward_malformed_packet-pymysql-t.py
+++ b/test/tap/tests/reg_test_3992_fast_forward_malformed_packet-pymysql-t.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# This is a regression test for issues #3992 and #4047. Test checks if queries
+# are executed successfully with MariaDB server via PyMySQL client having fast
+# forward flag set to true and false.
+
+import pymysql
+import sys
+import os
+
+proxy_addr = os.environ['TAP_HOST']
+proxy_port = int(os.environ['TAP_PORT'])
+
+users = ['mariadbuser', 'mariadbuserff']
+
+db = 'information_schema'
+
+error_count = 0
+
+for user in users:
+    connection = pymysql.connect(host=proxy_addr, port=proxy_port, user=user, passwd=user, db=db,
+                                 charset='utf8')
+    with connection.cursor() as cursor:
+        error = None
+
+        try:
+            cursor.execute('select * from information_schema.GLOBAL_VARIABLES '
+                           'where variable_name =\'sql_mode\';')
+        except Exception as e:
+            ok_msg = 'not ok'
+            error_count += 1
+            error = e
+        else:
+            ok_msg = 'ok'
+
+        print('{} - \'PyMySQL\' select command should be correctly executed. Error was: {}'
+              .format(ok_msg, error))
+
+sys.exit(error_count)


### PR DESCRIPTION
Related to issues #3992 and #4047, and to pull request #3996