### PR TITLE
Clear SSL error queue on shutdown

### DIFF
--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -433,7 +433,8 @@ MySQL_Data_Stream::~MySQL_Data_Stream() {
 			// other part, we perform a 'quiet' shutdown. For more context see
 			// MYSQL #29579.
 			SSL_set_quiet_shutdown(ssl, 1);
-			SSL_shutdown(ssl);
+			if (SSL_shutdown(ssl) < 0)
+				ERR_clear_error();
 		}
 		if (ssl) SSL_free(ssl);
 	}
@@ -515,7 +516,8 @@ void MySQL_Data_Stream::shut_hard() {
 		// other part, we perform a 'quiet' shutdown. For more context see
 		// MYSQL #29579.
 		SSL_set_quiet_shutdown(ssl, 1);
-		SSL_shutdown(ssl);
+		if (SSL_shutdown(ssl) < 0)
+			ERR_clear_error();
 	}
 	if (fd >= 0) {
 		shutdown(fd, SHUT_RDWR);


### PR DESCRIPTION
SSL_shutdown can return an error and if it is not cleared it will be left on the thread's error queue since they are thread local causing unrelated connections running on the same thread to be incorrectly terminated. Clear the error queue now if SSL_shutdown returns an error to keep us from impacting other connections.