### PR TITLE
V3.0 update actions triggers v3

### DIFF
--- a/.github/workflows/CI-3p-django-framework.yml
+++ b/.github/workflows/CI-3p-django-framework.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
-  run:
+  run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
     secrets: inherit
@@ -20,3 +20,21 @@ jobs:
       trigger: ${{ toJson(github) }}
       infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
       connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}
+
+  run-mariadb:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mariadb }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mariadb }}
+
+  run-pgsql:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_pgsql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_pgsql }}

--- a/.github/workflows/CI-3p-django-framework.yml
+++ b/.github/workflows/CI-3p-django-framework.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
   
 concurrency:

--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run:
+  run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
     secrets: inherit
@@ -20,3 +20,19 @@ jobs:
       trigger: ${{ toJson(github) }}
       infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
       connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}
+  run-mariadb:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mariadb }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mariadb }}
+  run-pgsql:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_pgsql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_pgsql }}

--- a/.github/workflows/CI-3p-mariadb-connector-c.yml
+++ b/.github/workflows/CI-3p-mariadb-connector-c.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-mysql-connector-j.yml
+++ b/.github/workflows/CI-3p-mysql-connector-j.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-php-pdo-mysql.yml
+++ b/.github/workflows/CI-3p-php-pdo-mysql.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run:
+  run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
     secrets: inherit
@@ -20,3 +20,21 @@ jobs:
       trigger: ${{ toJson(github) }}
       infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mysql }}
       connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mysql }}
+
+  run-mariadb:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_mariadb }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_mariadb }}
+
+  run-pgsql:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}
+      infradb: ${{ vars.MATRIX_3P_SQLALCHEMY_infradb_pgsql }}
+      connector: ${{ vars.MATRIX_3P_SQLALCHEMY_connector_pgsql }}

--- a/.github/workflows/CI-basictests.yml
+++ b/.github/workflows/CI-basictests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-builds.yml
+++ b/.github/workflows/CI-builds.yml
@@ -1,18 +1,14 @@
 name: CI-builds
-run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
-  push:
-#    branches: [ 'v[0-9]+.x','v[0-9]+.[0-9]+','v[0-9]+.[0-9]+.[0-9]+' ]
-    paths-ignore:
-    - '.github/**'
-    - '**.md'
-#  schedule:
-#    - cron: '15 13 * * 3'
   workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ in_progress ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/CI-codeql.yml
+++ b/.github/workflows/CI-codeql.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-maketest.yml
+++ b/.github/workflows/CI-maketest.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-repltests.yml
+++ b/.github/workflows/CI-repltests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-selftests.yml
+++ b/.github/workflows/CI-selftests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-shuntest.yml
+++ b/.github/workflows/CI-shuntest.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests-asan.yml
+++ b/.github/workflows/CI-taptests-asan.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests-groups.yml
+++ b/.github/workflows/CI-taptests-groups.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests-ssl.yml
+++ b/.github/workflows/CI-taptests-ssl.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests.yml
+++ b/.github/workflows/CI-taptests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-trigger.yml
+++ b/.github/workflows/CI-trigger.yml
@@ -1,0 +1,18 @@
+name: CI-trigger
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  push:
+    paths-ignore:
+    - '.github/**'
+    - '**.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    uses: sysown/proxysql/.github/workflows/ci-trigger.yml@GH-Actions
+    secrets: inherit


### PR DESCRIPTION
Create `CI-trigger` workflow and re-arrange triggers to preserve context and cache accessibility.

created cache is available only from:
- current branch
- default branch
- branches of current

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
https://stackoverflow.com/questions/69365200/github-actions-how-to-cache-dependencies-between-workflow-runs-of-different-bra
https://medium.com/@everton.spader/how-to-cache-package-dependencies-between-branches-with-github-actions-e6a19f33783a