### PR TITLE
Update GH workflow triggers

### DIFF
--- a/.github/workflows/CI-3p-django-framework.yml
+++ b/.github/workflows/CI-3p-django-framework.yml
@@ -1,20 +1,11 @@
 name: CI-3p-django-framework
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
-
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
+  
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -1,19 +1,10 @@
 name: CI-3p-laravel-framework
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-3p-mariadb-connector-c.yml
+++ b/.github/workflows/CI-3p-mariadb-connector-c.yml
@@ -1,19 +1,10 @@
 name: CI-3p-mariadb-connector-c
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-3p-mysql-connector-j.yml
+++ b/.github/workflows/CI-3p-mysql-connector-j.yml
@@ -1,19 +1,10 @@
 name: CI-3p-mysql-connector-j
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-3p-php-pdo-mysql.yml
+++ b/.github/workflows/CI-3p-php-pdo-mysql.yml
@@ -1,19 +1,10 @@
 name: CI-3p-php-pdo-mysql
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -1,19 +1,10 @@
 name: CI-3p-sqlalchemy
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-basictests.yml
+++ b/.github/workflows/CI-basictests.yml
@@ -1,19 +1,10 @@
 name: CI-basictests
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-builds.yml
+++ b/.github/workflows/CI-builds.yml
@@ -2,12 +2,12 @@ name: CI-builds
 
 on:
   push:
-#    branches: [ "v2.7" ]
+#    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
     paths-ignore:
     - '.github/**'
     - '**.md'
   pull_request:
-#    branches: [ "v2.7" ]
+#    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
     paths-ignore:
     - '.github/**'
     - '**.md'

--- a/.github/workflows/CI-codeql.yml
+++ b/.github/workflows/CI-codeql.yml
@@ -1,19 +1,10 @@
 name: CI-CodeQL
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-maketest.yml
+++ b/.github/workflows/CI-maketest.yml
@@ -1,19 +1,10 @@
 name: CI-maketest
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-package-build.yml
+++ b/.github/workflows/CI-package-build.yml
@@ -2,15 +2,15 @@ name: CI-Package-Build
 
 on:
   push:
-#    branches: [ "v[0-9]+.x?[0-9]*.?x?[0-9]*" ]
+    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
     paths-ignore:
     - '.github/**'
     - '**.md'
-#  pull_request:
-#    branches: [ "v2.x" ]
-#    paths-ignore:
-#    - '.github/**'
-#    - '**.md'
+  pull_request:
+    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
+    paths-ignore:
+    - '.github/**'
+    - '**.md'
 #  schedule:
 #    - cron: '15 13 * * 3'
   workflow_dispatch:

--- a/.github/workflows/CI-repltests.yml
+++ b/.github/workflows/CI-repltests.yml
@@ -1,19 +1,10 @@
 name: CI-repltests
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-selftests.yml
+++ b/.github/workflows/CI-selftests.yml
@@ -1,19 +1,10 @@
 name: CI-selftests
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-shuntest.yml
+++ b/.github/workflows/CI-shuntest.yml
@@ -1,19 +1,10 @@
 name: CI-shuntest
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-taptests-asan.yml
+++ b/.github/workflows/CI-taptests-asan.yml
@@ -1,19 +1,10 @@
 name: CI-taptests-asan
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-taptests-groups.yml
+++ b/.github/workflows/CI-taptests-groups.yml
@@ -1,19 +1,10 @@
 name: CI-taptests-groups
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-taptests-ssl.yml
+++ b/.github/workflows/CI-taptests-ssl.yml
@@ -1,19 +1,10 @@
 name: CI-taptests-ssl
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/CI-taptests.yml
+++ b/.github/workflows/CI-taptests.yml
@@ -1,19 +1,10 @@
 name: CI-taptests
 
 on:
-  push:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
-#    branches: [ "v2.x" ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-builds ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
use `workflow_run` triggers to run dependencies first
this will allow removal of polling for build availability in GH-Action branch scripts