### PR TITLE
SSL support on Unix Socket reinstated

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1501,7 +1501,7 @@ __exit_set_wait_timeout:
 bool MySQL_Monitor_State_Data::create_new_connection() {
 		mysql=mysql_init(NULL);
 		assert(mysql);
-		if (use_ssl && port) {
+		if (use_ssl) {
 			mysql_ssl_set(mysql,
 					mysql_thread___ssl_p2s_key,
 					mysql_thread___ssl_p2s_cert,

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -709,7 +709,7 @@ void MySQL_Connection::connect_start() {
 		}
 		mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "mysql_bug_102266", "Avoid MySQL bug https://bugs.mysql.com/bug.php?id=102266 , https://github.com/sysown/proxysql/issues/3276");
 	}
-	if (parent->use_ssl && parent->port) {
+	if (parent->use_ssl) {
 		mysql_ssl_set(mysql,
 				mysql_thread___ssl_p2s_key,
 				mysql_thread___ssl_p2s_cert,


### PR DESCRIPTION
Resolves [Issue#4243](https://github.com/sysown/proxysql/issues/4243)