### PR TITLE
Add a "demuxed" status to proxysql_connection_pool_conn to track connections with multiplexing disabled

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -186,6 +186,7 @@ class MySrvConnList {
 	MySQL_Connection * get_random_MyConn(MySQL_Session *sess, bool ff);
 	void get_random_MyConn_inner_search(unsigned int start, unsigned int end, unsigned int& conn_found_idx, unsigned int& connection_quality_level, unsigned int& number_of_matching_session_variables, const MySQL_Connection * client_conn);
 	unsigned int conns_length() { return conns->len; }
+	unsigned int conns_with_multiplexing_disabled();
 	void drop_all_connections();
 	MySQL_Connection *index(unsigned int);
 };
@@ -509,6 +510,7 @@ struct p_hg_dyn_gauge {
 	enum metric {
 		connection_pool_conn_free = 0,
 		connection_pool_conn_used,
+		connection_pool_conn_demuxed,
 		connection_pool_latency_us,
 		connection_pool_status,
 		__size
@@ -888,6 +890,7 @@ class MySQL_HostGroups_Manager {
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_conn_free_map {};
 		std::map<std::string, prometheus::Counter*> p_connection_pool_conn_ok_map {};
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_conn_used_map {};
+		std::map<std::string, prometheus::Gauge*> p_connection_pool_conn_demuxed_map {};
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_latency_us_map {};
 		std::map<std::string, prometheus::Counter*> p_connection_pool_queries_map {};
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_status_map {};


### PR DESCRIPTION
This is a feature we've found highly useful on a daily basis in our dashboards and alerts.  I've implemented it as an additional status label on `proxysql_connection_pool_conn`. 

_Question for reviewers:_ Would it be better as an entirely new metric?

Here's a simple illustration of the metric in use.  First, we use `GET_LOCK()` to open a connection with multiplexing disabled:
```
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="demuxed"} 1
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="used"} 1
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="free"} 0
```
Note that the demultiplexed connection is counted twice, as both `used` and `demuxed`.

Now execute a long-running query in one of the other client sessions. Now we have two `used` connections, but still just one `demuxed`.
```
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="demuxed"} 1
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="used"} 2
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="free"} 0
```

Release the lock and free the de-multiplexed connection:
```
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="demuxed"} 0
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="used"} 1
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="free"} 1
```

Finally, the other query completes and we have two free connections in the pool:
```
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="demuxed"} 0
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="used"} 0
proxysql_connpool_conns{endpoint="mysql-m1:3306",hostgroup="0",status="free"} 2
```
