### PR TITLE
Fixed crash when a lone semicolon (;) is sent as input (MySQL and PostgreSQL Admin Interfaces)

### DIFF
--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -5626,6 +5626,7 @@ void ProxySQL_Admin::send_error_msg_to_client(S* sess, const char *msg, uint16_t
 	} else if constexpr (std::is_same_v<S, PgSQL_Session>) {
 		// Code for PostgreSQL clients
 		PgSQL_Data_Stream* myds = sess->client_myds;
+		myds->DSS = STATE_QUERY_SENT_DS;
 		char* new_msg = (char*)malloc(strlen(msg) + sizeof(prefix_msg));
 		sprintf(new_msg, "%s%s", prefix_msg, msg);
 		myds->myprot.generate_error_packet(true, true, new_msg, PGSQL_ERROR_CODES::ERRCODE_RAISE_EXCEPTION, false);

--- a/test/tap/tests/mysql-reg_test_4716_single_semicolon-t.cpp
+++ b/test/tap/tests/mysql-reg_test_4716_single_semicolon-t.cpp
@@ -1,0 +1,64 @@
+ /**
+  * @file mysql-reg_test_4716_single_semicolon-t.cpp
+  * @brief  This test aims to verify that ProxySQL handles a lone semicolon (;) input
+  * crashing. The expected behavior is for ProxySQL to either ignore the input or return an
+  * appropriate error message, rather than crashing or becoming unresponsive.
+  */
+
+#include <string>
+#include <sstream>
+
+#include "mysql.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+CommandLine cl;
+
+enum ConnType {
+    ADMIN,
+    BACKEND
+};
+
+int main(int argc, char** argv) {
+
+    std::vector<const char*> queries = { ";", " ", "", ";  ", "  ;" };
+
+    plan(queries.size() + 1); // Total number of tests planned
+
+    if (cl.getEnv())
+        return exit_status();
+
+    // Initialize Admin connection
+    MYSQL* proxysql_admin = mysql_init(NULL);
+    if (!proxysql_admin) {
+        fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+        return -1;
+    }
+
+    // Connnect to ProxySQL Admin
+    if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+        fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+        return -1;
+    }
+
+    for (const char* query : queries) {
+        MYSQL_QUERY_err(proxysql_admin, query);
+        const int _errorno = mysql_errno(proxysql_admin);
+        ok(_errorno > 0, "Error Code:%d, Message:%s", _errorno, mysql_error(proxysql_admin));
+    }
+
+    // Test a valid query to ensure the connection is working
+    if (mysql_query(proxysql_admin, "SELECT 1") == 0) {
+        MYSQL_RES* res = mysql_store_result(proxysql_admin);
+        ok(res != nullptr, "Query executed successfully. %s", mysql_error(proxysql_admin));
+        mysql_free_result(res);
+    }
+    else {
+        ok(false, "Error executing query. %s", mysql_error(proxysql_admin));
+    }
+
+    mysql_close(proxysql_admin);
+
+    return exit_status();
+}

--- a/test/tap/tests/pgsql-reg_test_4716_single_semicolon-t.cpp
+++ b/test/tap/tests/pgsql-reg_test_4716_single_semicolon-t.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file pgsql-reg_test_4716_single_semicolon-t.cpp
+ * @brief  This test aims to verify that ProxySQL handles a lone semicolon (;) input 
+ * crashing. The expected behavior is for ProxySQL to either ignore the input or return an 
+ * appropriate error message, rather than crashing or becoming unresponsive.
+ */
+
+#include <string>
+#include <sstream>
+
+#include "libpq-fe.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+CommandLine cl;
+
+enum ConnType {
+    ADMIN,
+    BACKEND
+};
+
+PGconn* createNewConnection(ConnType conn_type, bool with_ssl) {
+    std::stringstream ss;
+    const char* host = (conn_type == BACKEND) ? cl.pgsql_host : cl.admin_host;
+    int port = (conn_type == BACKEND) ? cl.pgsql_port : cl.admin_port;
+    const char* username = (conn_type == BACKEND) ? cl.pgsql_username : cl.admin_username;
+    const char* password = (conn_type == BACKEND) ? cl.pgsql_password : cl.admin_password;
+    
+
+    ss << "host=" << host << " port=" << port;
+    ss << " user=" << username << " password=" << password;
+    ss << (with_ssl ? " sslmode=require" : " sslmode=disable");
+
+    PGconn* conn = PQconnectdb(ss.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        diag("Connection failed to '%s': %s", (conn_type == BACKEND ? "Backend" : "Admin"), PQerrorMessage(conn));
+        PQfinish(conn);
+        return nullptr;
+    }
+    return conn;
+}
+
+int main(int argc, char** argv) {
+
+    std::vector<const char*> queries = { ";", " ", "", ";  ", "  ;" };
+
+    plan(queries.size() + 1); // Total number of tests planned
+
+    if (cl.getEnv())
+        return exit_status();
+
+    PGconn* conn = createNewConnection(ADMIN, false);
+
+    if (conn == nullptr)
+        return exit_status();
+
+    PGresult* res = nullptr;
+
+    for (const char* query : queries) {
+        PGresult* res = PQexec(conn, query);
+
+        ok(PQresultStatus(res) == PGRES_FATAL_ERROR,
+            "Error. %s", PQerrorMessage(conn));
+        PQclear(res);
+    }
+
+    res = PQexec(conn, "SELECT 1");
+    ok(PQresultStatus(res) == PGRES_TUPLES_OK,
+        "Query executed sucessfully. %s", PQerrorMessage(conn));
+    PQclear(res);
+
+    // Close the connection
+    PQfinish(conn);
+
+    return exit_status();
+}


### PR DESCRIPTION
(same as title)

Fixes [#4716 ](https://github.com/sysown/proxysql/issues/4716)