### PR TITLE
Change default jemalloc conf enabling 'prof_accum' by default

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -149,11 +149,18 @@ ifeq ($(TEST_WITHASAN),1)
 	WASAN += -DTEST_WITHASAN
 endif
 
+NOJEMALLOC := $(shell echo $(NOJEMALLOC))
+ifeq ($(NOJEMALLOC),1)
+NOJEM=-DNOJEM
+else
+NOJEM=
+endif
+
 MYCXXFLAGS := $(STDCPP)
 ifeq ($(CXX),clang++)
 	MYCXXFLAGS += -fuse-ld=lld
 endif
-MYCXXFLAGS += $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH) -DGITVERSION=\"$(GIT_VERSION)\" $(WGCOV) $(WASAN)
+MYCXXFLAGS += $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH) -DGITVERSION=\"$(GIT_VERSION)\" $(NOJEM) $(WGCOV) $(WASAN)
 
 
 STATICMYLIBS := -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -409,7 +409,7 @@ static volatile int load_;
 //#else
 //const char *malloc_conf = "xmalloc:true,lg_tcache_max:16,purge:decay";
 #ifndef __FreeBSD__
-const char *malloc_conf = "xmalloc:true,lg_tcache_max:16,prof:true,prof_leak:true,lg_prof_sample:20,lg_prof_interval:30,prof_active:false";
+const char *malloc_conf = "xmalloc:true,lg_tcache_max:16,prof:true,prof_accum:true,prof_leak:true,lg_prof_sample:20,lg_prof_interval:30,prof_active:false";
 #endif
 //#endif /* DEBUG */
 //const char *malloc_conf = "prof_leak:true,lg_prof_sample:0,prof_final:true,xmalloc:true,lg_tcache_max:16";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1859,7 +1859,7 @@ void handleProcessRestart() {
 				// Calculate wait time using exponential backoff
 				int waitTime = 1 << restartAttempts;
 				parent_open_error_log();
-				proxy_info("ProxySQL exited after only %d seconds , below the %d seconds threshold. Restarting attempt %d\n", elapsed_seconds, EXECUTION_THRESHOLD, restartAttempts);
+				proxy_info("ProxySQL exited after only %ld seconds , below the %d seconds threshold. Restarting attempt %d\n", elapsed_seconds, EXECUTION_THRESHOLD, restartAttempts);
 				proxy_info("Angel process is waiting %d seconds before starting a new ProxySQL process\n", waitTime);
 				parent_close_error_log();
 


### PR DESCRIPTION
This PR includes one change for jemalloc default configuration, and extra logging for jemalloc config.

### Details

Enabling 'prof_accum' for jemalloc will enable cumulative counts for profile dumps. This will increment memory consumption, but will also increase tracing resolution and increase the changes for small leak detection even in consistent/steady allocation pattern workloads. Hopefully this will help to identify small and consistent leaks. Enabling this option also will allow access to other cumulative stats (e.g. `alloc_space`) to which we currently don't have access.

Since jemalloc default config can always be overridden via env variable `MALLOC_CON`,  this PR prints the jemalloc config at startup, allowing to verify via error log which was the final selected config.