### PR TITLE
Remove redundant client_connections metrics from MySQL_Thread

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -288,8 +288,6 @@ struct p_th_counter {
 		queries_backends_bytes_recv,
 		queries_frontends_bytes_sent,
 		queries_frontends_bytes_recv,
-		client_connections_created,
-		client_connections_aborted,
 		query_processor_time_nsec,
 		backend_query_time_nsec,
 		com_backend_stmt_prepare,

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -653,25 +653,6 @@ th_metrics_map = std::make_tuple(
 		),
 		// ====================================================================
 
-		// ====================================================================
-		std::make_tuple (
-			p_th_counter::client_connections_created,
-			"proxysql_client_connections_total",
-			"Total number of client connections created or failed (including improperly closed).",
-			metric_tags {
-				{ "status", "created" }
-			}
-		),
-		std::make_tuple (
-			p_th_counter::client_connections_aborted,
-			"proxysql_client_connections_total",
-			"Total number of client connections created or failed (including improperly closed).",
-			metric_tags {
-				{ "status", "aborted" }
-			}
-		),
-		// ====================================================================
-
 		std::make_tuple (
 			p_th_counter::query_processor_time_nsec,
 			"proxysql_query_processor_time_seconds_total",


### PR DESCRIPTION
This was a bug affecting the `proxysql_client_connections_total` Prometheus metric.  The unused metric identifiers `p_th_counter::client_connections_created` and `p_th_counter::client_connections_aborted`, through their association with the metric name `proxysql_client_connections_total` (which conflicted with similar `p_hg_counter` metric identifiers), were causing corruption to the client connections metric.  The `p_th_counter` identifiers serve no purpose and appear to have been added by accident, so this PR removes them.

Before this change, we see a discrepancy between the internal `Client_Connections_created` variable in `stats.stats_mysql_global` and the corresponding Prometheus metric:
```
+--------------------------------------+----------------+
| Variable_Name                        | Variable_Value |
+--------------------------------------+----------------+
| Client_Connections_aborted           | 0              |
| Client_Connections_created           | 408            |
```
```
# HELP proxysql_client_connections_total Total number of client connections created.
# TYPE proxysql_client_connections_total counter
proxysql_client_connections_total{status="aborted"} 0.000000
proxysql_client_connections_total{status="created"} 52822022.000000
```
After this change, the values match:
```
+--------------------------------------+----------------+
| Variable_Name                        | Variable_Value |
+--------------------------------------+----------------+
| Client_Connections_aborted           | 0              |
| Client_Connections_created           | 408            |
```
```
# HELP proxysql_client_connections_total Total number of client connections created.
# TYPE proxysql_client_connections_total counter
proxysql_client_connections_total{status="aborted"} 0.000000
proxysql_client_connections_total{status="created"} 408.000000
```

`Client_Connections_aborted` has also been verified by artificially generating an aborted connection:

```
+-------------------------------------+----------------+
| Variable_Name                       | Variable_Value |
+-------------------------------------+----------------+
| Client_Connections_aborted          | 1              |
| Client_Connections_connected        | 0              |
| Client_Connections_created          | 1              |
```
```
# TYPE proxysql_client_connections_total counter
proxysql_client_connections_total{status="aborted"} 1.000000
proxysql_client_connections_total{status="created"} 1.000000
```