### PR TITLE
Document FreeBSD installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ Installing:
 yum install proxysql OR yum install proxysql-version
 ```
 
+#### FreeBSD:
+
+Installing (via pkg):
+```bash
+pkg install proxysql
+```
+
+Installing (via ports):
+```bash
+cd /usr/ports/databases/proxysql/ && make install clean
+```
+
 ### Service management
 Once the software is installed, you can use the `service` command to control the process:  
 


### PR DESCRIPTION
I've created a port/package of proxysql for FreeBSD users.  You can view details here:
[proxysql port](https://www.freshports.org/databases/proxysql)

This will enable them to easily install proxysql via ports or the FreeBSD package management system.

If interested, there are various tweaks to the source that might make future maintenance a little easier:

- Convert gnugrep regexes: grep -Po '\d\d\d\d\d\dL' -> egrep '[0-9]{5}L': gnugrep is not installed by default.
- Consider adding support for log file close/reopen via a signal (or config file knob to allow printing log lines without the timestamp so that they may be easily forwarded to syslog or native syslog support).  FreeBSD's newsyslog doesn't support the 'copytruncate' option that logrotate does.
- Update syntax when using ln: ln -fsT -> ln -fs: FreeBSD lacks the -T arg.
- Make PROXYSQLCLICKHOUSE configurable via an environment variable:  Most users probably don't need clickhouse support and their library didn't trivially compile for me.
- Make paths (/etc, /var/lib/proxysql, etc.) more easily configurable at build time.