### PR TITLE
Reduce log clutter

### DIFF
--- a/include/proxysql.h
+++ b/include/proxysql.h
@@ -109,8 +109,8 @@ int pkt_end(unsigned char *, unsigned int);
 int pkt_com_query(unsigned char *, unsigned int);
 enum MySQL_response_type mysql_response(unsigned char *, unsigned int);
 
-__attribute__((__format__ (__printf__, 2, 3)))
-void proxy_error_func(int errcode, const char *, ...);
+__attribute__((__format__ (__printf__, 3, 4)))
+void proxy_error_func(int errcode, int loglevel, const char *, ...);
 void print_backtrace(void);
 void proxy_info_(const char* msg, ...);
 

--- a/include/proxysql_debug.h
+++ b/include/proxysql_debug.h
@@ -47,6 +47,12 @@ extern int gdbg;
 /*
 #ifdef DEBUG
 */
+
+// define the levels of logging messages
+const int loglevel_error = 1;
+const int loglevel_warning = 2;
+const int loglevel_info = 3;
+
 #define proxy_error(fmt, ...) \
 	do { \
 		time_t __timer; \
@@ -55,7 +61,7 @@ extern int gdbg;
 		time(&__timer); \
 		localtime_r(&__timer, &__tm_info); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", &__tm_info); \
-		proxy_error_func(0, "%s %s:%d:%s(): [ERROR] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
+		proxy_error_func(0, loglevel_error, "%s %s:%d:%s(): [ERROR] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
 	} while(0)
 
 #define proxy_error2(ecode, fmt, ...) \
@@ -66,7 +72,7 @@ extern int gdbg;
         time(&__timer); \
         localtime_r(&__timer, &__tm_info); \
         strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", &__tm_info); \
-        proxy_error_func(ecode, "%s %s:%d:%s(): [ERROR] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
+        proxy_error_func(ecode, loglevel_error, "%s %s:%d:%s(): [ERROR] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
     } while(0)
 
 #define proxy_error_inline(fi, li, fu, fmt, ...) \
@@ -77,7 +83,7 @@ extern int gdbg;
 		time(&__timer); \
 		localtime_r(&__timer, &__tm_info); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", &__tm_info); \
-		proxy_error_func(0, "%s %s:%d:%s(): [ERROR] " fmt, __buffer, fi, li, fu , ## __VA_ARGS__); \
+		proxy_error_func(0, loglevel_error, "%s %s:%d:%s(): [ERROR] " fmt, __buffer, fi, li, fu , ## __VA_ARGS__); \
 	} while(0)
 /*
 #else
@@ -104,7 +110,7 @@ extern int gdbg;
 		time(&__timer); \
 		__tm_info = localtime(&__timer); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", __tm_info); \
-		proxy_error_func(0, "%s %s:%d:%s(): [WARNING] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
+		proxy_error_func(0, loglevel_warning, "%s %s:%d:%s(): [WARNING] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
 	} while(0)
 
 #define proxy_warning2(ecode, fmt, ...) \
@@ -115,7 +121,7 @@ extern int gdbg;
 		time(&__timer); \
 		__tm_info = localtime(&__timer); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", __tm_info); \
-		proxy_error_func(ecode, "%s %s:%d:%s(): [WARNING] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
+		proxy_error_func(ecode, loglevel_warning, "%s %s:%d:%s(): [WARNING] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
 	} while(0)
 
 /*
@@ -141,7 +147,7 @@ extern int gdbg;
 		time(&__timer); \
 		__tm_info = localtime(&__timer); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", __tm_info); \
-		proxy_error_func(0, "%s %s:%d:%s(): [INFO] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
+		proxy_error_func(0, loglevel_info, "%s %s:%d:%s(): [INFO] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
 	} while(0)
 
 #define proxy_info2(ecode, fmt, ...) \
@@ -152,7 +158,7 @@ extern int gdbg;
 		time(&__timer); \
 		__tm_info = localtime(&__timer); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", __tm_info); \
-		proxy_error_func(ecode, "%s %s:%d:%s(): [INFO] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
+		proxy_error_func(ecode, loglevel_info, "%s %s:%d:%s(): [INFO] " fmt, __buffer, __FILE__, __LINE__, __func__ , ## __VA_ARGS__); \
 	} while(0)
 #else
 #define proxy_info(fmt, ...) \
@@ -163,7 +169,7 @@ extern int gdbg;
 		time(&__timer); \
 		__tm_info = localtime(&__timer); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", __tm_info); \
-		proxy_error_func(0, "%s [INFO] " fmt , __buffer , ## __VA_ARGS__); \
+		proxy_error_func(0, loglevel_info, "%s [INFO] " fmt , __buffer , ## __VA_ARGS__); \
 	} while(0)
 
 #define proxy_info2(fmt, ...) \
@@ -174,7 +180,7 @@ extern int gdbg;
 		time(&__timer); \
 		__tm_info = localtime(&__timer); \
 		strftime(__buffer, 25, "%Y-%m-%d %H:%M:%S", __tm_info); \
-		proxy_error_func(ecode, "%s [INFO] " fmt , __buffer , ## __VA_ARGS__); \
+		proxy_error_func(ecode, loglevel_info, "%s [INFO] " fmt , __buffer , ## __VA_ARGS__); \
 	} while(0)
 #endif
 

--- a/include/proxysql_glovars.hpp
+++ b/include/proxysql_glovars.hpp
@@ -74,6 +74,7 @@ class ProxySQL_GlobalVariables {
 	char *errorlog;
 	char *pid;
 	int restart_on_missing_heartbeats;
+	int console_logging_verbosity_level;
 	char * execute_on_exit_failure;
 	char * sqlite3_plugin;
 	char * web_interface_plugin;

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -331,10 +331,11 @@ unordered_map<string, ProxySQL_messages_stats> umap_msg_stats {};
  *   Any other use of the function is UNSAFE. And will result in unespecified behavior.
  * @param msgid The message id of the message to be logged, when non-zero, stats about the message are updated in
  *   'umap_msg_stats'.
+ * @param loglevel The level of log entry (as per LOG_LEVEL_*)
  * @param fmt The formatted string to be pass to 'vfprintf'.
  * @param ... The variadic list of arguments to be passed to 'vfprintf'.
  */
-void proxy_error_func(int msgid, const char *fmt, ...) {
+void proxy_error_func(int msgid, int loglevel, const char *fmt, ...) {
 	va_list ap;
 	va_start(ap, fmt);
 
@@ -375,7 +376,10 @@ void proxy_error_func(int msgid, const char *fmt, ...) {
 		}
 	}
 
-	vfprintf(stderr, fmt, ap);
+	if (GloVars.console_logging_verbosity_level >= loglevel) {
+		vfprintf(stderr, fmt, ap);
+	}
+	
 	va_end(ap);	
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -479,6 +479,7 @@ void ProxySQL_Main_process_global_variables(int argc, const char **argv) {
 	GloVars.parse(argc,argv);
 	GloVars.process_opts_pre();
 	GloVars.restart_on_missing_heartbeats = 10; // default
+	GloVars.console_logging_verbosity_level = loglevel_info; // output all logging entries to stderr by default
 	// alwasy try to open a config file
 	if (GloVars.confFile->OpenFile(GloVars.config_file) == true) {
 		GloVars.configfile_open=true;
@@ -491,6 +492,15 @@ void ProxySQL_Main_process_global_variables(int argc, const char **argv) {
 			rc=root.lookupValue("restart_on_missing_heartbeats", restart_on_missing_heartbeats);
 			if (rc==true) {
 				GloVars.restart_on_missing_heartbeats=restart_on_missing_heartbeats;
+			}
+		}
+		if (root.exists("console_logging_verbosity_level")==true) {
+			// read console_logging_verbosity_level from config file
+			int console_logging_verbosity_level;
+			bool rc;
+			rc=root.lookupValue("console_logging_verbosity_level", console_logging_verbosity_level);
+			if (rc==true) {
+				GloVars.console_logging_verbosity_level=console_logging_verbosity_level;
 			}
 		}
 		if (root.exists("execute_on_exit_failure")==true) {


### PR DESCRIPTION
Reduce log clutter by setting console_logging_verbosity_level to "errors only" (by setting console_logging_verbosity_level= 1) or "errors & warnings" (= 2) in proxysql.cnf; default is "errors, warnings & info" (= 3)