### PR TITLE
V2.6.0 fix test ssl pollout

### DIFF
--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -1713,3 +1713,53 @@ void check_query_count(MYSQL* admin, vector<uint32_t> queries, uint32_t hg) {
 		dump_conn_stats(admin, { hg });
 	}
 };
+
+const char* get_env_str(const char* envname, const char* envdefault) {
+
+	const char* envval = std::getenv(envname);
+
+	if (envval != NULL)
+		return envval;
+
+	return envdefault;
+};
+
+int get_env_int(const char* envname, int envdefault) {
+
+	const char* envval = std::getenv(envname);
+	int res = envdefault;
+
+	if (envval != NULL)
+		res = strtol(envval, NULL, 0);
+//	diag("%s: %s='%s' >>> %d", __FUNCTION__, envname, envval, res);
+
+	return res;
+};
+
+bool get_env_bool(const char* envname, bool envdefault) {
+
+	const char* envval = std::getenv(envname);
+	int res = envdefault;
+
+	if (envval != NULL) {
+		if (strcasecmp(envval, "true") == 0) {
+			res = 1;
+		} else if (strcasecmp(envval, "false") == 0) {
+			res = 0;
+		} else if (strcasecmp(envval, "yes") == 0) {
+			res = 1;
+		} else if (strcasecmp(envval, "no") == 0) {
+			res = 0;
+		} else if (strcasecmp(envval, "on") == 0) {
+			res = 1;
+		} else if (strcasecmp(envval, "off") == 0) {
+			res = 0;
+		} else {
+			res = strtol(envval, NULL, 0);
+		}
+	}
+
+//	diag("%s: %s='%s' >>> %d", __FUNCTION__, envname, envval, res);
+
+	return (bool) res;
+};

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -643,4 +643,15 @@ void check_conn_count(MYSQL* admin, const std::string& conn_type, uint32_t conn_
 void check_query_count(MYSQL* admin, uint32_t queries, uint32_t hg);
 void check_query_count(MYSQL* admin, std::vector<uint32_t> queries, uint32_t hg);
 
+/**
+ * @brief fetches and converts env var value to str/int/bool if possible otherwise uses default
+ * @details helper function for fetching str/int/bool from env
+ * @param envname - name for the env variable
+ * @param envdefault - default value to use
+ * @return str/int/bool value or default
+ */
+const char* get_env_str(const char* envname, const char* envdefault);
+int get_env_int(const char* envname, int envdefault);
+bool get_env_bool(const char* envname, bool envdefault);
+
 #endif // #define UTILS_H

--- a/test/tap/tests/reg_test_3765_ssl_pollout-t.cpp
+++ b/test/tap/tests/reg_test_3765_ssl_pollout-t.cpp
@@ -59,7 +59,7 @@ int create_connections(const conn_opts_t& conn_opts, uint32_t cons_num, std::vec
 const uint32_t ADMIN_CONN_NUM = 100;
 const uint32_t MYSQL_CONN_NUM = 100;
 const uint32_t REPORT_INTV_SEC = 5;
-const double MAX_ALLOWED_CPU_USAGE = 13.0;
+double MAX_ALLOWED_CPU_USAGE = (double) get_env_int("TAP_MAX_ALLOWED_CPU_USAGE", 13);
 
 int get_idle_conns_cpu_usage(CommandLine& cl, uint64_t mode, double& idle_cpu_ms, double& final_cpu_ms) {
 	// get ProxySQL idle cpu usage


### PR DESCRIPTION
reg_test_3765_ssl_pollout-t is measuring cpu utilization
allow override the default of `MAX_ALLOWED_CPU_USAGE = 13.0`
setting environment variable `TAP_MAX_ALLOWED_CPU_USAGE=20` via `export`
or via environment file `reg_test_3765_ssl_pollout-t.env`

this is useful for ASAN testing with extra overhead