### PR TITLE
Add several optimizations to stats_mysql_query_digest table fetching

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -418,11 +418,11 @@ class ProxySQL_Admin {
 
 	void p_update_metrics();
 	void stats___mysql_query_rules();
-	void stats___save_mysql_query_digest_to_sqlite(
+	int stats___save_mysql_query_digest_to_sqlite(
 		const bool reset, const bool copy, const SQLite3_result *resultset,
 		const umap_query_digest *digest_umap, const umap_query_digest_text *digest_text_umap
 	);
-	void stats___mysql_query_digests(bool reset, bool copy=false);
+	int stats___mysql_query_digests(bool reset, bool copy=false);
 	//void stats___mysql_query_digests_reset();
 	void stats___mysql_commands_counters();
 	void stats___mysql_processlist();

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -5,6 +5,7 @@
 #include <prometheus/counter.h>
 #include <prometheus/gauge.h>
 
+#include "query_processor.h"
 #include "proxy_defines.h"
 #include "proxysql.h"
 #include "cpp.h"
@@ -417,6 +418,10 @@ class ProxySQL_Admin {
 
 	void p_update_metrics();
 	void stats___mysql_query_rules();
+	void stats___save_mysql_query_digest_to_sqlite(
+		const bool reset, const bool copy, const SQLite3_result *resultset,
+		const umap_query_digest *digest_umap, const umap_query_digest_text *digest_text_umap
+	);
 	void stats___mysql_query_digests(bool reset, bool copy=false);
 	//void stats___mysql_query_digests_reset();
 	void stats___mysql_commands_counters();

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -423,6 +423,7 @@ class ProxySQL_Admin {
 		const umap_query_digest *digest_umap, const umap_query_digest_text *digest_text_umap
 	);
 	int stats___mysql_query_digests(bool reset, bool copy=false);
+	int stats___mysql_query_digests_v2(bool reset, bool copy, bool use_resultset);
 	//void stats___mysql_query_digests_reset();
 	void stats___mysql_commands_counters();
 	void stats___mysql_processlist();

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -324,7 +324,9 @@ class Query_Processor {
 	SQLite3_result * get_query_digests();
 	SQLite3_result * get_query_digests_reset();
 	std::pair<SQLite3_result *, int> get_query_digests_v2(const bool use_resultset = true);
-	std::pair<SQLite3_result *, int> get_query_digests_reset_v2(const bool use_resultset = true);
+	std::pair<SQLite3_result *, int> get_query_digests_reset_v2(
+		const bool copy, const bool use_resultset = true
+	);
 	void get_query_digests_reset(umap_query_digest *uqd, umap_query_digest_text *uqdt);
 	unsigned long long purge_query_digests(bool async_purge, bool parallel, char **msg);
 	unsigned long long purge_query_digests_async(char **msg);

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -323,8 +323,8 @@ class Query_Processor {
 	SQLite3_result * get_stats_commands_counters();
 	SQLite3_result * get_query_digests();
 	SQLite3_result * get_query_digests_reset();
-	SQLite3_result * get_query_digests_v2(const bool use_resultset = true);
-	SQLite3_result * get_query_digests_reset_v2(const bool use_resultset = true);
+	std::pair<SQLite3_result *, int> get_query_digests_v2(const bool use_resultset = true);
+	std::pair<SQLite3_result *, int> get_query_digests_reset_v2(const bool use_resultset = true);
 	void get_query_digests_reset(umap_query_digest *uqd, umap_query_digest_text *uqdt);
 	unsigned long long purge_query_digests(bool async_purge, bool parallel, char **msg);
 	unsigned long long purge_query_digests_async(char **msg);

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -61,7 +61,10 @@ class QP_query_digest_stats {
 	unsigned long long rows_sent;
 	int hid;
 	QP_query_digest_stats(char *u, char *s, uint64_t d, char *dt, int h, char *ca);
-	void add_time(unsigned long long t, unsigned long long n, unsigned long long ra, unsigned long long rs);
+	void add_time(
+		unsigned long long t, unsigned long long n, unsigned long long ra, unsigned long long rs,
+		unsigned long long cnt = 1
+	);
 	~QP_query_digest_stats();
 	char **get_row(umap_query_digest_text *digest_text_umap, query_digest_stats_pointers_t *qdsp);
 };
@@ -319,6 +322,7 @@ class Query_Processor {
 	SQLite3_result * get_stats_commands_counters();
 	SQLite3_result * get_query_digests();
 	SQLite3_result * get_query_digests_reset();
+	SQLite3_result * get_query_digests_v2();
 	void get_query_digests_reset(umap_query_digest *uqd, umap_query_digest_text *uqdt);
 	unsigned long long purge_query_digests(bool async_purge, bool parallel, char **msg);
 	unsigned long long purge_query_digests_async(char **msg);

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -323,6 +323,7 @@ class Query_Processor {
 	SQLite3_result * get_query_digests();
 	SQLite3_result * get_query_digests_reset();
 	SQLite3_result * get_query_digests_v2();
+	SQLite3_result * get_query_digests_reset_v2();
 	void get_query_digests_reset(umap_query_digest *uqd, umap_query_digest_text *uqdt);
 	unsigned long long purge_query_digests(bool async_purge, bool parallel, char **msg);
 	unsigned long long purge_query_digests_async(char **msg);

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -323,8 +323,8 @@ class Query_Processor {
 	SQLite3_result * get_stats_commands_counters();
 	SQLite3_result * get_query_digests();
 	SQLite3_result * get_query_digests_reset();
-	SQLite3_result * get_query_digests_v2();
-	SQLite3_result * get_query_digests_reset_v2();
+	SQLite3_result * get_query_digests_v2(const bool use_resultset = true);
+	SQLite3_result * get_query_digests_reset_v2(const bool use_resultset = true);
 	void get_query_digests_reset(umap_query_digest *uqd, umap_query_digest_text *uqdt);
 	unsigned long long purge_query_digests(bool async_purge, bool parallel, char **msg);
 	unsigned long long purge_query_digests_async(char **msg);

--- a/include/query_processor.h
+++ b/include/query_processor.h
@@ -66,6 +66,7 @@ class QP_query_digest_stats {
 		unsigned long long cnt = 1
 	);
 	~QP_query_digest_stats();
+	char *get_digest_text(const umap_query_digest_text *digest_text_umap);
 	char **get_row(umap_query_digest_text *digest_text_umap, query_digest_stats_pointers_t *qdsp);
 };
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -9449,7 +9449,7 @@ void ProxySQL_Admin::stats___save_mysql_query_digest_to_sqlite(
 	// If the function do not receives a resultset, it gets the values directly from the digest_umap
 	while (resultset ? i != resultset->rows_count : it != digest_umap->end()) {
 		QP_query_digest_stats *qds = (QP_query_digest_stats *)it->second;
-		SQLite3_row *row  = resultset ? resultset->rows[i] : NULL; i++;
+		SQLite3_row *row  = resultset ? resultset->rows[i] : NULL;
 		string digest_hex_str;
 		if (!resultset) {
 			std::ostringstream digest_stream;
@@ -9496,6 +9496,10 @@ void ProxySQL_Admin::stats___save_mysql_query_digest_to_sqlite(
 			rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, statsdb);
 			rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, statsdb);
 		}
+#ifdef DEBUG
+		if (resultset)
+			assert(row_idx == i);
+#endif
 		row_idx++;
 		if (resultset)
 			i++;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -4080,6 +4080,28 @@ void admin_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *pkt) {
 						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
 						run_query=false;
 						break;
+					case 25:
+						// get all the entries from the digest map AND RESET, but WRITING to DB
+						// it uses multiple threads
+						// It locks the maps while generating the resultset
+						r1 = SPA->stats___mysql_query_digests(true, true);
+						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
+						run_query=false;
+						break;
+					case 26:
+						// get all the entries from the digest map AND RESET, but WRITING to DB
+						// it uses multiple threads for creating the resultset
+						r1 = ProxySQL_Test___GetDigestTable_v2(true, true);
+						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
+						run_query=false;
+						break;
+					case 27:
+						// get all the entries from the digest map AND RESET, but WRITING to DB
+						// Do not create a resultset, uses the digest_umap
+						r1 = ProxySQL_Test___GetDigestTable_v2(true, false);
+						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
+						run_query=false;
+						break;
 					case 31:
 						{
 							if (test_arg1==0) {

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -9673,7 +9673,7 @@ int ProxySQL_Admin::stats___mysql_query_digests_v2(bool reset, bool copy, bool u
 	if (!GloQPro) return 0;
 	std::pair<SQLite3_result *, int> res;
 	if (reset == true) {
-		res = GloQPro->get_query_digests_reset_v2(use_resultset);
+		res = GloQPro->get_query_digests_reset_v2(copy, use_resultset);
 	} else {
 		res = GloQPro->get_query_digests_v2(use_resultset);
 	}

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1073,7 +1073,7 @@ incoming_servers_t::incoming_servers_t(
 	incoming_hostgroup_attributes(incoming_hostgroup_attributes)
 {}
 
-int ProxySQL_Test___GetDigestTable_v2(bool reset, bool use_resultset) {
+int ProxySQL_Test___GetDigestTable_v2(bool reset, bool copy, bool use_resultset) {
 	int r = 0;
 	if (!GloQPro) return 0;
 	std::pair<SQLite3_result *, int> res;
@@ -4069,14 +4069,14 @@ void admin_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *pkt) {
 					case 23:
 						// get all the entries from the digest map, but WRITING to DB
 						// it uses multiple threads for creating the resultset
-						r1 = ProxySQL_Test___GetDigestTable_v2(false, true);
+						r1 = ProxySQL_Test___GetDigestTable_v2(false, false, true);
 						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
 						run_query=false;
 						break;
 					case 24:
 						// get all the entries from the digest map, but WRITING to DB
 						// Do not create a resultset, uses the digest_umap
-						r1 = ProxySQL_Test___GetDigestTable_v2(false, false);
+						r1 = ProxySQL_Test___GetDigestTable_v2(false, false, false);
 						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
 						run_query=false;
 						break;
@@ -4091,14 +4091,14 @@ void admin_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *pkt) {
 					case 26:
 						// get all the entries from the digest map AND RESET, but WRITING to DB
 						// it uses multiple threads for creating the resultset
-						r1 = ProxySQL_Test___GetDigestTable_v2(true, true);
+						r1 = ProxySQL_Test___GetDigestTable_v2(true, true, true);
 						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
 						run_query=false;
 						break;
 					case 27:
 						// get all the entries from the digest map AND RESET, but WRITING to DB
 						// Do not create a resultset, uses the digest_umap
-						r1 = ProxySQL_Test___GetDigestTable_v2(true, false);
+						r1 = ProxySQL_Test___GetDigestTable_v2(true, true, false);
 						SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, r1);
 						run_query=false;
 						break;

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1189,7 +1189,7 @@ unsigned long long Query_Processor::get_query_digests_total_size() {
 	return ret;
 }
 
-SQLite3_result * Query_Processor::get_query_digests_v2(const bool use_resultset) {
+std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const bool use_resultset) {
 	proxy_debug(PROXY_DEBUG_MYSQL_QUERY_PROCESSOR, 4, "Dumping current query digest\n");
 	SQLite3_result *result = NULL;
 	// Create two auxiliary maps and swap its content with the main maps. This
@@ -1259,7 +1259,7 @@ SQLite3_result * Query_Processor::get_query_digests_v2(const bool use_resultset)
 			}
 		}
 	}
-	GloAdmin->stats___save_mysql_query_digest_to_sqlite(
+	int num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
 		false, false, result, &digest_umap_aux, &digest_text_umap_aux
 	);
 	if (map_size >= DIGEST_STATS_FAST_MINSIZE) {
@@ -1294,7 +1294,8 @@ SQLite3_result * Query_Processor::get_query_digests_v2(const bool use_resultset)
 	digest_text_umap_aux.clear();
 	pthread_rwlock_unlock(&digest_rwlock);
 
-	return result;
+	std::pair<SQLite3_result *, int> res{result, num_rows};
+	return res;
 }
 
 SQLite3_result * Query_Processor::get_query_digests() {
@@ -1364,7 +1365,7 @@ SQLite3_result * Query_Processor::get_query_digests() {
 	return result;
 }
 
-SQLite3_result * Query_Processor::get_query_digests_reset_v2(const bool use_resultset) {
+std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(const bool use_resultset) {
 	SQLite3_result *result = NULL;
 	umap_query_digest digest_umap_aux;
 	umap_query_digest_text digest_text_umap_aux;
@@ -1438,7 +1439,7 @@ SQLite3_result * Query_Processor::get_query_digests_reset_v2(const bool use_resu
 			}
 		}
 	}
-	GloAdmin->stats___save_mysql_query_digest_to_sqlite(
+	int num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
 		false, false, result, &digest_umap_aux, &digest_text_umap_aux
 	);
 	digest_umap_aux.clear();
@@ -1464,7 +1465,9 @@ SQLite3_result * Query_Processor::get_query_digests_reset_v2(const bool use_resu
 			}
 		}
 	}
-	return result;
+
+	std::pair<SQLite3_result *, int> res{result, num_rows};
+	return res;
 }
 
 void Query_Processor::get_query_digests_reset(umap_query_digest *uqd, umap_query_digest_text *uqdt) {

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1287,6 +1287,7 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 			qds_equal->add_time(
 				qds->min_time, qds->last_seen, qds->rows_affected, qds->rows_sent, qds->count_star
 			);
+			delete qds_equal;
 		} else {
 			digest_umap.insert(element);
 		}

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1374,7 +1374,7 @@ SQLite3_result * Query_Processor::get_query_digests_reset_v2(const bool use_resu
 	pthread_rwlock_unlock(&digest_rwlock);
 	unsigned long long curtime1;
 	unsigned long long curtime2;
-	size_t map_size = digest_umap.size();
+	size_t map_size = digest_umap_aux.size(); // we need to use the new map
 	bool free_me = false;
 	bool defer_free = false;
 	int n=DIGEST_STATS_FAST_THREADS;

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1293,9 +1293,9 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 		}
 	}
 	digest_text_umap.insert(digest_text_umap_aux.begin(), digest_text_umap_aux.end());
+	pthread_rwlock_unlock(&digest_rwlock);
 	digest_umap_aux.clear();
 	digest_text_umap_aux.clear();
-	pthread_rwlock_unlock(&digest_rwlock);
 
 	std::pair<SQLite3_result *, int> res{result, num_rows};
 	return res;

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1201,6 +1201,7 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 	digest_umap.swap(digest_umap_aux);
 	digest_text_umap.swap(digest_text_umap_aux);
 	pthread_rwlock_unlock(&digest_rwlock);
+	int num_rows = 0;
 	unsigned long long curtime1;
 	unsigned long long curtime2;
 	size_t map_size = digest_umap_aux.size();
@@ -1258,10 +1259,11 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 				free(a);
 			}
 		}
+	} else {
+		num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
+			false, false, NULL, &digest_umap_aux, &digest_text_umap_aux
+		);
 	}
-	int num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
-		false, false, result, &digest_umap_aux, &digest_text_umap_aux
-	);
 	if (map_size >= DIGEST_STATS_FAST_MINSIZE) {
 		curtime2=monotonic_time();
 		curtime1 = curtime1/1000;
@@ -1373,6 +1375,7 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(con
 	digest_umap.swap(digest_umap_aux);
 	digest_text_umap.swap(digest_text_umap_aux);
 	pthread_rwlock_unlock(&digest_rwlock);
+	int num_rows = 0;
 	unsigned long long curtime1;
 	unsigned long long curtime2;
 	size_t map_size = digest_umap_aux.size(); // we need to use the new map
@@ -1438,10 +1441,11 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(con
 				delete qds;
 			}
 		}
+	} else {
+		num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
+			false, false, result, &digest_umap_aux, &digest_text_umap_aux
+		);
 	}
-	int num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
-		false, false, result, &digest_umap_aux, &digest_text_umap_aux
-	);
 	digest_umap_aux.clear();
 	// this part is always single-threaded
 	for (std::unordered_map<uint64_t, char *>::iterator it=digest_text_umap_aux.begin(); it!=digest_text_umap_aux.end(); ++it) {

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -232,6 +232,30 @@ QP_query_digest_stats::~QP_query_digest_stats() {
 		client_address=NULL;
 	}
 }
+
+// Funtion to get the digest text associated to a QP_query_digest_stats.
+// QP_query_digest_stats member type "char *digest_text" may by NULL, so we
+// have to get the digest text from "digest_text_umap".
+char *QP_query_digest_stats::get_digest_text(const umap_query_digest_text *digest_text_umap) {
+	char *digest_text_str = NULL;
+
+	if (digest_text) {
+		digest_text_str = digest_text;
+	} else {
+		std::unordered_map<uint64_t, char *>::const_iterator it;
+		it = digest_text_umap->find(digest);
+		if (it != digest_text_umap->end()) {
+			digest_text_str = it->second;
+		} else {
+			// LCOV_EXCL_START
+			assert(0);
+			// LCOV_EXCL_STOP
+		}
+	}
+
+	return digest_text_str;
+}
+
 char **QP_query_digest_stats::get_row(umap_query_digest_text *digest_text_umap, query_digest_stats_pointers_t *qdsp) {
 	char **pta=qdsp->pta;
 
@@ -247,19 +271,7 @@ char **QP_query_digest_stats::get_row(umap_query_digest_text *digest_text_umap, 
 	sprintf(qdsp->digest,"0x%016llX", (long long unsigned int)digest);
 	pta[3]=qdsp->digest;
 
-	if (digest_text) {
-		pta[4]=digest_text;
-	} else {
-		std::unordered_map<uint64_t, char *>::iterator it;
-		it=digest_text_umap->find(digest);
-		if (it != digest_text_umap->end()) {
-			pta[4] = it->second;
-		} else {
-			// LCOV_EXCL_START
-			assert(0);
-			// LCOV_EXCL_STOP
-		}
-	}
+	pta[4] = get_digest_text(digest_text_umap);
 
 	//sprintf(qdsp->count_star,"%u",count_star);
 	my_itoa(qdsp->count_star, count_star);

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1284,20 +1284,19 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 
 	// Once we do the swap, we merge the content of the first auxiliary maps
 	// in the main maps and clear the content of the auxiliary maps.
-	digest_text_umap_aux.swap(digest_text_umap);
-	for (const auto& element : digest_umap_aux) {
+	for (const auto& element : digest_umap_aux_2) {
 		uint64_t digest = element.first;
 		QP_query_digest_stats *qds = (QP_query_digest_stats *)element.second;
-		std::unordered_map<uint64_t, void *>::iterator it = digest_umap_aux_2.find(digest);
-		if (it != digest_umap_aux_2.end()) {
+		std::unordered_map<uint64_t, void *>::iterator it = digest_umap_aux.find(digest);
+		if (it != digest_umap_aux.end()) {
 			// found
 			QP_query_digest_stats *qds_equal = (QP_query_digest_stats *)it->second;
 			qds_equal->add_time(
 				qds->min_time, qds->last_seen, qds->rows_affected, qds->rows_sent, qds->count_star
 			);
-			delete qds_equal;
+			delete qds;
 		} else {
-			digest_umap_aux_2.insert(element);
+			digest_umap_aux.insert(element);
 		}
 	}
 	digest_text_umap.insert(digest_text_umap_aux.begin(), digest_text_umap_aux.end());
@@ -1321,7 +1320,7 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 			qds_equal->add_time(
 				qds->min_time, qds->last_seen, qds->rows_affected, qds->rows_sent, qds->count_star
 			);
-			delete qds_equal;
+			delete qds;
 		} else {
 			digest_umap.insert(element);
 		}

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1480,6 +1480,14 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(con
 		num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
 			false, false, result, &digest_umap_aux, &digest_text_umap_aux
 		);
+		for (
+			std::unordered_map<uint64_t, void *>::iterator it = digest_umap_aux.begin();
+			it != digest_umap_aux.end();
+			++it
+		) {
+			QP_query_digest_stats *qds = (QP_query_digest_stats *)it->second;
+			delete qds;
+		}
 	}
 	digest_umap_aux.clear();
 	// this part is always single-threaded

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1401,7 +1401,9 @@ SQLite3_result * Query_Processor::get_query_digests() {
 	return result;
 }
 
-std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(const bool use_resultset) {
+std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(
+	const bool copy, const bool use_resultset
+) {
 	SQLite3_result *result = NULL;
 	umap_query_digest digest_umap_aux;
 	umap_query_digest_text digest_text_umap_aux;
@@ -1477,7 +1479,7 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(con
 		}
 	} else {
 		num_rows = GloAdmin->stats___save_mysql_query_digest_to_sqlite(
-			false, false, result, &digest_umap_aux, &digest_text_umap_aux
+			true, copy, result, &digest_umap_aux, &digest_text_umap_aux
 		);
 		for (
 			std::unordered_map<uint64_t, void *>::iterator it = digest_umap_aux.begin();

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1205,10 +1205,10 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 	unsigned long long curtime1;
 	unsigned long long curtime2;
 	size_t map_size = digest_umap_aux.size();
+	curtime1 = monotonic_time(); // curtime1 must always be initialized
 	if (use_resultset) {
 		if (map_size >= DIGEST_STATS_FAST_MINSIZE) {
 			result = new SQLite3_result(14, true);
-			curtime1 = monotonic_time();
 		} else {
 			result = new SQLite3_result(14);
 		}
@@ -1268,7 +1268,7 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_v2(const boo
 		curtime2=monotonic_time();
 		curtime1 = curtime1/1000;
 		curtime2 = curtime2/1000;
-		proxy_info("Running query on stats_mysql_query_digest: %llums to retrieve %lu entries\n", curtime2-curtime1, map_size);
+		proxy_info("Running query on stats_mysql_query_digest: (not locked) %llums to retrieve %lu entries\n", curtime2-curtime1, map_size);
 	}
 
 	// Once we finish creating the resultset or writing to SQLite, we use a
@@ -1341,9 +1341,9 @@ SQLite3_result * Query_Processor::get_query_digests() {
 	unsigned long long curtime1;
 	unsigned long long curtime2;
 	size_t map_size = digest_umap.size();
+	curtime1 = monotonic_time(); // curtime1 must always be initialized
 	if (map_size >= DIGEST_STATS_FAST_MINSIZE) {
 		result = new SQLite3_result(14, true);
-		curtime1 = monotonic_time();
 	} else {
 		result = new SQLite3_result(14);
 	}
@@ -1419,11 +1419,11 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(
 	bool defer_free = false;
 	int n=DIGEST_STATS_FAST_THREADS;
 	get_query_digests_parallel_args args[n];
+	curtime1 = monotonic_time(); // curtime1 must always be initialized
 	if (use_resultset) {
 		free_me = true;
 		defer_free = true;
 		if (map_size >= DIGEST_STATS_FAST_MINSIZE) {
-			curtime1=monotonic_time();
 			result = new SQLite3_result(14, true);
 		} else {
 			result = new SQLite3_result(14);
@@ -1500,7 +1500,7 @@ std::pair<SQLite3_result *, int> Query_Processor::get_query_digests_reset_v2(
 		curtime2=monotonic_time();
 		curtime1 = curtime1/1000;
 		curtime2 = curtime2/1000;
-		proxy_info("Running query on stats_mysql_query_digest_reset: %llums to retrieve %lu entries\n", curtime2-curtime1, map_size);
+		proxy_info("Running query on stats_mysql_query_digest: (not locked) %llums to retrieve %lu entries\n", curtime2-curtime1, map_size);
 		if (free_me) {
 			if (defer_free) {
 				for (int i=0; i<n; i++) {
@@ -1535,8 +1535,8 @@ SQLite3_result * Query_Processor::get_query_digests_reset() {
 	int n=DIGEST_STATS_FAST_THREADS;
 	get_query_digests_parallel_args args[n];
 	size_t map_size = digest_umap.size();
+	curtime1 = monotonic_time(); // curtime1 must always be initialized
 	if (map_size >= DIGEST_STATS_FAST_MINSIZE) {
-		curtime1=monotonic_time();
 		result = new SQLite3_result(14, true);
 	} else {
 		result = new SQLite3_result(14);

--- a/test/tap/tests/admin_various_commands3-t.cpp
+++ b/test/tap/tests/admin_various_commands3-t.cpp
@@ -1,0 +1,132 @@
+#include <algorithm>
+#include <string>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <vector>
+#include <tuple>
+
+#include <mysql.h>
+#include <mysql/mysqld_error.h>
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+using std::string;
+
+/* this test:
+	* enables mysql-have_ssl
+	* execute various command
+*/
+
+std::vector<std::string> queries_t = {
+	"PROXYSQLTEST 22",
+	"PROXYSQLTEST 23",
+	"PROXYSQLTEST 24",
+	"PROXYSQLTEST 25",
+	"PROXYSQLTEST 26",
+	"PROXYSQLTEST 27",
+	"SELECT COUNT(*) FROM stats_mysql_query_digest"
+	};
+
+
+//std::vector<unsigned int> vals = { 100, 345, 800, 999, 2037, 12345 };
+//std::vector<unsigned int> vals = { 100, 345, 800, 999, 2037 };
+std::vector<unsigned int> vals = { 100, 345, 800 };
+
+std::vector<std::string> queries = {};
+
+int run_q(MYSQL *mysql, const char *q) {
+	MYSQL_QUERY(mysql,q);
+	return 0;
+}
+int main() {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	srandom(123);
+	
+
+	for (auto it = vals.begin() ; it != vals.end() ; it++) {
+		std::string q = "PROXYSQLTEST 1 " + std::to_string(*it);
+		queries.push_back(q);
+		for (int i=0; i<5; i++) {
+			queries.push_back(queries_t[rand()%queries_t.size()]);
+		}
+		queries.push_back("SELECT COUNT(*) FROM stats_mysql_query_digest");
+		for (int i=0; i<5; i++) {
+			queries.push_back(queries_t[rand()%queries_t.size()]);
+		}
+		if (rand()%2 == 0) {
+		queries.push_back("SELECT COUNT(*) FROM stats_mysql_query_digest_reset");
+		} else {
+			queries.push_back("TRUNCATE TABLE stats.stats_mysql_query_digest");
+		}
+	}
+	queries.push_back("TRUNCATE TABLE stats.stats_mysql_query_digest");
+
+
+
+	MYSQL* proxysql_admin = mysql_init(NULL);
+	// Initialize connections
+	if (!proxysql_admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return -1;
+	}
+
+	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return -1;
+	}
+
+	MYSQL_QUERY(proxysql_admin, "SET mysql-have_ssl='true'");
+	MYSQL_QUERY(proxysql_admin, "SET mysql-have_compress='true'");
+	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+
+
+	unsigned int p = queries.size();
+	for (std::vector<std::string>::iterator it2 = queries.begin(); it2 != queries.end(); it2++) {
+		if (
+			(strncasecmp(it2->c_str(), "SELECT ", 7)==0)
+		) {
+			// extra test for each queries returning a resultset
+			p++;
+		}
+	}
+	plan(p);
+	diag("Running test with %lu queries", queries.size());
+
+
+	for (std::vector<std::string>::iterator it2 = queries.begin(); it2 != queries.end(); it2++) {
+		MYSQL* proxysql_admin = mysql_init(NULL); // local scope
+		if (!proxysql_admin) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+			return -1;
+		}
+		mysql_ssl_set(proxysql_admin, NULL, NULL, NULL, NULL, NULL);
+		if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, CLIENT_SSL|CLIENT_COMPRESS)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+			return -1;
+		}
+		int rc = run_q(proxysql_admin, it2->c_str());
+		ok(rc==0, "Query: %s" , it2->c_str());
+		if (
+			(strncasecmp(it2->c_str(), "SELECT ", 7)==0)
+		) {
+			MYSQL_RES* proxy_res = mysql_store_result(proxysql_admin);
+			unsigned long long num_rows = mysql_num_rows(proxy_res);
+			ok(num_rows != 0 , "Returned rows: %llu" , num_rows);
+			mysql_free_result(proxy_res);
+		}
+		mysql_close(proxysql_admin);
+	}
+	mysql_close(proxysql_admin);
+
+	return exit_status();
+}

--- a/test/tap/tests/test_digest_umap_aux-t.cpp
+++ b/test/tap/tests/test_digest_umap_aux-t.cpp
@@ -1,0 +1,291 @@
+/**
+ * @file test_digest_umap_aux-t.cpp
+ * @brief This tests that the auxiliary digest map is working correctly.
+ * @details This test sends dummy queries to ProxySQL while also sending
+ * queries to read table stats_mysql_query_digest. Then, it checks that the
+ * execution time of the dummy queries has no been afected by the execution
+ * time of the queries that read from table stats_mysql_query_digest. Finally,
+ * check that the data stored in stats_mysql_query_digest is correct.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <mysql.h>
+#include <vector>
+#include <string>
+#include <chrono>
+#include <thread>
+#include <atomic>
+
+#include "proxysql_utils.h"
+#include "command_line.h"
+#include "utils.h"
+#include "tap.h"
+
+using std::vector;
+using std::string;
+
+CommandLine cl;
+double slowest_query = 0.0;
+double fastest_query = 0.0;
+std::atomic_bool stop(false);
+
+vector<const char*> DUMMY_QUERIES = {
+	"SELECT 1",
+	"SELECT 1 UNION SELECT 2 UNION SELECT 3",
+	"SELECT 1 UNION SELECT 2",
+};
+int num_dummy_queries_executed = 0;
+
+struct digest_stats {
+	int hostgroup;
+	string schemaname;
+	string username;
+	string client_address;
+	string digest;
+	string digest_text;
+	int count_star;
+	int first_seen;
+	int last_seen;
+	int sum_time;
+	int min_time;
+	int max_time;
+	int sum_rows_affected;
+	int sum_rows_sent;
+};
+
+class timer {
+public:
+	std::chrono::time_point<std::chrono::high_resolution_clock> lastTime;
+	timer() : lastTime(std::chrono::high_resolution_clock::now()) {}
+	inline double elapsed() {
+		std::chrono::time_point<std::chrono::high_resolution_clock> thisTime = std::chrono::high_resolution_clock::now();
+		double deltaTime = std::chrono::duration<double>(thisTime-lastTime).count();
+		lastTime = thisTime;
+		return deltaTime;
+	}
+};
+
+vector<digest_stats> get_digest_stats(MYSQL* proxy_admin) {
+	const char* get_digest_stats_query =
+		"SELECT * FROM stats_mysql_query_digest WHERE username='root' AND "
+		"digest_text IN ('SELECT ?', 'SELECT ? UNION SELECT ?', 'SELECT ? UNION SELECT ? UNION SELECT ?') "
+		"ORDER BY hostgroup, schemaname, username, client_address, digest";
+	diag("Running: %s", get_digest_stats_query);
+	vector<digest_stats> ds_vector;
+
+	int err = mysql_query(proxy_admin, get_digest_stats_query);
+	if (err) {
+		diag("Failed to executed query `%s`. Error: `%s`", get_digest_stats_query, mysql_error(proxy_admin));
+		return ds_vector;
+	}
+
+	MYSQL_RES *res = NULL;
+	res = mysql_store_result(proxy_admin);
+	MYSQL_ROW row;
+	while (row = mysql_fetch_row(res)) {
+		digest_stats ds = {};
+		ds.hostgroup = atoi(row[0]);
+		ds.schemaname = row[1];
+		ds.username = row[2];
+		ds.client_address = row[3];
+		ds.digest = row[4];
+		ds.digest_text = row[5];
+		ds.count_star = atoi(row[6]);
+		ds.first_seen = atoi(row[7]);
+		ds.last_seen = atoi(row[8]);
+		ds.sum_time = atoi(row[9]);
+		ds.min_time = atoi(row[10]);
+		ds.max_time = atoi(row[11]);
+		ds.sum_rows_affected = atoi(row[12]);
+		ds.sum_rows_sent = atoi(row[13]);
+		ds_vector.push_back(ds);
+	}
+	mysql_free_result(res);
+
+	return ds_vector;
+}
+
+void run_dummy_queries() {
+	MYSQL* proxy_mysql = mysql_init(NULL);
+
+	if (!mysql_real_connect(proxy_mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy_mysql));
+		slowest_query = -1.0;
+		return;
+	}
+
+	vector<double> execution_times = {};
+	MYSQL_RES *res = NULL;
+	while (!stop) {
+		for (int i = 0; i < DUMMY_QUERIES.size(); i++) {
+			timer stopwatch;
+			int err = mysql_query(proxy_mysql, DUMMY_QUERIES[i]);
+			execution_times.push_back(stopwatch.elapsed());
+			if (err) {
+				diag(
+					"Failed to executed query `%s`. Error: `%s`",
+					DUMMY_QUERIES[i], mysql_error(proxy_mysql)
+				);
+				slowest_query = -1.0;
+				mysql_close(proxy_mysql);
+				return;
+			}
+			res = mysql_store_result(proxy_mysql);
+			mysql_free_result(res);
+		}
+		num_dummy_queries_executed++;
+	}
+	mysql_close(proxy_mysql);
+
+	slowest_query = *std::max_element(execution_times.begin(), execution_times.end());
+}
+
+void run_stats_digest_query(MYSQL* proxy_admin) {
+	const char *count_digest_stats_query = "SELECT COUNT(*) FROM stats_mysql_query_digest";
+	vector<double> execution_times = {};
+	const int num_queries = 3;
+	MYSQL_RES *res;
+
+	for (int i; i < num_queries; i++) {
+		diag("Running: %s", count_digest_stats_query);
+		timer stopwatch;
+		int err = mysql_query(proxy_admin, count_digest_stats_query);
+		execution_times.push_back(stopwatch.elapsed());
+		if (err) {
+			diag(
+				"Failed to executed query `%s`. Error: `%s`",
+				count_digest_stats_query, mysql_error(proxy_admin)
+			);
+			fastest_query = -1.0;
+			return;
+		}
+		res = mysql_store_result(proxy_admin);
+		mysql_free_result(res);
+	}
+
+	fastest_query = *std::min_element(execution_times.begin(), execution_times.end());
+}
+
+int main(int argc, char** argv) {
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
+
+	plan(1 + DUMMY_QUERIES.size() * 3); // always specify the number of tests that are going to be performed
+
+	MYSQL *proxy_admin = mysql_init(NULL);
+	if (!mysql_real_connect(proxy_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy_admin));
+		return EXIT_FAILURE;
+	}
+
+	vector<const char*> admin_queries = {
+		"DELETE FROM mysql_query_rules",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+		"PROXYSQLTEST 1 1000",
+	};
+	for (const auto &query : admin_queries) {
+		diag("Running: %s", query);
+		MYSQL_QUERY(proxy_admin, query);
+	}
+
+	MYSQL *proxy_mysql = mysql_init(NULL);
+	if (!mysql_real_connect(proxy_mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy_mysql));
+		mysql_close(proxy_admin);
+		return EXIT_FAILURE;
+	}
+
+	MYSQL_RES *res = NULL;
+	for (const auto &query : DUMMY_QUERIES) {
+		diag("Running: %s", query);
+		MYSQL_QUERY(proxy_mysql, query);
+		res = mysql_store_result(proxy_mysql);
+		mysql_free_result(res);
+	}
+	mysql_close(proxy_mysql);
+
+	vector<digest_stats> ds_vector_before = get_digest_stats(proxy_admin);
+
+	std::thread run_dummy_queries_thread(run_dummy_queries);
+	std::thread run_stats_digest_query_thread(run_stats_digest_query, proxy_admin);
+
+	run_stats_digest_query_thread.join();
+	if (fastest_query == -1.0) {
+		fprintf(
+			stderr, "File %s, line %d, Error: "
+			"thread run_stats_digest_query_thread finished with errors", __FILE__, __LINE__
+		);
+		mysql_close(proxy_admin);
+		return EXIT_FAILURE;
+	}
+
+	stop = true;
+	run_dummy_queries_thread.join();
+	if (slowest_query == -1.0) {
+		fprintf(
+			stderr, "File %s, line %d, Error: "
+			"thread run_dummy_queries_thread finished with errors", __FILE__, __LINE__
+		);
+		mysql_close(proxy_admin);
+		return EXIT_FAILURE;
+	}
+
+	ok(
+		slowest_query < fastest_query,
+		"The slowest dummy query must be faster than the fastest digests stats query.\n"
+		"    Slowest dummy query time: %f.\n"
+		"    Fastest count digest stats query time: %f.",
+		slowest_query, fastest_query
+	);
+
+	vector<digest_stats> ds_vector_after = get_digest_stats(proxy_admin);
+	for (int i = 0; i < DUMMY_QUERIES.size(); i++) {
+		ok(
+			ds_vector_before[i].hostgroup == ds_vector_after[i].hostgroup &&
+			ds_vector_before[i].schemaname == ds_vector_after[i].schemaname &&
+			ds_vector_before[i].username == ds_vector_after[i].username &&
+			ds_vector_before[i].client_address == ds_vector_after[i].client_address &&
+			ds_vector_before[i].digest == ds_vector_after[i].digest &&
+			ds_vector_before[i].digest_text == ds_vector_after[i].digest_text &&
+			ds_vector_before[i].first_seen - 1 <= ds_vector_after[i].first_seen &&
+			ds_vector_after[i].first_seen <= ds_vector_before[i].first_seen + 1,
+			"Hostgroup, schemaname, username, client_address, digest, digest_test and first_seen "
+			"should be equal in both digest stats.\n"
+			"    Hostgroup -> before:`%d` - after:`%d`.\n"
+			"    Schemaname -> before:`%s` - after:`%s`.\n"
+			"    Username -> before:`%s` - after:`%s`.\n"
+			"    Client_address -> before:`%s` - after:`%s`.\n"
+			"    Digests -> before:`%s` - after:`%s`.\n"
+			"    Digests_text -> before:`%s` - after:`%s`.\n"
+			"    First_seen -> before:`%d` - after:`%d`.",
+			ds_vector_before[i].hostgroup, ds_vector_after[i].hostgroup,
+			ds_vector_before[i].schemaname.c_str(), ds_vector_after[i].schemaname.c_str(),
+			ds_vector_before[i].username.c_str(), ds_vector_after[i].username.c_str(),
+			ds_vector_before[i].client_address.c_str(), ds_vector_after[i].client_address.c_str(),
+			ds_vector_before[i].digest.c_str(), ds_vector_after[i].digest.c_str(),
+			ds_vector_before[i].digest_text.c_str(), ds_vector_after[i].digest_text.c_str(),
+			ds_vector_before[i].first_seen, ds_vector_after[i].first_seen
+		);
+		ok(
+			ds_vector_after[i].count_star - ds_vector_before[i].count_star == num_dummy_queries_executed,
+			"Query `%s` should be executed %d times. Act:'%d'",
+			ds_vector_after[i].digest_text.c_str(), num_dummy_queries_executed,
+			ds_vector_after[i].count_star - ds_vector_before[i].count_star
+		);
+		ok(
+			ds_vector_before[i].last_seen < ds_vector_after[i].last_seen &&
+			ds_vector_before[i].sum_time < ds_vector_after[i].sum_time,
+			"Last_seen and sum_time must have increased.\n"
+			"    Last_seen -> before:`%d` - after:`%d`.\n"
+			"    Sum_time -> before:`%d` - after:`%d`.",
+			ds_vector_before[i].last_seen, ds_vector_after[i].last_seen,
+			ds_vector_before[i].sum_time, ds_vector_after[i].sum_time
+		);
+	}
+
+	return exit_status();
+}


### PR DESCRIPTION
1. Add auxiliary maps to work on them while the main maps are being used.
2. Create stats_mysql_query_digest statements directly from the digest_umap, without creating a ResultSet