### PR TITLE
 Handle 'SELECT LAST_INSERT_ID() FROM DUAL' - Closes #4493 

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -44,6 +44,8 @@
 #define SELECT_CONNECTION_ID_LEN 22
 #define SELECT_LAST_INSERT_ID "SELECT LAST_INSERT_ID()"
 #define SELECT_LAST_INSERT_ID_LEN 23
+#define SELECT_LAST_INSERT_ID_FROM_DUAL "SELECT LAST_INSERT_ID() FROM DUAL"
+#define SELECT_LAST_INSERT_ID_FROM_DUAL_LEN 33
 #define SELECT_LAST_INSERT_ID_LIMIT1 "SELECT LAST_INSERT_ID() LIMIT 1"
 #define SELECT_LAST_INSERT_ID_LIMIT1_LEN 31
 #define SELECT_VARIABLE_IDENTITY "SELECT @@IDENTITY"
@@ -7266,6 +7268,8 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 			//handle 2564
 			if (
 				(pkt->size==SELECT_LAST_INSERT_ID_LEN+5 && *((char *)(pkt->ptr)+4)==(char)0x03 && strncasecmp((char *)SELECT_LAST_INSERT_ID,(char *)pkt->ptr+5,pkt->size-5)==0)
+				||
+				(pkt->size==SELECT_LAST_INSERT_ID_FROM_DUAL_LEN+5 && *((char *)(pkt->ptr)+4)==(char)0x03 && strncasecmp((char *)SELECT_LAST_INSERT_ID_FROM_DUAL,(char *)pkt->ptr+5,pkt->size-5)==0)
 				||
 				(pkt->size==SELECT_LAST_INSERT_ID_LIMIT1_LEN+5 && *((char *)(pkt->ptr)+4)==(char)0x03 && strncasecmp((char *)SELECT_LAST_INSERT_ID_LIMIT1,(char *)pkt->ptr+5,pkt->size-5)==0)
                 ||

--- a/test/tap/tests/mysql-last_insert_id-t.cpp
+++ b/test/tap/tests/mysql-last_insert_id-t.cpp
@@ -18,8 +18,9 @@ inline unsigned long long monotonic_time() {
 }
 
 
-std::string queries[4] = {
+std::string queries[5] = {
 	"SELECT LAST_INSERT_ID() LIMIT 1",
+	"SELECT LAST_INSERT_ID() FROM DUAL",
 	"SELECT LAST_INSERT_ID()",
 	"SELECT @@IDENTITY LIMIT 1",
 	"SELECT @@IDENTITY"


### PR DESCRIPTION
As the title says. Once merged documentation should be updated [here](https://proxysql.com/documentation/global-variables/mysql-variables/#mysql-auto_increment_delay_multiplex).