### PR TITLE
bump version to 2.7.1 at the beginning of the development cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ O3 := -O3 -mtune=native
 ALL_DEBUG := $(O0) -ggdb -DDEBUG
 NO_DEBUG := $(O2) -ggdb
 DEBUG := $(ALL_DEBUG)
-CURVER ?= 2.7.0
+CURVER ?= 2.7.1
 #export DEBUG
 #export EXTRALINK
 export MAKE


### PR DESCRIPTION
update version `CURVER=2.7.1` in `Makefile`
tag `2.7.1` at the beginning of the development cycle