### PR TITLE
Correct free/used typo in Prometheus 'connection_pool' gauge cleanup

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -4380,13 +4380,13 @@ void MySQL_HostGroups_Manager::p_update_connection_pool() {
 		status.p_dyn_gauge_array[p_hg_dyn_gauge::connection_pool_status]->Remove(gauge);
 		status.p_connection_pool_status_map.erase(key);
 
-		gauge = status.p_connection_pool_conn_used_map[key];
-		status.p_dyn_gauge_array[p_hg_dyn_gauge::connection_pool_conn_free]->Remove(gauge);
-		status.p_connection_pool_conn_used_map.erase(key);
-
 		gauge = status.p_connection_pool_conn_free_map[key];
-		status.p_dyn_gauge_array[p_hg_dyn_gauge::connection_pool_conn_used]->Remove(gauge);
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::connection_pool_conn_free]->Remove(gauge);
 		status.p_connection_pool_conn_free_map.erase(key);
+
+		gauge = status.p_connection_pool_conn_used_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::connection_pool_conn_used]->Remove(gauge);
+		status.p_connection_pool_conn_used_map.erase(key);
 
 		gauge = status.p_connection_pool_latency_us_map[key];
 		status.p_dyn_gauge_array[p_hg_dyn_gauge::connection_pool_latency_us]->Remove(gauge);


### PR DESCRIPTION
In `MySQL_HostGroups_Manager::p_update_connection_pool()`, in the section that cleans up connection pool gauge metrics associated with missing servers, this is correcting a typo switching "free" and "used" such that the "Remove" method is being called on the wrong gauge.