### PR TITLE
Check POLLHUP if unable to read anything from network

### DIFF
--- a/deps/mariadb-client-library/x509cache.patch
+++ b/deps/mariadb-client-library/x509cache.patch
@@ -35,6 +35,9 @@ index 916024a8..79564a10 100644
  
  int STDCALL mysql_set_server_option(MYSQL *mysql,
 diff --git libmariadb/secure/openssl.c libmariadb/secure/openssl.c
+index 916024a8..79564a10 100644
+--- libmariadb/secure/openssl.c
++++ libmariadb/secure/openssl.c
 @@ -30,6 +30,11 @@
  #include <openssl/conf.h>
  #include <openssl/md4.h>
@@ -81,9 +84,9 @@ diff --git libmariadb/secure/openssl.c libmariadb/secure/openssl.c
 +      close(fd);
 +      return 0;
 +    }
-+    // Compute the SHA-1 hash
 +    SHA1(fb, statbuf.st_size, temp);
-+    for (int i=0; i < SHA_DIGEST_LENGTH; i++) {
++    int i=0;
++    for (i=0; i < SHA_DIGEST_LENGTH; i++) {
 +      sprintf((char*)&(file_sha1[i*2]), "%02x", temp[i]);
 +    }
 +    free(fb);

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -722,6 +722,12 @@ int MySQL_Data_Stream::read_from_net() {
 				// it seems we end in shut_soft() anyway
 			}
 		}
+		if ( (revents & POLLHUP) ) {
+			// this is a final check
+			// Only if the amount of data read is 0 or less, then we check POLLHUP
+			proxy_debug(PROXY_DEBUG_NET, 5, "Session=%p, Datastream=%p -- shutdown soft. revents=%d , bytes read = %d\n", sess, this, revents, r);
+			shut_soft();
+		}
 	} else {
 		queue_w(queueIN,r);
 		bytes_info.bytes_recv+=r;


### PR DESCRIPTION
This solves a possible infinite loop that arises after commit e81895e . Commit e81895e prevents closing connections in case of temporary failures, but on the other side it doesn't allow to close faulty connections.