### PR TITLE
Fix infinite loop for SSL connections - Closes #4314 

### DIFF
--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -667,10 +667,10 @@ int MySQL_Data_Stream::read_from_net() {
 				proxy_debug(PROXY_DEBUG_NET, 5, "Session=%p, Datastream=%p -- SSL_get_error() is SSL_ERROR_SYSCALL, errno: %d\n", sess, this, errno);
 			} else {
 				if (r==0) { // we couldn't read any data
-					if ((revents & POLLIN) || ((revents & POLLIN) && (revents & POLLHUP))) {
+					if (revents & POLLIN) {
 						// If revents is holding either POLLIN, or POLLIN and POLLHUP, but 'recv()' returns 0,
-						// reading no data, the socket has been already closed by the peer. Second part of the
-						// check is obviously redundant, but is left for clarity on the cases being covered.
+						// reading no data, the socket has been already closed by the peer. Due to this we can
+						// ignore POLLHUP in this check, since we should reach here ONLY if POLLIN was set.
 						proxy_debug(PROXY_DEBUG_NET, 5, "Session=%p, Datastream=%p -- shutdown soft\n", sess, this);
 						shut_soft();
 					}

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -240,7 +240,7 @@ std::string tap_curtime();
  *  'ms' in the specified interval.
  * @return 0 if success, -1 in case of error.
  */
-int get_proxysql_cpu_usage(const CommandLine& cl, uint32_t intv, uint32_t& cpu_usage);
+int get_proxysql_cpu_usage(const CommandLine& cl, uint32_t intv, double& cpu_usage);
 
 /**
  * @brief Helper struct holding connection options for helper functions creating MySQL connections.


### PR DESCRIPTION
If a peer closes the socket under certain timing conditions, e.g. during connection establishment, an infinite loop will take place if `POLLHUP` and `POLLIN` are set in the socket, and no data is present, just the final `EOF`.

**Fix details**:

This was due to `read_data_from_net` **only** expecting `POLLIN` flag to be set in `revents`. The scenario were `POLLHUP` and `POLLIN` are both present is now covered by this PR.