### PR TITLE
remove empty .gcno files

### DIFF
--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -203,6 +203,8 @@ tests: tests-cpp \
 	prepare_statement_err3024_async-t \
 	reg_test_mariadb_stmt_store_result_libmysql-t \
 	reg_test_mariadb_stmt_store_result_async-t
+tests:
+	find -L . -type f -name '*.gcno' -empty -delete
 
 tests-cpp: $(patsubst %.cpp,%,$(wildcard *-t.cpp))
 tests-php: $(patsubst %,php-%,$(wildcard *-t.php))

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -204,7 +204,8 @@ tests: tests-cpp \
 	reg_test_mariadb_stmt_store_result_libmysql-t \
 	reg_test_mariadb_stmt_store_result_async-t
 tests:
-	find -L . -type f -name '*.gcno' -empty -delete
+	@echo "Removing empty .gcno files ..."
+	find -L . -type f -name '*.gcno' -empty -ls -delete
 
 tests-cpp: $(patsubst %.cpp,%,$(wildcard *-t.cpp))
 tests-php: $(patsubst %,php-%,$(wildcard *-t.php))

--- a/test/tap/tests_with_deps/deprecate_eof_support/Makefile
+++ b/test/tap/tests_with_deps/deprecate_eof_support/Makefile
@@ -154,6 +154,8 @@ $(TEST_MYSQL_LDIR)/libmysqlclient.a:
 
 #tests: build_test_deps
 tests: $(patsubst %.cpp,%,$(wildcard *-t.cpp)) ok_packet_mixed_queries-t fwd_eof_query fwd_eof_ok_query
+tests:
+	find -L . -type f -name '*.gcno' -empty -delete
 
 COMMONARGS = $(OPT) -Wl,-Bdynamic -ltap -lcpp_dotenv -lcurl -lre2 -lssl -lcrypto -lz -ldl -lpthread -DGITVERSION=\"$(GIT_VERSION)\"
 

--- a/test/tap/tests_with_deps/deprecate_eof_support/Makefile
+++ b/test/tap/tests_with_deps/deprecate_eof_support/Makefile
@@ -155,7 +155,8 @@ $(TEST_MYSQL_LDIR)/libmysqlclient.a:
 #tests: build_test_deps
 tests: $(patsubst %.cpp,%,$(wildcard *-t.cpp)) ok_packet_mixed_queries-t fwd_eof_query fwd_eof_ok_query
 tests:
-	find -L . -type f -name '*.gcno' -empty -delete
+	@echo "Removing empty .gcno files ..."
+	find -L . -type f -name '*.gcno' -empty -ls -delete
 
 COMMONARGS = $(OPT) -Wl,-Bdynamic -ltap -lcpp_dotenv -lcurl -lre2 -lssl -lcrypto -lz -ldl -lpthread -DGITVERSION=\"$(GIT_VERSION)\"
 


### PR DESCRIPTION
remove empty `.gcno` files left by `gcc`
these trigger errors in `fastcov` when processing coverage