### PR TITLE
make OpenSSL 3 special handling only for almalinux8

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,15 +1,22 @@
 #!/bin/make -f
 
 
-SYS_KERN := $(shell uname -s)
-SYS_ARCH := $(shell uname -m)
+GIT_VERSION ?= $(shell git describe --long --abbrev=7)
+ifndef GIT_VERSION
+    $(error GIT_VERSION is not set)
+endif
+
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+DISTRO := $(shell grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
 
 CENTOSVER := Unknown
 ifneq (,$(wildcard /etc/system-release))
 	CENTOSVER := $(shell rpm --eval %rhel)
 endif
 
-IS_ARM := $(if $(findstring aarch64, $(SYS_ARCH)),true,false)
+IS_ARM := $(if $(findstring aarch64, $(UNAME_M)),true,false)
 IS_CENTOS := $(if $(findstring Unknown, $(CENTOSVER)),false,true)
 
 # to compile libmariadb_client with support for valgrind enabled, run:
@@ -39,7 +46,7 @@ STDCPP := -std=c++$(shell echo $(CPLUSPLUS) | cut -c3-4) -DCXX$(shell echo $(CPL
 
 
 targets := check_openssl_version libconfig libdaemon jemalloc mariadb_client re2 sqlite3 pcre lz4 cityhash microhttpd curl ev libhttpserver libinjection prometheus-cpp postgresql libusual libscram
-ifeq ($(SYS_KERN),Linux)
+ifeq ($(UNAME_S),Linux)
 	targets += coredumper
 endif
 ifeq ($(PROXYSQLCLICKHOUSE),1)
@@ -60,7 +67,7 @@ ifneq ($(CENTOSVER),6)
 	cd libinjection/libinjection && patch -p1 < ../update-build-py3.diff
 	cd libinjection/libinjection && patch -p1 < ../libinjection_sqli.c.patch
 endif
-ifeq ($(SYS_KERN),Darwin)
+ifeq ($(UNAME_S),Darwin)
 	sed -i '' 's/CC=/CC?=/' libinjection/libinjection/src/Makefile
 else
 	sed -i -e 's/CC=/CC?=/' libinjection/libinjection/src/Makefile
@@ -69,18 +76,16 @@ endif
 
 libinjection: libinjection/libinjection/src/libinjection.a
 
-DISTRO := $(shell lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
-OPENSSL_VERSION_3 := 3.0.0
-
 ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
 LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
 LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
-ifeq ($(DISTRO), almalinux)
-ifeq ($(CENTOSVER), 8)
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
 	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
 	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
 	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)
 endif
+else
 endif
 SSL_LDIR := $(dir $(LIB_SSL_PATH))
 
@@ -93,8 +98,9 @@ else
     $(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
 endif
 
+OPENSSL_VERSION_3 := 3.0.0
 check_openssl_version:
-	@if [ "$(DISTRO)" = "almalinux" && "$(CENTOSVER)" = "8" ]; then \
+	@if [[ "$(DISTRO)" = "almalinux" && "$(CENTOSVER)" = "8" ]]; then \
 		@current_version=$$(openssl3 version | awk '{print $$2}'); \
 	else \
 		@current_version=$$(openssl version | awk '{print $$2}'); \
@@ -148,7 +154,7 @@ curl/curl/lib/.libs/libcurl.a:
 	cd curl && tar -zxf curl-*.tar.gz
 #	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
 	cd curl/curl && autoreconf -fi
-ifeq ($(SYS_KERN),Darwin)
+ifeq ($(UNAME_S),Darwin)
 	cd curl/curl && patch configure < ../configure.patch
 endif
 	cd curl/curl && CPPFLAGS="-I$(SSL_IDIR)" LDFLAGS="$(LIB_SSL_PATH) $(LIB_CRYPTO_PATH)" ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-librtmp --without-libpsl --without-zstd --with-ssl --enable-shared=yes
@@ -307,7 +313,7 @@ re2/re2/obj/libre2.a:
 #	cd re2/re2 && sed -i -e 's/-O3 -g /-O3 -fPIC /' Makefile
 #	cd re2/re2 && patch util/mutex.h < ../mutex.h.patch
 	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
-ifeq ($(SYS_KERN),Darwin)
+ifeq ($(UNAME_S),Darwin)
 	cd re2/re2 && sed -i '' -e 's/-O3 -g/-O3 -g -${STDCPP} -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
 #	cd re2/re2 && sed -i '' -e 's/RE2_CXXFLAGS?=-std=c++11 /RE2_CXXFLAGS?=-std=c++11 -fPIC /' Makefile
 else

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -72,29 +72,29 @@ libinjection: libinjection/libinjection/src/libinjection.a
 DISTRO := $(shell lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
 OPENSSL_VERSION_3 := 3.0.0
 
+ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
+LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
+LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
 ifeq ($(DISTRO), almalinux)
+ifeq ($(CENTOSVER), 8)
 	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
 	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
 	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)
-    SSL_LDIR := $(dir $(LIB_SSL_PATH))
-else
-	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
-	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
-    SSL_LDIR := $(dir $(LIB_SSL_PATH))
 endif
+endif
+SSL_LDIR := $(dir $(LIB_SSL_PATH))
 
 ifneq ($(ssl_header_path),)
 	SSL_IDIR := $(shell dirname $(shell dirname $(ssl_header_path)))
     $(info Found OpenSSL headers at $(SSL_IDIR))
     $(info OpenSSL lib full path is $(LIB_SSL_PATH))
-    $(info OpenSSL libs directory is $(SSL_LDIR))	
+    $(info OpenSSL libs directory is $(SSL_LDIR))
 else
-    $(error Warning: OpenSSL headers not found. exiting, please install openssl.)
+    $(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
 endif
 
 check_openssl_version:
-	@if [ "$(DISTRO)" = "almalinux" ]; then \
+	@if [ "$(DISTRO)" = "almalinux" && "$(CENTOSVER)" = "8" ]; then \
 		@current_version=$$(openssl3 version | awk '{print $$2}'); \
 	else \
 		@current_version=$$(openssl version | awk '{print $$2}'); \

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -6,6 +6,11 @@ ifndef GIT_VERSION
     $(error GIT_VERSION is not set)
 endif
 
+CENTOSVER := Unknown
+ifneq (,$(wildcard /etc/system-release))
+	CENTOSVER := $(shell rpm --eval %rhel)
+endif
+
 DEPS_PATH := ../deps
 
 UNAME_S := $(shell uname -s)
@@ -49,17 +54,18 @@ CURL_IDIR := $(CURL_DIR)/include
 
 DISTRO := $(shell lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
 
+ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
 ifeq ($(DISTRO), almalinux)
+ifeq ($(CENTOSVER), 8)
 	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
-else
-	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
+endif
 endif
 
 ifneq ($(ssl_header_path),)
 	SSL_IDIR := $(shell dirname $(shell dirname $(ssl_header_path)))
-    $(info Found yash OpenSSL headers at $(SSL_IDIR))
+    $(info Found OpenSSL headers at $(SSL_IDIR))
 else
-    $(error Warning: OpenSSL headers not found. exiting, please install openssl.)
+    $(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
 endif
 
 EV_DIR := $(DEPS_PATH)/libev/libev/

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -6,15 +6,25 @@ ifndef GIT_VERSION
     $(error GIT_VERSION is not set)
 endif
 
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+DISTRO := $(shell grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+
 CENTOSVER := Unknown
 ifneq (,$(wildcard /etc/system-release))
 	CENTOSVER := $(shell rpm --eval %rhel)
 endif
 
-DEPS_PATH := ../deps
+IS_ARM := $(if $(findstring aarch64, $(UNAME_M)),true,false)
+IS_CENTOS := $(if $(findstring Unknown, $(CENTOSVER)),false,true)
 
-UNAME_S := $(shell uname -s)
 
+PROXYSQL_PATH := ..
+PROXYSQL_IDIR := $(PROXYSQL_PATH)/include
+PROXYSQL_LDIR := $(PROXYSQL_PATH)/lib
+
+DEPS_PATH := $(PROXYSQL_PATH)/deps
 
 MARIADB_PATH := $(DEPS_PATH)/mariadb-client-library/mariadb_client
 MARIADB_IDIR := $(MARIADB_PATH)/include
@@ -52,18 +62,23 @@ COREDUMPER_IDIR := $(COREDUMPER_DIR)/include
 CURL_DIR := $(DEPS_PATH)/curl/curl
 CURL_IDIR := $(CURL_DIR)/include
 
-DISTRO := $(shell lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
-
 ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-ifeq ($(DISTRO), almalinux)
-ifeq ($(CENTOSVER), 8)
+LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
+LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
 	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
+	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
+	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)endif
 endif
 endif
+SSL_LDIR := $(dir $(LIB_SSL_PATH))
 
 ifneq ($(ssl_header_path),)
 	SSL_IDIR := $(shell dirname $(shell dirname $(ssl_header_path)))
     $(info Found OpenSSL headers at $(SSL_IDIR))
+    $(info OpenSSL lib full path is $(LIB_SSL_PATH))
+    $(info OpenSSL libs directory is $(SSL_LDIR))
 else
     $(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,10 +6,18 @@ ifndef GIT_VERSION
     $(error GIT_VERSION is not set)
 endif
 
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+DISTRO := $(shell grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+
 CENTOSVER := Unknown
 ifneq (,$(wildcard /etc/system-release))
 	CENTOSVER := $(shell rpm --eval %rhel)
 endif
+
+IS_ARM := $(if $(findstring aarch64, $(UNAME_M)),true,false)
+IS_CENTOS := $(if $(findstring Unknown, $(CENTOSVER)),false,true)
 
 
 PROXYSQL_PATH := ..
@@ -81,13 +89,11 @@ CURL_PATH := $(DEPS_PATH)/curl/curl
 CURL_IDIR := $(CURL_PATH)/include
 CURL_LDIR := $(CURL_PATH)/lib/.libs
 
-DISTRO := $(shell lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
-
 ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
 LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
 LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
-ifeq ($(DISTRO), almalinux)
-ifeq ($(CENTOSVER), 8)
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
 	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
 	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
 	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)
@@ -124,7 +130,6 @@ IDIRS := -I$(PROXYSQL_IDIR) -I$(JEMALLOC_IDIR) -I$(MARIADB_IDIR) -I$(LIBCONFIG_I
 LDIRS := -L$(PROXYSQL_LDIR) -L$(JEMALLOC_LDIR) -L$(MARIADB_LDIR) -L$(LIBCONFIG_LDIR) -L$(LIBDAEMON_LDIR) -L$(RE2_LDIR) -L$(PCRE_LDIR) -L$(MICROHTTPD_LDIR) -L$(LIBHTTPSERVER_LDIR) -L$(LIBINJECTION_LDIR) -L$(CURL_LDIR) -L$(EV_LDIR) -L$(SSL_LDIR) -L$(PROMETHEUS_LDIR) -L$(POSTGRESQL_LDIR) -L$(LIBUSUAL_LDIR) -L$(LIBSCRAM_LDIR)
 
 
-UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	LDIRS += -L$(COREDUMPER_LDIR)
 endif
@@ -202,8 +207,8 @@ ifeq ($(UNAME_S),Linux)
 endif
 
 MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lgnutls -lpthread -lssl -lcrypto -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
-ifeq ($(DISTRO), almalinux)
-ifeq ($(CENTOSVER), 8)
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
 	MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lgnutls -lpthread $(LIB_SSL_PATH) $(LIB_CRYPTO_PATH) -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
 endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -83,25 +83,25 @@ CURL_LDIR := $(CURL_PATH)/lib/.libs
 
 DISTRO := $(shell lsb_release -si 2>/dev/null || grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
 
+ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
+LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
+LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
 ifeq ($(DISTRO), almalinux)
+ifeq ($(CENTOSVER), 8)
 	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
 	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
 	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)
-    SSL_LDIR := $(dir $(LIB_SSL_PATH))
-else
-	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
-	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
-    SSL_LDIR := $(dir $(LIB_SSL_PATH))
 endif
+endif
+SSL_LDIR := $(dir $(LIB_SSL_PATH))
 
 ifneq ($(ssl_header_path),)
 	SSL_IDIR := $(shell dirname $(shell dirname $(ssl_header_path)))
     $(info Found OpenSSL headers at $(SSL_IDIR))
     $(info OpenSSL lib full path is $(LIB_SSL_PATH))
-    $(info OpenSSL libs directory is $(SSL_LDIR))	
+    $(info OpenSSL libs directory is $(SSL_LDIR))
 else
-	$(error Warning: OpenSSL headers not found. exiting, please install openssl.)
+	$(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
 endif
 
 EV_PATH := $(DEPS_PATH)/libev/libev/
@@ -201,10 +201,11 @@ ifeq ($(UNAME_S),Linux)
 	STATICMYLIBS += -lcoredumper
 endif
 
+MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lgnutls -lpthread -lssl -lcrypto -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
 ifeq ($(DISTRO), almalinux)
+ifeq ($(CENTOSVER), 8)
 	MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lgnutls -lpthread $(LIB_SSL_PATH) $(LIB_CRYPTO_PATH) -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
-else
-	MYLIBS := -Wl,--export-dynamic $(STATICMYLIBS) -Wl,-Bdynamic -lgnutls -lpthread -lssl -lcrypto -lm -lz -lrt -lprometheus-cpp-pull -lprometheus-cpp-core -luuid $(EXTRALINK)
+endif
 endif
 
 ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
 on Almalinux8, OpenSSL3 is installed from EPEL into an alternative path
includes are in `/usr/include/openssl/openssl3`
the binary is called `openssl3` instead just `openssl`

Almalinux9 has OpenSSL3 by default, no need for special handling there.

This patch restricts the special handling to Almalinux8 ONLY