### PR TITLE
test/tap/tests: link dynamic libuuid instead of static

### DIFF
--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -116,8 +116,8 @@ ifeq ($(UNAME_S),Linux)
 endif
 
 MYLIBS := -Wl,--export-dynamic
-MYLIBS += -Wl,-Bdynamic -lgnutls -ltap -lcpp_dotenv -lcurl -lssl -lcrypto
-MYLIBS += -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lev -lprometheus-cpp-pull -lprometheus-cpp-core -luuid
+MYLIBS += -Wl,-Bdynamic -lgnutls -ltap -lcpp_dotenv -lcurl -lssl -lcrypto -luuid
+MYLIBS += -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lev -lprometheus-cpp-pull -lprometheus-cpp-core
 MYLIBS += -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl $(EXTRALINK)
 #MYLIBS := -Wl,--export-dynamic -Wl,-Bdynamic -lssl -lcrypto -lgnutls -ltap -lcpp_dotenv -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lev -lprometheus-cpp-pull -lprometheus-cpp-core -luuid -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl $(EXTRALINK)
 MYLIBSJEMALLOC := -Wl,-Bstatic -ljemalloc


### PR DESCRIPTION
Ubuntu ships libuuid.a in uuid-dev package which is why it could work. Fedora doesn't ship libuuid.a in any package. But it isn't picked up because `-luuid` flag is preceded by `-Wl,-Bstatic`:
```
 $ make build_tap_test_debug
cd deps && OPTZ="-O0 -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 PROXYDEBUG=1 CC=cc CXX=g++ make make[1]: Entering directory '/proxysql/deps'
make[1]: Nothing to be done for 'default'.
make[1]: Leaving directory '/proxysql/deps'
cd lib && OPTZ="-O0 -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=cc CXX=g++ make make[1]: Entering directory '/proxysql/lib'
make[1]: Nothing to be done for 'default'.
make[1]: Leaving directory '/proxysql/lib'
cd src && OPTZ="-O0 -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=cc CXX=g++ make make[1]: Entering directory '/proxysql/src'
make[1]: 'proxysql' is up to date.
make[1]: Leaving directory '/proxysql/src'
cd test/tap && OPTZ="-O0 -ggdb -DDEBUG" CC=cc CXX=g++ make debug make[1]: Entering directory '/proxysql/test/tap'
cd tap && CC=cc CXX=g++ make
make[2]: Entering directory '/proxysql/test/tap/tap' make[2]: Nothing to be done for 'default'.
make[2]: Leaving directory '/proxysql/test/tap/tap' cd ../deps && CC=cc CXX=g++ make
make[2]: Entering directory '/proxysql/test/deps'
make[2]: Nothing to be done for 'default'.
make[2]: Leaving directory '/proxysql/test/deps'
cd tests && CC=cc CXX=g++ make debug
make[2]: Entering directory '/proxysql/test/tap/tests'
g++ admin-listen_on_unix-t.cpp -I../tap -I/proxysql/deps/re2/re2 -I/proxysql/include -I/proxysql/deps/jemalloc/jemalloc/include/jemalloc -I/proxysql/deps/libconfig/libconfig/lib -I/proxysql/deps/mariadb-client-library/mariadb_client/include -I/proxysql/deps/libdaemon/libdaemon -I/proxysql/deps/libmicrohttpd/libmicrohttpd/src/include -I/proxysql/deps/libhttpserver/libhttpserver/src -I/proxysql/deps/curl/curl/include -I/proxysql/deps/libev/libev/ -I/proxysql/deps/prometheus-cpp/prometheus-cpp/pull/include -I/proxysql/deps/prometheus-cpp/prometheus-cpp/core/include -I../tap/cpp-dotenv/dynamic/cpp-dotenv/include -I/proxysql/deps/libssl/openssl//include -I/proxysql/deps/sqlite3/sqlite3 -I/proxysql/deps/json -L../tap -L/proxysql/deps/re2/re2/obj -L/proxysql/lib -L/proxysql/deps/jemalloc/jemalloc/lib -L/proxysql/deps/libconfig/libconfig/lib/.libs -L/proxysql/deps/mariadb-client-library/mariadb_client/libmariadb -L/proxysql/deps/libdaemon/libdaemon/libdaemon/.libs -L/proxysql/deps/libmicrohttpd/libmicrohttpd/src/microhttpd/.libs -L/proxysql/deps/libhttpserver/libhttpserver/build/src/.libs/ -L/proxysql/deps/curl/curl/lib/.libs -L/proxysql/deps/libev/libev//.libs -L/proxysql/deps/prometheus-cpp/prometheus-cpp/lib -L../tap -L/proxysql/deps/libssl/openssl/ -L/proxysql/deps/pcre/pcre/.libs -L/proxysql/deps/libinjection/libinjection/src -L/proxysql/deps/coredumper/coredumper/src -std=c++17 -DCXX17 -O0 -DDEBUG -ggdb -Wl,--no-as-needed -Wl,-rpath,../tap   -DGITVERSION=\"2.6.3-2-g1d5ed29\" -Wl,--export-dynamic -Wl,-Bdynamic -lgnutls -ltap -lcpp_dotenv -lcurl -lssl -lcrypto -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lev -lprometheus-cpp-pull -lprometheus-cpp-core -luuid -Wl,-Bdynamic -lpthread -lm -lz -lrt -ldl  /proxysql/deps/cityhash/cityhash//src/.libs/libcityhash.a /proxysql/deps/coredumper/coredumper/src/libcoredumper.a -o admin-listen_on_unix-t
/usr/bin/ld: cannot find -luuid: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:226: admin-listen_on_unix-t] Error 1
make[2]: Leaving directory '/proxysql/test/tap/tests'
make[1]: *** [Makefile:21: tests] Error 2
make[1]: Leaving directory '/proxysql/test/tap'
make: *** [Makefile:236: build_tap_tests_debug] Error 2
```