### PR TITLE
Fix Admin support for MySQL client `8.1.0` - Closes #4300

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -390,7 +390,7 @@ class ProxySQL_Admin {
 	void admin_shutdown();
 	bool is_command(std::string);
 	void send_MySQL_OK(MySQL_Protocol *myprot, char *msg, int rows=0);
-	void send_MySQL_ERR(MySQL_Protocol *myprot, char *msg);
+	void send_MySQL_ERR(MySQL_Protocol *myprot, char *msg, uint32_t code=1045);
 #ifdef DEBUG
 	// these two following functions used to just call and return one function each
 	// this approach was replaced when we introduced debug filters

--- a/include/proxysql_utils.h
+++ b/include/proxysql_utils.h
@@ -210,4 +210,39 @@ std::string replace_str(const std::string& str, const std::string& match, const 
 std::string generate_multi_rows_query(int rows, int params);
 
 void close_all_non_term_fd(std::vector<int> excludeFDs);
+
+/**
+ * @brief Suggested implementation of 'mismatch_' from ['cppreference'](https://en.cppreference.com/w/cpp/algorithm/mismatch).
+ *
+ * @param first1 begin of the first range of the elements.
+ * @param last1 end of the first range of the elements.
+ * @param first2 begin of the second range of the elements.
+ * @param last2 end of the second range of the elements.
+ * @param p binary predicate which returns `true` if the elements should be treated as equal.
+ *
+ * @return std::pair with iterators to the first two non-equal elements.
+ */
+template<class InputIt1, class InputIt2, class BinaryPredicate>
+std::pair<InputIt1, InputIt2> mismatch_(
+	InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, BinaryPredicate p
+) {
+    while (first1 != last1 && first2 != last2 && p(*first1, *first2)) {
+        ++first1, ++first2;
+    }
+    return std::make_pair(first1, first2);
+}
+
+/**
+ * @brief Returns a sorted copy in ascending order of the supplied version numbers.
+ * @details Expected version numbers formats are: ['N', 'N.N', 'N.N.N', ...]
+ */
+std::vector<std::string> sort_versions(std::vector<std::string> versions);
+
+/**
+ * @brief Returns the expected error for query 'SELECT $$'.
+ * @param version The 'server_version' for which the error should match.
+ * @return A pair of the shape '{err_code,err_msg}'.
+ */
+std::pair<int,const char*> get_dollar_quote_error(const char* version);
+
 #endif

--- a/include/proxysql_utils.h
+++ b/include/proxysql_utils.h
@@ -212,33 +212,6 @@ std::string generate_multi_rows_query(int rows, int params);
 void close_all_non_term_fd(std::vector<int> excludeFDs);
 
 /**
- * @brief Suggested implementation of 'mismatch_' from ['cppreference'](https://en.cppreference.com/w/cpp/algorithm/mismatch).
- *
- * @param first1 begin of the first range of the elements.
- * @param last1 end of the first range of the elements.
- * @param first2 begin of the second range of the elements.
- * @param last2 end of the second range of the elements.
- * @param p binary predicate which returns `true` if the elements should be treated as equal.
- *
- * @return std::pair with iterators to the first two non-equal elements.
- */
-template<class InputIt1, class InputIt2, class BinaryPredicate>
-std::pair<InputIt1, InputIt2> mismatch_(
-	InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, BinaryPredicate p
-) {
-    while (first1 != last1 && first2 != last2 && p(*first1, *first2)) {
-        ++first1, ++first2;
-    }
-    return std::make_pair(first1, first2);
-}
-
-/**
- * @brief Returns a sorted copy in ascending order of the supplied version numbers.
- * @details Expected version numbers formats are: ['N', 'N.N', 'N.N.N', ...]
- */
-std::vector<std::string> sort_versions(std::vector<std::string> versions);
-
-/**
  * @brief Returns the expected error for query 'SELECT $$'.
  * @param version The 'server_version' for which the error should match.
  * @return A pair of the shape '{err_code,err_msg}'.

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1365,6 +1365,22 @@ bool MySQL_Session::handler_special_queries(PtrSize_t *pkt) {
 		l_free(pkt->size,pkt->ptr);
 		return true;
 	}
+	// MySQL client check command for dollars quote support, starting at version '8.1.0'. See #4300.
+	if ((pkt->size == strlen("SELECT $$") + 5) && strncasecmp("SELECT $$", (char*)pkt->ptr + 5, pkt->size - 5) == 0) {
+		pair<int,const char*> err_info { get_dollar_quote_error(mysql_thread___server_version) };
+
+		client_myds->DSS=STATE_QUERY_SENT_NET;
+		client_myds->myprot.generate_pkt_ERR(true, NULL, NULL, 1, err_info.first, (char *)"HY000", err_info.second, true);
+		client_myds->DSS=STATE_SLEEP;
+		status=WAITING_CLIENT_DATA;
+
+		if (mirror==false) {
+			RequestEnd(NULL);
+		}
+		l_free(pkt->size,pkt->ptr);
+
+		return true;
+	}
 	if (locked_on_hostgroup >= 0 && (strncasecmp((char *)"SET ",(char *)pkt->ptr+5,4)==0)) {
 		// this is a circuit breaker, we will send everything to the backend
 		//

--- a/lib/proxysql_utils.cpp
+++ b/lib/proxysql_utils.cpp
@@ -1,4 +1,5 @@
 #include "proxysql_utils.h"
+#include "mysqld_error.h"
 
 #include <functional>
 #include <sstream>
@@ -428,6 +429,50 @@ void close_all_non_term_fd(std::vector<int> excludeFDs) {
 					close(fd);
 				}
 			}
+		}
+	}
+}
+
+vector<string> sort_versions(vector<string> versions) {
+	std::sort(
+		versions.begin(), versions.end(),
+		[](const string& v1, const string& v2) {
+			const auto result =
+				mismatch_(
+					v1.cbegin(), v1.cend(), v2.cbegin(), v2.cend(),
+					[](const unsigned char lhs, const unsigned char rhs) {
+						return tolower(lhs) == tolower(rhs);
+					}
+				);
+
+			const bool not_equal = result.second != v2.cend();
+			const bool fst_shorter = result.first == v1.cend();
+			const bool fst_lesser = std::tolower(*result.first) < std::tolower(*result.second);
+
+			return not_equal && (fst_shorter || fst_lesser);
+		}
+	);
+
+	return versions;
+}
+
+std::pair<int,const char*> get_dollar_quote_error(const char* version) {
+	const char* ER_PARSE_MSG {
+		"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server"
+			" version for the right syntax to use near '$$' at line 1'"
+	};
+
+	if (strcasecmp(version,"8.1.0") == 0) {
+		return { ER_PARSE_ERROR, ER_PARSE_MSG };
+	} else {
+		const vector<string> sorted { sort_versions({"8.1.0", version}) };
+
+		if (sorted[0] == "8.1.0") {
+			// SQLSTATE: 42000
+			return { ER_PARSE_ERROR, ER_PARSE_MSG };
+		} else {
+			// SQLSTATE: 42S22
+			return { ER_BAD_FIELD_ERROR, "Unknown column '$$' in 'field list'" };
 		}
 	}
 }

--- a/lib/proxysql_utils.cpp
+++ b/lib/proxysql_utils.cpp
@@ -436,7 +436,7 @@ void close_all_non_term_fd(std::vector<int> excludeFDs) {
 std::pair<int,const char*> get_dollar_quote_error(const char* version) {
 	const char* ER_PARSE_MSG {
 		"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server"
-			" version for the right syntax to use near '$$' at line 1'"
+			" version for the right syntax to use near '$$' at line 1"
 	};
 
 	if (strcasecmp(version,"8.1.0") == 0) {

--- a/lib/proxysql_utils.cpp
+++ b/lib/proxysql_utils.cpp
@@ -433,29 +433,6 @@ void close_all_non_term_fd(std::vector<int> excludeFDs) {
 	}
 }
 
-vector<string> sort_versions(vector<string> versions) {
-	std::sort(
-		versions.begin(), versions.end(),
-		[](const string& v1, const string& v2) {
-			const auto result =
-				mismatch_(
-					v1.cbegin(), v1.cend(), v2.cbegin(), v2.cend(),
-					[](const unsigned char lhs, const unsigned char rhs) {
-						return tolower(lhs) == tolower(rhs);
-					}
-				);
-
-			const bool not_equal = result.second != v2.cend();
-			const bool fst_shorter = result.first == v1.cend();
-			const bool fst_lesser = std::tolower(*result.first) < std::tolower(*result.second);
-
-			return not_equal && (fst_shorter || fst_lesser);
-		}
-	);
-
-	return versions;
-}
-
 std::pair<int,const char*> get_dollar_quote_error(const char* version) {
 	const char* ER_PARSE_MSG {
 		"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server"
@@ -465,9 +442,7 @@ std::pair<int,const char*> get_dollar_quote_error(const char* version) {
 	if (strcasecmp(version,"8.1.0") == 0) {
 		return { ER_PARSE_ERROR, ER_PARSE_MSG };
 	} else {
-		const vector<string> sorted { sort_versions({"8.1.0", version}) };
-
-		if (sorted[0] == "8.1.0") {
+		if (strncasecmp(version, "8.1", 3) == 0) {
 			// SQLSTATE: 42000
 			return { ER_PARSE_ERROR, ER_PARSE_MSG };
 		} else {

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -518,4 +518,18 @@ enum SQ3_RES_T {
  */
 sq3_res_t sqlite3_execute_stmt(sqlite3* db, const std::string& query);
 
+/**
+ * @brief If found returns the element index, -1 otherwise.
+ */
+template <typename T>
+int64_t get_elem_idx(const T& e, const std::vector<T>& v) {
+	const auto& it = std::find(v.begin(), v.end(), e);
+
+	if (it == v.end()) {
+		return -1;
+	} else {
+		return it - v.begin();
+	}
+}
+
 #endif // #define UTILS_H

--- a/test/tap/tests/reg_test_4300-dollar_quote_check-t.cpp
+++ b/test/tap/tests/reg_test_4300-dollar_quote_check-t.cpp
@@ -25,7 +25,7 @@
 using std::vector;
 using std::string;
 
-const vector<string> versions { "5.6", "5.7", "8.0", "8.1.0", "8.1", "8.2" };
+const vector<string> versions { "5.6", "5.7", "8.0", "8.1.0", "8.1", "8.1.4" };
 
 int test_supports_dollar_quote(MYSQL* conn, int v_idx, int v8_1_0_idx) {
 	int rc = mysql_query_t(conn, "SELECT $$");

--- a/test/tap/tests/reg_test_4300-dollar_quote_check-t.cpp
+++ b/test/tap/tests/reg_test_4300-dollar_quote_check-t.cpp
@@ -1,0 +1,149 @@
+/**
+ * @file reg_test_4300-dollar_quote_check-t.cpp
+ * @brief Checks that ProxySQL properly handles the query 'SELECT $$'.
+ * @details A check via 'SELECT $$' was introduced by MySQL client in version '8.1.0'. It's used for testing
+ *  whether the server supports multiple '$$' signs or returns a syntax error (deprecated).
+ */
+
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <mysql.h>
+#include <mysql/mysqld_error.h>
+
+#include "tap.h"
+#include "utils.h"
+#include "command_line.h"
+
+using std::vector;
+using std::string;
+
+const vector<string> versions { "5.6", "5.7", "8.0", "8.1.0", "8.1", "8.2" };
+
+int test_supports_dollar_quote(MYSQL* conn, int v_idx, int v8_1_0_idx) {
+	int rc = mysql_query_t(conn, "SELECT $$");
+
+	int exp_code = -1;
+	int act_code = mysql_errno(conn);
+
+	const char* exp_msg = "";
+	const char* act_msg = mysql_error(conn);
+
+	if (v_idx < v8_1_0_idx) {
+		exp_code = ER_BAD_FIELD_ERROR;
+		exp_msg = "Unknown column '$$' in 'field list'";
+	} else {
+		exp_code = ER_PARSE_ERROR;
+		exp_msg = "You have an error in your SQL syntax";
+	}
+
+	bool code_match = exp_code == act_code;
+	bool msg_match = strstr(act_msg, exp_msg) != nullptr;
+
+	ok(
+		rc && code_match && msg_match,
+		"Error code and message should match expected - exp:{%d,'%s'}, act:{%d,'%s'}",
+		exp_code, exp_msg, act_code, act_msg
+	);
+
+	const string rnd_str { random_string(30) };
+	rc = mysql_query_t(conn, ("SELECT '" + rnd_str + "'").c_str());
+	MYSQL_RES* myres = mysql_store_result(conn);
+	MYSQL_ROW myrow = mysql_fetch_row(myres);
+	string rnd_res { myrow[0] };
+	mysql_free_result(myres);
+
+	ok(
+		rc == 0 && rnd_str == rnd_res,
+		"Simple 'SELECT' is correctly executed after intercepted one - exp:'%s', act:'%s'",
+		rnd_str.c_str(), rnd_res.c_str()
+	);
+
+	return EXIT_SUCCESS;
+}
+
+int test_versions_mysql(MYSQL* admin, MYSQL* proxy, const vector<string>& versions) {
+	const int64_t v8_1_0_idx { get_elem_idx(string { "8.1.0" }, versions) };
+	assert(v8_1_0_idx != -1 && "Invalid test payload, no '8.1.0' present in tested versions");
+
+	for (size_t i = 0; i < versions.size(); i++) {
+		const string& v { versions[i] };
+		const string v_minor { v == "8.1.0" ? v : v + "." + std::to_string(rand()) };
+
+		MYSQL_QUERY_T(admin, ("UPDATE global_variables SET variable_value='" + v_minor + "' WHERE variable_name='mysql-server_version'").c_str());
+		MYSQL_QUERY_T(admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+		test_supports_dollar_quote(proxy, i, v8_1_0_idx);
+	}
+
+	return EXIT_SUCCESS;
+}
+
+int test_versions_admin(CommandLine& cl, MYSQL* admin, const vector<string>& versions) {
+	const int64_t v8_1_0_idx { get_elem_idx(string { "8.1.0" }, versions) };
+	assert(v8_1_0_idx != -1 && "Invalid test payload, no '8.1.0' present in tested versions");
+
+
+	for (size_t i = 0; i < versions.size(); i++) {
+		const string& v { versions[i] };
+		const string v_minor { v == "8.1.0" ? v : v + "." + std::to_string(rand()) };
+
+		MYSQL_QUERY_T(admin, ("UPDATE global_variables SET variable_value='" + v_minor + "' WHERE variable_name='mysql-server_version'").c_str());
+		MYSQL_QUERY_T(admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+		MYSQL* new_admin = mysql_init(NULL);
+
+		if (!mysql_real_connect(new_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(new_admin));
+			return EXIT_FAILURE;
+		}
+
+		test_supports_dollar_quote(new_admin, i, v8_1_0_idx);
+
+		mysql_close(new_admin);
+	}
+
+	return EXIT_SUCCESS;
+}
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	plan((versions.size()*2 + 1)*2);
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
+
+	MYSQL* proxy = mysql_init(NULL);
+	MYSQL* admin = mysql_init(NULL);
+
+	if (!mysql_real_connect(proxy, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy));
+		return EXIT_FAILURE;
+	}
+
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return EXIT_FAILURE;
+	}
+
+	int rc = test_versions_mysql(admin, proxy, versions);
+	ok(rc == EXIT_SUCCESS, "Multiple 'mysql-server_version' tested correctly against MySQL interface");
+
+	rc = test_versions_admin(cl, admin, versions);
+	ok(rc == EXIT_SUCCESS, "Multiple 'mysql-server_version' tested correctly against Admin interface");
+
+	mysql_close(proxy);
+	mysql_close(admin);
+
+	return exit_status();
+}


### PR DESCRIPTION
This PR adds support for the MySQL client check command for dollars quote support introduced in `8.1.0`. The query `SELECT $$` is now intercepted and replied with an error depending on the current value of `mysql-server_version` variable.