### PR TITLE
Make logging of Galera nodes status conditional to 'mysql-hostgroup_manager_verbose' - Closes #4612

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -5062,7 +5062,13 @@ bool Galera_Info::update(int b, int r, int o, int mw, int mtb, bool _a, int _w, 
 	return ret;
 }
 
+/**
+ * @brief Dumps to stderr the current info for the monitored Galera hosts ('Galera_Hosts_Map').
+ * @details No action if `mysql_thread___hostgroup_manager_verbose=0`.
+ */
 void print_galera_nodes_last_status() {
+	if (!mysql_thread___hostgroup_manager_verbose) return;
+
 	std::unique_ptr<SQLite3_result> result { new SQLite3_result(13) };
 
 	result->add_column_definition(SQLITE_TEXT,"hostname");

--- a/src/SQLite3_Server.cpp
+++ b/src/SQLite3_Server.cpp
@@ -930,10 +930,12 @@ __run_query:
 				if (resultset->rows_count == 0) {
 					PROXY_TRACE();
 				}
+#ifdef TEST_GALERA_RANDOM
 				if (rand() % 20 == 0) {
 					// randomly add some latency on 5% of the traffic
 					sleep(2);
 				}
+#endif
 			}
 #endif // TEST_GALERA
 #ifdef TEST_GROUPREP


### PR DESCRIPTION
Logging of the status fetched for Galera nodes can now be disabled via `mysql-hostgroup_manager_verbose=0`.