### PR TITLE
Fix value on first fetch for connpool prometheus metrics

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -3314,12 +3314,13 @@ void MySQL_HostGroups_Manager::p_update_connection_pool_update_counter(
 		counter_id->second->Increment(value - cur_val);
 	} else {
 		auto& new_counter = status.p_dyn_counter_array[idx];
-		m_map.insert(
+		const auto& new_counter_it = m_map.insert(
 			{
 				endpoint_id,
 				std::addressof(new_counter->Add(labels))
 			}
 		);
+		new_counter_it.first->second->Increment(value);
 	}
 }
 
@@ -3332,12 +3333,13 @@ void MySQL_HostGroups_Manager::p_update_connection_pool_update_gauge(
 		counter_id->second->Set(value);
 	} else {
 		auto& new_counter = status.p_dyn_gauge_array[idx];
-		m_map.insert(
+		const auto& new_gauge_it = m_map.insert(
 			{
 				endpoint_id,
 				std::addressof(new_counter->Add(labels))
 			}
 		);
+		new_gauge_it.first->second->Set(value);
 	}
 }
 

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -1607,23 +1607,27 @@ json fetch_internal_session(MYSQL* proxy, bool verbose) {
 	}
 }
 
+pair<string, string> split_line_by_last(const string& ln, char c) {
+	size_t pos = ln.find_last_of(c);
+
+	if (pos == string::npos) {
+		return { ln, "" };
+	} else {
+		const string f { ln.substr(0, pos) };
+		const string s { ln.substr(pos + 1) };
+
+		return { f, s };
+	}
+}
+
 map<string, double> parse_prometheus_metrics(const string& s) {
-	vector<string> lines { split(s, '\n') };
+	const vector<string> lines { split(s, '\n') };
 	map<string, double> metrics_map {};
 
 	for (const string ln : lines) {
-		const vector<string> line_values { split(ln, ' ') };
-
 		if (ln.empty() == false && ln[0] != '#') {
-			if (line_values.size() > 2) {
-				size_t delim_pos_st = ln.rfind("} ");
-				string metric_key = ln.substr(0, delim_pos_st);
-				string metric_val = ln.substr(delim_pos_st + 2);
-
-				metrics_map.insert({metric_key, stod(metric_val)});
-			} else {
-				metrics_map.insert({line_values.front(), stod(line_values.back())});
-			}
+			pair<string, string> p_line_val { split_line_by_last(ln, ' ') };
+			metrics_map.insert({p_line_val.first, stod(p_line_val.second)});
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a minor inaccuracy present in the first fetch performed to connection pool `prometheus` metrics. The initial value for metrics using `p_update_connection_pool_update_*` helpers were missing.

This only affects to the first metrics fetch, during the metric creation on the internal maps, subsequent fetches will
find the already created metric and updated the value properly. As real counters are internal, this doesn't affect the correctness of the value in subsequent fetches.

The PR also improves `prometheus` metrics test with new checks for these metrics.