### PR TITLE
Read mysql_hostgroup_attributes from proxysql configuration file

### DIFF
--- a/lib/ProxySQL_Config.cpp
+++ b/lib/ProxySQL_Config.cpp
@@ -996,12 +996,10 @@ int ProxySQL_Config::Write_MySQL_Servers_to_configfile(std::string& data) {
 				addField(data, "multiplex", r->fields[5], "");
 				addField(data, "connection_warming", r->fields[6], "");
 				addField(data, "throttle_connections_per_sec", r->fields[7], "");
-				addField(data, "ignore_session_variables", r->fields[8], "");
-				addField(data, "hostgroup_settings", r->fields[9], "");
-				addField(data, "servers_defaults", r->fields[10], "");
-				addField(data, "min_lag_ms", r->fields[11], "");
-				addField(data, "lag_num_checks", r->fields[12], "");
-				addField(data, "comment", r->fields[13]);
+				addField(data, "ignore_session_variables", r->fields[8]);
+				addField(data, "hostgroup_settings", r->fields[9]);
+				addField(data, "servers_defaults", r->fields[10]);
+				addField(data, "comment", r->fields[11]);
 
 				data += "\t}";
 				isNext = true;

--- a/test/tap/tests/mysql_hostgroup_attributes_config_file-t.cpp
+++ b/test/tap/tests/mysql_hostgroup_attributes_config_file-t.cpp
@@ -23,11 +23,11 @@ using std::fstream;
 
 int validate_mysql_hostgroup_attributes_from_config(MYSQL* admin) {
 	string hostgroup_attributes_values[5][12] = {
-			{"1", "900000", "-1", "11", "ic1", "0", "1", "9001", "{\"isv\":100}", "{\"hs\":200}", "{\"weight\":100,\"max_connections\":500}", "com1"},
-			{"2", "900001", "0", "12", "ic2", "1", "0", "9002", "{\"isv\":101}", "{\"hs\":201}", "{\"weight\":101,\"max_connections\":501}", "com2"},
-			{"3", "900002", "1", "13", "ic3", "0", "1", "9003", "{\"isv\":102}", "{\"hs\":202}", "{\"weight\":102,\"max_connections\":502}", "com3"},
-			{"4", "900003", "-1", "14", "ic4", "1", "0", "9004", "{\"isv\":103}", "{\"hs\":203}", "{\"weight\":103,\"max_connections\":503}", "com4"},
-			{"5", "900004", "0", "15", "ic5", "0", "1", "9005", "{\"isv\":104}", "{\"hs\":204}", "{\"weight\":104,\"max_connections\":504}", "com5"}};
+			{"900000", "900000", "-1", "11", "ic1", "0", "1", "9001", "{\"isv\":100}", "{\"hs\":200}", "{\"weight\":100,\"max_connections\":500}", "attributes test hostgroup 900000"},
+			{"900001", "900001", "0", "12", "ic2", "1", "0", "9002", "{\"isv\":101}", "{\"hs\":201}", "{\"weight\":101,\"max_connections\":501}", "attributes test hostgroup 900001"},
+			{"900002", "900002", "1", "13", "ic3", "0", "1", "9003", "{\"isv\":102}", "{\"hs\":202}", "{\"weight\":102,\"max_connections\":502}", "attributes test hostgroup 900002"},
+			{"900003", "900003", "-1", "14", "ic4", "1", "0", "9004", "{\"isv\":103}", "{\"hs\":203}", "{\"weight\":103,\"max_connections\":503}", "attributes test hostgroup 900003"},
+			{"900004", "900004", "0", "15", "ic5", "0", "1", "9005", "{\"isv\":104}", "{\"hs\":204}", "{\"weight\":104,\"max_connections\":504}", "attributes test hostgroup 900004"}};
 
 	auto check_result = [&] () {
 		MYSQL_RES* myres = mysql_store_result(admin);
@@ -87,7 +87,7 @@ void make_hostgroup_attributes_config_lines(std::vector<std::string>& config_lin
 		"mysql_hostgroup_attributes:",
 		"(",
 		"	{",
-		"		hostgroup_id=1",
+		"		hostgroup_id=900000",
 		"		max_num_online_servers=900000",
 		"		autocommit=-1",
 		"		free_connections_pct=11",
@@ -98,10 +98,10 @@ void make_hostgroup_attributes_config_lines(std::vector<std::string>& config_lin
 		"		ignore_session_variables=\"{\"isv\":100}\"",
 		"		hostgroup_settings=\"{\"hs\":200}\"",
 		"		servers_defaults=\"{\"weight\":100,\"max_connections\":500}\"",
-		"		comment=\"com1\"",
+		"		comment=\"attributes test hostgroup 900000\"",
 		"	},",
 		"	{",
-		"		hostgroup_id=2",
+		"		hostgroup_id=900001",
 		"		max_num_online_servers=900001",
 		"		autocommit=0",
 		"		free_connections_pct=12",
@@ -112,10 +112,10 @@ void make_hostgroup_attributes_config_lines(std::vector<std::string>& config_lin
 		"		ignore_session_variables=\"{\"isv\":101}\"",
 		"		hostgroup_settings=\"{\"hs\":201}\"",
 		"		servers_defaults=\"{\"weight\":101,\"max_connections\":501}\"",
-		"		comment=\"com2\"",
+		"		comment=\"attributes test hostgroup 900001\"",
 		"	},",
 		"	{",
-		"		hostgroup_id=3",
+		"		hostgroup_id=900002",
 		"		max_num_online_servers=900002",
 		"		autocommit=1",
 		"		free_connections_pct=13",
@@ -126,10 +126,10 @@ void make_hostgroup_attributes_config_lines(std::vector<std::string>& config_lin
 		"		ignore_session_variables=\"{\"isv\":102}\"",
 		"		hostgroup_settings=\"{\"hs\":202}\"",
 		"		servers_defaults=\"{\"weight\":102,\"max_connections\":502}\"",
-		"		comment=\"com3\"",
+		"		comment=\"attributes test hostgroup 900002\"",
 		"	},",
 		"	{",
-		"		hostgroup_id=4",
+		"		hostgroup_id=900003",
 		"		max_num_online_servers=900003",
 		"		autocommit=-1",
 		"		free_connections_pct=14",
@@ -140,10 +140,10 @@ void make_hostgroup_attributes_config_lines(std::vector<std::string>& config_lin
 		"		ignore_session_variables=\"{\"isv\":103}\"",
 		"		hostgroup_settings=\"{\"hs\":203}\"",
 		"		servers_defaults=\"{\"weight\":103,\"max_connections\":503}\"",
-		"		comment=\"com4\"",
+		"		comment=\"attributes test hostgroup 900003\"",
 		"	},",
 		"	{",
-		"		hostgroup_id=5",
+		"		hostgroup_id=900004",
 		"		max_num_online_servers=900004",
 		"		autocommit=0",
 		"		free_connections_pct=15",
@@ -154,7 +154,7 @@ void make_hostgroup_attributes_config_lines(std::vector<std::string>& config_lin
 		"		ignore_session_variables=\"{\"isv\":104}\"",
 		"		hostgroup_settings=\"{\"hs\":204}\"",
 		"		servers_defaults=\"{\"weight\":104,\"max_connections\":504}\"",
-		"		comment=\"com5\"",
+		"		comment=\"attributes test hostgroup 900004\"",
 		"	}",
 		")"
 	};

--- a/test/tap/tests/mysql_hostgroup_attributes_config_file-t.cpp
+++ b/test/tap/tests/mysql_hostgroup_attributes_config_file-t.cpp
@@ -1,0 +1,123 @@
+/**
+ * @file mysql_hostgroup_attributes_config_file-t.cpp
+ * @brief Reading and saving 'mysql_hostgroup_attributes' table from configuration file:
+ *   1. Correct values should be inserted into 'mysql_hostgroup_attributes' table.
+ *   2. Correct saving of mysql_hostgroup_attributes into config file.
+ *   3. Delete all the values from 'mysql_hostgroup_attributes' table
+ *   4. Correct load of 'mysql_hostgroup_attributes' table values from config file
+ */
+
+#include <cstring>
+#include <string>
+#include <fstream>
+#include <unistd.h>
+
+#include "mysql.h"
+#include "mysqld_error.h"
+
+#include "json.hpp"
+
+#include "tap.h"
+#include "utils.h"
+#include "command_line.h"
+
+using nlohmann::json;
+using std::string;
+using std::fstream;
+
+int save_and_read_mysql_hostgroup_attributes_from_config(MYSQL* admin) {
+	json j_servers_defaults { { "weight", 100 }, { "max_connections", 10000 }, { "use_ssl", 1}, };
+
+	// To run this test locally copy a ProxySQL config file into this path.
+	string save_config_query = {"SAVE CONFIG TO FILE /var/lib/jenkins//scripts/"
+								"docker-mysql-proxysql/conf/proxysql/proxysql.cnf"};
+
+	const string INSERT_QUERY {
+		"INSERT INTO mysql_hostgroup_attributes (hostgroup_id, servers_defaults, comment)"
+			" VALUES (0, '" + j_servers_defaults.dump() + "', 'read config test')"
+	};
+
+	MYSQL_QUERY_T(admin, "DELETE FROM mysql_hostgroup_attributes");
+	MYSQL_QUERY_T(admin, INSERT_QUERY.c_str());
+	MYSQL_QUERY_T(admin, save_config_query.c_str());
+	MYSQL_QUERY_T(admin, "DELETE FROM mysql_hostgroup_attributes");
+	MYSQL_QUERY_T(admin, "LOAD MYSQL SERVERS FROM CONFIG;");
+
+	diag("Checking that config saved value matches INSERTED");
+	MYSQL_QUERY_T(admin, "SELECT servers_defaults FROM mysql_hostgroup_attributes WHERE hostgroup_id=0");
+
+	const auto extract_json_result = [] (MYSQL* admin) {
+		json j_result {};
+		MYSQL_RES* myres = mysql_store_result(admin);
+		MYSQL_ROW myrow = mysql_fetch_row(myres);
+
+		if (myrow && myrow[0]) {
+			try {
+				j_result = json::parse(myrow[0]);
+			} catch (const std::exception& e) {
+				diag("ERROR: Failed to parse retrieved 'servers_defaults' - '%s'", e.what());
+			}
+		}
+
+		mysql_free_result(myres);
+
+		return j_result;
+	};
+
+	json j_config_servers_defaults = extract_json_result(admin);
+
+	ok(
+		j_servers_defaults == j_config_servers_defaults,
+		"INSERTED 'servers_defaults' should match config value - Exp: `%s`, Act: `%s`",
+		j_servers_defaults.dump().c_str(), j_config_servers_defaults.dump().c_str()
+	);
+
+	MYSQL_QUERY_T(admin, "DELETE FROM mysql_hostgroup_attributes");
+	MYSQL_QUERY_T(admin, save_config_query.c_str());
+	MYSQL_QUERY_T(admin, "LOAD MYSQL SERVERS FROM CONFIG;");		
+	diag("Checking that config saved value matches INSERTED");
+	MYSQL_QUERY_T(admin, "SELECT servers_defaults FROM mysql_hostgroup_attributes WHERE hostgroup_id=0");
+
+	j_config_servers_defaults = extract_json_result(admin);
+	json j_empty = {};
+
+	ok(
+		j_empty == j_config_servers_defaults,
+		"mysql_hostgroup_attributes should be empty. j_config_servers_defaults: `%s`",
+		j_config_servers_defaults.dump().c_str()
+	);
+
+	return EXIT_SUCCESS;
+}
+
+int main(int, char**) {
+	plan(2);
+
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
+
+	MYSQL* admin = mysql_init(NULL);
+
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return EXIT_FAILURE;
+	}
+
+	// Cleanup
+	MYSQL_QUERY_T(admin, "DROP TABLE IF EXISTS mysql_hostgroup_attributes_0508");
+	MYSQL_QUERY_T(admin, "CREATE TABLE mysql_hostgroup_attributes_0508 AS SELECT * FROM mysql_hostgroup_attributes");
+	MYSQL_QUERY_T(admin, "DELETE FROM mysql_hostgroup_attributes");
+
+	save_and_read_mysql_hostgroup_attributes_from_config(admin);
+
+cleanup:
+
+	MYSQL_QUERY_T(admin, "DELETE FROM mysql_hostgroup_attributes");
+	MYSQL_QUERY_T(admin, "INSERT INTO mysql_hostgroup_attributes SELECT * FROM mysql_hostgroup_attributes_0508");
+	mysql_close(admin);
+	return exit_status();
+}


### PR DESCRIPTION
Previously mysql_hostgroup_attributes was not read from configuration file.
Now mysql_hostgroup_attributes will be read from configuration file.
Issue for the same is #4552