### PR TITLE
Feature for troubleshooting purpose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ endif
 ###     ```
 ###     make build_deps_debug -j$(nproc) && make debug -j$(nproc) && make build_tap_test_debug -j$(nproc)
 ###     ```
+###
+### ** to use on-demand coredump generation feature, compile code without ASAN option (WITHASAN=0).
 
 O0=-O0
 O2=-O2

--- a/include/MySQL_Data_Stream.h
+++ b/include/MySQL_Data_Stream.h
@@ -113,6 +113,8 @@ class MySQL_Data_Stream
 
 	PtrSizeArray *PSarrayIN;
 	PtrSizeArray *PSarrayOUT;
+	FixedSizeQueue data_packets_history_IN;
+	FixedSizeQueue data_packets_history_OUT;
 	//PtrSizeArray *PSarrayOUTpending;
 	PtrSizeArray *resultset;
 	unsigned int resultset_length;

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -584,6 +584,7 @@ class MySQL_Threads_Handler
 		bool enable_server_deprecate_eof;
 		bool enable_load_data_local_infile;
 		bool log_mysql_warnings_enabled;
+		int data_packets_history_size;
 	} variables;
 	struct {
 		unsigned int mirror_sessions_current;

--- a/include/proxysql.h
+++ b/include/proxysql.h
@@ -58,7 +58,7 @@
 #include "proxysql_structs.h"
 #include "proxysql_debug.h"
 #include "proxysql_macros.h"
-
+#include "proxysql_coredump.h"
 #include "jemalloc.h"
 
 #ifndef NOJEM

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -213,6 +213,8 @@ class ProxySQL_Admin {
 #ifdef DEBUG
 		bool debug;
 #endif /* DEBUG */
+		int coredump_generation_interval_ms;
+		int coredump_generation_threshold;
 	} variables;
 
 	unsigned long long last_p_memory_metrics_ts;
@@ -238,6 +240,10 @@ class ProxySQL_Admin {
 	void flush_debug_filters_runtime_to_database(SQLite3DB *db);
 	void flush_debug_filters_database_to_runtime(SQLite3DB *db);
 #endif /* DEBUG */
+
+	// Coredump Filters
+	void dump_coredump_filter_values_table();
+	bool flush_coredump_filters_database_to_runtime(SQLite3DB *db);
 
 //	void __insert_or_ignore_maintable_select_disktable(); // commented in 2.3
 	void __insert_or_replace_maintable_select_disktable();
@@ -448,7 +454,10 @@ class ProxySQL_Admin {
 
 	void load_mysql_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { flush_mysql_variables___database_to_runtime(admindb, true, checksum, epoch); }
 	void save_mysql_variables_from_runtime() { flush_mysql_variables___runtime_to_database(admindb, true, true, false); }
-
+	
+	// Coredump filters
+	bool load_coredump_to_runtime() { return flush_coredump_filters_database_to_runtime(admindb); }
+	
 	void p_update_metrics();
 	void stats___mysql_query_rules();
 	int stats___save_mysql_query_digest_to_sqlite(

--- a/include/proxysql_coredump.h
+++ b/include/proxysql_coredump.h
@@ -1,0 +1,27 @@
+#ifndef __PROXYSQL_COREDUMP_H
+#define __PROXYSQL_COREDUMP_H
+#include <unordered_set>
+
+#define S1(x) #x
+#define S2(x) S1(x)
+#define LOCATION() __FILE__ ":" S2(__LINE__)
+
+extern bool coredump_enabled;
+extern int coredump_generation_threshold;
+extern int coredump_generation_interval_ms;
+
+void init_coredump_struct();
+void proxy_coredump_load_filters(std::unordered_set<std::string>&& filters);
+void proxy_coredump_get_filters(std::unordered_set<std::string>& filters);
+bool proxy_coredump_filter_exists(const std::string& filter);
+void proxy_coredump_reset_stats();
+void proxy_coredump_generate();
+
+#define generate_coredump() if (unlikely(coredump_enabled)) {\
+	if (proxy_coredump_filter_exists(LOCATION())) {\
+		proxy_info("Coredump filter location '" LOCATION() "' was hit.\n");\
+		proxy_coredump_generate();\
+	}\
+}
+
+#endif // __PROXYSQL_COREDUMP_H

--- a/include/proxysql_glovars.hpp
+++ b/include/proxysql_glovars.hpp
@@ -121,6 +121,7 @@ class ProxySQL_GlobalVariables {
 		char * ssl_key_pem_mem;
 		char * ssl_cert_pem_mem;
 		bool sqlite3_server;
+		int data_packets_history_size;
 #ifdef PROXYSQLCLICKHOUSE
 		bool clickhouse_server;
 #endif /* PROXYSQLCLICKHOUSE */

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -144,7 +144,7 @@ MYCXXFLAGS=-std=c++11 $(MYCFLAGS) $(PSQLCH) $(ENABLE_EPOLL)
 default: libproxysql.a
 .PHONY: default
 
-_OBJ_CXX = ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo SpookyV2.oo MySQL_Authentication.oo gen_utils.oo sqlite3db.oo mysql_connection.oo MySQL_HostGroups_Manager.oo mysql_data_stream.oo MySQL_Thread.oo MySQL_Session.oo MySQL_Protocol.oo mysql_backend.oo Query_Processor.oo ProxySQL_Admin.oo ProxySQL_Config.oo ProxySQL_Restapi.oo MySQL_Monitor.oo MySQL_Logger.oo thread.oo MySQL_PreparedStatement.oo ProxySQL_Cluster.oo ClickHouse_Authentication.oo ClickHouse_Server.oo ProxySQL_Statistics.oo Chart_bundle_js.oo ProxySQL_HTTP_Server.oo ProxySQL_RESTAPI_Server.oo font-awesome.min.css.oo main-bundle.min.css.oo set_parser.oo MySQL_Variables.oo c_tokenizer.oo proxysql_utils.oo
+_OBJ_CXX = ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo SpookyV2.oo MySQL_Authentication.oo gen_utils.oo sqlite3db.oo mysql_connection.oo MySQL_HostGroups_Manager.oo mysql_data_stream.oo MySQL_Thread.oo MySQL_Session.oo MySQL_Protocol.oo mysql_backend.oo Query_Processor.oo ProxySQL_Admin.oo ProxySQL_Config.oo ProxySQL_Restapi.oo MySQL_Monitor.oo MySQL_Logger.oo thread.oo MySQL_PreparedStatement.oo ProxySQL_Cluster.oo ClickHouse_Authentication.oo ClickHouse_Server.oo ProxySQL_Statistics.oo Chart_bundle_js.oo ProxySQL_HTTP_Server.oo ProxySQL_RESTAPI_Server.oo font-awesome.min.css.oo main-bundle.min.css.oo set_parser.oo MySQL_Variables.oo c_tokenizer.oo proxysql_utils.oo proxysql_coredump.oo
 OBJ_CXX = $(patsubst %,$(ODIR)/%,$(_OBJ_CXX))
 HEADERS = ../include/*.h ../include/*.hpp
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -579,6 +579,7 @@ static char * mysql_thread_variables_names[]= {
 	(char *)"stats_time_backend_query",
 	(char *)"stats_time_query_processor",
 	(char *)"query_cache_stores_empty_result",
+	(char *)"data_packets_history_size",
 	NULL
 };
 
@@ -1198,6 +1199,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.enable_server_deprecate_eof=true;
 	variables.enable_load_data_local_infile=false;
 	variables.log_mysql_warnings_enabled=false;
+	variables.data_packets_history_size=0;
 	// status variables
 	status_variables.mirror_sessions_current=0;
 	__global_MySQL_Thread_Variables_version=1;
@@ -2081,6 +2083,16 @@ bool MySQL_Threads_Handler::set_variable(char *name, const char *value) {	// thi
 		}
 		return false;
 	}
+	if (!strcasecmp(name,"data_packets_history_size")) {
+		int intv=atoi(value);
+		if (intv >= 0 && intv < INT_MAX) {
+			variables.data_packets_history_size = intv;
+			GloVars.global.data_packets_history_size = intv;
+			return true;
+		} else {
+			return false;
+		}
+	}
 	return false;
 }
 
@@ -2259,7 +2271,7 @@ char ** MySQL_Threads_Handler::get_variables_list() {
 		VariablesPointers_int["binlog_reader_connect_retry_msec"] = make_tuple(&variables.binlog_reader_connect_retry_msec, 0, 0, true);
 		VariablesPointers_int["eventslog_format"] = make_tuple(&variables.eventslog_format, 0, 0, true);
 		VariablesPointers_int["wait_timeout"]     = make_tuple(&variables.wait_timeout,     0, 0, true);
-
+		VariablesPointers_int["data_packets_history_size"] = make_tuple(&variables.data_packets_history_size, 0, 0, true);
 
 	}
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>    // std::sort
 #include <memory>
 #include <vector>       // std::vector
+#include <unordered_set>
 #include <prometheus/exposer.h>
 #include <prometheus/counter.h>
 #include "MySQL_HostGroups_Manager.h"
@@ -575,6 +576,10 @@ MHD_Result http_handler(void *cls, struct MHD_Connection *connection, const char
 
 #define ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_GALERA_HOSTGROUPS "CREATE TABLE runtime_mysql_galera_hostgroups (writer_hostgroup INT CHECK (writer_hostgroup>=0) NOT NULL PRIMARY KEY , backup_writer_hostgroup INT CHECK (backup_writer_hostgroup>=0 AND backup_writer_hostgroup<>writer_hostgroup) NOT NULL , reader_hostgroup INT NOT NULL CHECK (reader_hostgroup<>writer_hostgroup AND backup_writer_hostgroup<>reader_hostgroup AND reader_hostgroup>0) , offline_hostgroup INT NOT NULL CHECK (offline_hostgroup<>writer_hostgroup AND offline_hostgroup<>reader_hostgroup AND backup_writer_hostgroup<>offline_hostgroup AND offline_hostgroup>=0) , active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 1 , max_writers INT NOT NULL CHECK (max_writers >= 0) DEFAULT 1 , writer_is_also_reader INT CHECK (writer_is_also_reader IN (0,1,2)) NOT NULL DEFAULT 0 , max_transactions_behind INT CHECK (max_transactions_behind>=0) NOT NULL DEFAULT 0 , comment VARCHAR , UNIQUE (reader_hostgroup) , UNIQUE (offline_hostgroup) , UNIQUE (backup_writer_hostgroup))"
 
+#define ADMIN_SQLITE_TABLE_COREDUMP_FILTERS "CREATE TABLE coredump_filters (filename VARCHAR NOT NULL , line INT NOT NULL , PRIMARY KEY (filename, line) )"
+
+#define ADMIN_SQLITE_RUNTIME_COREDUMP_FILTERS "CREATE TABLE runtime_coredump_filters (filename VARCHAR NOT NULL , line INT NOT NULL , PRIMARY KEY (filename, line) )"
+
 // AWS Aurora
 
 #define ADMIN_SQLITE_TABLE_MYSQL_AWS_AURORA_HOSTGROUPS_V2_0_8 "CREATE TABLE mysql_aws_aurora_hostgroups (writer_hostgroup INT CHECK (writer_hostgroup>=0) NOT NULL PRIMARY KEY , reader_hostgroup INT NOT NULL CHECK (reader_hostgroup<>writer_hostgroup AND reader_hostgroup>0) , active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 1 , aurora_port INT NOT NUlL DEFAULT 3306 , domain_name VARCHAR NOT NULL CHECK (SUBSTR(domain_name,1,1) = '.') , max_lag_ms INT NOT NULL CHECK (max_lag_ms>= 10 AND max_lag_ms <= 600000) DEFAULT 600000 , check_interval_ms INT NOT NULL CHECK (check_interval_ms >= 100 AND check_interval_ms <= 600000) DEFAULT 1000 , check_timeout_ms INT NOT NULL CHECK (check_timeout_ms >= 80 AND check_timeout_ms <= 3000) DEFAULT 800 , writer_is_also_reader INT CHECK (writer_is_also_reader IN (0,1)) NOT NULL DEFAULT 0 , new_reader_weight INT CHECK (new_reader_weight >= 0 AND new_reader_weight <=10000000) NOT NULL DEFAULT 1 , comment VARCHAR , UNIQUE (reader_hostgroup))"
@@ -674,7 +679,9 @@ static char * admin_variables_names[]= {
 	(char *)"debug",
 	(char *)"debug_output",
 #endif /* DEBUG */
-  NULL
+	(char *)"coredump_generation_interval_ms",
+	(char *)"coredump_generation_threshold",
+	NULL
 };
 
 using metric_name = std::string;
@@ -989,6 +996,11 @@ const std::vector<std::string> SAVE_MYSQL_VARIABLES_TO_MEMORY = {
 	"SAVE MYSQL VARIABLES FROM RUNTIME" ,
 	"SAVE MYSQL VARIABLES FROM RUN" };
 
+const std::vector<std::string> LOAD_COREDUMP_FROM_MEMORY = {
+	"LOAD COREDUMP FROM MEMORY" ,
+	"LOAD COREDUMP FROM MEM" ,
+	"LOAD COREDUMP TO RUNTIME" ,
+	"LOAD COREDUMP TO RUN" };
 
 static unordered_map<string,std::tuple<string, vector<string>, vector<string>>> load_save_disk_commands;
 
@@ -2643,6 +2655,23 @@ bool admin_handler_command_load_or_save(char *query_no_space, unsigned int query
 
 	}
 
+	if ((query_no_space_length > 14) && (!strncasecmp("LOAD COREDUMP ", query_no_space, 14))) {
+
+		if ( is_admin_command_or_alias(LOAD_COREDUMP_FROM_MEMORY, query_no_space, query_no_space_length) ) {
+			proxy_info("Received %s command\n", query_no_space);
+			ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
+			bool rc = SPA->load_coredump_to_runtime();
+			if (rc) {
+				proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded coredump filters to RUNTIME\n");
+				SPA->send_MySQL_OK(&sess->client_myds->myprot, NULL);
+			} else {
+				proxy_debug(PROXY_DEBUG_ADMIN, 1, "Error while loading coredump filters to RUNTIME\n");
+				SPA->send_MySQL_ERR(&sess->client_myds->myprot, (char*)"Error while loading coredump filters to RUNTIME");
+			}
+			return false;
+		}
+	}
+
 	if ((query_no_space_length>19) && ( (!strncasecmp("SAVE MYSQL SERVERS ", query_no_space, 19)) || (!strncasecmp("LOAD MYSQL SERVERS ", query_no_space, 19))) ) {
 
 		if (FlushCommandWrapper(sess, "mysql_servers", query_no_space, query_no_space_length) == true)
@@ -3102,6 +3131,8 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 	bool runtime_proxysql_servers=false;
 	bool runtime_checksums_values=false;
 
+	bool runtime_coredump_filters=false;
+
 	bool stats_mysql_prepared_statements_info = false;
 
 #ifdef PROXYSQLCLICKHOUSE
@@ -3254,7 +3285,9 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 			if (strstr(query_no_space,"runtime_checksums_values")) {
 				runtime_checksums_values=true; refresh=true;
 			}
-
+			if (strstr(query_no_space,"runtime_coredump_filters")) {
+				runtime_coredump_filters=true; refresh=true;
+			}
 #ifdef PROXYSQLCLICKHOUSE
 			if (( GloVars.global.clickhouse_server == true ) && strstr(query_no_space,"runtime_clickhouse_users")) {
 				runtime_clickhouse_users=true; refresh=true;
@@ -3399,6 +3432,9 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 			}
 			if (runtime_checksums_values) {
 				dump_checksums_values_table();
+			}
+			if (runtime_coredump_filters) {
+				dump_coredump_filter_values_table();
 			}
 #ifdef PROXYSQLCLICKHOUSE
 			if (runtime_clickhouse_users) {
@@ -5892,7 +5928,8 @@ ProxySQL_Admin::ProxySQL_Admin() :
 	debug_output = 1;
 	proxysql_set_admin_debug_output(debug_output);
 #endif /* DEBUG */
-
+	variables.coredump_generation_interval_ms = 30000;
+	variables.coredump_generation_threshold = 10;
 	last_p_memory_metrics_ts = 0;
 	// create the scheduler
 	scheduler=new ProxySQL_External_Scheduler();
@@ -6072,8 +6109,10 @@ bool ProxySQL_Admin::init() {
 	insert_into_tables_defs(tables_defs_admin,"runtime_mysql_firewall_whitelist_rules", ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_FIREWALL_WHITELIST_RULES);
 	insert_into_tables_defs(tables_defs_admin,"mysql_firewall_whitelist_sqli_fingerprints", ADMIN_SQLITE_TABLE_MYSQL_FIREWALL_WHITELIST_SQLI_FINGERPRINTS);
 	insert_into_tables_defs(tables_defs_admin,"runtime_mysql_firewall_whitelist_sqli_fingerprints", ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_FIREWALL_WHITELIST_SQLI_FINGERPRINTS);
-	insert_into_tables_defs(tables_defs_admin, "restapi_routes", ADMIN_SQLITE_TABLE_RESTAPI_ROUTES);
-	insert_into_tables_defs(tables_defs_admin, "runtime_restapi_routes", ADMIN_SQLITE_TABLE_RUNTIME_RESTAPI_ROUTES);
+	insert_into_tables_defs(tables_defs_admin,"restapi_routes", ADMIN_SQLITE_TABLE_RESTAPI_ROUTES);
+	insert_into_tables_defs(tables_defs_admin,"runtime_restapi_routes", ADMIN_SQLITE_TABLE_RUNTIME_RESTAPI_ROUTES);
+	insert_into_tables_defs(tables_defs_admin,"coredump_filters", ADMIN_SQLITE_TABLE_COREDUMP_FILTERS);
+	insert_into_tables_defs(tables_defs_admin,"runtime_coredump_filters", ADMIN_SQLITE_RUNTIME_COREDUMP_FILTERS);
 #ifdef DEBUG
 	insert_into_tables_defs(tables_defs_admin,"debug_levels", ADMIN_SQLITE_TABLE_DEBUG_LEVELS);
 	insert_into_tables_defs(tables_defs_admin,"debug_filters", ADMIN_SQLITE_TABLE_DEBUG_FILTERS);
@@ -8032,6 +8071,14 @@ char * ProxySQL_Admin::get_variable(char *name) {
 		return strdup(intbuf);
 	}
 #endif /* DEBUG */
+	if (!strcasecmp(name,"coredump_generation_interval_ms")) {
+		sprintf(intbuf,"%d",variables.coredump_generation_interval_ms);
+		return strdup(intbuf);
+	}
+	if (!strcasecmp(name,"coredump_generation_threshold")) {
+		sprintf(intbuf,"%d",variables.coredump_generation_threshold);
+		return strdup(intbuf);
+	}
 	return NULL;
 }
 
@@ -8703,6 +8750,28 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		return false;
 	}
 #endif /* DEBUG */
+	if (!strcasecmp(name,"coredump_generation_interval_ms")) {
+		int intv=atoi(value);
+		if (intv >= 0 && intv < INT_MAX) {
+			variables.coredump_generation_interval_ms=intv;
+			coredump_generation_interval_ms=intv;
+			proxy_coredump_reset_stats();
+			return true;
+		} else {
+			return false;
+		}
+	}
+	if (!strcasecmp(name,"coredump_generation_threshold")) {
+		int intv=atoi(value);
+		if (intv > 0 && intv <= 500) {
+			variables.coredump_generation_threshold=intv;
+			coredump_generation_threshold=intv;
+			proxy_coredump_reset_stats();
+			return true;
+		} else {
+			return false;
+		}
+	}
 	return false;
 }
 
@@ -13605,6 +13674,66 @@ void ProxySQL_Admin::save_proxysql_servers_runtime_to_database(bool _runtime) {
 	resultset=NULL;
 }
 
+bool ProxySQL_Admin::flush_coredump_filters_database_to_runtime(SQLite3DB* db) {
+	bool success = false;
+	char *error=NULL;
+	int cols=0;
+	int affected_rows=0;
+	SQLite3_result *resultset=NULL;
+	const char* query = "SELECT filename, line FROM coredump_filters";
+	admindb->execute_statement(query, &error , &cols , &affected_rows , &resultset);
+	if (error) {
+		// LCOV_EXCL_START
+		proxy_error("Error on %s : %s\n", query, error);
+		assert(0);
+		// LCOV_EXCL_STOP
+	} else {
+		std::unordered_set<std::string> filters;
+		for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
+			SQLite3_row *r=*it;
+			std::string key; // we create a string with the row
+			// remember the format is filename:line
+			// no column can be null
+			key = r->fields[0];
+			key += ":";
+			key += r->fields[1];
+			filters.emplace(std::move(key));
+		}
+		proxy_coredump_load_filters(std::move(filters));
+		success = true;
+	}
+	if (resultset) delete resultset;
+
+	return success;
+}
+
+void ProxySQL_Admin::dump_coredump_filter_values_table() {
+	
+	std::unordered_set<std::string> filters;
+	proxy_coredump_get_filters(filters);
+
+	int rc;
+	const char *query = "REPLACE INTO runtime_coredump_filters VALUES (?1,?2)";
+	sqlite3_stmt *stmt = NULL;
+	rc = admindb->prepare_v2(query,&stmt);
+	ASSERT_SQLITE_OK(rc, admindb);
+	admindb->execute((char *)"BEGIN");
+	admindb->execute((char *)"DELETE FROM runtime_coredump_filters");
+	for (const auto& filter : filters) {
+		char *filename=nullptr; char *lineno=nullptr;
+		c_split_2(filter.c_str(), ":", &filename, &lineno);
+		rc=(*proxy_sqlite3_bind_text)(stmt, 1, filename, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb);
+		rc=(*proxy_sqlite3_bind_int64)(stmt, 2, atoi(lineno)); ASSERT_SQLITE_OK(rc, admindb);
+		SAFE_SQLITE3_STEP2(stmt);
+		rc=(*proxy_sqlite3_clear_bindings)(stmt); ASSERT_SQLITE_OK(rc, admindb);
+		rc=(*proxy_sqlite3_reset)(stmt); ASSERT_SQLITE_OK(rc, admindb);
+
+		free(filename);
+		free(lineno);
+	}
+	admindb->execute((char *)"COMMIT");
+	(*proxy_sqlite3_finalize)(stmt);
+}
 
 void ProxySQL_Admin::stats___mysql_prepared_statements_info() {
 	if (!GloMyStmt) return;

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -144,6 +144,7 @@ ProxySQL_GlobalVariables::ProxySQL_GlobalVariables() :
 #endif
 
 	global.sqlite3_server=false;
+	global.data_packets_history_size=0;
 #ifdef PROXYSQLCLICKHOUSE
 	global.clickhouse_server=false;
 #endif /* PROXYSQLCLICKHOUSE */

--- a/lib/ProxySQL_GloVars.cpp
+++ b/lib/ProxySQL_GloVars.cpp
@@ -295,7 +295,7 @@ void ProxySQL_GlobalVariables::process_opts_pre() {
 #ifdef DEBUG
 	init_debug_struct();
 #endif
-
+	init_coredump_struct();
 };
 
 void ProxySQL_GlobalVariables::process_opts_post() {

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -495,6 +495,7 @@ void MySQL_Data_Stream::check_data_flow() {
 		// there is data at both sides of the data stream: this is considered a fatal error
 		proxy_error("Session=%p, DataStream=%p -- Data at both ends of a MySQL data stream: IN <%d bytes %d packets> , OUT <%d bytes %d packets>\n", sess, this, PSarrayIN->len , queue_data(queueIN) , PSarrayOUT->len , queue_data(queueOUT));
 		shut_soft();
+		generate_coredump();
 	}
 	if ((myds_type==MYDS_BACKEND) && myconn && (myconn->fd==0) && (revents & POLLOUT)) {
 		int rc;

--- a/lib/proxysql_coredump.cpp
+++ b/lib/proxysql_coredump.cpp
@@ -1,0 +1,84 @@
+#include <string>
+#include <unordered_set>
+
+#include "proxysql_coredump.h"
+#include "gen_utils.h"
+#if (defined(__i386__) || defined(__x86_64__) || defined(__ARM_ARCH_3__) || defined(__mips__)) && defined(__linux)
+// currently only support x86-32, x86-64, ARM, and MIPS on Linux
+#include "coredumper/coredumper.h"
+#endif
+
+bool coredump_enabled = false;
+int coredump_generation_threshold = 0;
+int coredump_generation_interval_ms = 0;
+
+static int coredump_generated = 0;
+static unsigned long long coredump_creation_time = 0;
+static pthread_rwlock_t coredump_filters_rwlock;
+static std::unordered_set<std::string> coredump_filters;
+
+//std::unordered_set<std::string>& get_coredump_filters() {
+//	static std::unordered_set<std::string> coredump_filters{};
+//	return coredump_filters;
+//}
+
+void init_coredump_struct() {
+	pthread_rwlock_init(&coredump_filters_rwlock, nullptr);
+	coredump_enabled = false;
+	coredump_generation_threshold = 0;
+	coredump_generation_interval_ms = 0;
+	proxy_coredump_reset_stats();
+}
+
+void proxy_coredump_load_filters(std::unordered_set<std::string>&& filters) {
+//	auto& coredump_filters = get_coredump_filters();
+	pthread_rwlock_wrlock(&coredump_filters_rwlock);
+	coredump_filters.clear();
+	coredump_filters = std::move(filters);
+	coredump_enabled = !coredump_filters.empty();
+	proxy_coredump_reset_stats();
+	pthread_rwlock_unlock(&coredump_filters_rwlock);
+}
+
+void proxy_coredump_get_filters(std::unordered_set<std::string>& filters) {
+//	const auto& coredump_filters = get_coredump_filters();
+	pthread_rwlock_rdlock(&coredump_filters_rwlock);
+	filters = coredump_filters;
+	pthread_rwlock_unlock(&coredump_filters_rwlock);
+}
+
+bool proxy_coredump_filter_exists(const std::string& filter) {
+	bool result = false;
+//	const auto& coredump_filters = get_coredump_filters();
+	pthread_rwlock_rdlock(&coredump_filters_rwlock);
+	result = (coredump_filters.find(filter) != coredump_filters.end());
+	pthread_rwlock_unlock(&coredump_filters_rwlock);
+	return result;
+}
+
+void proxy_coredump_reset_stats() {
+	proxy_info("Reset coredump stats\n");
+	coredump_generated = 0;
+	coredump_creation_time = 0;
+}
+
+void proxy_coredump_generate() {
+#if (defined(__i386__) || defined(__x86_64__) || defined(__ARM_ARCH_3__) || defined(__mips__)) && defined(__linux)
+	const auto currtime = monotonic_time();;
+
+	if ((coredump_creation_time == 0 || coredump_generation_interval_ms == 0 || 
+		(currtime > (coredump_creation_time + (coredump_generation_interval_ms*1000)))) &&
+		coredump_generated < coredump_generation_threshold) {
+		
+		char core_filename[128];
+		sprintf(core_filename, "core.%d.%d", getpid(), coredump_generated);
+		proxy_info("Generating coredump file '%s'...\n", core_filename);
+		WriteCompressedCoreDump(core_filename, SIZE_MAX, COREDUMPER_COMPRESSED, NULL);
+		coredump_generated++;
+		coredump_creation_time = currtime;
+		proxy_info("Coredump file '%s' was generated ['%llu']. Total core files generated '%d'.\n", core_filename, coredump_creation_time, coredump_generated);
+	}
+#else
+	proxy_warning("Coredump generation is not supported on this platform.\n");
+#endif
+}

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -89,8 +89,11 @@ endif
 MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev -Wl,-Bdynamic -lgnutls -lpthread -lm -lz -lrt $(EXTRALINK) -lprometheus-cpp-pull -lprometheus-cpp-core -luuid
 STATIC_LIBS= $(SSL_LDIR)/libssl.a $(SSL_LDIR)/libcrypto.a $(CITYHASH_LDIR)/libcityhash.a
 
+LIBCOREDUMPERAR=
+
 ifeq ($(UNAME_S),Linux)
-  STATIC_LIBS+= $(COREDUMPER_LDIR)/libcoredumper.a
+  LIBCOREDUMPERAR=$(COREDUMPER_LDIR)/libcoredumper.a
+  STATIC_LIBS+= $(LIBCOREDUMPERAR)
 endif
 
 .PHONY: all
@@ -162,7 +165,7 @@ test_mysql_query_digests_stages-t: test_mysql_query_digests_stages-t.cpp $(TAP_L
 	g++ test_mysql_query_digests_stages-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -lproxysql -ltap -Wl,--no-as-needed -ldl -lpthread -o test_mysql_query_digests_stages-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 sqlite3-t: sqlite3-t.cpp $(TAP_LIBDIR)/libtap.a
-	g++ sqlite3-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 -lproxysql $(MYLIBS) -ltap -Wl,--no-as-needed -ldl -lpthread -o sqlite3-t -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ sqlite3-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 -lproxysql $(MYLIBS) -ltap -Wl,--no-as-needed -ldl -lpthread $(LIBCOREDUMPERAR) -o sqlite3-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 test_gtid_forwarding-t: test_gtid_forwarding-t.cpp $(TAP_LIBDIR)/libtap.a
 	g++ test_gtid_forwarding-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -ltap -Wl,--no-as-needed -ldl -lpthread -o test_gtid_forwarding-t -DGITVERSION=\"$(GIT_VERSION)\"
@@ -173,8 +176,8 @@ test_admin_prometheus_metrics_dump-t: test_admin_prometheus_metrics_dump-t.cpp $
 create_connection_annotation: test_connection_annotation-t.cpp
 	g++ -DTEST_AURORA -DDEBUG test_connection_annotation-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) $(MYLIBS) -ltap -ldl $(STATIC_LIBS) -o test_connection_annotation-t -DGITVERSION=\"$(GIT_VERSION)\"
 
-setparser_test: setparser_test.cpp $(TAP_LIBDIR)/libtap.a $(RE2_PATH)/util/test.cc $(LDIR)/set_parser.cpp $(LIBPROXYSQLAR)
-	g++ -DDEBUG setparser_test.cpp $(RE2_PATH)/util/test.cc $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 -lproxysql $(MYLIBS) -ltap -ldl -lpthread $(WASAN) -o setparser_test -DGITVERSION=\"$(GIT_VERSION)\"
+setparser_test: setparser_test.cpp $(TAP_LIBDIR)/libtap.a $(RE2_PATH)/util/test.cc $(LDIR)/set_parser.cpp $(LIBPROXYSQLAR) $(LIBCOREDUMPERAR)
+	g++ -DDEBUG setparser_test.cpp $(RE2_PATH)/util/test.cc $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 -lproxysql $(MYLIBS) -ltap -ldl -lpthread $(WASAN) $(LIBCOREDUMPERAR) -o setparser_test -DGITVERSION=\"$(GIT_VERSION)\"
 
 reg_test_3504-change_user_libmariadb_helper: reg_test_3504-change_user_helper.cpp
 	$(CXX) -DDEBUG reg_test_3504-change_user_helper.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl -std=c++11 -ltap $(STATIC_LIBS) -o reg_test_3504-change_user_libmariadb_helper -DGITVERSION=\"$(GIT_VERSION)\"


### PR DESCRIPTION
Feature for troubleshooting purposes. It allows capturing and storing data packet history for easier debugging and analysis.

The history queue will aid in troubleshooting frontend and backend communication issues by providing a record of the packets exchanged.

By default this feature is disabled. To activate this feature, you need to configure the **'mysql-data_packets_history_size'** variable to the desired maximum size for storing data packets. When the number of incoming or outgoing packets exceeds this limit, oldest packets are removed from the queue to make room for the new ones.

-------------------------------------------------------------------------------------------------------------------------------------------

Implemented the functionality to generate a coredump upon reaching a specific source file and line number.

To enable coredump feature, specify the filename and line number in the coredump_filters table.

Example:
```
INSERT INTO coredump_filters (filename,line) VALUES ('mysql_data_stream.cpp', 498);
LOAD COREDUMP TO RUNTIME;
```

Note:
* Coredump filters cannot be persisted on disk and will always be empty when a new instance is created.
* Filenames are case-sensitive

* 'admin-coredump_generation_threshold', has been introduced to specify the maximum number of core files that can be generated.
* 'admin-coredump_generation_interval_ms', has been implemented to define the time gap between the generation of core files.