### PR TITLE
Fixes for various memory leaks

### DIFF
--- a/deps/libscram/src/scram.c
+++ b/deps/libscram/src/scram.c
@@ -1148,6 +1148,7 @@ char *build_server_final_message(ScramState *scram_state)
 	if (!result) 
 		goto failed;
 	snprintf(result, len, "v=%s", server_signature);
+	free(server_signature);
 	return result;
 
 failed:

--- a/lib/PgSQL_Protocol.cpp
+++ b/lib/PgSQL_Protocol.cpp
@@ -767,6 +767,7 @@ EXECUTION_STATE PgSQL_Protocol::process_handshake_response_packet(unsigned char*
 #endif // debug
 		(*myds)->sess->default_hostgroup = default_hostgroup;
 		//(*myds)->sess->default_schema = default_schema; // just the pointer is passed
+		if ((*myds)->sess->user_attributes) free((*myds)->sess->user_attributes);
 		(*myds)->sess->user_attributes = attributes; // just the pointer is passed
 		//(*myds)->sess->schema_locked = schema_locked;
 		(*myds)->sess->transaction_persistent = transaction_persistent;
@@ -794,6 +795,8 @@ EXECUTION_STATE PgSQL_Protocol::process_handshake_response_packet(unsigned char*
 				password = l_strdup(mysql_thread___monitor_password);
 			}
 		}
+
+		if (attributes) free(attributes);
 	}
 
 	if (password) {

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -2720,6 +2720,9 @@ PgSQL_Thread::~PgSQL_Thread() {
 	if (my_idle_conns)
 		free(my_idle_conns);
 
+	if (pgsql_thread___monitor_username) { free(pgsql_thread___monitor_username); pgsql_thread___monitor_username = NULL; }
+	if (pgsql_thread___monitor_password) { free(pgsql_thread___monitor_password); pgsql_thread___monitor_password = NULL; }
+
 	if (mysql_thread___monitor_username) { free(mysql_thread___monitor_username); mysql_thread___monitor_username = NULL; }
 	if (mysql_thread___monitor_password) { free(mysql_thread___monitor_password); mysql_thread___monitor_password = NULL; }
 	if (mysql_thread___monitor_replication_lag_use_percona_heartbeat) {


### PR DESCRIPTION
* Released memory allocated for `pgsql_thread___monitor_username` and `pgsql_thread___monitor_password` during the destruction of the PgSQL_Thread.
* Resolved a memory leak in the `libscram` library within the `build_server_final_message `function.
* Fixed memory leak in `process_handshake_response_packet`.