### PR TITLE
V2.6.x ubuntu24 fedora40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensu
 amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux9-clang almalinux9-dbg
 amd64-centos: centos7 centos7-dbg centos8 centos8-clang centos8-dbg centos9 centos9-clang centos9-dbg
 amd64-debian: debian10 debian10-dbg debian11 debian11-clang debian11-dbg debian12 debian12-clang debian12-dbg
-amd64-fedora: fedora38 fedora38-clang fedora38-dbg fedora39 fedora39-clang fedora39-dbg
+amd64-fedora: fedora38 fedora38-clang fedora38-dbg fedora39 fedora39-clang fedora39-dbg fedora40 fedora40-clang fedora40-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg
 amd64-ubuntu: ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-clang ubuntu20-dbg ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 
@@ -313,7 +313,7 @@ arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensu
 arm64-almalinux: almalinux8 almalinux9
 arm64-centos: centos7 centos8 centos9
 arm64-debian: debian10 debian11 debian12
-arm64-fedora: fedora38 fedora39
+arm64-fedora: fedora38 fedora39 fedora40
 arm64-opensuse: opensuse15
 arm64-ubuntu: ubuntu16 ubuntu18 ubuntu20 ubuntu22 ubuntu24
 

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ amd64-centos: centos7 centos7-dbg centos8 centos8-clang centos8-dbg centos9 cent
 amd64-debian: debian10 debian10-dbg debian11 debian11-clang debian11-dbg debian12 debian12-clang debian12-dbg
 amd64-fedora: fedora38 fedora38-clang fedora38-dbg fedora39 fedora39-clang fedora39-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg
-amd64-ubuntu: ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-clang ubuntu20-dbg ubuntu22 ubuntu22-clang ubuntu22-dbg
+amd64-ubuntu: ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-clang ubuntu20-dbg ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 
 arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux
 arm64-almalinux: almalinux8 almalinux9
@@ -315,7 +315,7 @@ arm64-centos: centos7 centos8 centos9
 arm64-debian: debian10 debian11 debian12
 arm64-fedora: fedora38 fedora39
 arm64-opensuse: opensuse15
-arm64-ubuntu: ubuntu16 ubuntu18 ubuntu20 ubuntu22
+arm64-ubuntu: ubuntu16 ubuntu18 ubuntu20 ubuntu22 ubuntu24
 
 almalinux%: build-almalinux% ;
 centos%: build-centos% ;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -320,6 +320,33 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
 
 ####################################################################################################
+  ubuntu24_build:
+    extends:
+      service: _build
+    image: proxysql/packaging:build-ubuntu24
+    volumes:
+      - ./docker/images/proxysql/deb-compliant/latest-package/ctl/:/root/ctl/
+      - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - PKG_RELEASE=ubuntu24
+      - PROXYSQL_BUILD_TYPE=clickhouse
+
+  ubuntu24_clang_build:
+    extends:
+      service: ubuntu24_build
+    image: proxysql/packaging:build-clang-ubuntu24
+    environment:
+      - PKG_RELEASE=ubuntu24-clang
+
+  ubuntu24_dbg_build:
+    extends:
+      service: ubuntu24_build
+    environment:
+      - PKG_RELEASE=dbg-ubuntu24
+      - PROXYSQL_BUILD_TYPE=debug
+
+####################################################################################################
 ####################################################################################################
   opensuse15_build:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,34 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
 
 ####################################################################################################
+  fedora40_build:
+    extends:
+      service: _build
+    image: proxysql/packaging:build-fedora40
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
+      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - PKG_RELEASE=fedora40
+      - PROXYSQL_BUILD_TYPE=clickhouse
+
+  fedora40_clang_build:
+    extends:
+      service: fedora40_build
+    image: proxysql/packaging:build-clang-fedora40
+    environment:
+      - PKG_RELEASE=fedora40-clang
+
+  fedora40_dbg_build:
+    extends:
+      service: fedora40_build
+    environment:
+      - PKG_RELEASE=dbg-fedora40
+      - PROXYSQL_BUILD_TYPE=debug
+
+####################################################################################################
 ####################################################################################################
   debian10_build:
     extends:


### PR DESCRIPTION
add builds and packaging for

- ubuntu24
- ubuntu24-dbg
- ubuntu24-clang
- fedora40
- fedora40-dbg
- fedora40-clang
