### PR TITLE
Input validation for mysql-server_capabilities

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1879,8 +1879,12 @@ bool MySQL_Threads_Handler::set_variable(char *name, const char *value) {	// thi
 		}
 	}
 	if (!strcasecmp(name,"server_capabilities")) {
-		int intv=atoi(value);
-		if (intv > 10 && intv <= 65535) {
+		// replaced atoi() with strtoul() to have a 32 bit result
+		uint32_t intv = strtoul(value, NULL, 10);
+		if (intv > 10) {
+			// Note that:
+			// - some capabilities are changed at runtime while performing the handshake with the client
+			// - even if we support 32 bits capabilities, many of them do not have any real meaning for proxysql (not supported)
 			variables.server_capabilities=intv;
 			return true;
 		} else {


### PR DESCRIPTION
Input validation on mysql-server_capabilities assumed that it was 16 bits (for historical reasons). This has now improved and supports up to 32 bits.

Notes:
- some capabilities are changed at runtime while performing the handshake with the client
- even if we support 32 bits capabilities, many of them do not have any real meaning for proxysql (not supported)

Closes #2091