### PR TITLE
Removed reset coredump stats from admin set_variables

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -8758,7 +8758,6 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		if (intv >= 0 && intv < INT_MAX) {
 			variables.coredump_generation_interval_ms=intv;
 			coredump_generation_interval_ms=intv;
-			proxy_coredump_reset_stats();
 			return true;
 		} else {
 			return false;
@@ -8769,7 +8768,6 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		if (intv > 0 && intv <= 500) {
 			variables.coredump_generation_threshold=intv;
 			coredump_generation_threshold=intv;
-			proxy_coredump_reset_stats();
 			return true;
 		} else {
 			return false;

--- a/lib/proxysql_coredump.cpp
+++ b/lib/proxysql_coredump.cpp
@@ -27,7 +27,8 @@ void init_coredump_struct() {
 	coredump_enabled = false;
 	coredump_generation_threshold = 0;
 	coredump_generation_interval_ms = 0;
-	proxy_coredump_reset_stats();
+	coredump_generated = 0;
+	coredump_creation_time = 0;
 }
 
 void proxy_coredump_load_filters(std::unordered_set<std::string>&& filters) {


### PR DESCRIPTION
Reset coredump stats exclusively when 'LOAD COREDUMP TO RUNTIME' command is executed