### PR TITLE
Better parsing of USE queries sent with COM_QUERY #4598

### DIFF
--- a/include/set_parser.h
+++ b/include/set_parser.h
@@ -43,6 +43,7 @@ class SetParser {
 	std::map<std::string, std::vector<std::string>> parse2();
 	std::string parse_character_set();
 	std::string parse_USE_query();
+	std::string remove_comments(const std::string& q);
 #ifdef DEBUG
 	// built-in testing
 	void test_parse_USE_query();

--- a/include/set_parser.h
+++ b/include/set_parser.h
@@ -42,6 +42,11 @@ class SetParser {
 	// First implemenation of the parser for TRANSACTION ISOLATION LEVEL and TRANSACTION READ/WRITE
 	std::map<std::string, std::vector<std::string>> parse2();
 	std::string parse_character_set();
+	std::string parse_USE_query();
+#ifdef DEBUG
+	// built-in testing
+	void test_parse_USE_query();
+#endif // DEBUG
 	~SetParser();
 };
 

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6138,30 +6138,27 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 	if (session_type == PROXYSQL_SESSION_MYSQL) {
 		__sync_fetch_and_add(&MyHGM->status.frontend_use_db, 1);
 		string nq=string((char *)pkt->ptr+sizeof(mysql_hdr)+1,pkt->size-sizeof(mysql_hdr)-1);
-		RE2::GlobalReplace(&nq,(char *)"(?U)/\\*.*\\*/",(char *)" ");
-		char *sn_tmp = (char *)nq.c_str();
-		while (sn_tmp < ( nq.c_str() + nq.length() - 4 ) && *sn_tmp == ' ')
-			sn_tmp++;
-		//char *schemaname=strdup(nq.c_str()+4);
-		char *schemaname=strdup(sn_tmp+3);
-		char *schemanameptr=trim_spaces_and_quotes_in_place(schemaname);
-		// handle cases like "USE `schemaname`
-		if(schemanameptr[0]=='`' && schemanameptr[strlen(schemanameptr)-1]=='`') {
-			schemanameptr[strlen(schemanameptr)-1]='\0';
-			schemanameptr++;
-		}
-		client_myds->myconn->userinfo->set_schemaname(schemanameptr,strlen(schemanameptr));
-		free(schemaname);
-		if (mirror==false) {
+		SetParser parser(nq);
+		string schemaname = parser.parse_USE_query();
+		if (schemaname != "") {
+			client_myds->myconn->userinfo->set_schemaname((char *)schemaname.c_str(),schemaname.length());
+			if (mirror==false) {
+				RequestEnd(NULL);
+			}
+			l_free(pkt->size,pkt->ptr);
+			client_myds->setDSS_STATE_QUERY_SENT_NET();
+			unsigned int nTrx=NumActiveTransactions();
+			uint16_t setStatus = (nTrx ? SERVER_STATUS_IN_TRANS : 0 );
+			if (autocommit) setStatus |= SERVER_STATUS_AUTOCOMMIT;
+			client_myds->myprot.generate_pkt_OK(true,NULL,NULL,1,0,0,setStatus,0,NULL);
+			GloMyLogger->log_audit_entry(PROXYSQL_MYSQL_INITDB, this, NULL);
+		} else {
+			l_free(pkt->size,pkt->ptr);
+			client_myds->setDSS_STATE_QUERY_SENT_NET();
+			std::string msg = "Unable to parse: " + nq;
+			client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,client_myds->pkt_sid+1,1148,(char *)"42000", msg.c_str());
 			RequestEnd(NULL);
 		}
-		l_free(pkt->size,pkt->ptr);
-		client_myds->setDSS_STATE_QUERY_SENT_NET();
-		unsigned int nTrx=NumActiveTransactions();
-		uint16_t setStatus = (nTrx ? SERVER_STATUS_IN_TRANS : 0 );
-		if (autocommit) setStatus |= SERVER_STATUS_AUTOCOMMIT;
-		client_myds->myprot.generate_pkt_OK(true,NULL,NULL,1,0,0,setStatus,0,NULL);
-		GloMyLogger->log_audit_entry(PROXYSQL_MYSQL_INITDB, this, NULL);
 		client_myds->DSS=STATE_SLEEP;
 	} else {
 		l_free(pkt->size,pkt->ptr);

--- a/lib/set_parser.cpp
+++ b/lib/set_parser.cpp
@@ -9,8 +9,6 @@
 #include <iostream>
 //#endif
 
-#include "pcrecpp.h"
-
 using namespace std;
 
 
@@ -624,8 +622,14 @@ std::string pattern = "";
 			re2::RE2 re2("\\s*$", opt2);
 			re2::RE2::Replace(&dbname, re2, "");
 			if (dbname[0] == '`') {
-				if (dbname[dbname.length()-1] == '`') {
-					return dbname;
+				if (dbname.length() > 2) {
+					if (dbname[dbname.length()-1] == '`') {
+						// Remove the first character
+						dbname.erase(0, 1);
+						// Remove the last character
+						dbname.erase(dbname.length() - 1);
+						return dbname;
+					}
 				}
 			} else {
 				return dbname;
@@ -698,46 +702,44 @@ void SetParser::test_parse_USE_query() {
 
 	// Define vector of pairs (query, expected dbname)
 	std::vector<std::pair<std::string, std::string>> testCases = {
-		{"USE my_database", "my_database"},                      // Basic Case
-		{"USE   my_database", "my_database"},                    // Basic Case
+		{"USE my_database",    "my_database"},                   // Basic Case
+		{"USE   my_database",  "my_database"},                   // Basic Case
 		{"USE   my_database ", "my_database"},                   // Basic Case
-		{"/* comment */USE dbname /* comment */",     "dbname"}, // With Comments
-		{"/* comment */   USE   dbname",              "dbname"}, // With Comments
-		{"USE    dbname           /* comment */",     "dbname"}, // With Comments
-		{"/* comment */USE `dbname` /* comment */",   "`dbname`"}, // With backtick
-		{"/* comment */USE `dbname`/* comment */",    "`dbname`"}, // With backtick
-		{"/* comment */USE`dbname` /* comment */",    "`dbname`"}, // With backtick
-		{"/* comment */USE `dbname`/* comment */",    "`dbname`"}, // With backtick
+		{"/* comment */USE dbname /* comment */",   "dbname"}, // With Comments
+		{"/* comment */   USE   dbname",            "dbname"}, // With Comments
+		{"USE    dbname           /* comment */",   "dbname"}, // With Comments
+		{"/* comment */USE `dbname` /* comment */", "dbname"}, // With backtick
+		{"/* comment */USE `dbname`/* comment */",  "dbname"}, // With backtick
+		{"/* comment */USE`dbname` /* comment */",  "dbname"}, // With backtick
+		{"/* comment */USE `dbname`/* comment */",  "dbname"}, // With backtick
 		{"/* comment\nmultiline comment */USE dbname /* comment */", "dbname"}, // Multiline Comment
-		{"/* comment */USE dbname # comment",         "dbname"}, // Hash Comment
-		{"/* comment */USE dbname -- comment",        "dbname"}, // Double Dash Comment
-		{"/* comment */USE dbname   # comment",       "dbname"}, // Hash Comment
-		{"/* comment */USE dbname    -- comment",     "dbname"}, // Double Dash Comment
-		{"USE dbname   # comment",                    "dbname"}, // Hash Comment
-		{"USE dbname    -- comment",                  "dbname"}, // Double Dash Comment
+		{"/* comment */USE dbname # comment",       "dbname"}, // Hash Comment
+		{"/* comment */USE dbname -- comment",      "dbname"}, // Double Dash Comment
+		{"/* comment */USE dbname   # comment",     "dbname"}, // Hash Comment
+		{"/* comment */USE dbname    -- comment",   "dbname"}, // Double Dash Comment
+		{"USE dbname   # comment",                  "dbname"}, // Hash Comment
+		{"USE dbname    -- comment",                "dbname"}, // Double Dash Comment
 		{"SELECT * FROM my_table", ""}, // No match
 		{"/*+ placeholder_comment */ USE test_use_comment", "test_use_comment"},
 
-		{"USE /*+ placeholder_comment */ `test_use_comment-a1`", "`test_use_comment-a1`"},
-		{"USE /*+ placeholder_comment */   `test_use_comment_1`", "`test_use_comment_1`"},
-		{"USE/*+ placeholder_comment */ `test_use_comment_2`", "`test_use_comment_2`"},
-		{"USE /*+ placeholder_comment */`test_use_comment_3`", "`test_use_comment_3`"},
-		{"USE /*+ placeholder_comment */   test_use_comment_4", "test_use_comment_4"},
-		{"USE/*+ placeholder_comment */ test_use_comment_5", "test_use_comment_5"},
-		{"USE /*+ placeholder_comment */test_use_comment_6", "test_use_comment_6"},
-		{"USE /*+ placeholder_comment */   `test_use_comment-1`", "`test_use_comment-1`"},
+		{"USE /*+ placeholder_comment */ `test_use_comment-a1`",  "test_use_comment-a1"},
+		{"USE /*+ placeholder_comment */   `test_use_comment_1`", "test_use_comment_1"},
+		{"USE/*+ placeholder_comment */ `test_use_comment_2`",    "test_use_comment_2"},
+		{"USE /*+ placeholder_comment */`test_use_comment_3`",    "test_use_comment_3"},
+		{"USE /*+ placeholder_comment */   test_use_comment_4",   "test_use_comment_4"},
+		{"USE/*+ placeholder_comment */ test_use_comment_5",      "test_use_comment_5"},
+		{"USE /*+ placeholder_comment */test_use_comment_6",      "test_use_comment_6"},
+		{"USE /*+ placeholder_comment */   `test_use_comment-1`", "test_use_comment-1"},
 		{"use my_database", "my_database"},
 		{"/* comment */  use dbname -- comment",        "dbname"},
 		{"/* comment\nmultiline comment */USE dbname /* comment\nmultiline comment */", "dbname"}, // Multiline Comment
 
-//    db_query.push_back(std::make_tuple("`test_use_comment-2`", "USE/*+ placeholder_comment */ `test_use_comment-2`", false));
-//    db_query.push_back(std::make_tuple("`test_use_comment-3`", "USE /*+ placeholder_comment */`test_use_comment-3`", true));
-//    db_query.push_back(std::make_tuple("`test_use_comment-4`", "/*+ placeholder_comment */USE          `test_use_comment-4`", false));
-//    db_query.push_back(std::make_tuple("`test_use_comment-5`", "USE/*+ placeholder_comment */`test_use_comment-5`", false));
-//    db_query.push_back(std::make_tuple("`test_use_comment-6`", "/* comment */USE`test_use_comment-6`", false));
-//    db_query.push_back(std::make_tuple("`test_use_comment-7`", "USE`test_use_comment-7`", false));
-
-
+		{"USE/*+ placeholder_comment */ `test_use_comment-2`",      "test_use_comment-2"},
+		{"USE /*+ placeholder_comment */`test_use_comment-3`",      "test_use_comment-3"},
+		{"/*+ placeholder_comment */USE      `test_use_comment-4`", "test_use_comment-4"},
+		{"USE/*+ placeholder_comment */`test_use_comment-5`",       "test_use_comment-5"},
+		{"/* comment */USE`test_use_comment-6`",                    "test_use_comment-6"},
+		{"USE`test_use_comment-7`",                                 "test_use_comment-7"},
 	};
 
 	// Run tests for each pair
@@ -745,7 +747,6 @@ void SetParser::test_parse_USE_query() {
 		set_query(p.first);
 		std::string dbname = parse_USE_query();
 		if (dbname != p.second) {
-			//std::cout << dbname << " : " << query << std::endl;
 			// we call parse_USE_query() again just to make it easier to create a breakpoint
 			std::string s = parse_USE_query();
 			assert(s == p.second);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1976,6 +1976,13 @@ int main(int argc, const char * argv[]) {
 //		std::cerr << "Main init phase0 completed in ";
 #endif
 	}
+#ifdef DEBUG
+	{
+		// Automated testing
+		SetParser parser("");
+		parser.test_parse_USE_query();
+	}
+#endif // DEBUG
 	{
 		cpu_timer t;
 		ProxySQL_Main_process_global_variables(argc, argv);


### PR DESCRIPTION
Closes #4598 

`USE` queries sent via `COM_QUERY` are not processed in a better way, improving their parsing:
* it is implemented into `SetParser` (even if it is not a `SET` statement !! , to minimize code changes)
* comments are removed
* it handles schemaname with and without backtick
* in case backtick is used, a space between `USE` and dbname is optional

This new parser passes the tests in existing `reg_test_3493-USE_with_comment-t` TAP test, and it also introduced a new set of tests that are automatically executed in debug build.