### PR TITLE
Remove default query rules in deprecate_eof_cache-t

### DIFF
--- a/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
+++ b/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
@@ -117,13 +117,6 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// Delete previous mysql_query_rules matching target digest
-	MYSQL_QUERY(
-		proxy_admin,
-		"DELETE FROM mysql_query_rules WHERE "
-		"match_digest='SELECT \\* FROM test\\.ok_packet_cache_test WHERE id=?'"
-	);
-
 	// Disable current ^SELECT query rule
 	MYSQL_QUERY(proxy_admin, "UPDATE mysql_query_rules SET active=0 WHERE rule_id=2");
 
@@ -302,17 +295,6 @@ int main(int argc, char** argv) {
 			eof_res_warnings
 		);
 	}
-
-	// Delete new query cache rule
-	MYSQL_QUERY(
-		proxy_admin,
-		"DELETE FROM mysql_query_rules WHERE "
-		"match_digest='SELECT \\* FROM test\\.ok_packet_cache_test WHERE id=?'"
-	);
-
-	// Enable old ^SELECT query rule
-	MYSQL_QUERY(proxy_admin, "UPDATE mysql_query_rules SET active=1 WHERE rule_id=2");
-	MYSQL_QUERY(proxy_admin, "LOAD MYSQL QUERY RULES TO RUNTIME");
 
 	mysql_close(proxy_admin);
 	mysql_close(proxy_mysql);

--- a/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
+++ b/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
@@ -117,8 +117,8 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// Disable current ^SELECT query rule
-	MYSQL_QUERY(proxy_admin, "UPDATE mysql_query_rules SET active=0 WHERE rule_id=2");
+	// Delete previous mysql_query_rules
+	MYSQL_QUERY(proxy_admin, "DELETE FROM mysql_query_rules");
 
 	// Add a new query rule with caching TTL for targgeting the cache
 	std::string query_digest { "SELECT \\* FROM test\\.ok_packet_cache_test WHERE id=?" };


### PR DESCRIPTION
In the new CI the query rules ids have changed. The query rules ids are now 0 and 1, so, the problem is that the SELECT query rules isn't being disabled, the query is being redirected to a replica, which doesn't have yet the data that has been written.

This PR remove all default query rules, not just one with a particular id, since the test only operates in the default hostgroup of the user being used.