### PR TITLE
add pkglist targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,9 +289,9 @@ build_src_debug_default: build_lib_debug_default
 SYS_KERN := $(shell uname -s)
 #SYS_DIST := $(shell source /etc/os-release &>/dev/null; if [ -z ${NAME} ]; then head -1 /etc/redhat-release; else echo ${NAME}; fi | awk '{ print $1 })
 SYS_ARCH := $(shell uname -m)
-REL_ARCH := $(subst x86_64,amd64,$(subst aarch64,arm64,$(SYS_ARCH)))
-RPM_ARCH := .$(SYS_ARCH)
-DEB_ARCH := _$(REL_ARCH)
+REL_ARCH = $(subst x86_64,amd64,$(subst aarch64,arm64,$(SYS_ARCH)))
+RPM_ARCH = .$(SYS_ARCH)
+DEB_ARCH = _$(REL_ARCH)
 REL_VERS := $(shell echo ${GIT_VERSION} | grep -Po '(?<=^v|^)[\d\.]+')
 RPM_VERS := -$(REL_VERS)-1
 DEB_VERS := _$(REL_VERS)
@@ -303,7 +303,9 @@ debian: $(REL_ARCH)-debian ;
 fedora: $(REL_ARCH)-fedora ;
 opensuse: $(REL_ARCH)-opensuse ;
 ubuntu: $(REL_ARCH)-ubuntu ;
+pkglist: $(REL_ARCH)-pkglist
 
+amd64-%: SYS_ARCH := x86_64
 amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensuse amd64-almalinux
 amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux9-clang almalinux9-dbg
 amd64-centos: centos8 centos8-clang centos8-dbg centos9 centos9-clang centos9-dbg
@@ -311,14 +313,19 @@ amd64-debian: debian10 debian10-dbg debian11 debian11-clang debian11-dbg debian1
 amd64-fedora: fedora38 fedora38-clang fedora38-dbg fedora39 fedora39-clang fedora39-dbg fedora40 fedora40-clang fedora40-dbg fedora41 fedora41-clang fedora41-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg
 amd64-ubuntu: ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-clang ubuntu20-dbg ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
+amd64-pkglist:
+	@make -nk amd64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+'
 
+arm64-%: SYS_ARCH := aarch64
 arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux
 arm64-almalinux: almalinux8 almalinux9
 arm64-centos: centos8 centos9
 arm64-debian: debian10 debian11 debian12
-arm64-fedora: fedora38 fedora39 fedora40
+arm64-fedora: fedora38 fedora39 fedora40 fedora41
 arm64-opensuse: opensuse15
 arm64-ubuntu: ubuntu18 ubuntu20 ubuntu22 ubuntu24
+arm64-pkglist:
+	@make -nk arm64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+'
 
 almalinux%: build-almalinux% ;
 centos%: build-centos% ;


### PR DESCRIPTION
- fix architecture string for package name when explicitly specified on foreign architecture
- add targets to list build-able packages for architecture

i.e.: want to know what target `amd64-packages` or `arm64-packages` would build?
run `make amd64-pkglist` or `make arm64-pkglist`
this is useful for automation and manual checks
