### PR TITLE
Fix halt on 'PROXYSQL RESUME' command

### DIFF
--- a/include/ProxySQL_Poll.h
+++ b/include/ProxySQL_Poll.h
@@ -34,7 +34,6 @@ class ProxySQL_Poll {
 	MySQL_Data_Stream **myds;
 	unsigned long long *last_recv;
 	unsigned long long *last_sent;
-	std::atomic<bool> bootstrapping_listeners;
 	volatile int pending_listener_add;
 	volatile int pending_listener_del;
 	unsigned int poll_timeout;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1200,7 +1200,11 @@ int MySQL_Threads_Handler::listener_del(const char *iface) {
 		}
 		for (i=0;i<num_threads;i++) {
 			MySQL_Thread *thr=(MySQL_Thread *)mysql_threads[i].worker;
-			while(__sync_fetch_and_add(&thr->mypolls.pending_listener_del,0));
+			while(__sync_fetch_and_add(&thr->mypolls.pending_listener_del,0)) {
+				// Since 'listeners_stop' is performed in 'maintenance_loops' by the
+				// workers this active-wait is likely to take some time.
+				usleep(std::min(std::max(mysql_thread___poll_timeout/20, 10000), 40000));
+			}
 		}
 		MLM->del(idx);
 #ifdef SO_REUSEPORT

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -3303,15 +3303,11 @@ void MySQL_Thread::run_BootstrapListener() {
 		if (n) {
 			poll_listener_add(n);
 			assert(__sync_bool_compare_and_swap(&mypolls.pending_listener_add,n,0));
-		} else {
-			if (GloMTH->bootstrapping_listeners == false) {
-				// we stop looping
-				mypolls.bootstrapping_listeners = false;
-			}
 		}
-#ifdef DEBUG
-		usleep(5+rand()%10);
-#endif
+		// The delay for the active-wait is a fraction of 'poll_timeout'. Since other
+		// threads may be waiting on poll for further operations, checks are meaningless
+		// until that timeout expires (other workers make progress).
+		usleep(std::min(std::max(mysql_thread___poll_timeout/20, 10000), 40000) + (rand() % 2000));
 	}
 }
 
@@ -3432,9 +3428,7 @@ __run_skip_1:
 #endif // IDLE_THREADS
 
 		pthread_mutex_unlock(&thread_mutex);
-		if (unlikely(mypolls.bootstrapping_listeners == true)) {
-			run_BootstrapListener();
-		}
+		run_BootstrapListener();
 
 		// flush mysql log file
 		GloMyLogger->flush();

--- a/lib/ProxySQL_Poll.cpp
+++ b/lib/ProxySQL_Poll.cpp
@@ -64,7 +64,6 @@ ProxySQL_Poll::ProxySQL_Poll() {
 	len=0;
 	pending_listener_add=0;
 	pending_listener_del=0;
-	bootstrapping_listeners = true;
 	size=MIN_POLL_LEN;
 	fds=(struct pollfd *)malloc(size*sizeof(struct pollfd));
 	myds=(MySQL_Data_Stream **)malloc(size*sizeof(MySQL_Data_Stream *));

--- a/test/tap/tests/reg_test_4402-mysql_fields-t.cpp
+++ b/test/tap/tests/reg_test_4402-mysql_fields-t.cpp
@@ -106,7 +106,9 @@ int main(int argc, char** argv) {
 
 		// to check table alias issue:
 		{
-			const std::string& query = "SELECT data FROM testdb.dummy_table AS " + generate_random_string(length);
+			// NOTE: The randomly generated string should be escaped \`\`, otherwise could collide
+			// with SQL reserved words, causing an invalid test failure.
+			const std::string& query = "SELECT data FROM testdb.dummy_table AS `" + generate_random_string(length) + "`";
 			MYSQL_QUERY__(proxysql, query.c_str());
 
 			MYSQL_RES* res = mysql_use_result(proxysql);


### PR DESCRIPTION
## Issue Description

During a `RESUME` operation, if a 'MySQL_Thread' is bootstrapping listeners (in `MySQL_Thread::run_BootstrapListener`) and detect that `MySQL_Threads_Handler::bootstrapping_listeners` is 'false', the thread prematurely shuts down its own bootstrapping flag from 'mypolls' (`ProxySQL_Poll::bootstrapping_listeners`). Since this thread wont ever bootstrap its corresponding listening sockets, the other working threads will be stalled waiting on it, eventually triggering the watchdog and crashing the instance.

## Solution

Simplified the logic using a unique flag for bootstrapping  (`MySQL_Threads_Handler::bootstrapping_listeners`) and introduced a sensible delay to reduce the potential overhead of the worker threads busy-waiting for its time to start their listening sockets, as well as the counterpart overhead on the `Admin` thread while performing the `PAUSE` operation.