### PR TITLE
update gh-actions scripts

### DIFF
--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -20,7 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run:
-    uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
+  run-mysql:
+    uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework_mysql.yml@GH-Actions
     secrets: inherit
-    
+  run-mariadb:
+    uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework_mariadb.yml@GH-Actions
+    secrets: inherit
+      

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -20,7 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run:
-    uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
+  run-mysql:
+    uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy_mysql.yml@GH-Actions
     secrets: inherit
-    
+  run-mariadb:
+    uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy_mariadb.yml@GH-Actions
+    secrets: inherit
+      


### PR DESCRIPTION
updating sqlalchemy jobs due to
enhanced sqlalchemy matrix INFRADB+CONNECTOR
requires splitting into dedicated scripts
to avoid over complicating matrix includes/excludes

- [ci-3p-sqlalchemy_mysql.yml](https://github.com/sysown/proxysql/blob/GH-Actions/.github/workflows/ci-3p-sqlalchemy_mysql.yml) 
- [ci-3p-sqlalchecmy_mariadb.yml](https://github.com/sysown/proxysql/blob/GH-Actions/.github/workflows/ci-3p-sqlalchemy_mariadb.yml)

Same for laravel-framework
- [ci-3p-laravel-faramework_mysql.yml](https://github.com/sysown/proxysql/blob/GH-Actions/.github/workflows/ci-3p-laravel-faramework_mysql.yml) 
- [ci-3p-laravel-faramework_mariadb.yml](https://github.com/sysown/proxysql/blob/GH-Actions/.github/workflows/ci-3p-laravel-faramework_mariadb.yml)

