### PR TITLE
V2.6.0 fix package licensing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,8 +341,9 @@ build-%:
 
 .NOTPARALLEL: binaries/proxysql%
 binaries/proxysql%:
-	@docker-compose -p $(IMG_NAME) down -v --remove-orphans
-	@docker-compose -p $(IMG_NAME) up $(IMG_NAME)$(IMG_TYPE)$(IMG_COMP)_build
+	@docker-compose -p proxysql down -v --remove-orphans
+	@docker-compose -p proxysql up $(IMG_NAME)$(IMG_TYPE)$(IMG_COMP)_build
+	@docker-compose -p proxysql down -v --remove-orphans
 
 
 ### clean targets

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ amd64-ubuntu: ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-clan
 
 arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux
 arm64-almalinux: almalinux8 almalinux9
-arm64-centos: centos7 centos8
+arm64-centos: centos7 centos8 centos9
 arm64-debian: debian10 debian11 debian12
 arm64-fedora: fedora38 fedora39
 arm64-opensuse: opensuse15

--- a/docker/images/proxysql/deb-compliant/ctl/copyright
+++ b/docker/images/proxysql/deb-compliant/ctl/copyright
@@ -3,4 +3,4 @@ Upstream-Name: proxysql
 Upstream-Contact: ProxySQL LLC <info@proxysql.com>
 Source: https://github.com/sysown/proxysql
 Copyright: 2013-PKG_YEAR ProxySQL LLC
-License: GPL-3.0-only
+License: GPL-3

--- a/docker/images/proxysql/deb-compliant/ctl/copyright
+++ b/docker/images/proxysql/deb-compliant/ctl/copyright
@@ -1,0 +1,6 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: proxysql
+Upstream-Contact: ProxySQL LLC <info@proxysql.com>
+Source: https://github.com/sysown/proxysql
+Copyright: 2013-PKG_YEAR ProxySQL LLC
+License: GPL-3.0-only

--- a/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/ctl/proxysql.ctl
@@ -1,4 +1,4 @@
-Section: misc
+Section: database
 Priority: optional
 Homepage: https://proxysql.com
 Standards-Version: 3.9.2
@@ -6,6 +6,7 @@ Standards-Version: 3.9.2
 Package: proxysql
 Version: PKG_VERSION_CURVER
 Maintainer: ProxySQL LLC <info@proxysql.com>
+Copyright: copyright
 Architecture: PKG_ARCH
 Depends: libgnutls28 | libgnutls-deb0-28 | libgnutls30
 # Changelog: CHANGELOG.md

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -51,8 +51,10 @@ echo "==> Packaging"
 mkdir -p /opt/proxysql/pkgroot/tmp || true
 pushd /opt/proxysql/pkgroot
 cp /root/ctl/proxysql.ctl ./proxysql.ctl
+cp /root/ctl/copyright ./copyright
 sed -i "s/PKG_VERSION_CURVER/${CURVER}/g" ./proxysql.ctl
 sed -i "s/PKG_ARCH/${ARCH}/g" ./proxysql.ctl
+sed -i "s/PKG_YEAR/$(date +%Y)/g" ./copyright
 cp ../src/proxysql ./
 cp -r ../etc ./etc
 cp -r ../tools ./tools

--- a/docker/images/proxysql/deb-compliant/latest-package/ctl/copyright
+++ b/docker/images/proxysql/deb-compliant/latest-package/ctl/copyright
@@ -3,4 +3,4 @@ Upstream-Name: proxysql
 Upstream-Contact: ProxySQL LLC <info@proxysql.com>
 Source: https://github.com/sysown/proxysql
 Copyright: 2013-PKG_YEAR ProxySQL LLC
-License: GPL-3.0-only
+License: GPL-3

--- a/docker/images/proxysql/deb-compliant/latest-package/ctl/copyright
+++ b/docker/images/proxysql/deb-compliant/latest-package/ctl/copyright
@@ -1,0 +1,6 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: proxysql
+Upstream-Contact: ProxySQL LLC <info@proxysql.com>
+Source: https://github.com/sysown/proxysql
+Copyright: 2013-PKG_YEAR ProxySQL LLC
+License: GPL-3.0-only

--- a/docker/images/proxysql/deb-compliant/latest-package/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/latest-package/ctl/proxysql.ctl
@@ -1,4 +1,4 @@
-Section: misc
+Section: database
 Priority: optional
 Homepage: https://proxysql.com
 Standards-Version: 3.9.2
@@ -6,6 +6,7 @@ Standards-Version: 3.9.2
 Package: proxysql
 Version: PKG_VERSION_CURVER
 Maintainer: ProxySQL LLC <info@proxysql.com>
+Copyright: copyright
 Architecture: PKG_ARCH
 Depends: libgnutls28 | libgnutls30
 # Changelog: CHANGELOG.md

--- a/docker/images/proxysql/deb-compliant/pre-systemd/ctl/copyright
+++ b/docker/images/proxysql/deb-compliant/pre-systemd/ctl/copyright
@@ -3,4 +3,4 @@ Upstream-Name: proxysql
 Upstream-Contact: ProxySQL LLC <info@proxysql.com>
 Source: https://github.com/sysown/proxysql
 Copyright: 2013-PKG_YEAR ProxySQL LLC
-License: GPL-3.0-only
+License: GPL-3

--- a/docker/images/proxysql/deb-compliant/pre-systemd/ctl/copyright
+++ b/docker/images/proxysql/deb-compliant/pre-systemd/ctl/copyright
@@ -1,0 +1,6 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: proxysql
+Upstream-Contact: ProxySQL LLC <info@proxysql.com>
+Source: https://github.com/sysown/proxysql
+Copyright: 2013-PKG_YEAR ProxySQL LLC
+License: GPL-3.0-only

--- a/docker/images/proxysql/deb-compliant/pre-systemd/ctl/proxysql.ctl
+++ b/docker/images/proxysql/deb-compliant/pre-systemd/ctl/proxysql.ctl
@@ -1,4 +1,4 @@
-Section: misc
+Section: database
 Priority: optional
 Homepage: https://proxysql.com
 Standards-Version: 3.9.2
@@ -6,6 +6,7 @@ Standards-Version: 3.9.2
 Package: proxysql
 Version: PKG_VERSION_CURVER
 Maintainer: ProxySQL LLC <info@proxysql.com>
+Copyright: copyright
 Architecture: PKG_ARCH
 Depends: libgnutls28 | libgnutls30 | libgnutls-deb0-28
 # Changelog: CHANGELOG.md

--- a/docker/images/proxysql/rhel-compliant/rhel6/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/rhel-compliant/rhel6/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -9,10 +9,9 @@ Summary: A high-performance MySQL proxy
 Name: proxysql
 Version: %{version}
 Release: 1
-License: GPL+
-Group: Development/Tools
-SOURCE0 : %{name}-%{version}.tar.gz
-URL: http://www.proxysql.com/
+License: GPL-3.0-only
+Source: %{name}-%{version}.tar.gz
+URL: https://www.proxysql.com/
 Requires: gnutls
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 

--- a/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -6,9 +6,8 @@ Summary: A high-performance MySQL proxy
 Name: proxysql
 Version: %{version}
 Release: 1
-License: GPL+
-Group: Development/Tools
-SOURCE0 : %{name}-%{version}.tar.gz
+License: GPL-3.0-only
+Source: %{name}-%{version}.tar.gz
 URL: https://proxysql.com/
 Requires: gnutls
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root

--- a/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -6,9 +6,8 @@ Summary: A high-performance MySQL proxy
 Name: proxysql
 Version: %{version}
 Release: 1
-License: GPL+
-Group: Development/Tools
-SOURCE0 : %{name}-%{version}.tar.gz
+License: GPL-3.0-only
+Source: %{name}-%{version}.tar.gz
 URL: https://proxysql.com/
 Requires: gnutls
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root


### PR DESCRIPTION
fix missing/incorrect licensing info embedded in packages
use `GPL-3.0-only` SPDX short identifier for rpm
https://spdx.org/licenses/GPL-3.0-only.html
use `GPL-3` DEP5 identifier for deb
https://wiki.debian.org/Proposals/CopyrightFormat