### PR TITLE
Fix busy-wait on client SSL connection

### DIFF
--- a/include/MySQL_Variables.h
+++ b/include/MySQL_Variables.h
@@ -20,6 +20,7 @@ bool update_server_variable(MySQL_Session* session, int idx, int &_rc);
 bool verify_server_variable(MySQL_Session* session, int idx, uint32_t client_hash, uint32_t server_hash);
 bool verify_set_names(MySQL_Session* session);
 bool logbin_update_server_variable(MySQL_Session* session, int idx, int &_rc);
+bool is_perm_track_err(int err, const char* varname);
 
 class MySQL_Variables {
 	static verify_var verifiers[SQL_NAME_LAST_HIGH_WM];

--- a/include/proxysql.h
+++ b/include/proxysql.h
@@ -117,6 +117,10 @@ void proxy_info_(const char* msg, ...);
 #ifdef DEBUG
 void init_debug_struct();
 void init_debug_struct_from_cmdline();
+/**
+ * @brief Add a debug entry in the error log. To be used through 'proxy_debug' macro.
+ * @details This function saves/restores the previous 'errno' value.
+ */
 __attribute__((__format__ (__printf__, 7, 8)))
 void proxy_debug_func(enum debug_module, int, int, const char *, int, const char *, const char *, ...);
 void proxy_debug_get_filters(std::set<std::string>&);

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -277,6 +277,11 @@ typedef struct {
 	char * default_value;       // default value
 	bool is_global_variable;	// is it a global variable?
 } mysql_variable_st;
+
+typedef struct {
+	int err;
+	const char* name;
+} var_track_err_st;
 #endif
 
 enum mysql_data_stream_status {
@@ -1218,10 +1223,9 @@ mysql_variable_st mysql_tracked_variables[] {
 	session_track_system_variables
 	session_track_transaction_info
 	*/
-
-
 };
 #else
 extern mysql_variable_st mysql_tracked_variables[];
+extern var_track_err_st perm_track_errs[];
 #endif // PROXYSQL_EXTERN
 #endif // MYSQL_TRACKED_VARIABLES

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2974,6 +2974,8 @@ bool MySQL_Session::handler_again___status_SETTING_GENERIC_VARIABLE(int *_rc, co
 					(myerr == 1193) // variable is not found
 					||
 					(myerr == 1651) // Query cache is disabled
+					||
+					(is_perm_track_err(myerr, var_name)) // Special permitted tracking errors (~= '1193')
 				) {
 					int idx = SQL_NAME_LAST_HIGH_WM;
 					for (int i=0; i<SQL_NAME_LAST_HIGH_WM; i++) {

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -9,7 +9,7 @@
 #endif
 
 #include <sstream>
-#include "mysql/mysqld_error.h"
+#include "mysqld_error.h"
 
 
 static inline char is_digit(char c) {

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -9,12 +9,30 @@
 #endif
 
 #include <sstream>
+#include "mysql/mysqld_error.h"
 
 
 static inline char is_digit(char c) {
 	if(c >= '0' && c <= '9')
 		return 1;
 	return 0;
+}
+
+var_track_err_st perm_track_errs[] {
+	// ERROR 1210 (HY000): Variable not supported in combination with Galera:
+	// - Changed by MySQL, previously 'ER_UNKNOWN_SYSTEM_VARIABLE'
+	{ ER_WRONG_ARGUMENTS, "sql_generate_invisible_primary_key" }
+};
+
+bool is_perm_track_err(int err, const char* varname) {
+	const size_t count = sizeof(perm_track_errs) / sizeof(var_track_err_st);
+
+	for (size_t i = 0; i < count; i++) {
+		if (perm_track_errs[i].err == err && (strcasecmp(varname, perm_track_errs[i].name) == 0)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 #include "proxysql_find_charset.h"

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -153,7 +153,8 @@ static void BQE1(SQLite3DB *db, const vector<string>& tbs, const string& p1, con
 }
 
 
-static int round_intv_to_time_interval(int& intv) {
+static int round_intv_to_time_interval(const char* name, int _intv) {
+	int intv = _intv;
 	if (intv > 300) {
 		intv = 600;
 	} else {
@@ -180,6 +181,9 @@ static int round_intv_to_time_interval(int& intv) {
 				}
 			}
 		}
+	}
+	if (intv != _intv) {
+		proxy_warning("Variable '%s' rounded to interval '%d'\n", name, intv);
 	}
 	return intv;
 }
@@ -8686,7 +8690,7 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		if (!strcasecmp(name,"stats_mysql_connection_pool")) {
 			int intv=atoi(value);
 			if (intv >= 0 && intv <= 300) {
-				intv = round_intv_to_time_interval(intv);
+				intv = round_intv_to_time_interval(name, intv);
 				variables.stats_mysql_connection_pool=intv;
 				GloProxyStats->variables.stats_mysql_connection_pool=intv;
 				return true;
@@ -8697,7 +8701,7 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		if (!strcasecmp(name,"stats_mysql_connections")) {
 			int intv=atoi(value);
 			if (intv >= 0 && intv <= 300) {
-				intv = round_intv_to_time_interval(intv);
+				intv = round_intv_to_time_interval(name, intv);
 				variables.stats_mysql_connections=intv;
 				GloProxyStats->variables.stats_mysql_connections=intv;
 				return true;
@@ -8708,7 +8712,7 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		if (!strcasecmp(name,"stats_mysql_query_cache")) {
 			int intv=atoi(value);
 			if (intv >= 0 && intv <= 300) {
-				intv = round_intv_to_time_interval(intv);
+				intv = round_intv_to_time_interval(name, intv);
 				variables.stats_mysql_query_cache=intv;
 				GloProxyStats->variables.stats_mysql_query_cache=intv;
 				return true;
@@ -8729,7 +8733,7 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		if (!strcasecmp(name,"stats_system_cpu")) {
 			int intv=atoi(value);
 			if (intv >= 0 && intv <= 600) {
-				intv = round_intv_to_time_interval(intv);
+				intv = round_intv_to_time_interval(name, intv);
 				variables.stats_system_cpu=intv;
 				GloProxyStats->variables.stats_system_cpu=intv;
 				return true;
@@ -8741,7 +8745,7 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 		if (!strcasecmp(name,"stats_system_memory")) {
 			int intv=atoi(value);
 			if (intv >= 0 && intv <= 600) {
-				intv = round_intv_to_time_interval(intv);
+				intv = round_intv_to_time_interval(name, intv);
 				variables.stats_system_memory=intv;
 				GloProxyStats->variables.stats_system_memory=intv;
 				return true;

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -1252,6 +1252,14 @@ handler_again:
 			//if (parent->use_ssl) {
 			{
 				// mariadb client library disables NONBLOCK for SSL connections ... re-enable it!
+				// CONTEXT: This shouldn't be confused with the previous incompatibility that 'mariadbclient'
+				// had between the NONBLOCK flags and SSL connections, and that was reported and solved via
+				// CONC-320, our patch for this incompatibility was dropped on connector upgrade for v2.0.9.
+				// Setting the socket back to NONBLOCK is SAFE. This is because a connection can be used for
+				// BOTH blocking and not blocking calls, as described here:
+				// - https://mariadb.com/kb/en/using-the-non-blocking-library/#mixing-blocking-and-non-blocking-operation
+				// In case of SSL connections, it's still required to set the socket back to NONBLOCK prior to
+				// non-blockig calls.
 				mysql_options(mysql, MYSQL_OPT_NONBLOCK, 0);
 				int f=fcntl(mysql->net.fd, F_GETFL);
 #ifdef FD_CLOEXEC

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -570,9 +570,7 @@ int MySQL_Data_Stream::read_from_net() {
 
 	int r=0;
 	int s=queue_available(queueIN);
-	if (encrypted) {
-	//	proxy_info("Queue available of %d bytes\n", s);
-	}
+
 	if (encrypted == false) {
 		if (pkts_recv) {
 			r = recv(fd, queue_w_ptr(queueIN), s, 0);
@@ -592,20 +590,6 @@ int MySQL_Data_Stream::read_from_net() {
 			}
 		}
 	} else { // encrypted == true
-/*
-		if (!SSL_is_init_finished(ssl)) {
-			int ret = SSL_do_handshake(ssl);
-			int ret2;
-			if (ret != 1) {
-				//ERR_print_errors_fp(stderr);
-				ret2 = SSL_get_error(ssl, ret);
-				fprintf(stderr,"%d\n",ret2);
-			}
-			return 0;
-		} else {
-			r = SSL_read (ssl, queue_w_ptr(queueIN), s);
-		}
-*/
 		PROXY_TRACE();
 		if (s < MY_SSL_BUFFER) {
 			return 0;	// no enough space for reads
@@ -623,7 +607,7 @@ int MySQL_Data_Stream::read_from_net() {
 			while (len > 0) {
 				n2 = BIO_write(rbio_ssl, src, len);
 				proxy_debug(PROXY_DEBUG_NET, 5, "Session=%p: write %d bytes into BIO %p, len=%d\n", sess, n2, rbio_ssl, len);
-				//proxy_info("BIO_write with len = %d and %d bytes\n", len , n2);
+
 				if (n2 <= 0) {
 					shut_soft();
 					return -1;
@@ -648,23 +632,12 @@ int MySQL_Data_Stream::read_from_net() {
 			n2 = SSL_read (ssl, queue_w_ptr(queueIN), s);
 			proxy_debug(PROXY_DEBUG_NET, 5, "Session=%p: read %d bytes from BIO %p into a buffer with %d bytes free\n", sess, n2, rbio_ssl, s);
 			r = n2;
-			//proxy_info("Read %d bytes from SSL\n", r);
-			if (n2 > 0) {
-			}
-/*
-			do {
-				n2 = SSL_read(ssl, buf2, sizeof(buf2));
-				if (n2 > 0) {
-					
-				}
-			} while (n > 0);
-*/
 			status = get_sslstatus(ssl, n2);
-			//proxy_info("SSL status = %d\n", status);
+
 			if (status == SSLSTATUS_WANT_IO) {
 				do {
 					n2 = BIO_read(wbio_ssl, buf2, sizeof(buf2));
-					//proxy_info("BIO_read with %d bytes\n", n2);
+
 					if (n2 > 0) {
           				queue_encrypted_bytes(buf2, n2);
 					} else if (!BIO_should_retry(wbio_ssl)) {
@@ -687,9 +660,9 @@ int MySQL_Data_Stream::read_from_net() {
 			r = ssl_recv_bytes;
 		}
 	}
-//__exit_read_from_next:
+
 	proxy_debug(PROXY_DEBUG_NET, 5, "Session=%p: read %d bytes from fd %d into a buffer of %d bytes free\n", sess, r, fd, s);
-	//proxy_error("read %d bytes from fd %d into a buffer of %d bytes free\n", r, fd, s);
+
 	if (r < 1) {
 		if (encrypted==false) {
 			int myds_errno=errno;

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -615,18 +615,18 @@ int MySQL_Data_Stream::read_from_net() {
 				src += n2;
 				len -= n2;
 				if (!SSL_is_init_finished(ssl)) {
-					//proxy_info("SSL_is_init_finished NOT completed\n");
+					proxy_debug(PROXY_DEBUG_NET, 5, "SSL handshake not finished yet   session=%p bytes=%d BIO=%p len=%d\n", sess, n2, rbio_ssl, len);
 					if (do_ssl_handshake() == SSLSTATUS_FAIL) {
-						//proxy_info("SSL_is_init_finished failed!!\n");
+						proxy_debug(PROXY_DEBUG_NET, 5, "SSL handshake failed   session=%p bytes=%d BIO=%p len=%d\n", sess, n2, rbio_ssl, len);
 						shut_soft();
 						return -1;
 					}
 					if (!SSL_is_init_finished(ssl)) {
-						//proxy_info("SSL_is_init_finished yet NOT completed\n");
+						proxy_debug(PROXY_DEBUG_NET, 5, "SSL handshake not finished yet   session=%p bytes=%d BIO=%p len=%d\n", sess, n2, rbio_ssl, len);
 						return 0;
 					}
 				} else {
-					//proxy_info("SSL_is_init_finished completed\n");
+					proxy_debug(PROXY_DEBUG_NET, 5, "SSL handshake finished   session=%p bytes=%d BIO=%p len=%d\n", sess, n2, rbio_ssl, len);
 				}
 			}
 			n2 = SSL_read (ssl, queue_w_ptr(queueIN), s);

--- a/test/tap/tap/tap.h
+++ b/test/tap/tap/tap.h
@@ -78,6 +78,10 @@ extern "C" {
    @see SKIP_BIG_TESTS
 */
 extern int skip_big_tests;
+/**
+ * @brief Specifies if time logging should include microseconds; either 1 or 0.
+ */
+extern volatile int tap_log_us;
 
 /**
   @defgroup MyTAP_API MyTAP API

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -199,8 +199,8 @@ std::size_t count_matches(const string& str, const string& substr) {
 	return result;
 }
 
-int mysql_query_t(MYSQL* mysql, const char* query) {
-	diag("%s: Issuing query '%s' to ('%s':%d)", get_formatted_time().c_str(), query, mysql->host, mysql->port);
+int mysql_query_t__(MYSQL* mysql, const char* query, const char* f, int ln, const char* fn) {
+	diag("%s:%d:%s(): Issuing query '%s' to ('%s':%d)", f, ln, fn, query, mysql->host, mysql->port);
 	return mysql_query(mysql, query);
 }
 

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -56,6 +56,18 @@ my_bool mysql_stmt_close_override(MYSQL_STMT* stmt, const char* file, int line);
 
 #endif 
 
+/**
+ * @brief Helper function to disable Core nodes scheduler from ProxySQL Cluster nodes.
+ * @details In the CI environment, 'Scheduler' is used to induce extra load via Admin interface on
+ *  all the cluster nodes. Disabling this allows for more accurate measurements on the primary.
+ * @param cl CommandLine arguments supplied to the test.
+ * @param admin Already opened Admin conn to the primary instance.
+ * @return On success, the opened Admin connections to the Core nodes used to change their config,
+ *  these conns should later be used to restore their original config. On failure, a pair of shape
+ *  '{ EXIT_FAILURE, {} }'.
+ */
+std::pair<int,std::vector<MYSQL*>> disable_core_nodes_scheduler(CommandLine& cl, MYSQL* admin);
+
 inline std::string get_formatted_time() {
 	time_t __timer;
 	char __buffer[30];

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -68,7 +68,18 @@ inline std::string get_formatted_time() {
 	return std::string(__buffer);
 }
 
-int mysql_query_t(MYSQL* mysql, const char* query);
+/**
+ * @brief Wrapper for 'mysql_query' with logging for convenience.
+ * @details Should be used through 'mysql_query_t' macro.
+ * @return Result of calling 'mysql_query'.
+ */
+int mysql_query_t__(MYSQL* mysql, const char* query, const char* f, int ln, const char* fn);
+
+/**
+ * @brief Convenience macro with query logging.
+ */
+#define mysql_query_t(mysql, query)\
+	mysql_query_t__(mysql, query, __FILE__, __LINE__, __func__)
 
 #define MYSQL_QUERY(mysql, query) \
 	do { \

--- a/test/tap/tests/max_connections_ff-t.cpp
+++ b/test/tap/tests/max_connections_ff-t.cpp
@@ -18,14 +18,12 @@
 
 #include <cstring>
 #include <chrono>
-#include <iostream>
 #include <string>
 #include <stdio.h>
 #include <vector>
 #include <unistd.h>
 
 #include "mysql.h"
-#include "mysqld_error.h"
 
 #include "json.hpp"
 
@@ -66,10 +64,10 @@ int set_max_conns(MYSQL* proxy_admin, int max_conns, int hg_id) {
 	string max_conn_query {};
 	string_format("UPDATE mysql_servers SET max_connections=%d WHERE hostgroup_id=%d", max_conn_query, max_conns, hg_id);
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), max_conn_query.c_str());
+	diag("Executing query `%s`...", max_conn_query.c_str());
 	MYSQL_QUERY(proxy_admin, max_conn_query.c_str());
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL SERVERS TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL SERVERS TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL SERVERS TO RUNTIME");
 
 	return EXIT_SUCCESS;
@@ -79,10 +77,10 @@ int set_srv_conn_to(MYSQL* proxy_admin, int connect_to) {
 	string srv_conn_to_query {};
 	string_format("SET mysql-connect_timeout_server_max=%d", srv_conn_to_query, connect_to);
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), srv_conn_to_query.c_str());
+	diag("Executing query `%s`...", srv_conn_to_query.c_str());
 	MYSQL_QUERY(proxy_admin, srv_conn_to_query.c_str());
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	return EXIT_SUCCESS;
@@ -93,10 +91,10 @@ int set_ff_for_user(MYSQL* proxy_admin, const string& user, bool ff) {
 	string upd_ff_query {};
 	string_format("UPDATE mysql_users SET fast_forward=%d WHERE username='%s'", upd_ff_query, ff, user.c_str());
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), upd_ff_query.c_str());
+	diag("Executing query `%s`...", upd_ff_query.c_str());
 	MYSQL_QUERY(proxy_admin, upd_ff_query.c_str());
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL USERS TO RUNTIME");
 
 	return EXIT_SUCCESS;
@@ -264,9 +262,9 @@ cleanup:
 
 	string reset_conn_to_srv {};
 	string_format("SET mysql-connect_timeout_server_max=%s", reset_conn_to_srv, str_connect_timeout_server_max.c_str());
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), reset_conn_to_srv.c_str());
+	diag("Executing query `%s`...", reset_conn_to_srv.c_str());
 	MYSQL_QUERY(proxy_admin, reset_conn_to_srv.c_str());
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	return EXIT_SUCCESS;
@@ -313,7 +311,7 @@ int test_ff_only_one_free_conn(const CommandLine& cl, MYSQL* proxy_admin, int ma
 
 	// Reset all the current stats for 'stats_mysql_connection_pool'
 	my_err = mysql_query(proxy_admin, reset_connpool_stats);
-	diag("%s: Executing query `%s` in new 'fast_forward' conn...", tap_curtime().c_str(), reset_connpool_stats);
+	diag("Executing query `%s` in new 'fast_forward' conn...", reset_connpool_stats);
 	if (my_err) {
 		diag("Query '%s' failed", reset_connpool_stats);
 		res = EXIT_FAILURE;
@@ -333,7 +331,7 @@ int test_ff_only_one_free_conn(const CommandLine& cl, MYSQL* proxy_admin, int ma
 		MYSQL* trx_conn = trx_conns.back();
 
 		diag("Freeing ONE connection by committing the transaction...");
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), "COMMIT");
+		diag("Executing query `%s`...", "COMMIT");
 		my_err = mysql_query(trx_conn, "COMMIT");
 		if (my_err) {
 			diag(
@@ -375,7 +373,7 @@ int test_ff_only_one_free_conn(const CommandLine& cl, MYSQL* proxy_admin, int ma
 		}
 
 		// 3.1 Issue a simple query into the new 'fast_forward' connection
-		diag("%s: Executing query `%s` in new 'fast_forward' conn...", tap_curtime().c_str(), "DO 1");
+		diag("Executing query `%s` in new 'fast_forward' conn...", "DO 1");
 		int q_my_err = mysql_query(proxy_ff, "DO 1");
 		if (q_my_err) {
 			diag(

--- a/test/tap/tests/reg_test_3223-restapi_return_codes-t.cpp
+++ b/test/tap/tests/reg_test_3223-restapi_return_codes-t.cpp
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
 			for (const string& params : req.params) {
 				const string ept { join_path(base_address, req.ept_info.name) };
 				diag(
-					"%s: Checking valid '%s' request - ept: '%s', params: '%s'", tap_curtime().c_str(),
+					"Checking valid '%s' request - ept: '%s', params: '%s'",
 					req.ept_info.method.c_str(), ept.c_str(), params.c_str()
 				);
 				std::chrono::nanoseconds duration;
@@ -308,7 +308,7 @@ int main(int argc, char** argv) {
 
 			const string ept { join_path(base_address, req.ept_info.name) };
 			diag(
-				"%s: Checking valid '%s' request - ept: '%s', params: '%s'", tap_curtime().c_str(),
+				"Checking valid '%s' request - ept: '%s', params: '%s'",
 				req.ept_info.method.c_str(), ept.c_str(), ept_pl.params.c_str()
 			);
 

--- a/test/tap/tests/reg_test_3765_ssl_pollout-t.cpp
+++ b/test/tap/tests/reg_test_3765_ssl_pollout-t.cpp
@@ -68,7 +68,7 @@ int get_idle_conns_cpu_usage(CommandLine& cl, uint64_t mode, double& no_conns_cp
 	// get ProxySQL idle cpu usage
 	int idle_err = get_proxysql_cpu_usage(cl, REPORT_INTV_SEC, no_conns_cpu);
 	if (idle_err) {
-	    diag("Unable to get 'idle_cpu' usage.");
+	    diag("Unable to get 'no_conns_cpu' usage.");
 		return idle_err;
 	}
 
@@ -92,7 +92,7 @@ int get_idle_conns_cpu_usage(CommandLine& cl, uint64_t mode, double& no_conns_cp
 
 	int final_err = get_proxysql_cpu_usage(cl, REPORT_INTV_SEC, idle_conns_cpu);
 	if (final_err) {
-	    diag("Unable to get 'final_cpu' usage.");
+	    diag("Unable to get 'idle_conns_cpu' usage.");
 		return idle_err;
 	}
 

--- a/test/tap/tests/reg_test_4402-mysql_fields-t.cpp
+++ b/test/tap/tests/reg_test_4402-mysql_fields-t.cpp
@@ -83,7 +83,9 @@ int main(int argc, char** argv) {
 
 		// to check column alias issue:
 		{
-			const std::string& query = "SELECT testdb.echo_int(1) AS " + generate_random_string(length);
+			// NOTE: The randomly generated string should be escaped \`\`, otherwise could collide
+			// with SQL reserved words, causing an invalid test failure.
+			const std::string& query = "SELECT testdb.echo_int(1) AS `" + generate_random_string(length) + "`";
 			MYSQL_QUERY__(proxysql, query.c_str());
 
 			MYSQL_RES* res = mysql_use_result(proxysql);

--- a/test/tap/tests/reg_test__ssl_client_busy_wait-t.cpp
+++ b/test/tap/tests/reg_test__ssl_client_busy_wait-t.cpp
@@ -1,0 +1,323 @@
+/**
+ * @file reg_test_3273_ssl_con-t.cpp
+ * @brief Regression test for SSL busy/infinite loops for frontend connections.
+ * @details When client disconnects unexpectedly closing the socket on a SSL connection, depending on the
+ *   timing conditions, either an infinite loop or a busy loop could take place. These scenarios are:
+ *   1. Closed socket while query running on backend (before data arrives), leads to busy loop.
+ *   2. Closed socket after all the data has been written into the socket, since no more writing would take
+ *      place in the socket an infinite loop would take place.
+ */
+
+#include <cstring>
+#include <string>
+#include <stdio.h>
+#include <unistd.h>
+#include <vector>
+#include <poll.h>
+#include <fcntl.h>
+
+#include <sys/epoll.h>
+
+
+#include "mysql.h"
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+using std::string;
+using std::vector;
+
+/* Helper function to do the waiting for events on the socket. */
+static int wait_for_mysql(MYSQL *mysql, int status) {
+	struct pollfd pfd;
+	int timeout, res;
+
+	pfd.fd = mysql_get_socket(mysql);
+	pfd.events =
+		(status & MYSQL_WAIT_READ ? POLLIN : 0) |
+		(status & MYSQL_WAIT_WRITE ? POLLOUT : 0) |
+		(status & MYSQL_WAIT_EXCEPT ? POLLPRI : 0);
+	if (status & MYSQL_WAIT_TIMEOUT)
+		timeout = 1000*mysql_get_timeout_value(mysql);
+	else
+		timeout = -1;
+	res = poll(&pfd, 1, timeout);
+	if (res == 0)
+		return MYSQL_WAIT_TIMEOUT;
+	else if (res < 0)
+		return MYSQL_WAIT_TIMEOUT;
+	else {
+		int status = 0;
+		if (pfd.revents & POLLIN) status |= MYSQL_WAIT_READ;
+		if (pfd.revents & POLLOUT) status |= MYSQL_WAIT_WRITE;
+		if (pfd.revents & POLLPRI) status |= MYSQL_WAIT_EXCEPT;
+		return status;
+	}
+}
+
+enum BUSY_LOOP_T {
+	BUSY_LOOP=0,
+	INF_LOOP=1
+};
+
+struct th_args__in_t {
+	// Input
+	int argc { 0 };
+	char** argv { nullptr };
+	int secs { 0 };
+	int busy_loop_type = BUSY_LOOP_T::BUSY_LOOP;
+	CommandLine& cl;
+};
+
+struct th_args__out_t {
+	// Output
+	volatile int* query_started { nullptr };
+	volatile int* routine_rc { nullptr };
+};
+
+struct th_args_t {
+	th_args__in_t in_args;
+	th_args__out_t out_args {};
+};
+
+void* perform_async_query(void* arg) {
+	th_args_t* th_args = static_cast<th_args_t*>(arg);
+
+	MYSQL* mysql = nullptr;
+
+	{
+		CommandLine& cl = th_args->in_args.cl;
+		mysql = mysql_init(NULL);
+		MYSQL* ret = NULL;
+		int query_ret = 0;
+
+		mysql_options(mysql, MYSQL_OPT_NONBLOCK, 0);
+		mysql_ssl_set(mysql, NULL, NULL, NULL, NULL, NULL);
+
+		int status = 0;
+
+		if (th_args->in_args.argc == 2 && (strcmp(th_args->in_args.argv[1], "admin") == 0)) {
+			status = mysql_real_connect_start(
+				&ret, mysql, cl.host, "radmin", "radmin", NULL, 6032, NULL, CLIENT_SSL
+			);
+			diag("Creating 'Admin' connection   thread=%ld ret=%p status=%d", pthread_self(), ret, status);
+		} else {
+			status = mysql_real_connect_start(
+				&ret, mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, CLIENT_SSL
+			);
+
+			diag("Creating 'MySQL' connection   thread=%ld ret=%p status=%d", pthread_self(), ret, status);
+		}
+		if (status == 0) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(mysql));
+			__sync_fetch_and_add(th_args->out_args.routine_rc, 1);
+			return NULL;
+		}
+
+		diag("Continue connection establishment   thread=%ld ret=%p status=%d", pthread_self(), ret, status);
+		while (status) {
+			status = wait_for_mysql(mysql, status);
+			status = mysql_real_connect_cont(&ret, mysql, status);
+			diag("'mysql_real_connect_cont'   thread=%ld ret=%p status=%d", pthread_self(), ret, status);
+		}
+
+		// NOTE: mariadbclient has an incompatibility between SSL and NONBLOCK flags. Flag needs to be reset
+		// after 'mysql_real_connect_cont', otherwise API would become blocking.
+		mysql_options(mysql, MYSQL_OPT_NONBLOCK, 0);
+		int f=fcntl(mysql->net.fd, F_GETFL);
+		fcntl(mysql->net.fd, F_SETFL, f|O_NONBLOCK);
+
+		const string sleep_query { "SELECT SLEEP(" + std::to_string(th_args->in_args.secs) + ")" };
+		diag("mysql_query_start   thread=%ld query=%s", pthread_self(), sleep_query.c_str());
+
+		status = mysql_real_query_start(&query_ret, mysql, sleep_query.c_str(), sleep_query.size());
+
+		if (th_args->in_args.busy_loop_type == BUSY_LOOP_T::INF_LOOP) {
+			// NOTE: When signaling after 'mysql_query_start' has finished, ProxySQL wont attempt to write more
+			// to the closed pipe, this corresponds to 'busy_loop_type=2' and infinite loop.
+			while (status) {
+				status = wait_for_mysql(mysql, status);
+				status = mysql_real_query_cont(&query_ret, mysql, status);
+				diag("'mysql_real_connect_cont'   thread=%ld ret=%p status=%d", pthread_self(), ret, status);
+			}
+		}
+
+		diag("Signaling query start   thread=%ld status=%d query_ret=%d", pthread_self(), status, query_ret);
+		__sync_fetch_and_add(th_args->out_args.query_started, 1);
+
+		// NOTE: Required for triggering the issue, thread exit isn't enough, either 'process exit' or
+		// 'close()'. They should be immediate to the previous action, otherwise timing could be invalid.
+		close(mysql->net.fd);
+
+		while (true) {
+			diag(
+				"Sleeping after query started...   thread=%ld status=%d query_ret=%d",
+				pthread_self(), status, query_ret
+			);
+			sleep(1);
+		}
+	}
+
+	return NULL;
+}
+
+struct pthread_data_t {
+	pthread_t id { 0 };
+	int query_started { 0 };
+	int routine_rc { EXIT_SUCCESS };
+};
+
+const int BUSY_THREADS = get_env_int("TAP_SSL_BUSY_WAIT__BUSY_THREADS", 4);
+const int BUSY_WAIT_SECS = get_env_int("TAP_SSL_BUSY_WAIT__BUSY_WAIT_SECS", 5);
+const int MAX_IDLE_CPU = get_env_int("TAP_SSL_BUSY_WAIT__MAX_IDLE_CPU", 20);
+const int MAX_BUSY_CPU = get_env_int("TAP_SSL_BUSY_WAIT__MAX_BUSY_CPU", 25);
+const int SAMPLE_INTV_SECS = get_env_int("TAP_SSL_BUSY_WAIT__SAMPLE_INTV_SEC", 2);
+
+void create_busy_loops(int argc, char** argv, CommandLine& cl, BUSY_LOOP_T loop_type) {
+	vector<pthread_data_t> ths_data {};
+	vector<std::unique_ptr<th_args_t>> ths_args {};
+
+	ths_data.resize(BUSY_THREADS);
+
+	for (size_t i = 0; i < BUSY_THREADS; i++) {
+		pthread_data_t& th_data = ths_data[i];
+		std::unique_ptr<th_args_t> th_args {
+			new th_args_t {
+				th_args__in_t {
+					argc, argv, BUSY_WAIT_SECS, loop_type, cl
+				},
+				th_args__out_t {
+					&th_data.query_started,
+					&th_data.routine_rc
+				}
+			}
+		};
+
+		pthread_create(&th_data.id, NULL, perform_async_query, th_args.get());
+		ths_args.push_back(std::move(th_args));
+
+		diag("Thread created   thread=%ld", th_data.id);
+	}
+
+	bool missing_query = true;
+	bool query_failed = false;
+
+	while (missing_query && !query_failed) {
+		bool all_query_started = true;
+
+		for (pthread_data_t& th_data : ths_data) {
+			bool query_started = __sync_fetch_and_add(&th_data.query_started, 0);
+			diag(
+				"Thread data   thread=%ld routine_rc=%d query_started=%d",
+				th_data.id, th_data.routine_rc, query_started
+			);
+
+			if (th_data.id == 0 && query_started == 1) {
+				diag(
+					"Thread alreay cancelled   thread=%ld routine_rc=%d query_started=%d",
+					th_data.id, th_data.routine_rc, query_started
+				);
+				continue;
+			}
+
+			query_failed = __sync_fetch_and_add(&th_data.routine_rc, 0);
+
+			if (query_failed) {
+				diag(
+					"Async query failed; aborting test   thread=%ld routine_rc=%d query_started=%d",
+					th_data.id, th_data.routine_rc, query_started
+				);
+				break;
+			}
+
+			all_query_started &= query_started;
+
+			if (query_started) {
+				diag(
+					"Async query started, killing thread   thread=%ld routine_rc=%d query_started=%d",
+					th_data.id, th_data.routine_rc, query_started
+				);
+				pthread_cancel(th_data.id);
+				th_data.id = 0;
+			} else {
+				diag(
+					"Waiting for async query to start...   thread=%ld routine_rc=%d query_started=%d",
+					th_data.id, th_data.routine_rc, query_started
+				);
+			}
+		}
+
+		missing_query = !all_query_started;
+		usleep(500 * 1000);
+	}
+}
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	plan(4);
+
+	diag("Checking ProxySQL idle CPU usage");
+	double idle_cpu = 0;
+	int ret_i_cpu = get_proxysql_cpu_usage(cl, SAMPLE_INTV_SECS, idle_cpu);
+	if (ret_i_cpu) {
+		diag("Getting initial CPU usage failed with error - %d", ret_i_cpu);
+		diag("Aborting further testing");
+
+		return EXIT_FAILURE;
+	}
+
+	ok(
+		idle_cpu < MAX_IDLE_CPU, "Idle CPU usage should be below expected - Exp:%d%%, Act: %lf%%",
+		MAX_IDLE_CPU, idle_cpu
+	);
+
+	create_busy_loops(argc, argv, cl, BUSY_LOOP_T::BUSY_LOOP);
+
+	double final_cpu_usage = 0;
+	int ret_f_cpu = get_proxysql_cpu_usage(cl, SAMPLE_INTV_SECS, final_cpu_usage);
+	diag("Getting the final CPU usage returned - %d", ret_f_cpu);
+
+	ok(
+		final_cpu_usage < MAX_BUSY_CPU,
+		"ProxySQL CPU usage should be below expected - Exp: %d%%, Act: %lf%%",
+		MAX_BUSY_CPU, final_cpu_usage
+	);
+
+	// Extra wait to ensure cleanup of faulty client conns
+	sleep(BUSY_WAIT_SECS < 5 ? 5 : BUSY_WAIT_SECS / 2);
+
+	ret_i_cpu = get_proxysql_cpu_usage(cl, SAMPLE_INTV_SECS, idle_cpu);
+	if (ret_i_cpu) {
+		diag("Getting initial CPU usage failed with error - %d", ret_i_cpu);
+		diag("Aborting further testing");
+
+		return EXIT_FAILURE;
+	}
+
+	ok(
+		idle_cpu < MAX_IDLE_CPU, "Idle CPU usage should be below expected - Exp:%d%%, Act: %lf%%",
+		MAX_IDLE_CPU, idle_cpu
+	);
+
+	create_busy_loops(argc, argv, cl, BUSY_LOOP_T::INF_LOOP);
+
+	final_cpu_usage = 0;
+	ret_f_cpu = get_proxysql_cpu_usage(cl, SAMPLE_INTV_SECS, final_cpu_usage);
+	diag("Getting the final CPU usage returned - %d", ret_f_cpu);
+
+	ok(
+		final_cpu_usage < MAX_BUSY_CPU,
+		"ProxySQL CPU usage should be below expected - Exp: %d%%, Act: %lf%%",
+		MAX_BUSY_CPU, final_cpu_usage
+	);
+
+
+	return exit_status();
+}

--- a/test/tap/tests/reg_test_sql_calc_found_rows-t.cpp
+++ b/test/tap/tests/reg_test_sql_calc_found_rows-t.cpp
@@ -13,7 +13,6 @@
 #include <unistd.h>
 
 #include "mysql.h"
-#include "mysqld_error.h"
 
 #include "json.hpp"
 
@@ -74,7 +73,7 @@ int main(int argc, char** argv) {
 	// 1. Prepare the 'SQL_CALC_FOUND_ROWS' stmt in a connection
 	MYSQL* proxy_mysql = mysql_init(NULL);
 
-	diag("%s: Openning initial connection...", tap_curtime().c_str());
+	diag("Openning initial connection...");
 	if (!mysql_real_connect(proxy_mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy_mysql));
 		return EXIT_FAILURE;
@@ -84,7 +83,7 @@ int main(int argc, char** argv) {
 	MYSQL_STMT* stmt_2 = mysql_stmt_init(proxy_mysql);
 	MYSQL_STMT* stmt_3 = nullptr;
 
-	diag("%s: Issuing the prepare for `%s` in init conn", tap_curtime().c_str(), Q_CALC_FOUND_ROWS_1);
+	diag("Issuing the prepare for `%s` in init conn", Q_CALC_FOUND_ROWS_1);
 	int my_err = mysql_stmt_prepare(stmt_1, Q_CALC_FOUND_ROWS_1, strlen(Q_CALC_FOUND_ROWS_1));
 	if (my_err) {
 		diag(
@@ -94,7 +93,7 @@ int main(int argc, char** argv) {
 		goto cleanup;
 	}
 
-	diag("%s: Issuing the prepare for `%s` in init conn", tap_curtime().c_str(), Q_CALC_FOUND_ROWS_2);
+	diag("Issuing the prepare for `%s` in init conn", Q_CALC_FOUND_ROWS_2);
 	my_err = mysql_stmt_prepare(stmt_2, Q_CALC_FOUND_ROWS_2, strlen(Q_CALC_FOUND_ROWS_2));
 	if (my_err) {
 		diag(
@@ -107,13 +106,13 @@ int main(int argc, char** argv) {
 	mysql_stmt_close(stmt_1);
 	mysql_stmt_close(stmt_2);
 
-	diag("%s: Closing initial connection...", tap_curtime().c_str());
+	diag("Closing initial connection...");
 	mysql_close(proxy_mysql);
 
 	// 2. Open a new connection and prepare the stmts it again in a new connection
 	proxy_mysql = mysql_init(NULL);
 
-	diag("%s: Openning new connection for testing 'Multiplex' disabling", tap_curtime().c_str());
+	diag("Openning new connection for testing 'Multiplex' disabling");
 	if (!mysql_real_connect(proxy_mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy_mysql));
 		return EXIT_FAILURE;
@@ -123,7 +122,7 @@ int main(int argc, char** argv) {
 	stmt_2 = mysql_stmt_init(proxy_mysql);
 	stmt_3 = mysql_stmt_init(proxy_mysql);
 
-	diag("%s: Issuing the prepare for `%s` in new conn", tap_curtime().c_str(), Q_CALC_FOUND_ROWS_1);
+	diag("Issuing the prepare for `%s` in new conn", Q_CALC_FOUND_ROWS_1);
 	my_err = mysql_stmt_prepare(stmt_1, Q_CALC_FOUND_ROWS_1, strlen(Q_CALC_FOUND_ROWS_1));
 	if (my_err) {
 		diag(
@@ -134,7 +133,7 @@ int main(int argc, char** argv) {
 	}
 
 	{
-		diag("%s: Issuing execute for `%s` in new conn", tap_curtime().c_str(), Q_CALC_FOUND_ROWS_1);
+		diag("Issuing execute for `%s` in new conn", Q_CALC_FOUND_ROWS_1);
 		my_err = mysql_stmt_execute(stmt_1);
 		if (my_err) {
 			diag("'mysql_stmt_execute' at line %d failed: %s", __LINE__, mysql_stmt_error(stmt_1));
@@ -149,7 +148,7 @@ int main(int argc, char** argv) {
 		}
 	}
 	{
-		diag("%s: Issuing the prepare for `%s` in new conn", tap_curtime().c_str(), Q_CALC_FOUND_ROWS_2);
+		diag("Issuing the prepare for `%s` in new conn", Q_CALC_FOUND_ROWS_2);
 		my_err = mysql_stmt_prepare(stmt_2, Q_CALC_FOUND_ROWS_2, strlen(Q_CALC_FOUND_ROWS_2));
 		if (my_err) {
 			diag(
@@ -160,7 +159,7 @@ int main(int argc, char** argv) {
 		}
 
 		{
-			diag("%s: Issuing execute for `%s` in new conn", tap_curtime().c_str(), Q_CALC_FOUND_ROWS_2);
+			diag("Issuing execute for `%s` in new conn", Q_CALC_FOUND_ROWS_2);
 			my_err = mysql_stmt_execute(stmt_2);
 			if (my_err) {
 				diag("'mysql_stmt_execute' at line %d failed: %s", __LINE__, mysql_stmt_error(stmt_2));
@@ -175,7 +174,7 @@ int main(int argc, char** argv) {
 			}
 		}
 
-		diag("%s: Issuing the prepare for `%s` in new conn", tap_curtime().c_str(), Q_FOUND_ROWS);
+		diag("Issuing the prepare for `%s` in new conn", Q_FOUND_ROWS);
 		my_err = mysql_stmt_prepare(stmt_3, Q_FOUND_ROWS, strlen(Q_FOUND_ROWS));
 		if (my_err) {
 			diag(

--- a/test/tap/tests/test_auto_increment_delay_multiplex-t.cpp
+++ b/test/tap/tests/test_auto_increment_delay_multiplex-t.cpp
@@ -25,11 +25,9 @@
 #include <vector>
 #include <string>
 #include <stdio.h>
-#include <iostream>
 
 #include <unistd.h>
 #include "mysql.h"
-#include "mysqld_error.h"
 
 #include "json.hpp"
 
@@ -142,14 +140,14 @@ int check_auto_increment_timeout(
 	const string set_auto_inc_to_query {
 		"SET mysql-auto_increment_delay_multiplex_timeout_ms=" + std::to_string(auto_inc_delay_to)
 	};
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_auto_inc_to_query.c_str());
+	diag("Executing query `%s`...", set_auto_inc_to_query.c_str());
 	MYSQL_QUERY(proxy_admin, set_auto_inc_to_query.c_str());
 
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	MYSQL_QUERY(proxy_mysql, INSERT_QUERY);
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), INSERT_QUERY);
+	diag("Executing query `%s`...", INSERT_QUERY);
 
 	// Wait at least '500' milliseconds over the poll period
 	usleep((poll_to + 500) * 1000);
@@ -197,7 +195,7 @@ int check_auto_increment_timeout(
 	}
 
 	MYSQL_QUERY(proxy_mysql, "DO 1");
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "DO 1");
+	diag("Executing query `%s`...", "DO 1");
 
 	uint32_t old_auto_inc_delay_mult = cur_auto_inc_delay_mult;
 	g_res = get_conn_auto_inc_delay_token(proxy_mysql, cur_auto_inc_delay_mult);
@@ -244,9 +242,9 @@ int check_variables_config(MYSQL* proxy_mysql, MYSQL* proxy_admin) {
 
 int check_auto_increment_delay_multiplex(MYSQL* proxy_mysql, MYSQL* proxy_admin) {
 	// Disable the 'timeout' for the this check since it can be fixated now
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "SET mysql-auto_increment_delay_multiplex_timeout_ms=0");
+	diag("Executing query `%s`...", "SET mysql-auto_increment_delay_multiplex_timeout_ms=0");
 	MYSQL_QUERY(proxy_admin, "SET mysql-auto_increment_delay_multiplex_timeout_ms=0");
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "SET mysql-connection_delay_multiplex_ms=0");
+	diag("Executing query `%s`...", "SET mysql-connection_delay_multiplex_ms=0");
 	MYSQL_QUERY(proxy_admin, "SET mysql-connection_delay_multiplex_ms=0");
 
 	int cur_auto_inc_delay_mult = 0;
@@ -310,13 +308,13 @@ int check_auto_increment_delay_multiplex_timeout(MYSQL* proxy_mysql, MYSQL* prox
 	uint64_t poll_timeout = 0;
 	int g_res = 0;
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_auto_inc_query.c_str());
+	diag("Executing query `%s`...", set_auto_inc_query.c_str());
 	MYSQL_QUERY(proxy_admin, set_auto_inc_query.c_str());
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "SET mysql-connection_delay_multiplex_ms=0");
+	diag("Executing query `%s`...", "SET mysql-connection_delay_multiplex_ms=0");
 	MYSQL_QUERY(proxy_admin, "SET mysql-connection_delay_multiplex_ms=0");
 
 	const string q_poll_timeout { "SELECT variable_value FROM global_variables WHERE variable_name='mysql-poll_timeout'" };
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), q_poll_timeout.c_str());
+	diag("Executing query `%s`...", q_poll_timeout.c_str());
 	g_res = get_query_result(proxy_admin, q_poll_timeout.c_str(), poll_timeout);
 	if (g_res != EXIT_SUCCESS) { return EXIT_FAILURE; }
 
@@ -357,14 +355,14 @@ int check_auto_increment_delay_multiplex_timeout(MYSQL* proxy_mysql, MYSQL* prox
 	if (g_res != EXIT_SUCCESS) { return EXIT_FAILURE; }
 
 	MYSQL_QUERY(proxy_admin, delay_query.c_str());
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), delay_query.c_str());
+	diag("Executing query `%s`...", delay_query.c_str());
 	MYSQL_QUERY(proxy_admin, timeout_query.c_str());
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), timeout_query.c_str());
+	diag("Executing query `%s`...", timeout_query.c_str());
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	{
 		// Insert disabling multiplexing for the connection
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), INSERT_QUERY);
+		diag("Executing query `%s`...", INSERT_QUERY);
 		MYSQL_QUERY(proxy_mysql, INSERT_QUERY);
 
 		// Perform queries in the same connection
@@ -373,7 +371,7 @@ int check_auto_increment_delay_multiplex_timeout(MYSQL* proxy_mysql, MYSQL* prox
 		while (waited < timeout_ms * 3) {
 			sleep(1);
 
-			diag("%s: Executing query `%s`...", tap_curtime().c_str(), "/* hostgroup=0 */ DO 1");
+			diag("Executing query `%s`...", "/* hostgroup=0 */ DO 1");
 			MYSQL_QUERY(proxy_mysql, "/* hostgroup=0 */ DO 1");
 			waited += 1000;
 		}
@@ -397,7 +395,7 @@ int check_auto_increment_delay_multiplex_timeout(MYSQL* proxy_mysql, MYSQL* prox
 		while (waited < timeout_ms * 3) {
 			sleep(1);
 
-			diag("%s: Executing query `%s`...", tap_curtime().c_str(), "SELECT 1");
+			diag("Executing query `%s`...", "SELECT 1");
 			MYSQL_QUERY(proxy_mysql, "SELECT 1");
 			mysql_free_result(mysql_store_result(proxy_mysql));
 
@@ -423,16 +421,16 @@ int check_auto_increment_delay_multiplex_timeout(MYSQL* proxy_mysql, MYSQL* prox
 
 	// Transactions connections should be preserved by 'auto_increment_delay_multiplex_timeout_ms'
 	{
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), "BEGIN");
+		diag("Executing query `%s`...", "BEGIN");
 		MYSQL_QUERY(proxy_mysql, "BEGIN");
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), INSERT_QUERY);
+		diag("Executing query `%s`...", INSERT_QUERY);
 		MYSQL_QUERY(proxy_mysql, INSERT_QUERY);
 
 		// Wait for the timeout and check the value
-		diag("%s: Waiting for timeout to expire...", tap_curtime().c_str());
+		diag("Waiting for timeout to expire...");
 		usleep(timeout_ms * 1000 + poll_timeout * 1000 + 500 * 1000 * 2);
 
-		diag("%s: Extracting current auto inc delay...", tap_curtime().c_str());
+		diag("Extracting current auto inc delay...");
 		int cur_delay = 0;
 		int g_res = get_conn_auto_inc_delay_token(proxy_mysql, cur_delay);
 		if (g_res != EXIT_SUCCESS) {
@@ -445,13 +443,13 @@ int check_auto_increment_delay_multiplex_timeout(MYSQL* proxy_mysql, MYSQL* prox
 			delay, cur_delay
 		);
 
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), "COMMIT");
+		diag("Executing query `%s`...", "COMMIT");
 		MYSQL_QUERY(proxy_mysql, "COMMIT");
 
-		diag("%s: Waiting for timeout to expire...", tap_curtime().c_str());
+		diag("Waiting for timeout to expire...");
 		usleep(timeout_ms * 1000 + poll_timeout * 1000 + 500 * 1000 * 2);
 
-		diag("%s: Extracting current auto inc delay...", tap_curtime().c_str());
+		diag("Extracting current auto inc delay...");
 		cur_delay = 0;
 		g_res = get_conn_auto_inc_delay_token(proxy_mysql, cur_delay);
 		if (g_res != EXIT_SUCCESS) {
@@ -468,16 +466,16 @@ int check_auto_increment_delay_multiplex_timeout(MYSQL* proxy_mysql, MYSQL* prox
 	// Multiplex disabled by any action should take precedence over 'auto_increment_delay_multiplex_timeout_ms'
 	{
 		const char* set_query { "SET @local_var='foo'" };
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_query);
+		diag("Executing query `%s`...", set_query);
 		MYSQL_QUERY(proxy_mysql, set_query);
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), INSERT_QUERY);
+		diag("Executing query `%s`...", INSERT_QUERY);
 		MYSQL_QUERY(proxy_mysql, INSERT_QUERY);
 
 		// Wait for the timeout and check the value
-		diag("%s: Waiting for timeout to expire...", tap_curtime().c_str());
+		diag("Waiting for timeout to expire...");
 		usleep(timeout_ms * 1000 + poll_timeout * 1000 + 500 * 1000 * 2);
 
-		diag("%s: Extracting current auto inc delay...", tap_curtime().c_str());
+		diag("Extracting current auto inc delay...");
 		int cur_delay = 0;
 		int g_res = get_conn_auto_inc_delay_token(proxy_mysql, cur_delay);
 		if (g_res != EXIT_SUCCESS) {
@@ -533,9 +531,9 @@ void check_connection_retained(MYSQL* proxy_mysql, uint32_t exp_conns) {
 int check_transactions_and_multiplex_disable(
 	MYSQL* proxy_mysql, const char* query, const uint32_t timeout, uint64_t poll_timeout=2
 ) {
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "BEGIN");
+	diag("Executing query `%s`...", "BEGIN");
 	MYSQL_QUERY(proxy_mysql, "BEGIN");
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), query);
+	diag("Executing query `%s`...", query);
 	MYSQL_QUERY(proxy_mysql, query);
 
 	diag("Checking connection present before timeout...");
@@ -547,7 +545,7 @@ int check_transactions_and_multiplex_disable(
 	diag("Checking connection is still present after timeout due to transaction...");
 	check_connection_retained(proxy_mysql, 1);
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "COMMIT");
+	diag("Executing query `%s`...", "COMMIT");
 	MYSQL_QUERY(proxy_mysql, "COMMIT");
 
 	diag("Sleeping for '%lf' seconds", timeout / 2.0);
@@ -565,7 +563,7 @@ int check_transactions_and_multiplex_disable(
 	diag("Checking multiplex disabled by any action take precedence over 'connection_delay_multiplex_ms'...");
 
 	const char* set_query { "SET @local_var='foo'" };
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_query);
+	diag("Executing query `%s`...", set_query);
 	MYSQL_QUERY(proxy_mysql, set_query);
 
 	diag("Sleeping for '%ld' seconds", timeout + poll_timeout);
@@ -587,13 +585,13 @@ int check_connection_delay_multiplex_ms(MYSQL* proxy_mysql, MYSQL* proxy_admin) 
 	string_format("SET mysql-connection_delay_multiplex_ms=%d", set_delay_multiplex, timeout * 1000);
 	const char* set_auto_inc_delay { "SET mysql-auto_increment_delay_multiplex_timeout_ms=0" };
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_delay_multiplex.c_str());
+	diag("Executing query `%s`...", set_delay_multiplex.c_str());
 	MYSQL_QUERY(proxy_admin, set_delay_multiplex.c_str());
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_auto_inc_delay);
+	diag("Executing query `%s`...", set_auto_inc_delay);
 	MYSQL_QUERY(proxy_admin, set_auto_inc_delay);
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	MYSQL_QUERY(proxy_mysql, "SELECT 1");
@@ -632,13 +630,13 @@ int check_multiplex_disabled_connection_delay_multiplex_ms(MYSQL* proxy_mysql, M
 	string_format("SET mysql-connection_delay_multiplex_ms=%d", set_delay_multiplex, timeout * 1000);
 	const char* set_auto_inc_delay { "SET mysql-auto_increment_delay_multiplex_timeout_ms=0" };
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_delay_multiplex.c_str());
+	diag("Executing query `%s`...", set_delay_multiplex.c_str());
 	MYSQL_QUERY(proxy_admin, set_delay_multiplex.c_str());
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_auto_inc_delay);
+	diag("Executing query `%s`...", set_auto_inc_delay);
 	MYSQL_QUERY(proxy_admin, set_auto_inc_delay);
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	// Check transactions behavior and multiplex disabling actions
@@ -652,11 +650,11 @@ int check_traffic_connection_delay_multiplex_ms(MYSQL* proxy_mysql, MYSQL* proxy
 	const char* set_delay_multiplex_query { "SET mysql-connection_delay_multiplex_ms=2000" };
 	const char* set_auto_inc_timeout_query { "SET mysql-auto_increment_delay_multiplex_timeout_ms=0" };
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_delay_multiplex_query);
+	diag("Executing query `%s`...", set_delay_multiplex_query);
 	MYSQL_QUERY(proxy_admin, set_delay_multiplex_query);
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_auto_inc_timeout_query);
+	diag("Executing query `%s`...", set_auto_inc_timeout_query);
 	MYSQL_QUERY(proxy_admin, set_auto_inc_timeout_query);
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	// Retain connection in 'hg=0'
@@ -664,7 +662,7 @@ int check_traffic_connection_delay_multiplex_ms(MYSQL* proxy_mysql, MYSQL* proxy
 
 	uint32_t waited = 0;
 	while (waited < 2*timeout) {
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), "DO 1");
+		diag("Executing query `%s`...", "DO 1");
 		MYSQL_QUERY(proxy_mysql, "DO 1");
 
 		sleep(1);
@@ -679,9 +677,9 @@ int check_traffic_connection_delay_multiplex_ms(MYSQL* proxy_mysql, MYSQL* proxy
 
 	diag("Check connection expiring when traffic issued to different hostgroup...");
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "DO 1");
+	diag("Executing query `%s`...", "DO 1");
 	MYSQL_QUERY(proxy_mysql, "DO 1");
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "SELECT 1");
+	diag("Executing query `%s`...", "SELECT 1");
 	MYSQL_QUERY(proxy_mysql, "SELECT 1");
 	mysql_free_result(mysql_store_result(proxy_mysql));
 
@@ -719,7 +717,7 @@ int check_traffic_connection_delay_multiplex_ms(MYSQL* proxy_mysql, MYSQL* proxy
 	// Check for connections retained in 'hg 0'
 	waited = 0;
 	while (waited < timeout * 2) {
-		diag("%s: Executing query `%s`...", tap_curtime().c_str(), "SELECT 1");
+		diag("Executing query `%s`...", "SELECT 1");
 		MYSQL_QUERY(proxy_mysql, "SELECT 1");
 		mysql_free_result(mysql_store_result(proxy_mysql));
 
@@ -768,18 +766,18 @@ int check_auto_inc_delay_and_conn_delay_multiplex(MYSQL* proxy_mysql, MYSQL* pro
 	const char* set_delay_multiplex_query { "SET mysql-connection_delay_multiplex_ms=2000" };
 	const char* set_auto_inc_timeout_query { "SET mysql-auto_increment_delay_multiplex_timeout_ms=0" };
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_delay_multiplex_query);
+	diag("Executing query `%s`...", set_delay_multiplex_query);
 	MYSQL_QUERY(proxy_admin, set_delay_multiplex_query);
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_auto_inc_timeout_query);
+	diag("Executing query `%s`...", set_auto_inc_timeout_query);
 	MYSQL_QUERY(proxy_admin, set_auto_inc_timeout_query);
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 	// Retain connection in 'hg=0'
 	diag("Checking connection not expiring due to 'auto_increment_delay_multiplex'.");
 
 	uint32_t waited = 0;
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), INSERT_QUERY);
+	diag("Executing query `%s`...", INSERT_QUERY);
 	MYSQL_QUERY(proxy_mysql, INSERT_QUERY);
 
 	diag("* Check connection retained after executing the query");
@@ -797,13 +795,13 @@ int check_auto_inc_delay_and_conn_delay_multiplex(MYSQL* proxy_mysql, MYSQL* pro
 	);
 
 	string_format("SET mysql-auto_increment_delay_multiplex_timeout_ms=%d", auto_inc_timeout_query, timeout*2*1000);
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), auto_inc_timeout_query.c_str());
+	diag("Executing query `%s`...", auto_inc_timeout_query.c_str());
 	MYSQL_QUERY(proxy_admin, auto_inc_timeout_query.c_str());
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), INSERT_QUERY);
+	diag("Executing query `%s`...", INSERT_QUERY);
 	MYSQL_QUERY(proxy_mysql, INSERT_QUERY);
 
 	diag("Sleeping for '%d' seconds", timeout + 1);
@@ -834,17 +832,17 @@ int check_auto_inc_delay_and_conn_delay_multiplex(MYSQL* proxy_mysql, MYSQL* pro
 	);
 
 	string_format("SET mysql-auto_increment_delay_multiplex_timeout_ms=%d", auto_inc_timeout_query, timeout*1000);
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), auto_inc_timeout_query.c_str());
+	diag("Executing query `%s`...", auto_inc_timeout_query.c_str());
 	MYSQL_QUERY(proxy_admin, auto_inc_timeout_query.c_str());
 
 	const char* set_delay_multiplex_query_2 { "SET mysql-connection_delay_multiplex_ms=4000" };
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), set_delay_multiplex_query_2);
+	diag("Executing query `%s`...", set_delay_multiplex_query_2);
 	MYSQL_QUERY(proxy_admin, set_delay_multiplex_query_2);
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), "LOAD MYSQL VARIABLES TO RUNTIME");
+	diag("Executing query `%s`...", "LOAD MYSQL VARIABLES TO RUNTIME");
 	MYSQL_QUERY(proxy_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
-	diag("%s: Executing query `%s`...", tap_curtime().c_str(), INSERT_QUERY);
+	diag("Executing query `%s`...", INSERT_QUERY);
 	MYSQL_QUERY(proxy_mysql, INSERT_QUERY);
 
 	diag("Sleeping for '%d' seconds", timeout + 1);

--- a/test/tap/tests/test_binlog_fast_forward-t.cpp
+++ b/test/tap/tests/test_binlog_fast_forward-t.cpp
@@ -84,7 +84,7 @@ int pull_replication(MYSQL *mysql, int server_id) {
 			}
 		}
 		if (print_diag == true)
-			diag("%s: server_id %d , event: %d , received events: %d , received heartbeats: %d", tap_curtime().c_str(), server_id, event->event_type, num_events, num_heartbeats);
+			diag("server_id %d , event: %d , received events: %d , received heartbeats: %d", server_id, event->event_type, num_events, num_heartbeats);
 	}
 	// we expects NHB heartbeats
 	ok(num_heartbeats == NHB , "For server_id %d received %d heartbeats", server_id, num_heartbeats);

--- a/test/tap/tests/test_session_status_flags-t.cpp
+++ b/test/tap/tests/test_session_status_flags-t.cpp
@@ -172,7 +172,7 @@ int prepare_stmt_queries(const CommandLine& cl, const vector<query_t>& p_queries
 	// 1. Prepare the stmt in a connection
 	MYSQL* proxy_mysql = mysql_init(NULL);
 
-	diag("%s: Openning INITIAL connection...", tap_curtime().c_str());
+	diag("Openning INITIAL connection...");
 	if (!mysql_real_connect(proxy_mysql, cl.root_host, cl.root_username, cl.root_password, NULL, cl.root_port, NULL, 0)) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxy_mysql));
 		return EXIT_FAILURE;
@@ -216,7 +216,7 @@ int prepare_stmt_queries(const CommandLine& cl, const vector<query_t>& p_queries
 			return EXIT_FAILURE;
 		}
 
-		diag("%s: Issuing PREPARE for `%s` in INIT conn", tap_curtime().c_str(), query.c_str());
+		diag("Issuing PREPARE for `%s` in INIT conn", query.c_str());
 		int my_err = mysql_stmt_prepare(stmt, query.c_str(), strlen(query.c_str()));
 		if (my_err) {
 			diag(
@@ -229,7 +229,7 @@ int prepare_stmt_queries(const CommandLine& cl, const vector<query_t>& p_queries
 		mysql_stmt_close(stmt);
 	}
 
-	diag("%s: Closing PREPARING connection...", tap_curtime().c_str());
+	diag("Closing PREPARING connection...");
 	mysql_close(proxy_mysql);
 
 	return EXIT_SUCCESS;
@@ -326,7 +326,7 @@ int exec_stmt_queries(MYSQL* proxy_mysql, const vector<query_t>& test_queries) {
 		} else {
 			MYSQL_STMT* stmt = mysql_stmt_init(proxy_mysql);
 
-			diag("%s: Issuing PREPARE for `%s` in new conn", tap_curtime().c_str(), query.c_str());
+			diag("Issuing PREPARE for `%s` in new conn", query.c_str());
 			int my_err = mysql_stmt_prepare(stmt, query.c_str(), strlen(query.c_str()));
 			if (my_err) {
 				diag(
@@ -339,7 +339,7 @@ int exec_stmt_queries(MYSQL* proxy_mysql, const vector<query_t>& test_queries) {
 			// TODO: Remember to DOC requiring to execute
 			{
 				if (rep_check.first == 0 || rep_check.second == 0) {
-					diag("%s: Issuing EXECUTE for `%s` in new conn", tap_curtime().c_str(), query.c_str());
+					diag("Issuing EXECUTE for `%s` in new conn", query.c_str());
 					my_err = mysql_stmt_execute(stmt);
 					if (my_err) {
 						diag("'mysql_stmt_execute' at line %d failed: %s", __LINE__, mysql_stmt_error(stmt));

--- a/test/tap/tests/test_unshun_algorithm-t.cpp
+++ b/test/tap/tests/test_unshun_algorithm-t.cpp
@@ -84,7 +84,7 @@ int shunn_server(MYSQL* proxysql_admin, uint32_t i, uint32_t j) {
 	std::string t_simulator_error_query { "PROXYSQL_SIMULATOR mysql_error %d 127.0.0.1:330%d 1234" };
 	std::string simulator_error_q_i {};
 	string_format(t_simulator_error_query, simulator_error_q_i, i, j);
-	diag("%s: running query: %s", tap_curtime().c_str(), simulator_error_q_i.c_str());
+	diag("running query: %s", simulator_error_q_i.c_str());
 	MYSQL_QUERY(proxysql_admin, simulator_error_q_i.c_str());
 
 	return EXIT_SUCCESS;
@@ -116,7 +116,7 @@ int wakup_target_server(MYSQL* proxysql_mysql, uint32_t i) {
 	string_format(t_simple_do_query, simple_do_query, i);
 
 	mysql_query(proxysql_mysql, simple_do_query.c_str());
-	diag("%s: running query: %s", tap_curtime().c_str(), simple_do_query.c_str());
+	diag("running query: %s", simple_do_query.c_str());
 
 	return EXIT_SUCCESS;
 }
@@ -127,7 +127,7 @@ int server_status_checker(MYSQL* admin, const string& f_st, const string& n_st, 
 	};
 	std::string server_status_query {};
 	string_format(t_server_status_query, server_status_query, i);
-	diag("%s: running query: %s", tap_curtime().c_str(), server_status_query.c_str());
+	diag("running query: %s", server_status_query.c_str());
 	MYSQL_QUERY(admin, server_status_query.c_str());
 
 	MYSQL_RES* status_res = mysql_store_result(admin);
@@ -193,9 +193,9 @@ int test_unshun_algorithm_variable(MYSQL* proxysql_admin) {
 	};
 
 	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES FROM DISK");
-	diag("%s: Line:%d running admin query to reload variables: LOAD MYSQL VARIABLES FROM DISK", tap_curtime().c_str(), __LINE__);
+	diag("Line:%d running admin query to reload variables: LOAD MYSQL VARIABLES FROM DISK", __LINE__);
 	MYSQL_QUERY(proxysql_admin, "SET mysql-hostgroup_manager_verbose=3");
-	diag("%s: Line:%d running admin query: SET mysql-hostgroup_manager_verbose=3", tap_curtime().c_str(), __LINE__);
+	diag("Line:%d running admin query: SET mysql-hostgroup_manager_verbose=3", __LINE__);
 	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 	int32_t def_unshun_value = get_current_unshun_algorithm_val(proxysql_admin);
 	ok(def_unshun_value == 0, "Default 'mysql-unshun_algorithm' should be '0', actual: %d", def_unshun_value);
@@ -206,7 +206,7 @@ int test_unshun_algorithm_variable(MYSQL* proxysql_admin) {
 		std::string set_unshun {};
 		string_format(t_set_unshun, set_unshun, i);
 		MYSQL_QUERY(proxysql_admin, set_unshun.c_str());
-		diag("%s: Line:%d running admin query: %s", tap_curtime().c_str(), __LINE__, set_unshun.c_str());
+		diag("Line:%d running admin query: %s", __LINE__, set_unshun.c_str());
 		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 		int32_t cur_unshun_val = get_current_unshun_algorithm_val(proxysql_admin);
@@ -217,7 +217,7 @@ int test_unshun_algorithm_variable(MYSQL* proxysql_admin) {
 		std::string set_unshun {};
 		string_format(t_set_unshun, set_unshun, VALID_RANGE + 1);
 		MYSQL_QUERY(proxysql_admin, set_unshun.c_str());
-		diag("%s: Line:%d running admin query: %s", tap_curtime().c_str(), __LINE__, set_unshun.c_str());
+		diag("Line:%d running admin query: %s", __LINE__, set_unshun.c_str());
 		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 		int32_t cur_unshun_val = get_current_unshun_algorithm_val(proxysql_admin);
@@ -276,13 +276,13 @@ int test_proxysql_simulator_error(MYSQL* proxysql_admin) {
  */
 int configure_mysql_shunning_variables(MYSQL* proxysql_admin) {
 	MYSQL_QUERY(proxysql_admin, "SET mysql-shun_on_failures=3");
-	diag("%s: Line:%d running admin query: SET mysql-shun_on_failures=3", tap_curtime().c_str(), __LINE__);
+	diag("Line:%d running admin query: SET mysql-shun_on_failures=3", __LINE__);
 
 	MYSQL_QUERY(proxysql_admin, "SET mysql-connect_retries_on_failure=3");
-	diag("%s: Line:%d running admin query: SET mysql-connect_retries_on_failure=3", tap_curtime().c_str(), __LINE__);
+	diag("Line:%d running admin query: SET mysql-connect_retries_on_failure=3", __LINE__);
 
 	MYSQL_QUERY(proxysql_admin, "SET mysql-connect_retries_delay=1000");
-	diag("%s: Line:%d running admin query: SET mysql-connect_retries_delay=1000", tap_curtime().c_str(), __LINE__);
+	diag("Line:%d running admin query: SET mysql-connect_retries_delay=1000", __LINE__);
 
 	return EXIT_SUCCESS;
 }
@@ -290,11 +290,11 @@ int configure_mysql_shunning_variables(MYSQL* proxysql_admin) {
 int test_unshun_algorithm_behavior(MYSQL* proxysql_mysql, MYSQL* proxysql_admin) {
 	// Configure Admin variables with lower thresholds
 	MYSQL_QUERY(proxysql_admin, "SET mysql-shun_recovery_time_sec=1");
-	diag("%s: Line:%d running admin query: SET mysql-shun_recovery_time_sec=1", tap_curtime().c_str(), __LINE__);
+	diag("Line:%d running admin query: SET mysql-shun_recovery_time_sec=1", __LINE__);
 
 	// Set verbosity up for extra information in ProxySQL log
 	MYSQL_QUERY(proxysql_admin, "SET mysql-hostgroup_manager_verbose=3");
-	diag("%s: Line:%d running admin query: SET mysql-hostgroup_manager_verbose=3", tap_curtime().c_str(), __LINE__);
+	diag("Line:%d running admin query: SET mysql-hostgroup_manager_verbose=3", __LINE__);
 
 	// Configure the relevant variables for the desired UNSHUNNING behavior
 	if (configure_mysql_shunning_variables(proxysql_admin)) {
@@ -327,7 +327,7 @@ int test_unshun_algorithm_behavior(MYSQL* proxysql_mysql, MYSQL* proxysql_admin)
 
 	{
 		MYSQL_QUERY(proxysql_admin, "SET mysql-unshun_algorithm=0");
-		diag("%s: Line:%d running admin query: SET mysql-unshun_algorithm=0", tap_curtime().c_str(), __LINE__);
+		diag("Line:%d running admin query: SET mysql-unshun_algorithm=0", __LINE__);
 		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 		int shunn_err = shunn_all_servers(proxysql_admin);
@@ -347,7 +347,7 @@ int test_unshun_algorithm_behavior(MYSQL* proxysql_mysql, MYSQL* proxysql_admin)
 
 	{
 		MYSQL_QUERY(proxysql_admin, "SET mysql-unshun_algorithm=1");
-		diag("%s: Line:%d running admin query: SET mysql-unshun_algorithm=1", tap_curtime().c_str(), __LINE__);
+		diag("Line:%d running admin query: SET mysql-unshun_algorithm=1", __LINE__);
 		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 		int shunn_err = shunn_all_servers(proxysql_admin);
@@ -367,7 +367,7 @@ int test_unshun_algorithm_behavior(MYSQL* proxysql_mysql, MYSQL* proxysql_admin)
 
 	{
 		MYSQL_QUERY(proxysql_admin, "SET mysql-unshun_algorithm=0");
-		diag("%s: Line:%d running admin query: SET mysql-unshun_algorithm=0", tap_curtime().c_str(), __LINE__);
+		diag("Line:%d running admin query: SET mysql-unshun_algorithm=0", __LINE__);
 		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 		int shunn_err = shunn_all_servers(proxysql_admin);
@@ -379,7 +379,7 @@ int test_unshun_algorithm_behavior(MYSQL* proxysql_mysql, MYSQL* proxysql_admin)
 		diag(" "); // empty line
 
 		MYSQL_QUERY(proxysql_admin, "SET mysql-unshun_algorithm=1");
-		diag("%s: Line:%d running admin query: SET mysql-unshun_algorithm=1", tap_curtime().c_str(), __LINE__);
+		diag("Line:%d running admin query: SET mysql-unshun_algorithm=1", __LINE__);
 		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
 
 		for (uint32_t i = 0; i < SERVERS_COUNT; i++) {


### PR DESCRIPTION
## Main Fix

This PR fixes the following busy-loop scenario when handling SSL client connections, the description is in terms of reads handling within `MySQL_Data_Stream::read_from_net` function:

1. A client connection was closed, leading to a return of 0 by 'recv', and 'errno' to be set with 'EAGAIN'.
2. Error handling is performed taking into account a never performed call to 'SSL_read' (as if this '0' was a result for this call).
3. The call to 'SSL_get_error' returns with 'SSL_ERROR_SYSCALL', as a result of using this invalid param of '0' (which for 'SSL_read' would mean non-retryable error), and the non-reset 'errno' would still be 'EAGAIN'.
4. This would create the illusion of an interrupted read. So a new read is tried again, while in reality the socket is closed. This busy loop will continue until 'POLLHUP' is received when we attempt to write back to the client and a 'RST' is received as a response.

## Minor Fix

This PR makes `proxy_debug_func` save/restore the `errno` value. This can prevent issues of logging influencing error handling.

## Extra fixes

1. Since this PR when a value supplied for an interval is rounded, a warning is printed in error log.
2. Due to recent changes in the CI this PR packs multiple fixes for issues recently observed within some tests, and some improvements for the tooling.