### PR TITLE
Disabling AWS RDS topology auto-discovery by default

### DIFF
--- a/include/MySQL_Monitor.hpp
+++ b/include/MySQL_Monitor.hpp
@@ -448,6 +448,7 @@ class MySQL_Monitor {
 	static void trigger_dns_cache_update();
 
 	void process_discovered_topology(const std::string& originating_server_hostname, const vector<MYSQL_ROW>& discovered_servers, int reader_hostgroup);
+	bool is_aws_rds_multi_az_db_cluster_topology(const std::vector<MYSQL_ROW>& discovered_servers);
 
 	private:
 	std::vector<table_def_t *> *tables_defs_monitor;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -3366,8 +3366,12 @@ bool MySQL_Monitor::is_aws_rds_multi_az_db_cluster_topology(const std::vector<MY
 
 	const std::vector<std::string> instance_names = {"-instance-1", "-instance-2", "-instance-3"};
 	int identified_hosts = 0;
-	for (std::string instance_str : instance_names) {
+	for (const std::string& instance_str : instance_names) {
 		for (MYSQL_ROW server : discovered_servers) {
+			if (server[2] == NULL || (server[2][0] == '\0')) {
+				continue;
+			}
+
 			std::string current_discovered_hostname = server[2];
 			if (current_discovered_hostname.find(instance_str) != std::string::npos) {
 				++identified_hosts;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -3367,9 +3367,9 @@ void * MySQL_Monitor::monitor_read_only() {
 	unsigned long long t2;
 	unsigned long long next_loop_at=0;
 	int topology_loop = 0;
-	int topology_loop_max = mysql_thread___monitor_aws_rds_topology_discovery_interval;
 
 	while (GloMyMon->shutdown==false && mysql_thread___monitor_enabled==true) {
+		int topology_loop_max = mysql_thread___monitor_aws_rds_topology_discovery_interval;
 		bool do_discovery_check = false;
 
 		unsigned int glover;
@@ -3404,11 +3404,13 @@ void * MySQL_Monitor::monitor_read_only() {
 			goto __end_monitor_read_only_loop;
 		}
 
-		if (topology_loop >= topology_loop_max) {
-			do_discovery_check = true;
-			topology_loop = 0;
+		if (topology_loop_max > 0) { // if the discovery interval is set to zero, do not query for the topology
+			if (topology_loop >= topology_loop_max) {
+				do_discovery_check = true;
+				topology_loop = 0;
+			} 
+			topology_loop += 1;
 		}
-		topology_loop += 1;
 
 		// resultset must be initialized before calling monitor_read_only_async
 		monitor_read_only_async(resultset, do_discovery_check);

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -986,7 +986,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.monitor_ping_max_failures=3;
 	variables.monitor_ping_timeout=1000;
 	variables.monitor_aws_rds_topology_discovery_interval=1000;
-	variables.monitor_read_only_interval=1000;
+	variables.monitor_read_only_interval=0;
 	variables.monitor_read_only_timeout=800;
 	variables.monitor_read_only_max_timeout_count=3;
 	variables.monitor_replication_lag_group_by_host=false;
@@ -2153,7 +2153,7 @@ char ** MySQL_Threads_Handler::get_variables_list() {
 		VariablesPointers_int["monitor_ping_timeout"]      = make_tuple(&variables.monitor_ping_timeout,      100,       600*1000, false);
 		VariablesPointers_int["monitor_ping_max_failures"] = make_tuple(&variables.monitor_ping_max_failures,   1,      1000*1000, false);
 
-		VariablesPointers_int["monitor_aws_rds_topology_discovery_interval"] = make_tuple(&variables.monitor_aws_rds_topology_discovery_interval, 1, 100000, false);
+		VariablesPointers_int["monitor_aws_rds_topology_discovery_interval"] = make_tuple(&variables.monitor_aws_rds_topology_discovery_interval, 0, 100000, false);
 		VariablesPointers_int["monitor_read_only_interval"]          = make_tuple(&variables.monitor_read_only_interval,        100, 7*24*3600*1000, false);
 		VariablesPointers_int["monitor_read_only_timeout"]           = make_tuple(&variables.monitor_read_only_timeout,         100,       600*1000, false);
 		VariablesPointers_int["monitor_read_only_max_timeout_count"] = make_tuple(&variables.monitor_read_only_max_timeout_count, 1,      1000*1000, false);

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -985,8 +985,8 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.monitor_ping_interval=8000;
 	variables.monitor_ping_max_failures=3;
 	variables.monitor_ping_timeout=1000;
-	variables.monitor_aws_rds_topology_discovery_interval=1000;
-	variables.monitor_read_only_interval=0;
+	variables.monitor_aws_rds_topology_discovery_interval=0;
+	variables.monitor_read_only_interval=1000;
 	variables.monitor_read_only_timeout=800;
 	variables.monitor_read_only_max_timeout_count=3;
 	variables.monitor_replication_lag_group_by_host=false;


### PR DESCRIPTION
This pull request provides an option to disable the AWS RDS MySQL Multi-AZ DB Cluster auto-discovery feature, added in v2.6.2. It also disables the feature by default and adds an additional check.

__Background__
Currently, ProxySql regularly (by default every 1000th time checking the `read_only` status of a server) queries the `mysql.rds_topology` table on any AWS RDS DB instance or cluster in its server list to find information about database endpoints. It is designed to work with [AWS RDS Multi-AZ DB Clusters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/multi-az-db-clusters-concepts.html), which consist of three individual RDS instances whose endpoints are stored in the `mysql.rds_topology` table and whose names end in `-instance-1`, `-instance-2`, and `-instance-3`, respectively.

__Issue__
The `mysql.rds_topology` table may however be used for other purposes in the future, so the endpoints in the table cannot by default be assumed to be instances in a Multi-AZ DB Cluster. If the table contains an endpoint, ProxySQL automatically adds this endpoint to the `runtime_mysql_servers` table and starts routing traffic to it. Depending on what kind of endpoint is in the `mysql.rds_topology`, this may result in undesired behavior.

__Solution__
To prevent accidentally reading from the `mysql.rds_topology` table, this PR disables the auto-discovery by default and adds an additional check to only process the information in the table if the topology matches a Multi-AZ DB Cluster deployment.
To (re-)enable the auto-discovery for Multi-AZ DB Clusters, in the ProxySql Admin DB, set the global variable `mysql-monitor_aws_rds_topology_discovery_interval` to a value greater than zero (it used to be 1000) and load the variables to runtime. ([As per the the code, the variable determines "How frequently a topology discovery is performed, e.g. a value of 500 means one topology discovery every 500 read-only checks".](https://github.com/sysown/proxysql/blob/25f02a33ce1560fb05788ed4881cf6be6071a257/lib/MySQL_Thread.cpp#L894))