### PR TITLE
Fix memory leak in resultset for 'group_replication_lag_action'

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -3548,6 +3548,11 @@ void MySQL_HostGroups_Manager::group_replication_lag_action(
 		}
 	}
 
+	if (rhid_res != nullptr) {
+		delete rhid_res;
+		rhid_res = nullptr;
+	}
+
 __exit_replication_lag_action:
 
 	wrunlock();


### PR DESCRIPTION
As the title says.