### PR TITLE
Fix 'user-after-free' when logging rewrited 'SET NAMES' queries

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1369,6 +1369,10 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 			l_free(pkt->size,pkt->ptr);
 			pkt->size=pkt_2.size;
 			pkt->ptr=pkt_2.ptr;
+			// Fix 'use-after-free': To change the pointer of the 'PtrSize_t' being processed by
+			// 'MySQL_Session::handler' we are forced to update 'MySQL_Session::CurrentQuery'.
+			CurrentQuery.QueryPointer = static_cast<unsigned char*>(pkt_2.ptr);
+			CurrentQuery.QueryLength = pkt_2.size;
 		}
 	}
 	if ((pkt->size < 60) && (pkt->size > 39) && (strncasecmp((char *)"SET SESSION character_set_results",(char *)pkt->ptr+5,33)==0) ) { // like the above
@@ -1389,6 +1393,10 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 			l_free(pkt->size,pkt->ptr);
 			pkt->size=pkt_2.size;
 			pkt->ptr=pkt_2.ptr;
+			// Fix 'use-after-free': To change the pointer of the 'PtrSize_t' being processed by
+			// 'MySQL_Session::handler' we are forced to update 'MySQL_Session::CurrentQuery'.
+			CurrentQuery.QueryPointer = static_cast<unsigned char*>(pkt_2.ptr);
+			CurrentQuery.QueryLength = pkt_2.size;
 		}
 	}
 	if (

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -3656,6 +3656,15 @@ void admin_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *pkt) {
 	// add global mutex, see bug #1188
 	pthread_mutex_lock(&pa->sql_query_global_mutex);
 
+	if (sess->session_type == PROXYSQL_SESSION_ADMIN) { // no stats
+		if (!strncasecmp("LOGENTRY ", query_no_space, strlen("LOGENTRY "))) {
+			proxy_info("Received command LOGENTRY: %s\n", query_no_space + strlen("LOGENTRY "));
+			SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL, NULL);
+			run_query=false;
+			goto __run_query;
+		 }
+	 }
+
 	// handle special queries from Cluster
 	// for bug #1188 , ProxySQL Admin needs to know the exact query
 


### PR DESCRIPTION
As the title says.