### PR TITLE
V2.7 features after crash: `--initial` and TLS reload , #4658 and #4659

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1477,6 +1477,13 @@ bool ProxySQL_daemonize_phase3() {
 		// automatic reload of TLS certificates after a crash , see #4658
 		std::string msg;
 		ProxySQL_create_or_load_TLS(false, msg);
+		//  Honor --initial after a crash , see #4659
+		if (GloVars.__cmd_proxysql_initial==true) {
+			std::cerr << "Renaming database file " << GloVars.admindb << endl;
+			char *newpath=(char *)malloc(strlen(GloVars.admindb)+8);
+			sprintf(newpath,"%s.bak",GloVars.admindb);
+			rename(GloVars.admindb,newpath);	// FIXME: should we check return value, or ignore whatever it successed or not?
+		}
 		parent_close_error_log();
 		return false;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1380,14 +1380,14 @@ bool ProxySQL_daemonize_phase2() {
  * @note This function does not return if an error occurs; it exits the process.
  */
 void call_execute_on_exit_failure() {
+	// Log a message indicating the attempt to call the external script
+	proxy_info("Trying to call external script after exit failure: %s\n", GloVars.execute_on_exit_failure ? GloVars.execute_on_exit_failure : "(null)");
+
 	// Check if the global variable execute_on_exit_failure is NULL
 	if (GloVars.execute_on_exit_failure == NULL) {
 		// Exit the function if the variable is not set
 		return;
 	}
-
-	// Log a message indicating the attempt to call the external script
-	proxy_error("Trying to call external script after exit failure: %s\n", GloVars.execute_on_exit_failure);
 
 	// Fork a child process
 	pid_t cpid;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1474,6 +1474,9 @@ bool ProxySQL_daemonize_phase3() {
 			proxy_info("ProxySQL SHA1 checksum: %s\n", binary_sha1);
 		}
 		call_execute_on_exit_failure();
+		// automatic reload of TLS certificates after a crash , see #4658
+		std::string msg;
+		ProxySQL_create_or_load_TLS(false, msg);
 		parent_close_error_log();
 		return false;
 	}


### PR DESCRIPTION
Closes #4658 
Closes #4659