### PR TITLE
Fix two memory leaks on SQLite3 prepared statements - Closes #4491

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -7663,6 +7663,7 @@ void MySQL_HostGroups_Manager::generate_mysql_hostgroup_attributes_table() {
 		}
 	}
 
+	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_hostgroup_attributes;
 	incoming_hostgroup_attributes=NULL;
 }
@@ -7717,6 +7718,7 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_ssl_params_table() {
 		string MapKey = MSSP.getMapKey(rand_del);
 		Servers_SSL_Params_map.emplace(MapKey, MSSP);
 	}
+	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_mysql_servers_ssl_params;
 	incoming_mysql_servers_ssl_params=NULL;
 }


### PR DESCRIPTION
Fixes two memory leaks that are exercised during tables regeneration due to servers reconfiguration.

### Details

Leaks are reflected in the amount of memory used by `SQLite3`. Leaks are small and will only affect environments with high frequency servers reconfiguration, the number of servers isn't relevant.

This PR also motivated PR #4506, which enables accumulative profile dumps for `jemalloc`.

#### Affected versions

*  `mysql_hostgroup_attributes`: Since `2.5.0`.
*  `mysql_servers_ssl_params`: Since `2.6.0`.