### PR TITLE
Do not shun servers with max_replication_lag = 0 #4018

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -3554,7 +3554,11 @@ void MySQL_HostGroups_Manager::replication_lag_action_inner(MyHGC *myhgc, char *
 				if (
 //					(current_replication_lag==-1 )
 //					||
-					(current_replication_lag>=0 && ((unsigned int)current_replication_lag > mysrvc->max_replication_lag))
+					(
+						current_replication_lag>=0 &&
+						mysrvc->max_replication_lag > 0 && // see issue #4018
+						((unsigned int)current_replication_lag > mysrvc->max_replication_lag)
+					)
 				) {
 					// always increase the counter
 					mysrvc->cur_replication_lag_count += 1;


### PR DESCRIPTION
If max_replication_lag is 0 and mysql-monitor_replication_lag_group_by_host='true', a replica was incorrectly shunned because of replication lag