### PR TITLE
Fix invalid free for `caching_sha2_password` and `CLIENT_COMPRESS`

### DIFF
--- a/test/tap/tests/test_auth_methods-t.cpp
+++ b/test/tap/tests/test_auth_methods-t.cpp
@@ -282,7 +282,7 @@ struct test_conf_t {
 	bool hashed_pass;
 	/* @brief Wether to attempt auth under SSL conn or not. */
 	bool use_ssl;
-	/* @brief Wether to attempt auth under SSL conn or not. */
+	/* @brief Wether to attempt auth with compression enabled or not. */
 	bool use_comp;
 };
 


### PR DESCRIPTION
This PR fixes and invalid free that takes places when starting a connection using `caching_sha2_password` and compression is enabled for the connection.