### PR TITLE
Introduced new HG attribute 'monitor_slave_lag_when_null' which takes precedence over 'mysql_thread_monitor_slave_lag_when_null'

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -541,10 +541,10 @@ using address_t = std::string;
 using port_t = unsigned int;
 using read_only_t = int;
 using current_replication_lag = int;
-using replace_current_replication_lag = bool;
+using override_replication_lag = bool;
 
 using read_only_server_t = std::tuple<hostname_t,port_t,read_only_t>;
-using replication_lag_server_t = std::tuple<hostgroupid_t,address_t,port_t,current_replication_lag,replace_current_replication_lag>;
+using replication_lag_server_t = std::tuple<hostgroupid_t,address_t,port_t,current_replication_lag,override_replication_lag>;
 
 enum READ_ONLY_SERVER_T {
 	ROS_HOSTNAME = 0,

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -291,6 +291,7 @@ class MyHGC {	// MySQL Host Group Container
 		char * ignore_session_variables_text; // this is the original version (text format) of ignore_session_variables
 		uint32_t max_num_online_servers;
 		uint32_t throttle_connections_per_sec;
+		int32_t monitor_slave_lag_when_null;
 		int8_t autocommit;
 		int8_t free_connections_pct;
 		int8_t handle_warnings;
@@ -309,6 +310,10 @@ class MyHGC {	// MySQL Host Group Container
 	inline
 	bool handle_warnings_enabled() const {
 		return attributes.configured == true && attributes.handle_warnings != -1 ? attributes.handle_warnings : mysql_thread___handle_warnings;
+	}
+	inline
+	int32_t get_monitor_slave_lag_when_null() const {
+		return attributes.configured == true && attributes.monitor_slave_lag_when_null != -1 ? attributes.monitor_slave_lag_when_null : mysql_thread___monitor_slave_lag_when_null;
 	}
 	MyHGC(int);
 	~MyHGC();

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -541,9 +541,10 @@ using address_t = std::string;
 using port_t = unsigned int;
 using read_only_t = int;
 using current_replication_lag = int;
+using replace_current_replication_lag = bool;
 
 using read_only_server_t = std::tuple<hostname_t,port_t,read_only_t>;
-using replication_lag_server_t = std::tuple<hostgroupid_t,address_t,port_t,current_replication_lag>;
+using replication_lag_server_t = std::tuple<hostgroupid_t,address_t,port_t,current_replication_lag,replace_current_replication_lag>;
 
 enum READ_ONLY_SERVER_T {
 	ROS_HOSTNAME = 0,
@@ -557,6 +558,7 @@ enum REPLICATION_LAG_SERVER_T {
 	RLS_ADDRESS,
 	RLS_PORT,
 	RLS_CURRENT_REPLICATION_LAG,
+	RLS_OVERRIDE_REPLICATION_LAG,
 	RLS__SIZE
 };
 
@@ -1090,7 +1092,7 @@ class MySQL_HostGroups_Manager {
 	void push_MyConn_to_pool_array(MySQL_Connection **, unsigned int);
 	void destroy_MyConn_from_pool(MySQL_Connection *, bool _lock=true);	
 
-	void replication_lag_action_inner(MyHGC *, const char*, unsigned int, int);
+	void replication_lag_action_inner(MyHGC *, const char*, unsigned int, int, bool);
 	void replication_lag_action(const std::list<replication_lag_server_t>& mysql_servers);
 	void read_only_action(char *hostname, int port, int read_only);
 	void read_only_action_v2(const std::list<read_only_server_t>& mysql_servers);

--- a/include/SQLite3_Server.h
+++ b/include/SQLite3_Server.h
@@ -56,7 +56,7 @@ class SQLite3_Server {
 	std::vector<table_def_t *> *tables_defs_readonly;
 #endif // TEST_READONLY
 #ifdef TEST_REPLICATIONLAG
-	std::unordered_map<std::string, int> replicationlag_map;
+	std::unordered_map<std::string, std::unique_ptr<int>> replicationlag_map;
 	std::vector<table_def_t*>* tables_defs_replicationlag;
 #endif // TEST_REPLICATIONLAG
 #if defined(TEST_AURORA) || defined(TEST_GALERA) || defined(TEST_GROUPREP) || defined(TEST_READONLY) || defined(TEST_REPLICATIONLAG)
@@ -105,7 +105,7 @@ class SQLite3_Server {
 #ifdef TEST_REPLICATIONLAG
 	pthread_mutex_t test_replicationlag_mutex;
 	void load_replicationlag_table(MySQL_Session* sess);
-	int replicationlag_test_value(const char* p);
+	int* replicationlag_test_value(const char* p);
 	int replicationlag_map_size() {
 		return replicationlag_map.size();
 	}

--- a/lib/MyHGC.cpp
+++ b/lib/MyHGC.cpp
@@ -33,6 +33,7 @@ void MyHGC::reset_attributes() {
 	attributes.autocommit = -1;
 	attributes.free_connections_pct = 10;
 	attributes.handle_warnings = -1;
+	attributes.monitor_slave_lag_when_null = -1;
 	attributes.multiplex = true;
 	attributes.connection_warming = false;
 	free(attributes.init_connect);

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2690,6 +2690,7 @@ void MySQL_HostGroups_Manager::replication_lag_action_inner(MyHGC *myhgc, const 
 	
 	if (current_replication_lag == -1 && override_repl_lag == true) {
 		current_replication_lag = myhgc->get_monitor_slave_lag_when_null();
+		override_repl_lag = false;
 		proxy_error("Replication lag on server %s:%d is NULL, using value %d\n", address, port, current_replication_lag);
 	}
 
@@ -2702,9 +2703,9 @@ void MySQL_HostGroups_Manager::replication_lag_action_inner(MyHGC *myhgc, const 
 //					(current_replication_lag==-1 )
 //					||
 					(
-						current_replication_lag>=0 &&
+						current_replication_lag >= 0 &&
 						mysrvc->max_replication_lag > 0 && // see issue #4018
-						((unsigned int)current_replication_lag > mysrvc->max_replication_lag)
+						(current_replication_lag > (int)mysrvc->max_replication_lag)
 					)
 				) {
 					// always increase the counter
@@ -2729,7 +2730,8 @@ void MySQL_HostGroups_Manager::replication_lag_action_inner(MyHGC *myhgc, const 
 			} else {
 				if (mysrvc->status==MYSQL_SERVER_STATUS_SHUNNED_REPLICATION_LAG) {
 					if (
-						(current_replication_lag>=0 && ((unsigned int)current_replication_lag <= mysrvc->max_replication_lag))
+						(/*current_replication_lag >= 0 &&*/override_repl_lag == false &&
+						(current_replication_lag <= (int)mysrvc->max_replication_lag))
 						||
 						(current_replication_lag==-2 && override_repl_lag == true) // see issue 959
 					) {

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -2792,11 +2792,9 @@ __exit_monitor_replication_lag_thread:
 							MYSQL_ROW row=mysql_fetch_row(mmsd->result);
 							if (row) {
 								repl_lag=-1; // this is old behavior
-							repl_lag=mysql_thread___monitor_slave_lag_when_null; // new behavior, see 669
 								if (row[j]) { // if Seconds_Behind_Master is not NULL
 									repl_lag=atoi(row[j]);
 								} else {
-									proxy_error("Replication lag on server %s:%d is NULL, using the value %d (mysql-monitor_slave_lag_when_null)\n", mmsd->hostname, mmsd->port, mysql_thread___monitor_slave_lag_when_null);
 									MyHGM->p_update_mysql_error_counter(p_mysql_error_type::proxysql, mmsd->hostgroup_id, mmsd->hostname, mmsd->port, ER_PROXYSQL_SRV_NULL_REPLICATION_LAG);
 								}
 							}
@@ -7820,11 +7818,9 @@ bool MySQL_Monitor::monitor_replication_lag_process_ready_tasks(const std::vecto
 					MYSQL_ROW row = mysql_fetch_row(mmsd->result);
 					if (row) {
 						repl_lag = -1; // this is old behavior
-						repl_lag = mysql_thread___monitor_slave_lag_when_null; // new behavior, see 669
 						if (row[j]) { // if Seconds_Behind_Master is not NULL
 							repl_lag = atoi(row[j]);
 						} else {
-							proxy_error("Replication lag on server %s:%d is NULL, using the value %d (mysql-monitor_slave_lag_when_null)\n", mmsd->hostname, mmsd->port, mysql_thread___monitor_slave_lag_when_null);
 							MyHGM->p_update_mysql_error_counter(p_mysql_error_type::proxysql, mmsd->hostgroup_id, mmsd->hostname, mmsd->port, ER_PROXYSQL_SRV_NULL_REPLICATION_LAG);
 						}
 					}

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -562,13 +562,6 @@ void ProxySQL_Node_Entry::set_checksums(MYSQL_RES *_r) {
 					checksums_values.mysql_servers.checksum, GloVars.checksums_values.mysql_servers.checksum, checksums_values.mysql_servers.diff_check);
 			}
 			if (strcmp(checksums_values.mysql_servers.checksum, GloVars.checksums_values.mysql_servers.checksum) == 0) {
-				// See LOGGING-NOTE at 'admin_variables' above.
-				if (checksums_values.mysql_servers.last_changed == now) {
-					proxy_info(
-						"Cluster: checksum for mysql_servers from peer %s:%d matches with local checksum %s , we won't sync.\n",
-						hostname, port, GloVars.checksums_values.mysql_servers.checksum
-					);
-				}
 				checksums_values.mysql_servers.diff_check = 0;
 				proxy_debug(PROXY_DEBUG_CLUSTER, 5, "Checksum for mysql_servers from peer %s:%d matches with local checksum %s, reset diff_check to 0.\n", hostname, port, GloVars.checksums_values.mysql_servers.checksum);
 			}
@@ -609,13 +602,6 @@ void ProxySQL_Node_Entry::set_checksums(MYSQL_RES *_r) {
 					checksums_values.mysql_servers_v2.checksum, GloVars.checksums_values.mysql_servers_v2.checksum, checksums_values.mysql_servers_v2.diff_check);
 			}
 			if (strcmp(checksums_values.mysql_servers_v2.checksum, GloVars.checksums_values.mysql_servers_v2.checksum) == 0) {
-				// See LOGGING-NOTE at 'admin_variables' above.
-				if (checksums_values.mysql_servers_v2.last_changed == now) {
-					proxy_info(
-						"Cluster: checksum for mysql_servers_v2 from peer %s:%d matches with local checksum %s , we won't sync.\n",
-						hostname, port, GloVars.checksums_values.mysql_servers_v2.checksum
-					);
-				}
 				checksums_values.mysql_servers_v2.diff_check = 0;
 				proxy_debug(PROXY_DEBUG_CLUSTER, 5, "Checksum for mysql_servers_v2 from peer %s:%d matches with local checksum %s, reset diff_check to 0.\n", hostname, port, GloVars.checksums_values.mysql_servers.checksum);
 			}

--- a/src/SQLite3_Server.cpp
+++ b/src/SQLite3_Server.cpp
@@ -2026,8 +2026,7 @@ void SQLite3_Server::load_replicationlag_table(MySQL_Session* sess) {
 			if (r->fields[2] == nullptr) {
 				replicationlag_map[s] = nullptr;
 			} else {
-				int* repl_lag = new int(atoi(r->fields[2]));
-				replicationlag_map[s] = std::unique_ptr<int>(repl_lag);
+				replicationlag_map[s] = std::make_unique<int>(atoi(r->fields[2]));
 			}
 		}
 	}

--- a/src/SQLite3_Server.cpp
+++ b/src/SQLite3_Server.cpp
@@ -2026,8 +2026,7 @@ void SQLite3_Server::load_replicationlag_table(MySQL_Session* sess) {
 			if (r->fields[2] == nullptr) {
 				replicationlag_map[s] = nullptr;
 			} else {
-				int* repl_lag = new int;
-				*repl_lag = atoi(r->fields[2]);
+				int* repl_lag = new int(atoi(r->fields[2]));
 				replicationlag_map[s] = std::unique_ptr<int>(repl_lag);
 			}
 		}

--- a/src/SQLite3_Server.cpp
+++ b/src/SQLite3_Server.cpp
@@ -879,11 +879,17 @@ __run_query:
 						// probably never initialized
 						GloSQLite3Server->load_replicationlag_table(sess);
 					}
-					const int rc = GloSQLite3Server->replicationlag_test_value(query_no_space + strlen("SELECT SLAVE STATUS "));
+					const int* rc = GloSQLite3Server->replicationlag_test_value(query_no_space + strlen("SELECT SLAVE STATUS "));
 					free(query);
-					char* a = (char*)"SELECT %d as Seconds_Behind_Master";
-					query = (char*)malloc(strlen(a) + 2);
-					sprintf(query, a, rc);
+					if (rc == nullptr) {
+						const char* a = (char*)"SELECT null as Seconds_Behind_Master";
+						query = (char*)malloc(strlen(a) + 2);
+						sprintf(query, a);
+					} else {
+						const char* a = (char*)"SELECT %d as Seconds_Behind_Master";
+						query = (char*)malloc(strlen(a) + 2);
+						sprintf(query, a, *rc);
+					}
 					pthread_mutex_unlock(&GloSQLite3Server->test_replicationlag_mutex);
 				}
 			}
@@ -1845,7 +1851,7 @@ bool SQLite3_Server::init() {
 	insert_into_tables_defs(tables_defs_replicationlag,
 		(const char*)"REPLICATIONLAG_HOST_STATUS",
 		(const char*)"CREATE TABLE REPLICATIONLAG_HOST_STATUS ("
-		"hostname VARCHAR NOT NULL, port INT NOT NULL, seconds_behind_master INT NOT NULL, PRIMARY KEY (hostname, port)"
+		"hostname VARCHAR NOT NULL, port INT NOT NULL, seconds_behind_master INT DEFAULT NULL, PRIMARY KEY (hostname, port)"
 		")"
 	);
 
@@ -2016,7 +2022,14 @@ void SQLite3_Server::load_replicationlag_table(MySQL_Session* sess) {
 		for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
 			SQLite3_row* r = *it;
 			const std::string& s = std::string(r->fields[0]) + ":" + std::string(r->fields[1]);
-			replicationlag_map[s] = atoi(r->fields[2]);
+
+			if (r->fields[2] == nullptr) {
+				replicationlag_map[s] = nullptr;
+			} else {
+				int* repl_lag = new int;
+				*repl_lag = atoi(r->fields[2]);
+				replicationlag_map[s] = std::unique_ptr<int>(repl_lag);
+			}
 		}
 	}
 	delete resultset;
@@ -2024,7 +2037,7 @@ void SQLite3_Server::load_replicationlag_table(MySQL_Session* sess) {
 		GloAdmin->admindb->execute_statement((char*)"SELECT DISTINCT hostname, port FROM mysql_servers WHERE hostgroup_id BETWEEN 5202 AND 5700", &error, &cols, &affected_rows, &resultset);
 		for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
 			SQLite3_row* r = *it;
-			const std::string& s = "INSERT INTO REPLICATIONLAG_HOST_STATUS VALUES ('" + std::string(r->fields[0]) + "'," + std::string(r->fields[1]) + ",0)";
+			const std::string& s = "INSERT INTO REPLICATIONLAG_HOST_STATUS VALUES ('" + std::string(r->fields[0]) + "'," + std::string(r->fields[1]) + ",null)";
 			sessdb->execute(s.c_str());
 		}
 		delete resultset;
@@ -2032,11 +2045,11 @@ void SQLite3_Server::load_replicationlag_table(MySQL_Session* sess) {
 	GloAdmin->mysql_servers_wrunlock();
 }
 
-int SQLite3_Server::replicationlag_test_value(const char* p) {
-	int rc = 0; // default
-	std::unordered_map<std::string, int>::iterator it = replicationlag_map.find(std::string(p));
+int* SQLite3_Server::replicationlag_test_value(const char* p) {
+	int* rc = 0; // default
+	std::unordered_map<std::string, std::unique_ptr<int>>::iterator it = replicationlag_map.find(std::string(p));
 	if (it != replicationlag_map.end()) {
-		rc = it->second;
+		rc = it->second.get();
 	}
 	return rc;
 }


### PR DESCRIPTION
Introduced a new hostgroup attribute '**monitor_slave_lag_when_null**' in '**mysql_hostgroup_attibutes->hostgroup_settings**', which takes precedence over '**mysql_thread_monitor_slave_lag_when_null**' if both are configured.

Example usage:
`INSERT INTO mysql_hostgroup_attributes (hostgroup_id, hostgroup_settings) VALUES (1, '{"monitor_slave_lag_when_null": 100}');`

_Note:_
_* Permitted values for 'mysql-monitor_slave_lag_when_null' also apply to the 'monitor_slave_lag_when_null' attribute._
_* If '**Seconds_Behind_Master**' is negative, it will bring previously shunned server, due to replication lag, back online._
_* True '**Seconds_Behind_Master**' values returned by the server will be logged in '**mysql_server_replication_lag_log** table. (Previously negative values were logged as null)_

Closes [#4521](https://github.com/sysown/proxysql/issues/4521)