### PR TITLE
[PENDING] Add new table `ssl_ciphers` to ProxySQL Admin 

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -289,6 +289,10 @@ class ProxySQL_Admin {
 	ProxySQL_External_Scheduler *scheduler;
 
 	void dump_mysql_collations();
+	/**
+	 * @brief Dumps into the Admin SQLite3 table 'ssl_ciphers' currently available ciphers.
+	 */
+	void dump_ssl_ciphers();
 	void insert_into_tables_defs(std::vector<table_def_t *> *, const char *table_name, const char *table_def);
 	void drop_tables_defs(std::vector<table_def_t *> *tables_defs);
 	void check_and_build_standard_tables(SQLite3DB *db, std::vector<table_def_t *> *tables_defs);

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -442,7 +442,7 @@ MHD_Result http_handler(void *cls, struct MHD_Connection *connection, const char
 
 #define ADMIN_SQLITE_TABLE_MYSQL_COLLATIONS "CREATE TABLE mysql_collations (Id INTEGER NOT NULL PRIMARY KEY , Collation VARCHAR NOT NULL , Charset VARCHAR NOT NULL , `Default` VARCHAR NOT NULL)"
 
-#define ADMIN_SQLITE_TABLE_SSL_CIPHERS "CREATE TABLE ssl_ciphers (cipher_name VARCHAR NOT NULL, cipher_description VARCHAR NOT NULL)"
+#define ADMIN_SQLITE_TABLE_SSL_CIPHERS "CREATE TABLE ssl_ciphers (cipher_name VARCHAR NOT NULL PRIMARY KEY , cipher_description VARCHAR NOT NULL)"
 
 #define ADMIN_SQLITE_TABLE_RESTAPI_ROUTES_V2_0_15 "CREATE TABLE restapi_routes (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT , active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 1 , interval_ms INTEGER CHECK (interval_ms>=100 AND interval_ms<=100000000) NOT NULL , method VARCHAR NOT NULL CHECK (UPPER(method) IN ('GET','POST')) , uri VARCHAR NOT NULL , script VARCHAR NOT NULL , comment VARCHAR NOT NULL DEFAULT '')"
 

--- a/test/tap/tests/admin_various_commands-t.cpp
+++ b/test/tap/tests/admin_various_commands-t.cpp
@@ -86,8 +86,9 @@ int main() {
 		{ 10, "SHOW MYSQL STATUS" },
 		{ 1, "SELECT DATABASE()" },
 		{ 1, "SELECT DATABASE() AS name" },
+		{ 1, "SELECT COUNT(*) FROM sqlite_schema WHERE type='table' AND name='ssl_ciphers'" },
+		{ 30, "SELECT * FROM ssl_ciphers" },
 /*
-		{  , "" },
 		{  , "" },
 		{  , "" },
 */


### PR DESCRIPTION
This PR adds a new table `ssl_ciphers` to ProxySQL Admin. This table allows to check the currently supported ciphers by ProxySQL. The table is populated during startup and it's never save to disk, in a similar fashion to `mysql_collations` table.

It's defined with two rows `cipher_name` and `cipher_description`. A simple output for completion:

```
mysql> SELECT * FROM ssl_ciphers LIMIT 2;
+------------------------------+-------------------------------------------------------------------------------------------------+
| cipher_name                  | cipher_description                                                                              |
+------------------------------+-------------------------------------------------------------------------------------------------+
| TLS_AES_256_GCM_SHA384       | TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD |
| TLS_CHACHA20_POLY1305_SHA256 | TLS_CHACHA20_POLY1305_SHA256   TLSv1.3 Kx=any      Au=any   Enc=CHACHA20/POLY1305(256) Mac=AEAD |
+------------------------------+-------------------------------------------------------------------------------------------------+
2 rows in set (0.00 sec)
```