### PR TITLE
Fix data left unsent to client for 'fast_forward' connections

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3582,6 +3582,10 @@ bool MySQL_Thread::process_data_on_data_stream(MySQL_Data_Stream *myds, unsigned
 					return true;
 				}
 				if (mypolls.fds[n].revents) {
+					proxy_debug(
+						PROXY_DEBUG_NET, 6, "Events for Session=%p, DataStream=%p, thread_session_id=%u, status=%d\n",
+						myds->sess, myds, myds->sess->thread_session_id, mypolls.myds[n]->DSS
+					);
 					if (mypolls.myds[n]->DSS < STATE_MARIADB_BEGIN || mypolls.myds[n]->DSS > STATE_MARIADB_END) {
 						// only if we aren't using MariaDB Client Library
 						int rb = 0;

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -627,6 +627,7 @@ int MySQL_Data_Stream::read_from_net() {
 		if (encrypted==false) {
 			int myds_errno=errno;
 			if (r==0 || (r==-1 && myds_errno != EINTR && myds_errno != EAGAIN)) {
+				proxy_debug(PROXY_DEBUG_NET, 5, "Session=%p: 'read' returned with '%d' bytes and errno '%d'\n", sess, r, myds_errno);
 				shut_soft();
 			}
 		} else {
@@ -926,6 +927,10 @@ int MySQL_Data_Stream::buffer2array() {
 		if (pkts_recv==0) { pkts_recv=1; }
 		queueIN.pkt.size=queue_data(queueIN);
 		ret=queueIN.pkt.size;
+		proxy_debug(
+			PROXY_DEBUG_PKT_ARRAY, 5, "Copying recv %d bytes for fast-forward Session=%p\n",
+			queueIN.pkt.size, sess
+		);
 		if (ret >= RESULTSET_BUFLEN_DS_16K) {
 			// legacy approach
 			queueIN.pkt.ptr=l_alloc(queueIN.pkt.size);


### PR DESCRIPTION
This PR is left as documentation, and a first attempt to solve an issue found for 'fast_forward' sessions when a backend connection is early terminated, either by the backend itself, or due to other conditions.

**NOTE:** This is not necessarily the best way to solve this issue, this probably requires further discussion, even if the approach presented here doesn't look "incorrect' at first sight.

**NOTE for reviewer:** At this moment, only the last two commits are relevant for the issue to fix.