### PR TITLE
Increase logging for test eof_fast_forward-t

### DIFF
--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -957,6 +957,8 @@ int get_cur_backend_conns(MYSQL* proxy_admin, const string& conn_type, uint32_t&
 int wait_for_backend_conns(
 	MYSQL* proxy_admin, const string& conn_type, uint32_t exp_conn_num, uint32_t timeout
 ) {
+	diag("Waiting for backend connections - type: %s, exp: %d, timeout: %d", conn_type.c_str(), exp_conn_num, timeout);
+
 	uint32_t total_conn_num = 0;
 	uint32_t waited = 0;
 
@@ -967,12 +969,14 @@ int wait_for_backend_conns(
 		if (total_conn_num == exp_conn_num) {
 			break;
 		} else {
+			diag("Not reached - exp: %d, act: %d, waiting: %ds", exp_conn_num, total_conn_num, 1);
 			sleep(1);
 			waited += 1;
 		}
 	}
 
 	if (waited >= timeout) {
+		diag("Timeout exceeded - type: %s, exp: %d, act: %d", conn_type.c_str(), exp_conn_num, total_conn_num);
 		return EXIT_FAILURE;
 	} else {
 		return EXIT_SUCCESS;

--- a/test/tap/tests_with_deps/deprecate_eof_support/eof_fast_forward-t.cpp
+++ b/test/tap/tests_with_deps/deprecate_eof_support/eof_fast_forward-t.cpp
@@ -247,7 +247,15 @@ int main(int argc, char** argv) {
 	}
 
 	// Impose a timeout to avoid race conditions
-	wait_for_backend_conns(admin, "ConnFree", 50, 1);
+	if(wait_for_backend_conns(admin, "ConnFree", 50, 5)) {
+		// Timeout exceeded. wait_for_backend_conns() failed.
+		std::string q0 =
+			(const std::string)"mysql -h " + cl.host + (const std::string)" -u " + cl.admin_username +
+			" -p" + cl.admin_password + " -P " + std::to_string(cl.admin_port) + " -t -e " +
+			"\"SELECT hostgroup, srv_host, srv_port, status, ConnUsed, ConnFree, ConnOK, ConnERR, MaxConnUsed, Queries"
+			" FROM stats_mysql_connection_pool\"";
+		system(q0.c_str());
+	}
 
 	// Check there are 'N' backend connections
 	uint32_t cur_free_conns = 0;


### PR DESCRIPTION
It also affects to other tests that use wait_for_backend_conns() function.