### PR TITLE
V3.0 update actions triggers v2

### DIFF
--- a/.github/workflows/CI-3p-django-framework.yml
+++ b/.github/workflows/CI-3p-django-framework.yml
@@ -1,4 +1,5 @@
 name: CI-3p-django-framework
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
   
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
   
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-django-framework.yml
+++ b/.github/workflows/CI-3p-django-framework.yml
@@ -14,4 +14,7 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}

--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -1,4 +1,5 @@
 name: CI-3p-laravel-framework
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -14,4 +14,7 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}

--- a/.github/workflows/CI-3p-mariadb-connector-c.yml
+++ b/.github/workflows/CI-3p-mariadb-connector-c.yml
@@ -1,4 +1,5 @@
 name: CI-3p-mariadb-connector-c
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-mariadb-connector-c.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-mariadb-connector-c.yml
+++ b/.github/workflows/CI-3p-mariadb-connector-c.yml
@@ -14,4 +14,7 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-3p-mariadb-connector-c.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}

--- a/.github/workflows/CI-3p-mysql-connector-j.yml
+++ b/.github/workflows/CI-3p-mysql-connector-j.yml
@@ -1,4 +1,5 @@
 name: CI-3p-mysql-connector-j
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-mysql-connector-j.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-mysql-connector-j.yml
+++ b/.github/workflows/CI-3p-mysql-connector-j.yml
@@ -14,4 +14,7 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-3p-mysql-connector-j.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}

--- a/.github/workflows/CI-3p-php-pdo-mysql.yml
+++ b/.github/workflows/CI-3p-php-pdo-mysql.yml
@@ -1,4 +1,5 @@
 name: CI-3p-php-pdo-mysql
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-php-pdo-mysql.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-php-pdo-mysql.yml
+++ b/.github/workflows/CI-3p-php-pdo-mysql.yml
@@ -14,4 +14,7 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-3p-php-pdo-mysql.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -1,4 +1,5 @@
 name: CI-3p-sqlalchemy
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -14,4 +14,7 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}

--- a/.github/workflows/CI-basictests.yml
+++ b/.github/workflows/CI-basictests.yml
@@ -14,4 +14,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-basictests.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-basictests.yml
+++ b/.github/workflows/CI-basictests.yml
@@ -1,4 +1,5 @@
 name: CI-basictests
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-basictests.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-builds.yml
+++ b/.github/workflows/CI-builds.yml
@@ -23,4 +23,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-builds.yml
+++ b/.github/workflows/CI-builds.yml
@@ -1,12 +1,8 @@
 name: CI-builds
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 
 on:
   push:
-#    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
 #    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
     paths-ignore:
     - '.github/**'

--- a/.github/workflows/CI-codeql.yml
+++ b/.github/workflows/CI-codeql.yml
@@ -14,4 +14,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-codeql.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-codeql.yml
+++ b/.github/workflows/CI-codeql.yml
@@ -1,4 +1,5 @@
 name: CI-CodeQL
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-codeql.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-maketest.yml
+++ b/.github/workflows/CI-maketest.yml
@@ -1,4 +1,5 @@
 name: CI-maketest
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-maketest.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-maketest.yml
+++ b/.github/workflows/CI-maketest.yml
@@ -14,4 +14,6 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-maketest.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      target: ${{ vars.MATRIX_MAKETEST_target }}

--- a/.github/workflows/CI-package-build.yml
+++ b/.github/workflows/CI-package-build.yml
@@ -1,12 +1,8 @@
-name: CI-Package-Build
+name: CI-package-build
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 
 on:
   push:
-    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-  pull_request:
     branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
     paths-ignore:
     - '.github/**'

--- a/.github/workflows/CI-package-build.yml
+++ b/.github/workflows/CI-package-build.yml
@@ -23,4 +23,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-package-build.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-repltests.yml
+++ b/.github/workflows/CI-repltests.yml
@@ -14,4 +14,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-repltests.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-repltests.yml
+++ b/.github/workflows/CI-repltests.yml
@@ -1,4 +1,5 @@
 name: CI-repltests
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-repltests.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-selftests.yml
+++ b/.github/workflows/CI-selftests.yml
@@ -14,4 +14,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-selftests.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-selftests.yml
+++ b/.github/workflows/CI-selftests.yml
@@ -1,4 +1,5 @@
 name: CI-selftests
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-selftests.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-shuntest.yml
+++ b/.github/workflows/CI-shuntest.yml
@@ -14,4 +14,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-shuntest.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-shuntest.yml
+++ b/.github/workflows/CI-shuntest.yml
@@ -1,4 +1,5 @@
 name: CI-shuntest
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-shuntest.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests-asan.yml
+++ b/.github/workflows/CI-taptests-asan.yml
@@ -1,4 +1,5 @@
 name: CI-taptests-asan
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-taptests-asan.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests-asan.yml
+++ b/.github/workflows/CI-taptests-asan.yml
@@ -14,4 +14,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-taptests-asan.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-taptests-groups.yml
+++ b/.github/workflows/CI-taptests-groups.yml
@@ -14,4 +14,6 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-taptests-groups.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      testgroup: ${{ vars.MATRIX_TAP_GROUPS_testgroup }}

--- a/.github/workflows/CI-taptests-groups.yml
+++ b/.github/workflows/CI-taptests-groups.yml
@@ -1,4 +1,5 @@
 name: CI-taptests-groups
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-taptests-groups.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests-ssl.yml
+++ b/.github/workflows/CI-taptests-ssl.yml
@@ -14,4 +14,5 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-taptests-ssl.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-taptests-ssl.yml
+++ b/.github/workflows/CI-taptests-ssl.yml
@@ -1,4 +1,5 @@
 name: CI-taptests-ssl
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-taptests-ssl.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests.yml
+++ b/.github/workflows/CI-taptests.yml
@@ -14,4 +14,6 @@ jobs:
   run:
     uses: sysown/proxysql/.github/workflows/ci-taptests.yml@GH-Actions
     secrets: inherit
-    
+    with:
+      trigger: ${{ toJson(github) }}
+      testgroup: ${{ vars.MATRIX_TAP_GROUPS_testgroup }}

--- a/.github/workflows/CI-taptests.yml
+++ b/.github/workflows/CI-taptests.yml
@@ -1,4 +1,5 @@
 name: CI-taptests
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
   workflow_dispatch:
@@ -7,11 +8,12 @@ on:
     types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-taptests.yml@GH-Actions
     secrets: inherit
     with:


### PR DESCRIPTION
`CI-builds` and `CI-package-build` actions are triggered by `push` event.

All the other actions depend on cached data built by `CI-builds` and are triggered by `workflow_run` event on conclusion of `CI-builds`
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
`workflow_run` event does not provide the correct context and requires explicitly passing the upstream contexts to `workflow_run`.
https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=in_progress#workflow_run

Using the passed context, set:
- run name - descriptive 'BRANCH ACTION COMMIT' name/title
- group concurrency - stopping outdated jobs on the same branch
- conditional execution - based on success of upstream dependency

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#run-name
https://stackoverflow.com/questions/63343937/how-to-use-the-github-actions-workflow-run-event
https://stackoverflow.com/questions/58457140/dependencies-between-workflows-on-github-actions
https://stackoverflow.com/questions/76184351/workflow-tiggered-by-another-workflow-runs-on-wrong-branch
https://github.com/orgs/community/discussions/50356

GH-Actions branch workflows are using actions to set the `run status` and `run checks`
https://github.com/marketplace/actions/github-checks
https://github.com/marketplace/actions/github-check-runs-action
