### PR TITLE
Log 'fast_forward' conns close due to 'log_unhealthy_connections'

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3900,8 +3900,18 @@ void MySQL_Thread::process_all_sessions() {
 		if (sess->healthy==0) {
 			char _buf[1024];
 			if (sess->client_myds) {
-				if (mysql_thread___log_unhealthy_connections && sess->session_fast_forward == false) {
-					proxy_warning("Closing unhealthy client connection %s:%d\n",sess->client_myds->addr.addr,sess->client_myds->addr.port);
+				if (mysql_thread___log_unhealthy_connections) {
+					if (sess->session_fast_forward == false) {
+						proxy_warning(
+							"Closing unhealthy client connection %s:%d\n", sess->client_myds->addr.addr,
+							sess->client_myds->addr.port
+						);
+					} else {
+						proxy_warning(
+							"Closing 'fast_forward' client connection %s:%d\n", sess->client_myds->addr.addr,
+							sess->client_myds->addr.port
+						);
+					}
 				}
 			}
 			sprintf(_buf,"%s:%d:%s()", __FILE__, __LINE__, __func__);


### PR DESCRIPTION
This is an improvement over commit #5751d71d.
Instead of avoiding to log when closing 'fast_forward' connections, now we log a dedicated message.