### PR TITLE
Avoid duplicate entries in Galera_Hosts_resultset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ deps/libev/libev-*/
 deps/libhttpserver/libhttpserver-*/
 deps/libinjection/libinjection-*/
 deps/libmicrohttpd/libmicrohttpd-*/
+deps/libmicrohttpd/libmicrohttpd
 deps/libssl/openssl-openssl-*/
 deps/lz4/lz4-*/
 deps/mariadb-client-library/mariadb-connector-c-*/

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2616,7 +2616,7 @@ void MySQL_HostGroups_Manager::generate_mysql_galera_hostgroups_table() {
 		SQLite3_result *resultset=NULL;
 		char *query=(char *)"SELECT writer_hostgroup, hostname, port, MAX(use_ssl) use_ssl , writer_is_also_reader , max_transactions_behind "
 			" FROM mysql_servers JOIN mysql_galera_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=backup_writer_hostgroup OR "
-			" hostgroup_id=reader_hostgroup OR hostgroup_id=offline_hostgroup WHERE active=1 GROUP BY hostgroup_id, hostname, port";
+			" hostgroup_id=reader_hostgroup OR hostgroup_id=offline_hostgroup WHERE active=1 GROUP BY writer_hostgroup, hostname, port";
 		mydb->execute_statement(query, &error , &cols , &affected_rows , &resultset);
 		if (resultset) {
 			if (GloMyMon->Galera_Hosts_resultset) {


### PR DESCRIPTION
Galera_Hosts_resultset is populated by a query on mysql_servers JOIN mysql_galera_hostgroups . An incorrect GROUP BY could have caused some servers to be present more than once.