### PR TITLE
Removing trailing semicolon from `USE` #4628

### DIFF
--- a/include/set_parser.h
+++ b/include/set_parser.h
@@ -42,7 +42,7 @@ class SetParser {
 	// First implemenation of the parser for TRANSACTION ISOLATION LEVEL and TRANSACTION READ/WRITE
 	std::map<std::string, std::vector<std::string>> parse2();
 	std::string parse_character_set();
-	std::string parse_USE_query();
+	std::string parse_USE_query(std::string& errmsg);
 	std::string remove_comments(const std::string& q);
 #ifdef DEBUG
 	// built-in testing

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6139,7 +6139,8 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 		__sync_fetch_and_add(&MyHGM->status.frontend_use_db, 1);
 		string nq=string((char *)pkt->ptr+sizeof(mysql_hdr)+1,pkt->size-sizeof(mysql_hdr)-1);
 		SetParser parser(nq);
-		string schemaname = parser.parse_USE_query();
+		string errmsg = "";
+		string schemaname = parser.parse_USE_query(errmsg);
 		if (schemaname != "") {
 			client_myds->myconn->userinfo->set_schemaname((char *)schemaname.c_str(),schemaname.length());
 			if (mirror==false) {
@@ -6156,6 +6157,9 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 			l_free(pkt->size,pkt->ptr);
 			client_myds->setDSS_STATE_QUERY_SENT_NET();
 			std::string msg = "Unable to parse: " + nq;
+			if (errmsg != "") {
+				msg = errmsg + ": " + nq;
+			}
 			client_myds->myprot.generate_pkt_ERR(true,NULL,NULL,client_myds->pkt_sid+1,1148,(char *)"42000", msg.c_str());
 			RequestEnd(NULL);
 		}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -6479,7 +6479,10 @@ bool MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 			RE2::GlobalReplace(&nq,(char *)"^/\\*!\\d\\d\\d\\d\\d SET(.*)\\*/",(char *)"SET\\1");
 			RE2::GlobalReplace(&nq,(char *)"(?U)/\\*.*\\*/",(char *)"");
 			// remove trailing space and semicolon if present. See issue#4380
-			nq.erase(nq.find_last_not_of(" ;") + 1);
+			size_t pos = nq.find_last_not_of(" ;");
+			if (pos != nq.npos) {
+				nq.erase(pos + 1); // remove trailing spaces and semicolumns
+			}
 /*
 			// we do not threat SET SQL_LOG_BIN as a special case
 			if (match_regexes && match_regexes[0]->match(dig)) {

--- a/lib/set_parser.cpp
+++ b/lib/set_parser.cpp
@@ -119,7 +119,10 @@ VALGRIND_ENABLE_ERROR_REPORTING;
 			} else if (strcasecmp("transaction_read_only", value4.c_str()) == 0) {
 				value4 = "tx_read_only";
 			}
-			value5.erase(value5.find_last_not_of(" \n\r\t,")+1);
+			size_t pos = value5.find_last_not_of(" \n\r\t,");
+			if (pos != value5.npos) {
+				value5.erase(pos+1);
+			}
 			key = value4;
 			if (value5 == "''" || value5 == "\"\"") {
 				op.push_back("");
@@ -405,7 +408,10 @@ VALGRIND_ENABLE_ERROR_REPORTING;
 			} else if (strcasecmp("transaction_read_only", value4.c_str()) == 0) {
 				value4 = "tx_read_only";
 			}
-			value5.erase(value5.find_last_not_of(" \n\r\t,")+1);
+			size_t pos = value5.find_last_not_of(" \n\r\t,");
+			if (pos != value5.npos) {
+				value5.erase(pos+1);
+			}
 			key = value4;
 			if (value5 == "''" || value5 == "\"\"") {
 				op.push_back("");
@@ -519,7 +525,10 @@ std::string SetParser::parse_USE_query(std::string& errmsg) {
 	opt2.set_longest_match(false);
 
 	std::string dbname = remove_comments(query);
-	dbname.erase(dbname.find_last_not_of(" ;") + 1); // remove trailing spaces and semicolumns
+	size_t pos = dbname.find_last_not_of(" ;");
+	if (pos != dbname.npos) {
+		dbname.erase(pos + 1); // remove trailing spaces and semicolumns
+	}
 	re2::RE2 re0("^\\s*", opt2);
 	re2::RE2::Replace(&dbname, re0, "");
 	if (dbname.size() >= 4) {


### PR DESCRIPTION
Trailing semicolon are now removed.

This commit also ensure that an error is returned if `USE` is part of a multi-statement.

Closes #4628 