### PR TITLE
remove redundant client_connections metrics from MySQL_Thread

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -288,8 +288,6 @@ struct p_th_counter {
 		queries_backends_bytes_recv,
 		queries_frontends_bytes_sent,
 		queries_frontends_bytes_recv,
-		client_connections_created,
-		client_connections_aborted,
 		query_processor_time_nsec,
 		backend_query_time_nsec,
 		com_backend_stmt_prepare,

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -653,25 +653,6 @@ th_metrics_map = std::make_tuple(
 		),
 		// ====================================================================
 
-		// ====================================================================
-		std::make_tuple (
-			p_th_counter::client_connections_created,
-			"proxysql_client_connections_total",
-			"Total number of client connections created or failed (including improperly closed).",
-			metric_tags {
-				{ "status", "created" }
-			}
-		),
-		std::make_tuple (
-			p_th_counter::client_connections_aborted,
-			"proxysql_client_connections_total",
-			"Total number of client connections created or failed (including improperly closed).",
-			metric_tags {
-				{ "status", "aborted" }
-			}
-		),
-		// ====================================================================
-
 		std::make_tuple (
 			p_th_counter::query_processor_time_nsec,
 			"proxysql_query_processor_time_seconds_total",


### PR DESCRIPTION
re-submiting original PR from
https://github.com/saunderst/proxysql/tree/proxysql_client_connections_total-metrics-fix