### PR TITLE
Several required fixes for the `WebInterfacePlugin`

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -122,7 +122,7 @@ ifeq ($(UNAME_S),FreeBSD)
 	sed -i -e 's/\/bin\/bash/\/usr\/local\/bin\/bash/' libhttpserver/libhttpserver/bootstrap
 endif
 	cd libhttpserver/libhttpserver && ./bootstrap && mkdir build
-	cd libhttpserver/libhttpserver/build && LDFLAGS=-L$(shell pwd)/libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/ CPPFLAGS=-I$(shell pwd)/libmicrohttpd/libmicrohttpd/src/include ../configure --disable-doxygen-doc --disable-doxygen-dot --disable-doxygen-man --disable-doxygen-html --enable-fastopen=false
+	cd libhttpserver/libhttpserver/build && LDFLAGS=-L$(shell pwd)/libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/ CPPFLAGS=-I$(shell pwd)/libmicrohttpd/libmicrohttpd/src/include ../configure --disable-doxygen-doc --disable-doxygen-dot --disable-doxygen-man --disable-doxygen-html --enable-fastopen=false --disable-examples
 	cd libhttpserver/libhttpserver/build && CC=${CC} CXX=${CXX} ${MAKE}
 
 libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -116,6 +116,7 @@ libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmi
 #endif
 	cd libhttpserver/libhttpserver && patch -p1 < ../final_val_post_process.patch
 	cd libhttpserver/libhttpserver && patch -p1 < ../empty_uri_log_crash.patch
+	cd libhttpserver/libhttpserver && patch -p0 < ../expose_raw_url.patch
 	cd libhttpserver/libhttpserver && patch -p0 < ../replace_static_global_strings.patch
 ifeq ($(UNAME_S),FreeBSD)
 	sed -i -e 's/\/bin\/bash/\/usr\/local\/bin\/bash/' libhttpserver/libhttpserver/bootstrap

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -116,6 +116,7 @@ libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmi
 #endif
 	cd libhttpserver/libhttpserver && patch -p1 < ../final_val_post_process.patch
 	cd libhttpserver/libhttpserver && patch -p1 < ../empty_uri_log_crash.patch
+	cd libhttpserver/libhttpserver && patch -p0 < ../replace_static_global_strings.patch
 ifeq ($(UNAME_S),FreeBSD)
 	sed -i -e 's/\/bin\/bash/\/usr\/local\/bin\/bash/' libhttpserver/libhttpserver/bootstrap
 endif

--- a/deps/libhttpserver/expose_raw_url.patch
+++ b/deps/libhttpserver/expose_raw_url.patch
@@ -1,0 +1,109 @@
+diff --git src/httpserver/details/modded_request.hpp src/httpserver/details/modded_request.hpp
+index 1ebe5b1..32d4154 100644
+--- src/httpserver/details/modded_request.hpp
++++ src/httpserver/details/modded_request.hpp
+@@ -38,6 +38,7 @@ struct modded_request
+     struct MHD_PostProcessor *pp = 0x0;
+     std::string* complete_uri = 0x0;
+     std::string* standardized_url = 0x0;
++    std::string* url = 0x0;
+     webserver* ws = 0x0;
+ 
+     const std::shared_ptr<http_response> (httpserver::http_resource::*callback)(const httpserver::http_request&);
+@@ -65,6 +66,9 @@ struct modded_request
+             delete dhr; //TODO: verify. It could be an error
+         delete complete_uri;
+         delete standardized_url;
++		if (url) {
++			delete url;
++		}
+     }
+ 
+ };
+diff --git src/httpserver/http_request.hpp src/httpserver/http_request.hpp
+index 0b83fa2..419585d 100644
+--- src/httpserver/http_request.hpp
++++ src/httpserver/http_request.hpp
+@@ -77,6 +77,15 @@ class http_request
+             return path;
+         }
+ 
++        /**
++         * Method used to get the path requested
++         * @return string representing the path requested.
++        **/
++        const std::string& get_url() const
++        {
++            return url;
++        }
++
+         /**
+          * Method used to get all pieces of the path requested; considering an url splitted by '/'.
+          * @return a vector of strings containing all pieces
+@@ -86,6 +95,22 @@ class http_request
+             return http::http_utils::tokenize_url(path);
+         }
+ 
++        /**
++         * Method used to get all pieces of the path requested; considering an url splitted by '/'.
++         * @return a vector of strings containing all pieces
++        **/
++        const std::vector<std::string> get_url_pieces() const
++        {
++            const std::vector<std::string> url_pieces { http::http_utils::tokenize_url(url) };
++            std::vector<std::string> dec_pieces { url_pieces };
++
++            for (std::string& p : dec_pieces) {
++                http::base_unescaper(p, nullptr);
++            }
++
++            return dec_pieces;
++        }
++
+         /**
+          * Method used to obtain a specified piece of the path; considering an url splitted by '/'.
+          * @param index the index of the piece selected
+@@ -233,6 +258,7 @@ class http_request
+         http_request& operator=(http_request&& b) = default;
+ 
+         std::string path;
++        std::string url;
+         std::string method;
+         std::map<std::string, std::string, http::arg_comparator> args;
+         std::string content = "";
+@@ -317,6 +343,15 @@ class http_request
+             this->path = path;
+         }
+ 
++        /**
++         * Sets the raw (unescaped) URL path. Used for 'get_pieces()'
++         * @param url The path searched by the request
++        **/
++        void set_url(const std::string& url)
++        {
++            this->url = url;
++        }
++
+         /**
+          * Method used to set the request METHOD
+          * @param method The method to set for the request
+diff --git src/webserver.cpp src/webserver.cpp
+index e7dd335..96e53b5 100644
+--- src/webserver.cpp
++++ src/webserver.cpp
+@@ -750,6 +750,7 @@ MHD_Result webserver::complete_request(
+     mr->ws = this;
+ 
+     mr->dhr->set_path(mr->standardized_url->c_str());
++    mr->dhr->set_url(mr->url->c_str());
+     mr->dhr->set_method(method);
+     mr->dhr->set_version(version);
+ 
+@@ -793,6 +794,7 @@ MHD_Result webserver::answer_to_connection(void* cls, MHD_Connection* connection
+ 
+     base_unescaper(t_url, static_cast<webserver*>(cls)->unescaper);
+     mr->standardized_url = new string(http_utils::standardize_url(t_url));
++    mr->url = new string(url);
+ 
+     mr->has_body = false;
+ 

--- a/deps/libhttpserver/replace_static_global_strings.patch
+++ b/deps/libhttpserver/replace_static_global_strings.patch
@@ -1,0 +1,390 @@
+diff --git src/http_utils.cpp src/http_utils.cpp
+index caefabc..fed5d9e 100644
+--- src/http_utils.cpp
++++ src/http_utils.cpp
+@@ -137,98 +137,98 @@ const int http_utils::http_not_extended = MHD_HTTP_NOT_EXTENDED;
+ 
+ const int http_utils::shoutcast_response = MHD_ICY_FLAG;
+ 
+-const std::string http_utils::http_header_accept = MHD_HTTP_HEADER_ACCEPT;
+-const std::string http_utils::http_header_accept_charset =
++const char* http_utils::http_header_accept = MHD_HTTP_HEADER_ACCEPT;
++const char* http_utils::http_header_accept_charset =
+     MHD_HTTP_HEADER_ACCEPT_CHARSET;
+-const std::string http_utils::http_header_accept_encoding =
++const char* http_utils::http_header_accept_encoding =
+     MHD_HTTP_HEADER_ACCEPT_ENCODING;
+-const std::string http_utils::http_header_accept_language =
++const char* http_utils::http_header_accept_language =
+     MHD_HTTP_HEADER_ACCEPT_LANGUAGE;
+-const std::string http_utils::http_header_accept_ranges =
++const char* http_utils::http_header_accept_ranges =
+     MHD_HTTP_HEADER_ACCEPT_RANGES;
+-const std::string http_utils::http_header_age = MHD_HTTP_HEADER_AGE;
+-const std::string http_utils::http_header_allow = MHD_HTTP_HEADER_ALLOW;
+-const std::string http_utils::http_header_authorization =
++const char* http_utils::http_header_age = MHD_HTTP_HEADER_AGE;
++const char* http_utils::http_header_allow = MHD_HTTP_HEADER_ALLOW;
++const char* http_utils::http_header_authorization =
+     MHD_HTTP_HEADER_AUTHORIZATION;
+-const std::string http_utils::http_header_cache_control =
++const char* http_utils::http_header_cache_control =
+     MHD_HTTP_HEADER_CACHE_CONTROL;
+-const std::string http_utils::http_header_connection =
++const char* http_utils::http_header_connection =
+     MHD_HTTP_HEADER_CONNECTION;
+-const std::string http_utils::http_header_content_encoding =
++const char* http_utils::http_header_content_encoding =
+     MHD_HTTP_HEADER_CONTENT_ENCODING;
+-const std::string http_utils::http_header_content_language =
++const char* http_utils::http_header_content_language =
+     MHD_HTTP_HEADER_CONTENT_LANGUAGE;
+-const std::string http_utils::http_header_content_length =
++const char* http_utils::http_header_content_length =
+     MHD_HTTP_HEADER_CONTENT_LENGTH;
+-const std::string http_utils::http_header_content_location =
++const char* http_utils::http_header_content_location =
+     MHD_HTTP_HEADER_CONTENT_LOCATION;
+-const std::string http_utils::http_header_content_md5 =
++const char* http_utils::http_header_content_md5 =
+     MHD_HTTP_HEADER_CONTENT_MD5;
+-const std::string http_utils::http_header_content_range =
++const char* http_utils::http_header_content_range =
+     MHD_HTTP_HEADER_CONTENT_RANGE;
+-const std::string http_utils::http_header_content_type =
++const char* http_utils::http_header_content_type =
+     MHD_HTTP_HEADER_CONTENT_TYPE;
+-const std::string http_utils::http_header_date = MHD_HTTP_HEADER_DATE;
+-const std::string http_utils::http_header_etag = MHD_HTTP_HEADER_ETAG;
+-const std::string http_utils::http_header_expect = MHD_HTTP_HEADER_EXPECT;
+-const std::string http_utils::http_header_expires = MHD_HTTP_HEADER_EXPIRES;
+-const std::string http_utils::http_header_from = MHD_HTTP_HEADER_FROM;
+-const std::string http_utils::http_header_host = MHD_HTTP_HEADER_HOST;
+-const std::string http_utils::http_header_if_match = MHD_HTTP_HEADER_IF_MATCH;
+-const std::string http_utils::http_header_if_modified_since =
++const char* http_utils::http_header_date = MHD_HTTP_HEADER_DATE;
++const char* http_utils::http_header_etag = MHD_HTTP_HEADER_ETAG;
++const char* http_utils::http_header_expect = MHD_HTTP_HEADER_EXPECT;
++const char* http_utils::http_header_expires = MHD_HTTP_HEADER_EXPIRES;
++const char* http_utils::http_header_from = MHD_HTTP_HEADER_FROM;
++const char* http_utils::http_header_host = MHD_HTTP_HEADER_HOST;
++const char* http_utils::http_header_if_match = MHD_HTTP_HEADER_IF_MATCH;
++const char* http_utils::http_header_if_modified_since =
+     MHD_HTTP_HEADER_IF_MODIFIED_SINCE;
+-const std::string http_utils::http_header_if_none_match =
++const char* http_utils::http_header_if_none_match =
+     MHD_HTTP_HEADER_IF_NONE_MATCH;
+-const std::string http_utils::http_header_if_range = MHD_HTTP_HEADER_IF_RANGE;
+-const std::string http_utils::http_header_if_unmodified_since =
++const char* http_utils::http_header_if_range = MHD_HTTP_HEADER_IF_RANGE;
++const char* http_utils::http_header_if_unmodified_since =
+     MHD_HTTP_HEADER_IF_UNMODIFIED_SINCE;
+-const std::string http_utils::http_header_last_modified =
++const char* http_utils::http_header_last_modified =
+     MHD_HTTP_HEADER_LAST_MODIFIED;
+-const std::string http_utils::http_header_location = MHD_HTTP_HEADER_LOCATION;
+-const std::string http_utils::http_header_max_forwards =
++const char* http_utils::http_header_location = MHD_HTTP_HEADER_LOCATION;
++const char* http_utils::http_header_max_forwards =
+     MHD_HTTP_HEADER_MAX_FORWARDS;
+-const std::string http_utils::http_header_pragma = MHD_HTTP_HEADER_PRAGMA;
+-const std::string http_utils::http_header_proxy_authenticate =
++const char* http_utils::http_header_pragma = MHD_HTTP_HEADER_PRAGMA;
++const char* http_utils::http_header_proxy_authenticate =
+     MHD_HTTP_HEADER_PROXY_AUTHENTICATE;
+-const std::string http_utils::http_header_proxy_authentication =
++const char* http_utils::http_header_proxy_authentication =
+     MHD_HTTP_HEADER_PROXY_AUTHORIZATION;
+-const std::string http_utils::http_header_range = MHD_HTTP_HEADER_RANGE;
+-const std::string http_utils::http_header_referer = MHD_HTTP_HEADER_REFERER;
+-const std::string http_utils::http_header_retry_after =
++const char* http_utils::http_header_range = MHD_HTTP_HEADER_RANGE;
++const char* http_utils::http_header_referer = MHD_HTTP_HEADER_REFERER;
++const char* http_utils::http_header_retry_after =
+     MHD_HTTP_HEADER_RETRY_AFTER;
+-const std::string http_utils::http_header_server = MHD_HTTP_HEADER_SERVER;
+-const std::string http_utils::http_header_te = MHD_HTTP_HEADER_TE;
+-const std::string http_utils::http_header_trailer = MHD_HTTP_HEADER_TRAILER;
+-const std::string http_utils::http_header_transfer_encoding =
++const char* http_utils::http_header_server = MHD_HTTP_HEADER_SERVER;
++const char* http_utils::http_header_te = MHD_HTTP_HEADER_TE;
++const char* http_utils::http_header_trailer = MHD_HTTP_HEADER_TRAILER;
++const char* http_utils::http_header_transfer_encoding =
+     MHD_HTTP_HEADER_TRANSFER_ENCODING;
+-const std::string http_utils::http_header_upgrade = MHD_HTTP_HEADER_UPGRADE;
+-const std::string http_utils::http_header_user_agent =
++const char* http_utils::http_header_upgrade = MHD_HTTP_HEADER_UPGRADE;
++const char* http_utils::http_header_user_agent =
+     MHD_HTTP_HEADER_USER_AGENT;
+-const std::string http_utils::http_header_vary = MHD_HTTP_HEADER_VARY;
+-const std::string http_utils::http_header_via = MHD_HTTP_HEADER_VIA;
+-const std::string http_utils::http_header_warning = MHD_HTTP_HEADER_WARNING;
+-const std::string http_utils::http_header_www_authenticate =
++const char* http_utils::http_header_vary = MHD_HTTP_HEADER_VARY;
++const char* http_utils::http_header_via = MHD_HTTP_HEADER_VIA;
++const char* http_utils::http_header_warning = MHD_HTTP_HEADER_WARNING;
++const char* http_utils::http_header_www_authenticate =
+     MHD_HTTP_HEADER_WWW_AUTHENTICATE;
+ 
+-const std::string http_utils::http_version_1_0 = MHD_HTTP_VERSION_1_0;
+-const std::string http_utils::http_version_1_1 = MHD_HTTP_VERSION_1_1;
++const char* http_utils::http_version_1_0 = MHD_HTTP_VERSION_1_0;
++const char* http_utils::http_version_1_1 = MHD_HTTP_VERSION_1_1;
+ 
+-const std::string http_utils::http_method_connect = MHD_HTTP_METHOD_CONNECT;
+-const std::string http_utils::http_method_delete = MHD_HTTP_METHOD_DELETE;
+-const std::string http_utils::http_method_get = MHD_HTTP_METHOD_GET;
+-const std::string http_utils::http_method_head = MHD_HTTP_METHOD_HEAD;
+-const std::string http_utils::http_method_options = MHD_HTTP_METHOD_OPTIONS;
+-const std::string http_utils::http_method_post = MHD_HTTP_METHOD_POST;
+-const std::string http_utils::http_method_put = MHD_HTTP_METHOD_PUT;
+-const std::string http_utils::http_method_trace = MHD_HTTP_METHOD_TRACE;
+-const std::string http_utils::http_method_patch = MHD_HTTP_METHOD_PATCH;
++const char* http_utils::http_method_connect = MHD_HTTP_METHOD_CONNECT;
++const char* http_utils::http_method_delete = MHD_HTTP_METHOD_DELETE;
++const char* http_utils::http_method_get = MHD_HTTP_METHOD_GET;
++const char* http_utils::http_method_head = MHD_HTTP_METHOD_HEAD;
++const char* http_utils::http_method_options = MHD_HTTP_METHOD_OPTIONS;
++const char* http_utils::http_method_post = MHD_HTTP_METHOD_POST;
++const char* http_utils::http_method_put = MHD_HTTP_METHOD_PUT;
++const char* http_utils::http_method_trace = MHD_HTTP_METHOD_TRACE;
++const char* http_utils::http_method_patch = MHD_HTTP_METHOD_PATCH;
+ 
+-const std::string http_utils::http_post_encoding_form_urlencoded =
++const char* http_utils::http_post_encoding_form_urlencoded =
+     MHD_HTTP_POST_ENCODING_FORM_URLENCODED;
+-const std::string http_utils::http_post_encoding_multipart_formdata =
++const char* http_utils::http_post_encoding_multipart_formdata =
+     MHD_HTTP_POST_ENCODING_MULTIPART_FORMDATA;
+ 
+-const std::string http_utils::text_plain = "text/plain";
++const char* http_utils::text_plain = "text/plain";
+ 
+ std::vector<std::string> http_utils::tokenize_url(
+         const std::string& str,
+diff --git src/httpserver/http_utils.hpp src/httpserver/http_utils.hpp
+index e2aa033..5059e06 100644
+--- src/httpserver/http_utils.hpp
++++ src/httpserver/http_utils.hpp
+@@ -189,71 +189,71 @@ class http_utils
+     static const int shoutcast_response;
+ 
+     /* See also: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html */
+-    static const std::string http_header_accept;
+-    static const std::string http_header_accept_charset;
+-    static const std::string http_header_accept_encoding;
+-    static const std::string http_header_accept_language;
+-    static const std::string http_header_accept_ranges;
+-    static const std::string http_header_age;
+-    static const std::string http_header_allow;
+-    static const std::string http_header_authorization;
+-    static const std::string http_header_cache_control;
+-    static const std::string http_header_connection;
+-    static const std::string http_header_content_encoding;
+-    static const std::string http_header_content_language;
+-    static const std::string http_header_content_length;
+-    static const std::string http_header_content_location;
+-    static const std::string http_header_content_md5;
+-    static const std::string http_header_content_range;
+-    static const std::string http_header_content_type;
+-    static const std::string http_header_date;
+-    static const std::string http_header_etag;
+-    static const std::string http_header_expect;
+-    static const std::string http_header_expires;
+-    static const std::string http_header_from;
+-    static const std::string http_header_host;
+-    static const std::string http_header_if_match;
+-    static const std::string http_header_if_modified_since;
+-    static const std::string http_header_if_none_match;
+-    static const std::string http_header_if_range;
+-    static const std::string http_header_if_unmodified_since;
+-    static const std::string http_header_last_modified;
+-    static const std::string http_header_location;
+-    static const std::string http_header_max_forwards;
+-    static const std::string http_header_pragma;
+-    static const std::string http_header_proxy_authenticate;
+-    static const std::string http_header_proxy_authentication;
+-    static const std::string http_header_range;
+-    static const std::string http_header_referer;
+-    static const std::string http_header_retry_after;
+-    static const std::string http_header_server;
+-    static const std::string http_header_te;
+-    static const std::string http_header_trailer;
+-    static const std::string http_header_transfer_encoding;
+-    static const std::string http_header_upgrade;
+-    static const std::string http_header_user_agent;
+-    static const std::string http_header_vary;
+-    static const std::string http_header_via;
+-    static const std::string http_header_warning;
+-    static const std::string http_header_www_authenticate;
+-
+-    static const std::string http_version_1_0;
+-    static const std::string http_version_1_1;
+-
+-    static const std::string http_method_connect;
+-    static const std::string http_method_delete;
+-    static const std::string http_method_head;
+-    static const std::string http_method_get;
+-    static const std::string http_method_options;
+-    static const std::string http_method_post;
+-    static const std::string http_method_put;
+-    static const std::string http_method_trace;
+-    static const std::string http_method_patch;
+-
+-    static const std::string http_post_encoding_form_urlencoded;
+-    static const std::string http_post_encoding_multipart_formdata;
+-
+-    static const std::string text_plain;
++    static const char* http_header_accept;
++    static const char* http_header_accept_charset;
++    static const char* http_header_accept_encoding;
++    static const char* http_header_accept_language;
++    static const char* http_header_accept_ranges;
++    static const char* http_header_age;
++    static const char* http_header_allow;
++    static const char* http_header_authorization;
++    static const char* http_header_cache_control;
++    static const char* http_header_connection;
++    static const char* http_header_content_encoding;
++    static const char* http_header_content_language;
++    static const char* http_header_content_length;
++    static const char* http_header_content_location;
++    static const char* http_header_content_md5;
++    static const char* http_header_content_range;
++    static const char* http_header_content_type;
++    static const char* http_header_date;
++    static const char* http_header_etag;
++    static const char* http_header_expect;
++    static const char* http_header_expires;
++    static const char* http_header_from;
++    static const char* http_header_host;
++    static const char* http_header_if_match;
++    static const char* http_header_if_modified_since;
++    static const char* http_header_if_none_match;
++    static const char* http_header_if_range;
++    static const char* http_header_if_unmodified_since;
++    static const char* http_header_last_modified;
++    static const char* http_header_location;
++    static const char* http_header_max_forwards;
++    static const char* http_header_pragma;
++    static const char* http_header_proxy_authenticate;
++    static const char* http_header_proxy_authentication;
++    static const char* http_header_range;
++    static const char* http_header_referer;
++    static const char* http_header_retry_after;
++    static const char* http_header_server;
++    static const char* http_header_te;
++    static const char* http_header_trailer;
++    static const char* http_header_transfer_encoding;
++    static const char* http_header_upgrade;
++    static const char* http_header_user_agent;
++    static const char* http_header_vary;
++    static const char* http_header_via;
++    static const char* http_header_warning;
++    static const char* http_header_www_authenticate;
++
++    static const char* http_version_1_0;
++    static const char* http_version_1_1;
++
++    static const char* http_method_connect;
++    static const char* http_method_delete;
++    static const char* http_method_head;
++    static const char* http_method_get;
++    static const char* http_method_options;
++    static const char* http_method_post;
++    static const char* http_method_put;
++    static const char* http_method_trace;
++    static const char* http_method_patch;
++
++    static const char* http_post_encoding_form_urlencoded;
++    static const char* http_post_encoding_multipart_formdata;
++
++    static const char* text_plain;
+ 
+     static std::vector<std::string> tokenize_url(const std::string&,
+         const char separator = '/'
+diff --git src/webserver.cpp src/webserver.cpp
+index 96e53b5..a7be951 100644
+--- src/webserver.cpp
++++ src/webserver.cpp
+@@ -537,22 +537,22 @@ MHD_Result webserver::requests_answer_first_step(
+     const char *encoding = MHD_lookup_connection_value (
+             connection,
+             MHD_HEADER_KIND,
+-            http_utils::http_header_content_type.c_str()
++            http_utils::http_header_content_type
+     );
+ 
+     if ( post_process_enabled &&
+         (
+             0x0 != encoding &&
+             ((0 == strncasecmp (
+-                                http_utils::http_post_encoding_form_urlencoded.c_str(),
++                                http_utils::http_post_encoding_form_urlencoded,
+                                 encoding,
+-                                http_utils::http_post_encoding_form_urlencoded.size()
++                                strlen(http_utils::http_post_encoding_form_urlencoded)
+                                 )
+               )
+              || (0 == strncasecmp (
+-                                   http_utils::http_post_encoding_multipart_formdata.c_str(),
++                                   http_utils::http_post_encoding_multipart_formdata,
+                                    encoding,
+-                                   http_utils::http_post_encoding_multipart_formdata.size()
++                                   strlen(http_utils::http_post_encoding_multipart_formdata)
+                                    )))
+         )
+     )
+@@ -803,43 +803,43 @@ MHD_Result webserver::answer_to_connection(void* cls, MHD_Connection* connection
+             *(mr->complete_uri) + " METHOD: " + method
+     );
+ 
+-    if( 0 == strcasecmp(method, http_utils::http_method_get.c_str()))
++    if( 0 == strcasecmp(method, http_utils::http_method_get))
+     {
+         mr->callback = &http_resource::render_GET;
+     }
+-    else if (0 == strcmp(method, http_utils::http_method_post.c_str()))
++    else if (0 == strcmp(method, http_utils::http_method_post))
+     {
+         mr->callback = &http_resource::render_POST;
+         mr->has_body = true;
+     }
+-    else if (0 == strcasecmp(method, http_utils::http_method_put.c_str()))
++    else if (0 == strcasecmp(method, http_utils::http_method_put))
+     {
+         mr->callback = &http_resource::render_PUT;
+         mr->has_body = true;
+     }
+-    else if (0 == strcasecmp(method,http_utils::http_method_delete.c_str()))
++    else if (0 == strcasecmp(method,http_utils::http_method_delete))
+     {
+         mr->callback = &http_resource::render_DELETE;
+         mr->has_body = true;
+     }
+-    else if (0 == strcasecmp(method, http_utils::http_method_patch.c_str()))
++    else if (0 == strcasecmp(method, http_utils::http_method_patch))
+     {
+         mr->callback = &http_resource::render_PATCH;
+         mr->has_body = true;
+     }
+-    else if (0 == strcasecmp(method, http_utils::http_method_head.c_str()))
++    else if (0 == strcasecmp(method, http_utils::http_method_head))
+     {
+         mr->callback = &http_resource::render_HEAD;
+     }
+-    else if (0 ==strcasecmp(method,http_utils::http_method_connect.c_str()))
++    else if (0 ==strcasecmp(method,http_utils::http_method_connect))
+     {
+         mr->callback = &http_resource::render_CONNECT;
+     }
+-    else if (0 == strcasecmp(method, http_utils::http_method_trace.c_str()))
++    else if (0 == strcasecmp(method, http_utils::http_method_trace))
+     {
+         mr->callback = &http_resource::render_TRACE;
+     }
+-    else if (0 ==strcasecmp(method,http_utils::http_method_options.c_str()))
++    else if (0 ==strcasecmp(method,http_utils::http_method_options))
+     {
+         mr->callback = &http_resource::render_OPTIONS;
+     }

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -736,7 +736,12 @@ int MySQL_Data_Stream::write_to_net() {
 					memmove(ssl_write_buf, ssl_write_buf+n, ssl_write_len-n);
 				}
 				ssl_write_len -= n;
-    			ssl_write_buf = (char*)realloc(ssl_write_buf, ssl_write_len);
+				if (ssl_write_len) {
+					ssl_write_buf = (char*)realloc(ssl_write_buf, ssl_write_len);
+				} else {
+					free(ssl_write_buf);
+					ssl_write_buf = NULL;
+				}
 				//proxy_info("new ssl_write_len: %u\n", ssl_write_len);
 				//if (ssl_write_len) {
     			//	return n; // stop here
@@ -887,7 +892,12 @@ int MySQL_Data_Stream::write_to_net_poll() {
 					memmove(ssl_write_buf, ssl_write_buf+n, ssl_write_len-n);
 				}
 				ssl_write_len -= n;
-    			ssl_write_buf = (char*)realloc(ssl_write_buf, ssl_write_len);
+				if (ssl_write_len) {
+					ssl_write_buf = (char*)realloc(ssl_write_buf, ssl_write_len);
+				} else {
+					free(ssl_write_buf);
+					ssl_write_buf = NULL;
+				}
 				//proxy_info("new ssl_write_len: %u\n", ssl_write_len);
 				if (ssl_write_len) {
     				return n; // stop here

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -959,6 +959,8 @@ static void LoadPlugins() {
 			if (GloWebInterface) {
 				//GloAdmin->init_WebInterfacePlugin();
 				//GloAdmin->load_ldap_variables_to_runtime();
+			} else {
+				proxy_error("Failed to load 'Web_Interface' plugin\n");
 			}
 		}
 	}
@@ -985,6 +987,11 @@ static void LoadPlugins() {
 			exit(EXIT_FAILURE);
 		} else {
 			GloMyLdapAuth = create_MySQL_LDAP_Authentication();
+
+			if (!GloMyLdapAuth) {
+				proxy_error("Failed to load 'MySQL_LDAP_Authentication' plugin\n");
+			}
+
 			// we are removing this from here, and copying in
 			//     ProxySQL_Main_init_phase2___not_started
 			// the keep record of these two lines to make sure we don't


### PR DESCRIPTION
Several minor fixes to ProxySQL itself, and some required changes to `libhttpserver` dependency, a brief summary:

- Fix ProxySQL running under Valgrind again. Right now execution is aborted due to a zero length realloc.
- Fix invalid tokenization of URLs by `libhttpserver` when URL contains characters that are required to be escaped.
- Fix double-free during plugin de-initialization due to `static global` variables on `libhttpserver`.