### PR TITLE
Update server status from SHUNNED to ONLINE if 'read_only' value is successfully retrieved

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -445,7 +445,7 @@ class MySQL_HostGroups_Manager {
 			MySrvC* srv = NULL;
 			unsigned int reader_hostgroup_id = -1;
 			unsigned int writer_hostgroup_id = -1;
-			MySerStatus server_status = MYSQL_SERVER_STATUS_OFFLINE_HARD;
+			//MySerStatus server_status = MYSQL_SERVER_STATUS_OFFLINE_HARD;
 		};
 
 		HostGroup_Server_Mapping(MySQL_HostGroups_Manager* hgm) : readonly_flag(1), myHGM(hgm) { }

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2002,7 +2002,7 @@ bool MySQL_HostGroups_Manager::commit(
 				}
 				
 				HostGroup_Server_Mapping::Node node;
-				node.server_status = static_cast<MySerStatus>(atoi(r->fields[3]));
+				//node.server_status = static_cast<MySerStatus>(atoi(r->fields[3]));
 				node.reader_hostgroup_id = atoi(r->fields[4]);
 				node.writer_hostgroup_id = atoi(r->fields[5]);
 				node.srv = reinterpret_cast<MySrvC*>(atoll(r->fields[6]));
@@ -7700,6 +7700,14 @@ void MySQL_HostGroups_Manager::HostGroup_Server_Mapping::copy_if_not_exists(Type
 	//dest_nodes.insert(dest_nodes.end(), append.begin(), append.end());
 
 	for (auto& node : append) {
+
+		if (node.srv->status == MYSQL_SERVER_STATUS_SHUNNED ||
+			node.srv->status == MYSQL_SERVER_STATUS_SHUNNED_REPLICATION_LAG) {
+			// Status updated from "*SHUNNED" to "ONLINE" as "read_only" value was successfully 
+			// retrieved from the backend server, indicating server is now online.
+			node.srv->status = MYSQL_SERVER_STATUS_ONLINE;
+		}
+
 		MySrvC* new_srv = insert_HGM(get_hostgroup_id(dest_type, node), node.srv);
 			
 		if (!new_srv) assert(0);


### PR DESCRIPTION
If the 'read_only' value is successfully retrieved from the backend server, update server status from '*SHUNNED' to 'ONLINE' as this indicates that the server is now ONLINE.
