### PR TITLE
Remove `libdaemon` imposed `umask` value when forking

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -211,6 +211,7 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
 libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
 	cd libdaemon && rm -rf libdaemon-*/ || true
 	cd libdaemon && tar -zxf libdaemon-0.14.tar.gz
+	cd libdaemon/libdaemon && patch -p0 < ../daemon_fork_umask.patch
 	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
 	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
 

--- a/deps/libdaemon/daemon_fork_umask.patch
+++ b/deps/libdaemon/daemon_fork_umask.patch
@@ -1,0 +1,13 @@
+diff --git libdaemon/dfork.c libdaemon/dfork.c
+index 70fce86..8373038 100644
+--- libdaemon/dfork.c
++++ libdaemon/dfork.c
+@@ -235,7 +235,7 @@ pid_t daemon_fork(void) {
+             goto fail;
+         }
+ 
+-        umask(0077);
++        // umask(0077);
+ 
+         if (chdir("/") < 0) {
+             daemon_log(LOG_ERR, "chdir() failed: %s", strerror(errno));


### PR DESCRIPTION
This PR allows users to control the desired `umask` value when ProxySQL is executed as a daemon, since it's no longer going to be limited by `libdaemon` hard-coded `0077` value.