### PR TITLE
Fix typo - consecutive 'the' occurrences

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -4929,7 +4929,7 @@ handler_again:
 								stmt_info=GloMyStmt->find_prepared_statement_by_stmt_id(CurrentQuery.stmt_global_id);
 								CurrentQuery.QueryLength=stmt_info->query_length;
 								CurrentQuery.QueryPointer=(unsigned char *)stmt_info->query;
-								// NOTE: Update 'first_comment' with the the from the retrieved
+								// NOTE: Update 'first_comment' with the 'first_comment' from the retrieved
 								// 'stmt_info' from the found prepared statement. 'CurrentQuery' requires its
 								// own copy of 'first_comment' because it will later be free by 'QueryInfo::end'.
 								if (stmt_info->first_comment) {

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -319,7 +319,7 @@ struct conn_cnf_t {
 std::string to_string(const conn_cnf_t& cnf);
 
 /**
- * @brief Execute the the test 'deprecate_eof_cache-t' with the 'mysql-variables'
+ * @brief Execute the test 'deprecate_eof_cache-t' with the 'mysql-variables'
  *  'mysql-enable_client_deprecate_eof' and 'mysql-enable_server_deprecate_eof'
  *  with the values suppplied in the parameters.
  *

--- a/test/tap/tests_with_deps/deprecate_eof_support/eof_conn_options_check-t.cpp
+++ b/test/tap/tests_with_deps/deprecate_eof_support/eof_conn_options_check-t.cpp
@@ -1,6 +1,6 @@
 /**
  * @file eof_cache_mixed_flags-t.cpp
- * @brief This test verifies that the the new introduced flags 'mysql-enable_client_deprecate_eof' and
+ * @brief This test verifies that the new introduced flags 'mysql-enable_client_deprecate_eof' and
  *   'mysql-enable_server_deprecate_eof' actually impose the addition or deletion of 'client_deprecate_eof'
  *   flag to the "MySQL_Connection::options::client_flag" field.
  *


### PR DESCRIPTION
Remove consecutive occurrences of 'the'
`s/the the /the /g`