### PR TITLE
IPv6 causes crash if OS is not properly configured to route it

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -223,6 +223,7 @@ endif
 	cd mariadb-client-library/mariadb_client && patch libmariadb/mariadb_stmt.c < ../mariadb_stmt.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/mariadb_lib.c < ../mariadb_lib.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/mariadb_lib.c < ../mariadb_lib.c.collation.patch # make sure this path is applied after mariadb_lib.c.patch
+	cd mariadb-client-library/mariadb_client && patch libmariadb/mariadb_lib.c < ../mariadb_lib.c.ipv6_fix.patch # make sure this patch is applied after mariadb_lib.c.collation.patch
 #	cd mariadb-client-library/mariadb_client && patch libmariadb/net.c < ../net.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/mariadb_async.c < ../mariadb_async.c.patch
 	cd mariadb-client-library/mariadb_client && patch libmariadb/ma_password.c < ../ma_password.c.patch

--- a/deps/mariadb-client-library/mariadb_lib.c.ipv6_fix.patch
+++ b/deps/mariadb-client-library/mariadb_lib.c.ipv6_fix.patch
@@ -4,7 +4,7 @@
      ma_pvio_close(pvio);
 +    if (mysql->options.extension && mysql->options.extension->async_context &&
 +        mysql->options.extension->async_context->pvio) {
-+        /* async_context->pvio contains dangling pointer. Setting async_context->pvio as NULL*/
++        /* async_context->pvio contains dangling pointer. Setting async_context->pvio to NULL*/
 +	    mysql->options.extension->async_context->pvio = NULL;
 +    }
      goto error;
@@ -16,7 +16,7 @@
        ma_pvio_close(pvio);
 +      if (mysql->options.extension->async_context &&
 +          mysql->options.extension->async_context->pvio) {
-+          /* async_context->pvio contains dangling pointer. Setting async_context->pvio as NULL*/
++          /* async_context->pvio contains dangling pointer. Setting async_context->pvio to NULL*/
 +          mysql->options.extension->async_context->pvio = NULL;
 +      }
        goto error;

--- a/deps/mariadb-client-library/mariadb_lib.c.ipv6_fix.patch
+++ b/deps/mariadb-client-library/mariadb_lib.c.ipv6_fix.patch
@@ -1,0 +1,24 @@
+@@ -1615,6 +1615,11 @@
+   if (ma_pvio_connect(pvio, &cinfo) != 0)
+   {
+     ma_pvio_close(pvio);
++    if (mysql->options.extension && mysql->options.extension->async_context &&
++        mysql->options.extension->async_context->pvio) {
++        /* async_context->pvio contains dangling pointer. Setting async_context->pvio as NULL*/
++	    mysql->options.extension->async_context->pvio = NULL;
++    }
+     goto error;
+   }
+ 
+@@ -1625,6 +1630,11 @@
+     if (ma_pvio_write(pvio, (unsigned char *)hdr, len) <= 0)
+     {
+       ma_pvio_close(pvio);
++      if (mysql->options.extension->async_context &&
++          mysql->options.extension->async_context->pvio) {
++          /* async_context->pvio contains dangling pointer. Setting async_context->pvio as NULL*/
++          mysql->options.extension->async_context->pvio = NULL;
++      }
+       goto error;
+     }
+   }


### PR DESCRIPTION
Backend having IPv6 causes crash (in ASAN) if OS is not properly configured to route it