### PR TITLE
Fix usage of wrlock by DNS_Cache::empty()

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -6764,7 +6764,7 @@ void DNS_Cache::clear() {
 bool DNS_Cache::empty() const {
 	bool result = true;
 
-	int rc = pthread_rwlock_rdlock(&rwlock_);
+	int rc = pthread_rwlock_wrlock(&rwlock_);
 	assert(rc == 0);
 	result = records.empty();
 	rc = pthread_rwlock_unlock(&rwlock_);


### PR DESCRIPTION
Emptying is a modifying operation, so it must claim write-mode lock, not read-mode lock.