### PR TITLE
Minor changes in TAP Makefile

### DIFF
--- a/test/tap/tap/SQLite3_Server.cpp
+++ b/test/tap/tap/SQLite3_Server.cpp
@@ -44,25 +44,6 @@
 #endif // MSG_NOSIGNAL
 #endif // __APPLE__
 
-#define SAFE_SQLITE3_STEP(_stmt) do {\
-  do {\
-    rc=sqlite3_step(_stmt);\
-    if (rc!=SQLITE_DONE) {\
-      assert(rc==SQLITE_LOCKED);\
-      usleep(100);\
-    }\
-  } while (rc!=SQLITE_DONE);\
-} while (0)
-
-#define SAFE_SQLITE3_STEP2(_stmt) do {\
-        do {\
-                rc=sqlite3_step(_stmt);\
-                if (rc==SQLITE_LOCKED || rc==SQLITE_BUSY) {\
-                        usleep(100);\
-                }\
-        } while (rc==SQLITE_LOCKED || rc==SQLITE_BUSY);\
-} while (0)
-
 struct cpu_timer
 {
 	cpu_timer() {

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -589,7 +589,7 @@ int wait_for_replication(
 	return result;
 }
 
-MARIADB_CHARSET_INFO * proxysql_find_charset_collate(const char *collatename) {
+MARIADB_CHARSET_INFO * proxysqlTap_find_charset_collate(const char *collatename) {
 	MARIADB_CHARSET_INFO *c = (MARIADB_CHARSET_INFO *)mariadb_compiled_charsets;
 	do {
 		if (!strcasecmp(c->name, collatename)) {

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -179,9 +179,9 @@ int wait_for_replication(
  * 'MySQL_Variables' is not a easy task due to its interdependeces with other ProxySQL modules.
  */
 #ifdef LIBMYSQL_HELPER
-MY_CHARSET_INFO * proxysql_find_charset_collate(const char *collatename);
+MY_CHARSET_INFO * proxysqlTap_find_charset_collate(const char *collatename);
 #else
-MARIADB_CHARSET_INFO * proxysql_find_charset_collate(const char *collatename);
+MARIADB_CHARSET_INFO * proxysqlTap_find_charset_collate(const char *collatename);
 #endif
 /**
  * @brief Creates the new supplied user in ProxySQL with the provided

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -90,7 +90,8 @@ ifeq ($(UNAME_S),Linux)
 	LDIRS+= -L$(COREDUMPER_LDIR)
 endif
 
-MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -ltap -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev  -lprometheus-cpp-pull -lprometheus-cpp-core -luuid -Wl,-Bdynamic -lgnutls -lpthread -lm -lz -lrt $(EXTRALINK)
+MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -ltap -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev  -lprometheus-cpp-pull -lprometheus-cpp-core -luuid -Wl,-Bdynamic -lgnutls -lpthread -lm -lz -lrt -ldl $(EXTRALINK)
+MYLIBSJEMALLOC=-Wl,-Bstatic -ljemalloc
 STATIC_LIBS= $(SSL_LDIR)/libssl.a $(SSL_LDIR)/libcrypto.a $(CITYHASH_LDIR)/libcityhash.a
 
 LIBCOREDUMPERAR=
@@ -148,44 +149,44 @@ py-%:
 	chmod +x $(patsubst py-%.py,%,$@)
 
 %-t: %-t.cpp $(TAP_LIBDIR)/libtap.a
-	$(CXX) -std=c++11 $< $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl $(STATIC_LIBS) -o $@
+	$(CXX) -std=c++11 $< $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) $(STATIC_LIBS) -o $@
 #	$(CXX) -std=c++11 $< $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl $(STATIC_LIBS) $(TAP_LIBDIR)/libtap.a -o $@
 
 galera_1_timeout_count: galera_1_timeout_count.cpp $(TAP_LIBDIR)/libtap.a
-	g++ -DTEST_GALERA -DDEBUG galera_1_timeout_count.cpp ../tap/SQLite3_Server.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) -lproxysql $(MYLIBS) -ltap -ldl $(STATIC_LIBS) -o galera_1_timeout_count -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ -DTEST_GALERA -DDEBUG galera_1_timeout_count.cpp ../tap/SQLite3_Server.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) $(MYLIBSJEMALLOC) $(MYLIBS) $(STATIC_LIBS) -o galera_1_timeout_count -DGITVERSION=\"$(GIT_VERSION)\"
 
 galera_2_timeout_no_count: galera_2_timeout_no_count.cpp $(TAP_LIBDIR)/libtap.a
-	g++ -DTEST_GALERA -DDEBUG galera_2_timeout_no_count.cpp ../tap/SQLite3_Server.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) -lproxysql $(MYLIBS) -ltap -ldl $(STATIC_LIBS) -o galera_2_timeout_no_count -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ -DTEST_GALERA -DDEBUG galera_2_timeout_no_count.cpp ../tap/SQLite3_Server.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) $(MYLIBSJEMALLOC) $(MYLIBS) $(STATIC_LIBS) -o galera_2_timeout_no_count -DGITVERSION=\"$(GIT_VERSION)\"
 
 generate_set_session_csv: generate_set_session_csv.cpp
 	g++ -o generate_set_session_csv generate_set_session_csv.cpp -O0 -ggdb
 
 aurora: aurora.cpp $(TAP_LIBDIR)/libtap.a
-	g++ -DTEST_AURORA -DDEBUG aurora.cpp ../tap/SQLite3_Server.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) -lproxysql $(MYLIBS) -ltap -ldl $(STATIC_LIBS) -o aurora -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ -DTEST_AURORA -DDEBUG aurora.cpp ../tap/SQLite3_Server.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) $(MYLIBSJEMALLOC) $(MYLIBS) $(STATIC_LIBS) -o aurora -DGITVERSION=\"$(GIT_VERSION)\"
 
 test_tokenizer-t: test_tokenizer-t.cpp $(TAP_LIBDIR)/libtap.a
-	g++ test_tokenizer-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -lproxysql -ltap -Wl,--no-as-needed -ldl -lpthread -o test_tokenizer-t -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ test_tokenizer-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -o test_tokenizer-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 test_mysql_query_digests_stages-t: test_mysql_query_digests_stages-t.cpp $(TAP_LIBDIR)/libtap.a
-	g++ test_mysql_query_digests_stages-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -lproxysql -ltap -Wl,--no-as-needed -ldl -lpthread -o test_mysql_query_digests_stages-t -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ test_mysql_query_digests_stages-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -o test_mysql_query_digests_stages-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 sqlite3-t: sqlite3-t.cpp $(TAP_LIBDIR)/libtap.a
-	g++ sqlite3-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 -lproxysql $(MYLIBS) -ltap -Wl,--no-as-needed -ldl -lpthread $(LIBCOREDUMPERAR) -o sqlite3-t -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ sqlite3-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) $(LIBCOREDUMPERAR) -o sqlite3-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 test_gtid_forwarding-t: test_gtid_forwarding-t.cpp $(TAP_LIBDIR)/libtap.a
-	g++ test_gtid_forwarding-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -ltap -Wl,--no-as-needed -ldl -lpthread -o test_gtid_forwarding-t -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ test_gtid_forwarding-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -o test_gtid_forwarding-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 test_admin_prometheus_metrics_dump-t: test_admin_prometheus_metrics_dump-t.cpp $(TAP_LIBDIR)/libtap.a
-	g++ test_admin_prometheus_metrics_dump-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -ltap -Wl,--no-as-needed -ldl -lpthread -o test_admin_prometheus_metrics_dump-t -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ test_admin_prometheus_metrics_dump-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) -o test_admin_prometheus_metrics_dump-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 create_connection_annotation: test_connection_annotation-t.cpp
-	g++ -DTEST_AURORA -DDEBUG test_connection_annotation-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) $(MYLIBS) -ltap -ldl $(STATIC_LIBS) -o test_connection_annotation-t -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ -DTEST_AURORA -DDEBUG test_connection_annotation-t.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) $(MYLIBS) $(STATIC_LIBS) -o test_connection_annotation-t -DGITVERSION=\"$(GIT_VERSION)\"
 
 setparser_test: setparser_test.cpp $(TAP_LIBDIR)/libtap.a $(RE2_PATH)/util/test.cc $(LDIR)/set_parser.cpp $(LIBPROXYSQLAR) $(LIBCOREDUMPERAR)
-	g++ -DDEBUG setparser_test.cpp $(RE2_PATH)/util/test.cc $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 -lproxysql $(MYLIBS) -ltap -ldl -lpthread $(WASAN) $(LIBCOREDUMPERAR) -o setparser_test -DGITVERSION=\"$(GIT_VERSION)\"
+	g++ -DDEBUG setparser_test.cpp $(RE2_PATH)/util/test.cc $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(MYLIBS) $(WASAN) $(LIBCOREDUMPERAR) -o setparser_test -DGITVERSION=\"$(GIT_VERSION)\"
 
 reg_test_3504-change_user_libmariadb_helper: reg_test_3504-change_user_helper.cpp
-	$(CXX) -DDEBUG reg_test_3504-change_user_helper.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl -std=c++11 -ltap $(STATIC_LIBS) -o reg_test_3504-change_user_libmariadb_helper -DGITVERSION=\"$(GIT_VERSION)\"
+	$(CXX) -DDEBUG reg_test_3504-change_user_helper.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -std=c++11 $(STATIC_LIBS) -o reg_test_3504-change_user_libmariadb_helper -DGITVERSION=\"$(GIT_VERSION)\"
 
 reg_test_3504-change_user_libmysql_helper: reg_test_3504-change_user_helper.cpp
 	$(CXX) -DLIBMYSQL_HELPER -DDEBUG reg_test_3504-change_user_helper.cpp -I/usr/include/mysql -I$(CURL_IDIR) -I$(SQLITE3_DIR) -I$(IDIR) -I$(JSON_IDIR) -I../tap -L$(TAP_LIBDIR) -lpthread -ldl -std=c++11 -ltap -lmysqlclient -o reg_test_3504-change_user_libmysql_helper -DGITVERSION=\"$(GIT_VERSION)\"

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -90,7 +90,7 @@ ifeq ($(UNAME_S),Linux)
 	LDIRS+= -L$(COREDUMPER_LDIR)
 endif
 
-MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -ljemalloc -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev -Wl,-Bdynamic -lgnutls -lpthread -lm -lz -lrt $(EXTRALINK) -lprometheus-cpp-pull -lprometheus-cpp-core -luuid
+MYLIBS=-Wl,--export-dynamic -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -ltap -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev  -lprometheus-cpp-pull -lprometheus-cpp-core -luuid -Wl,-Bdynamic -lgnutls -lpthread -lm -lz -lrt $(EXTRALINK)
 STATIC_LIBS= $(SSL_LDIR)/libssl.a $(SSL_LDIR)/libcrypto.a $(CITYHASH_LDIR)/libcityhash.a
 
 LIBCOREDUMPERAR=
@@ -148,7 +148,8 @@ py-%:
 	chmod +x $(patsubst py-%.py,%,$@)
 
 %-t: %-t.cpp $(TAP_LIBDIR)/libtap.a
-	$(CXX) $^ $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl -std=c++11 -ltap $(STATIC_LIBS) -o $@
+	$(CXX) -std=c++11 $< $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl $(STATIC_LIBS) -o $@
+#	$(CXX) -std=c++11 $< $(INCLUDEDIRS) $(LDIRS) $(OPT) $(MYLIBS) -lpthread -ldl $(STATIC_LIBS) $(TAP_LIBDIR)/libtap.a -o $@
 
 galera_1_timeout_count: galera_1_timeout_count.cpp $(TAP_LIBDIR)/libtap.a
 	g++ -DTEST_GALERA -DDEBUG galera_1_timeout_count.cpp ../tap/SQLite3_Server.cpp $(INCLUDEDIRS) $(LDIRS) $(OPT) -std=c++11 $(OBJ) -lproxysql $(MYLIBS) -ltap -ldl $(STATIC_LIBS) -o galera_1_timeout_count -DGITVERSION=\"$(GIT_VERSION)\"

--- a/test/tap/tests/aurora.cpp
+++ b/test/tap/tests/aurora.cpp
@@ -41,25 +41,6 @@
 
 extern SQLite3_Server *GloSQLite3Server;
 
-#define SAFE_SQLITE3_STEP(_stmt) do {\
-  do {\
-    rc=sqlite3_step(_stmt);\
-    if (rc!=SQLITE_DONE) {\
-      assert(rc==SQLITE_LOCKED);\
-      usleep(100);\
-    }\
-  } while (rc!=SQLITE_DONE);\
-} while (0)
-
-#define SAFE_SQLITE3_STEP2(_stmt) do {\
-        do {\
-                rc=sqlite3_step(_stmt);\
-                if (rc==SQLITE_LOCKED || rc==SQLITE_BUSY) {\
-                        usleep(100);\
-                }\
-        } while (rc==SQLITE_LOCKED || rc==SQLITE_BUSY);\
-} while (0)
-
 void SQLite3_Server::init_aurora_ifaces_string(std::string& s) {
 	if(!s.empty())
 		s += ";";

--- a/test/tap/tests/galera_1_timeout_count.cpp
+++ b/test/tap/tests/galera_1_timeout_count.cpp
@@ -52,25 +52,6 @@ extern MySQL_HostGroups_Manager *MyHGM;
 
 static bool init_tap=false;
 
-#define SAFE_SQLITE3_STEP(_stmt) do {\
-  do {\
-    rc=sqlite3_step(_stmt);\
-    if (rc!=SQLITE_DONE) {\
-      assert(rc==SQLITE_LOCKED);\
-      usleep(100);\
-    }\
-  } while (rc!=SQLITE_DONE);\
-} while (0)
-
-#define SAFE_SQLITE3_STEP2(_stmt) do {\
-        do {\
-                rc=sqlite3_step(_stmt);\
-                if (rc==SQLITE_LOCKED || rc==SQLITE_BUSY) {\
-                        usleep(100);\
-                }\
-        } while (rc==SQLITE_LOCKED || rc==SQLITE_BUSY);\
-} while (0)
-
 void SQLite3_Server::init_galera_ifaces_string(std::string& s) {
 	if(!s.empty())
 		s += ";";

--- a/test/tap/tests/galera_2_timeout_no_count.cpp
+++ b/test/tap/tests/galera_2_timeout_no_count.cpp
@@ -53,25 +53,6 @@ extern MySQL_HostGroups_Manager *MyHGM;
 static bool init_tap=false;
 static std::vector<int> timeouts;
 
-#define SAFE_SQLITE3_STEP(_stmt) do {\
-  do {\
-    rc=sqlite3_step(_stmt);\
-    if (rc!=SQLITE_DONE) {\
-      assert(rc==SQLITE_LOCKED);\
-      usleep(100);\
-    }\
-  } while (rc!=SQLITE_DONE);\
-} while (0)
-
-#define SAFE_SQLITE3_STEP2(_stmt) do {\
-        do {\
-                rc=sqlite3_step(_stmt);\
-                if (rc==SQLITE_LOCKED || rc==SQLITE_BUSY) {\
-                        usleep(100);\
-                }\
-        } while (rc==SQLITE_LOCKED || rc==SQLITE_BUSY);\
-} while (0)
-
 void SQLite3_Server::init_galera_ifaces_string(std::string& s) {
 	if(!s.empty())
 		s += ";";

--- a/test/tap/tests/test_com_reset_connection_com_change_user-t.cpp
+++ b/test/tap/tests/test_com_reset_connection_com_change_user-t.cpp
@@ -965,7 +965,7 @@ int test_mysql_server_variables(MYSQL*, const CommandLine& cl, const std::vector
 	MYSQL* mysql = mysql_init(NULL);
 
 	// Use a known default charset for the connection
-	MARIADB_CHARSET_INFO* latin2_charset = proxysql_find_charset_collate("latin2_general_ci");
+	MARIADB_CHARSET_INFO* latin2_charset = proxysqlTap_find_charset_collate("latin2_general_ci");
 	mysql->charset = latin2_charset;
 
 	if (!mysql_real_connect(mysql, cl.host, "root", "root", NULL, 13306, NULL, 0)) {
@@ -1060,7 +1060,7 @@ int test_mysql_server_variables(MYSQL*, const CommandLine& cl, const std::vector
 			std::string username = std::get<0>(user_configs[1]);
 			std::string password = std::get<1>(user_configs[1]);
 
-			MARIADB_CHARSET_INFO* charset = proxysql_find_charset_collate("latin2_general_ci");
+			MARIADB_CHARSET_INFO* charset = proxysqlTap_find_charset_collate("latin2_general_ci");
 			mysql->charset = charset;
 
 			int err_code = mysql_change_user(mysql, username.c_str(), password.c_str(), NULL);
@@ -1127,7 +1127,7 @@ int main(int argc, char** argv) {
 	MYSQL* proxysql = mysql_init(NULL);
 
 	// Use a known default charset for the connection
-	MARIADB_CHARSET_INFO* latin2_charset = proxysql_find_charset_collate("latin2_general_ci");
+	MARIADB_CHARSET_INFO* latin2_charset = proxysqlTap_find_charset_collate("latin2_general_ci");
 	proxysql->charset = latin2_charset;
 
 	if (

--- a/test/tap/tests/test_set_collation-t.cpp
+++ b/test/tap/tests/test_set_collation-t.cpp
@@ -33,7 +33,7 @@ int create_proxysql_connections(const CommandLine& cl, const std::vector<std::st
 
 	for (const auto& collation : collations) {
 		MYSQL* mysql = mysql_init(NULL);
-		const MARIADB_CHARSET_INFO* charset = proxysql_find_charset_collate(collation.c_str());
+		const MARIADB_CHARSET_INFO* charset = proxysqlTap_find_charset_collate(collation.c_str());
 		mysql->charset = charset;
 
 		if (!mysql_real_connect(mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
@@ -57,7 +57,7 @@ int run_change_user_on_all(const CommandLine& cl, const std::vector<std::string>
 	for (int i = 0; i < conns.size(); i++) {
 		MYSQL* mysql = conns[i];
 		MYSQL_QUERY(mysql, "START TRANSACTION");
-		const MARIADB_CHARSET_INFO* charset = proxysql_find_charset_collate(collations[i].c_str());
+		const MARIADB_CHARSET_INFO* charset = proxysqlTap_find_charset_collate(collations[i].c_str());
 		mysql->charset = charset;
 		if (mysql_change_user(mysql,cl.username, cl.password, NULL)) {
 			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(mysql));


### PR DESCRIPTION
Disabling jemalloc from TAP tests it saves around 5MB per binary

Also renamed proxysql_find_charset_collate() in proxysqlTap_find_charset_collate()