### PR TITLE
Fix read-after-free in test multiple_prepared_statements-t

### DIFF
--- a/test/tap/tests/multiple_prepared_statements-t.cpp
+++ b/test/tap/tests/multiple_prepared_statements-t.cpp
@@ -269,7 +269,9 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	for (int i=0; i<NCONNS; i++) {
+	// Half of the connections were freed earlier. We only iterate the other
+	// half that has not been freed.
+	for (int i=1; i<NCONNS; i+=2) {
 		mysql_close(conns[i]);
 	}
 


### PR DESCRIPTION
The test closes half the connections and later tries to close all the connections, even the ones that have been closed before.