### PR TITLE
Update Prometheus HELP statement for proxysql_connpool_conns_status

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -569,7 +569,7 @@ hg_metrics_map = std::make_tuple(
 		std::make_tuple (
 			p_hg_dyn_gauge::connection_pool_status,
 			"proxysql_connpool_conns_status",
-			"The status of the backend server (1 - ONLINE, 2 - SHUNNED, 3 - OFFLINE_SOFT, 4 - OFFLINE_HARD).",
+			"The status of the backend server (1 - ONLINE, 2 - SHUNNED, 3 - OFFLINE_SOFT, 4 - OFFLINE_HARD, 5 - SHUNNED_REPLICATION_LAG).",
 			metric_tags {}
 		)
 	}


### PR DESCRIPTION
The `MYSQL_SERVER_STATUS_SHUNNED_REPLICATION_LAG` status was added at some point in the past, and the Prometheus `HELP` statements do not reflect that addition.

Add that in.