### PR TITLE
OpenSSL library better detection and support use of custom openssl path (v3.0)

### DIFF
--- a/common_mk/openssl_flags.mk
+++ b/common_mk/openssl_flags.mk
@@ -13,10 +13,17 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
+    ifeq ($(OPENSSL_PACKAGE),openssl3)
+        SSL_IDIR := $(shell pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+        SSL_LDIR := $(shell pkg-config --variable=libdir $(OPENSSL_PACKAGE))
+        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so.3" 2>/dev/null | head -n 1)
+        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so.3" 2>/dev/null | head -n 1)
+    else
+        SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+        SSL_LDIR := $(shell pkg-config --variable=libdir $(OPENSSL_PACKAGE))
+        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
+    endif
 else
     SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
     SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64

--- a/common_mk/openssl_flags.mk
+++ b/common_mk/openssl_flags.mk
@@ -1,0 +1,40 @@
+CUSTOM_OPENSSL_PATH ?=
+
+OPENSSL_PACKAGE := openssl
+
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
+    OPENSSL_PACKAGE := openssl3
+endif
+endif
+
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+
+# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
+ifeq ($(CUSTOM_OPENSSL_PATH),)
+    $(info No custom path specified.)
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
+else
+    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
+    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
+endif
+
+# Check if required flags are set and provide feedback
+ifneq ($(SSL_IDIR),)
+ifneq ($(SSL_LDIR),)
+    $(info SSL_IDIR: $(SSL_IDIR))
+    $(info SSL_LDIR: $(SSL_LDIR))
+    $(info LIB_SSL_PATH: $(LIB_SSL_PATH))
+    $(info LIB_CRYPTO_PATH: $(LIB_CRYPTO_PATH))
+else
+    $(error Warning: OpenSSL libraries directory (SSL_LDIR) not found. Exiting. Please ensure the correct path is set or install OpenSSL version 3.)
+endif
+else
+    $(error Warning: OpenSSL headers (SSL_IDIR) not found. Exiting. Please install OpenSSL version 3.)
+endif

--- a/common_mk/openssl_version_check.mk
+++ b/common_mk/openssl_version_check.mk
@@ -1,0 +1,44 @@
+REQUIRED_OPENSSL_VERSION := 3.0.0
+
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+
+check_openssl_version:
+	@echo "Checking OpenSSL version..."
+	@if [ -n "$(CUSTOM_OPENSSL_PATH)" ]; then \
+		echo "Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH)"; \
+		header_path="$(CUSTOM_OPENSSL_PATH)/include/openssl/opensslv.h"; \
+		if [ ! -f "$$header_path" ]; then \
+			echo "OpenSSL header file not found at $$header_path"; \
+			exit 1; \
+		fi; \
+		version_number=$$(grep -oP '# define OPENSSL_VERSION_STR "\K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?' $$header_path | tr -d '[:space:]'); \
+		if [ -z "$$version_number" ]; then \
+			echo "Failed to extract OPENSSL_VERSION_STR from $$header_path"; \
+			exit 1; \
+		fi; \
+		major=$$(echo $$version_number | cut -d'.' -f1); \
+		minor=$$(echo $$version_number | cut -d'.' -f2); \
+		patch=$$(echo $$version_number | cut -d'.' -f3); \
+		echo "Detected OpenSSL version from header: $$major.$$minor.$$patch"; \
+		required_major=3; \
+		required_minor=0; \
+		required_patch=0; \
+		if [ $$major -gt $$required_major ] || { [ $$major -eq $$required_major ] && { [ $$minor -gt $$required_minor ] || { [ $$minor -eq $$required_minor ] && [ $$patch -ge $$required_patch ]; }; }; }; then \
+			echo "OpenSSL version is valid."; \
+		else \
+			echo "OpenSSL version must be >= $(REQUIRED_OPENSSL_VERSION). Detected: $$major.$$minor.$$patch"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "Using pkg-config to detect OpenSSL"; \
+		openssl_version=$$(pkg-config --modversion $(OPENSSL_PACKAGE) 2>/dev/null); \
+		if [ -z "$$openssl_version" ]; then \
+			echo "OpenSSL not found via pkg-config."; \
+			exit 1; \
+		fi; \
+		echo "Detected OpenSSL version from pkg-config: $$openssl_version"; \
+		if [ "$$(printf '%s\n' "$(REQUIRED_OPENSSL_VERSION)" "$$openssl_version" | sort -V | head -n1)" != "$(REQUIRED_OPENSSL_VERSION)" ]; then \
+			echo "OpenSSL version must be >= $(REQUIRED_OPENSSL_VERSION). Detected: $$openssl_version"; \
+			exit 1; \
+		fi; \
+	fi

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -76,85 +76,8 @@ endif
 
 libinjection: libinjection/libinjection/src/libinjection.a
 
-CUSTOM_OPENSSL_PATH ?=
-
-OPENSSL_PACKAGE := openssl
-
-ifeq ($(DISTRO),almalinux)
-ifeq ($(CENTOSVER),8)
-    OPENSSL_PACKAGE := openssl3
-endif
-endif
-
-$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
-# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
-ifeq ($(CUSTOM_OPENSSL_PATH),)
-    $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
-else
-    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
-    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
-endif
-
-# Check if required flags are set and provide feedback
-ifneq ($(SSL_IDIR),)
-    $(info SSL_IDIR: $(SSL_IDIR))
-    $(info SSL_LDIR: $(SSL_LDIR))
-    $(info LIB_SSL_PATH: $(LIB_SSL_PATH))
-    $(info LIB_CRYPTO_PATH: $(LIB_CRYPTO_PATH))	
-else
-    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
-endif
-
-REQUIRED_OPENSSL_VERSION := 3.0.0
-PKG_CONFIG := pkg-config
-
-check_openssl_version:
-	@echo "Checking OpenSSL version..."
-	@if [ -n "$(CUSTOM_OPENSSL_PATH)" ]; then \
-		echo "Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH)"; \
-		header_path="$(CUSTOM_OPENSSL_PATH)/include/openssl/opensslv.h"; \
-		if [ ! -f "$$header_path" ]; then \
-			echo "OpenSSL header file not found at $$header_path"; \
-			exit 1; \
-		fi; \
-		version_number=$$(grep -oP '# define OPENSSL_VERSION_STR "\K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?' $$header_path | tr -d '[:space:]'); \
-		if [ -z "$$version_number" ]; then \
-			echo "Failed to extract OPENSSL_VERSION_STR from $$header_path"; \
-			exit 1; \
-		fi; \
-		major=$$(echo $$version_number | cut -d'.' -f1); \
-		minor=$$(echo $$version_number | cut -d'.' -f2); \
-		patch=$$(echo $$version_number | cut -d'.' -f3); \
-		echo "Detected OpenSSL version from header: $$major.$$minor.$$patch"; \
-		required_major=3; \
-		required_minor=0; \
-		required_patch=0; \
-		if [ $$major -gt $$required_major ] || { [ $$major -eq $$required_major ] && { [ $$minor -gt $$required_minor ] || { [ $$minor -eq $$required_minor ] && [ $$patch -ge $$required_patch ]; }; }; }; then \
-			echo "OpenSSL version is valid."; \
-		else \
-			echo "OpenSSL version must be >= $(REQUIRED_OPENSSL_VERSION). Detected: $$major.$$minor.$$patch"; \
-			exit 1; \
-		fi; \
-	else \
-		echo "Using pkg-config to detect OpenSSL"; \
-		openssl_version=$$(pkg-config --modversion openssl 2>/dev/null); \
-		if [ -z "$$openssl_version" ]; then \
-			echo "OpenSSL not found via pkg-config."; \
-			exit 1; \
-		fi; \
-		echo "Detected OpenSSL version from pkg-config: $$openssl_version"; \
-		if [ "$$(printf '%s\n' "$(REQUIRED_OPENSSL_VERSION)" "$$openssl_version" | sort -V | head -n1)" != "$(REQUIRED_OPENSSL_VERSION)" ]; then \
-			echo "OpenSSL version must be >= $(REQUIRED_OPENSSL_VERSION). Detected: $$openssl_version"; \
-			exit 1; \
-		fi; \
-	fi
+include ../common_mk/openssl_flags.mk
+include ../common_mk/openssl_version_check.mk
 
 libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
 	cd libhttpserver && rm -rf libhttpserver-*/ || true

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -76,26 +76,38 @@ endif
 
 libinjection: libinjection/libinjection/src/libinjection.a
 
-ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
-LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
+CUSTOM_OPENSSL_PATH ?=
+
+OPENSSL_PACKAGE := openssl
+
 ifeq ($(DISTRO),almalinux)
 ifeq ($(CENTOSVER),8)
-	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
-	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
-	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)
+    OPENSSL_PACKAGE := openssl3
 endif
-else
 endif
-SSL_LDIR := $(dir $(LIB_SSL_PATH))
 
-ifneq ($(ssl_header_path),)
-	SSL_IDIR := $(shell dirname $(shell dirname $(ssl_header_path)))
-    $(info Found OpenSSL headers at $(SSL_IDIR))
-    $(info OpenSSL lib full path is $(LIB_SSL_PATH))
-    $(info OpenSSL libs directory is $(SSL_LDIR))
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
+ifeq ($(CUSTOM_OPENSSL_PATH),)
+    $(info No custom path specified.)
+    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    $(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
+    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
+endif
+
+# Check if required flags are set and provide feedback
+ifneq ($(SSL_IDIR),)
+    $(info SSL_IDIR: $(SSL_IDIR))
+    $(info SSL_LDIR: $(SSL_LDIR))
+    $(info LIB_SSL_PATH: $(LIB_SSL_PATH))
+    $(info LIB_CRYPTO_PATH: $(LIB_CRYPTO_PATH))	
+else
+    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
 endif
 
 OPENSSL_VERSION_3 := 3.0.0

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -90,13 +90,15 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
     SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
     LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
     LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
 endif
 
@@ -110,18 +112,48 @@ else
     $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
 endif
 
-OPENSSL_VERSION_3 := 3.0.0
+REQUIRED_OPENSSL_VERSION := 3.0.0
+PKG_CONFIG := pkg-config
+
 check_openssl_version:
-	@if [[ "$(DISTRO)" = "almalinux" && "$(CENTOSVER)" = "8" ]]; then \
-		@current_version=$$(openssl3 version | awk '{print $$2}'); \
+	@echo "Checking OpenSSL version..."
+	@if [ -n "$(CUSTOM_OPENSSL_PATH)" ]; then \
+		echo "Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH)"; \
+		header_path="$(CUSTOM_OPENSSL_PATH)/include/openssl/opensslv.h"; \
+		if [ ! -f "$$header_path" ]; then \
+			echo "OpenSSL header file not found at $$header_path"; \
+			exit 1; \
+		fi; \
+		version_number=$$(grep -oP '# define OPENSSL_VERSION_STR "\K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?' $$header_path | tr -d '[:space:]'); \
+		if [ -z "$$version_number" ]; then \
+			echo "Failed to extract OPENSSL_VERSION_STR from $$header_path"; \
+			exit 1; \
+		fi; \
+		major=$$(echo $$version_number | cut -d'.' -f1); \
+		minor=$$(echo $$version_number | cut -d'.' -f2); \
+		patch=$$(echo $$version_number | cut -d'.' -f3); \
+		echo "Detected OpenSSL version from header: $$major.$$minor.$$patch"; \
+		required_major=3; \
+		required_minor=0; \
+		required_patch=0; \
+		if [ $$major -gt $$required_major ] || { [ $$major -eq $$required_major ] && { [ $$minor -gt $$required_minor ] || { [ $$minor -eq $$required_minor ] && [ $$patch -ge $$required_patch ]; }; }; }; then \
+			echo "OpenSSL version is valid."; \
+		else \
+			echo "OpenSSL version must be >= $(REQUIRED_OPENSSL_VERSION). Detected: $$major.$$minor.$$patch"; \
+			exit 1; \
+		fi; \
 	else \
-		@current_version=$$(openssl version | awk '{print $$2}'); \
-	fi; \
-	echo "Installed OpenSSL version: $$current_version"; \
-	compare_result=`printf "%s\n%s" "$(OPENSSL_VERSION_3)" "$$current_version" | sort -V | head -n 1`; \
-	if [ "$$compare_result" != "$(OPENSSL_VERSION_3)" ]; then \
-		echo "Error: Installed OpenSSL version must be $(OPENSSL_VERSION_3) or higher, Please upgrade OpenSSL."; \
-		exit 1; \
+		echo "Using pkg-config to detect OpenSSL"; \
+		openssl_version=$$(pkg-config --modversion openssl 2>/dev/null); \
+		if [ -z "$$openssl_version" ]; then \
+			echo "OpenSSL not found via pkg-config."; \
+			exit 1; \
+		fi; \
+		echo "Detected OpenSSL version from pkg-config: $$openssl_version"; \
+		if [ "$$(printf '%s\n' "$(REQUIRED_OPENSSL_VERSION)" "$$openssl_version" | sort -V | head -n1)" != "$(REQUIRED_OPENSSL_VERSION)" ]; then \
+			echo "OpenSSL version must be >= $(REQUIRED_OPENSSL_VERSION). Detected: $$openssl_version"; \
+			exit 1; \
+		fi; \
 	fi
 
 libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -62,42 +62,7 @@ COREDUMPER_IDIR := $(COREDUMPER_DIR)/include
 CURL_DIR := $(DEPS_PATH)/curl/curl
 CURL_IDIR := $(CURL_DIR)/include
 
-CUSTOM_OPENSSL_PATH ?=
-
-OPENSSL_PACKAGE := openssl
-
-ifeq ($(DISTRO),almalinux)
-ifeq ($(CENTOSVER),8)
-    OPENSSL_PACKAGE := openssl3
-endif
-endif
-
-$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
-
-# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
-ifeq ($(CUSTOM_OPENSSL_PATH),)
-    $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
-else
-    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
-    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
-endif
-
-# Check if required flags are set and provide feedback
-ifneq ($(SSL_IDIR),)
-    $(info SSL_IDIR: $(SSL_IDIR))
-    $(info SSL_LDIR: $(SSL_LDIR))
-    $(info LIB_SSL_PATH: $(LIB_SSL_PATH))
-    $(info LIB_CRYPTO_PATH: $(LIB_CRYPTO_PATH))	
-else
-    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
-endif
+include ../common_mk/openssl_flags.mk
 
 EV_DIR := $(DEPS_PATH)/libev/libev/
 EV_IDIR := $(EV_DIR)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -77,13 +77,15 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
     SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
     LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
     LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
 endif
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -62,25 +62,39 @@ COREDUMPER_IDIR := $(COREDUMPER_DIR)/include
 CURL_DIR := $(DEPS_PATH)/curl/curl
 CURL_IDIR := $(CURL_DIR)/include
 
-ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
-LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
+CUSTOM_OPENSSL_PATH ?=
+
+OPENSSL_PACKAGE := openssl
+
 ifeq ($(DISTRO),almalinux)
 ifeq ($(CENTOSVER),8)
-	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
-	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
-	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)endif
+    OPENSSL_PACKAGE := openssl3
 endif
 endif
-SSL_LDIR := $(dir $(LIB_SSL_PATH))
 
-ifneq ($(ssl_header_path),)
-	SSL_IDIR := $(shell dirname $(shell dirname $(ssl_header_path)))
-    $(info Found OpenSSL headers at $(SSL_IDIR))
-    $(info OpenSSL lib full path is $(LIB_SSL_PATH))
-    $(info OpenSSL libs directory is $(SSL_LDIR))
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+
+# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
+ifeq ($(CUSTOM_OPENSSL_PATH),)
+    $(info No custom path specified.)
+    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    $(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
+    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
+endif
+
+# Check if required flags are set and provide feedback
+ifneq ($(SSL_IDIR),)
+    $(info SSL_IDIR: $(SSL_IDIR))
+    $(info SSL_LDIR: $(SSL_LDIR))
+    $(info LIB_SSL_PATH: $(LIB_SSL_PATH))
+    $(info LIB_CRYPTO_PATH: $(LIB_CRYPTO_PATH))	
+else
+    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
 endif
 
 EV_DIR := $(DEPS_PATH)/libev/libev/

--- a/src/Makefile
+++ b/src/Makefile
@@ -89,42 +89,7 @@ CURL_PATH := $(DEPS_PATH)/curl/curl
 CURL_IDIR := $(CURL_PATH)/include
 CURL_LDIR := $(CURL_PATH)/lib/.libs
 
-CUSTOM_OPENSSL_PATH ?=
-
-OPENSSL_PACKAGE := openssl
-
-ifeq ($(DISTRO),almalinux)
-ifeq ($(CENTOSVER),8)
-    OPENSSL_PACKAGE := openssl3
-endif
-endif
-
-$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
-
-# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
-ifeq ($(CUSTOM_OPENSSL_PATH),)
-    $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
-else
-    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
-    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
-endif
-
-# Check if required flags are set and provide feedback
-ifneq ($(SSL_IDIR),)
-    $(info SSL_IDIR: $(SSL_IDIR))
-    $(info SSL_LDIR: $(SSL_LDIR))
-    $(info LIB_SSL_PATH: $(LIB_SSL_PATH))
-    $(info LIB_CRYPTO_PATH: $(LIB_CRYPTO_PATH))	
-else
-    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
-endif
+include ../common_mk/openssl_flags.mk
 
 EV_PATH := $(DEPS_PATH)/libev/libev/
 EV_IDIR := $(EV_PATH)

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,13 +104,15 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
     SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
     LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
     LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -89,25 +89,39 @@ CURL_PATH := $(DEPS_PATH)/curl/curl
 CURL_IDIR := $(CURL_PATH)/include
 CURL_LDIR := $(CURL_PATH)/lib/.libs
 
-ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
-LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so" 2>/dev/null | head -n 1)
+CUSTOM_OPENSSL_PATH ?=
+
+OPENSSL_PACKAGE := openssl
+
 ifeq ($(DISTRO),almalinux)
 ifeq ($(CENTOSVER),8)
-	ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl3/*" 2>/dev/null | head -n 1)
-	LIB_SSL_PATH := $(shell find /usr /usr/local /opt -name "libssl.so.3" 2>/dev/null | head -n 1)
-	LIB_CRYPTO_PATH := $(shell find /usr /usr/local /opt -name "libcrypto.so.3" 2>/dev/null | head -n 1)
+    OPENSSL_PACKAGE := openssl3
 endif
 endif
-SSL_LDIR := $(dir $(LIB_SSL_PATH))
 
-ifneq ($(ssl_header_path),)
-	SSL_IDIR := $(shell dirname $(shell dirname $(ssl_header_path)))
-    $(info Found OpenSSL headers at $(SSL_IDIR))
-    $(info OpenSSL lib full path is $(LIB_SSL_PATH))
-    $(info OpenSSL libs directory is $(SSL_LDIR))
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+
+# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
+ifeq ($(CUSTOM_OPENSSL_PATH),)
+    $(info No custom path specified.)
+    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-	$(error Warning: OpenSSL headers not found. exiting, please install openssl version 3.)
+    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
+endif
+
+# Check if required flags are set and provide feedback
+ifneq ($(SSL_IDIR),)
+    $(info SSL_IDIR: $(SSL_IDIR))
+    $(info SSL_LDIR: $(SSL_LDIR))
+    $(info LIB_SSL_PATH: $(LIB_SSL_PATH))
+    $(info LIB_CRYPTO_PATH: $(LIB_CRYPTO_PATH))	
+else
+    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
 endif
 
 EV_PATH := $(DEPS_PATH)/libev/libev/

--- a/test/Makefile
+++ b/test/Makefile
@@ -55,14 +55,7 @@ endif
 
 $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 
-# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
-ifeq ($(CUSTOM_OPENSSL_PATH),)
-    $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-else
-    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
-    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
-endif
+include ../common_mk/openssl_flags.mk
 
 # Check if required flags are set and provide feedback
 ifneq ($(SSL_IDIR),)

--- a/test/Makefile
+++ b/test/Makefile
@@ -58,7 +58,7 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
 else
     SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))

--- a/test/Makefile
+++ b/test/Makefile
@@ -43,13 +43,32 @@ MICROHTTPD_IDIR := $(MICROHTTPD_PATH)/src/include
 CURL_PATH := $(DEPS_PATH)/curl/curl
 CURL_IDIR := -I$(CURL_PATH)/include
 
-ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
+CUSTOM_OPENSSL_PATH ?=
 
-ifneq ($(ssl_header_path),)
-    SSL_IDIR := $(shell dirname $(ssl_header_path))
-    $(info Found OpenSSL headers at $(SSL_IDIR))
+OPENSSL_PACKAGE := openssl
+
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
+    OPENSSL_PACKAGE := openssl3
+endif
+endif
+
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+
+# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
+ifeq ($(CUSTOM_OPENSSL_PATH),)
+    $(info No custom path specified.)
+    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
 else
-    $(error Warning: OpenSSL headers not found. exiting, please install openssl.)
+    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
+    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
+endif
+
+# Check if required flags are set and provide feedback
+ifneq ($(SSL_IDIR),)
+    $(info SSL_IDIR: $(SSL_IDIR))
+else
+    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
 endif
 
 EV_PATH := $(DEPS_PATH)/libev/libev/

--- a/test/Makefile
+++ b/test/Makefile
@@ -43,26 +43,7 @@ MICROHTTPD_IDIR := $(MICROHTTPD_PATH)/src/include
 CURL_PATH := $(DEPS_PATH)/curl/curl
 CURL_IDIR := -I$(CURL_PATH)/include
 
-CUSTOM_OPENSSL_PATH ?=
-
-OPENSSL_PACKAGE := openssl
-
-ifeq ($(DISTRO),almalinux)
-ifeq ($(CENTOSVER),8)
-    OPENSSL_PACKAGE := openssl3
-endif
-endif
-
-$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
-
 include ../common_mk/openssl_flags.mk
-
-# Check if required flags are set and provide feedback
-ifneq ($(SSL_IDIR),)
-    $(info SSL_IDIR: $(SSL_IDIR))
-else
-    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
-endif
 
 EV_PATH := $(DEPS_PATH)/libev/libev/
 EV_IDIR := $(EV_PATH)

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -62,22 +62,34 @@ LIBINJECTION_DIR := $(DEPS_PATH)/libinjection/libinjection
 LIBINJECTION_IDIR := $(LIBINJECTION_DIR)/src
 LIBINJECTION_LDIR := $(LIBINJECTION_DIR)/src
 
-libssl_path := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
+CUSTOM_OPENSSL_PATH ?=
 
-ifneq ($(libssl_path),)
-    SSL_LDIR := $(dir $(libssl_path))
-    $(info Found OpenSSL libs at $(SSL_LDIR))
-else
-    $(error Warning: OpenSSL library not found. exiting, please install openssl.)
+OPENSSL_PACKAGE := openssl
+
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
+    OPENSSL_PACKAGE := openssl3
+endif
 endif
 
-ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-
-ifneq ($(ssl_header_path),)
-    SSL_IDIR := $(shell dirname $(ssl_header_path))
-    $(info Found OpenSSL headers at $(SSL_IDIR))
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
+ifeq ($(CUSTOM_OPENSSL_PATH),)
+    $(info No custom path specified.)
+    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
 else
-    $(error Warning: OpenSSL headers not found. exiting, please install openssl.)
+    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
+endif
+
+# Check if required flags are set and provide feedback
+ifneq ($(SSL_IDIR),)
+    $(info SSL_IDIR: $(SSL_IDIR))
+    $(info SSL_LDIR: $(SSL_LDIR))
+else
+    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
 endif
 
 EV_DIR := $(DEPS_PATH)/libev/libev/

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -76,11 +76,15 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
     SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
 endif
 

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -62,39 +62,7 @@ LIBINJECTION_DIR := $(DEPS_PATH)/libinjection/libinjection
 LIBINJECTION_IDIR := $(LIBINJECTION_DIR)/src
 LIBINJECTION_LDIR := $(LIBINJECTION_DIR)/src
 
-CUSTOM_OPENSSL_PATH ?=
-
-OPENSSL_PACKAGE := openssl
-
-ifeq ($(DISTRO),almalinux)
-ifeq ($(CENTOSVER),8)
-    OPENSSL_PACKAGE := openssl3
-endif
-endif
-
-$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
-# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
-ifeq ($(CUSTOM_OPENSSL_PATH),)
-    $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
-else
-    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
-    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
-endif
-
-# Check if required flags are set and provide feedback
-ifneq ($(SSL_IDIR),)
-    $(info SSL_IDIR: $(SSL_IDIR))
-    $(info SSL_LDIR: $(SSL_LDIR))
-else
-    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
-endif
+include ../../../common_mk/openssl_flags.mk
 
 EV_DIR := $(DEPS_PATH)/libev/libev/
 EV_IDIR := $(EV_DIR)

--- a/test/tap/tests_with_deps/common_defs.Makefile
+++ b/test/tap/tests_with_deps/common_defs.Makefile
@@ -58,11 +58,15 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
     SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
 endif
 

--- a/test/tap/tests_with_deps/common_defs.Makefile
+++ b/test/tap/tests_with_deps/common_defs.Makefile
@@ -44,39 +44,7 @@ LIBINJECTION_DIR=$(DEPS_PATH)/libinjection/libinjection
 LIBINJECTION_IDIR=$(LIBINJECTION_DIR)/src
 LIBINJECTION_LDIR=$(LIBINJECTION_DIR)/src
 
-CUSTOM_OPENSSL_PATH ?=
-
-OPENSSL_PACKAGE := openssl
-
-ifeq ($(DISTRO),almalinux)
-ifeq ($(CENTOSVER),8)
-    OPENSSL_PACKAGE := openssl3
-endif
-endif
-
-$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
-# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
-ifeq ($(CUSTOM_OPENSSL_PATH),)
-    $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
-else
-    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
-    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
-endif
-
-# Check if required flags are set and provide feedback
-ifneq ($(SSL_IDIR),)
-    $(info SSL_IDIR: $(SSL_IDIR))
-    $(info SSL_LDIR: $(SSL_LDIR))
-else
-    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
-endif
+include ../../../common_mk/openssl_flags.mk
 
 EV_DIR=$(DEPS_PATH)/libev/libev/
 EV_IDIR=$(EV_DIR)

--- a/test/tap/tests_with_deps/deprecate_eof_support/Makefile
+++ b/test/tap/tests_with_deps/deprecate_eof_support/Makefile
@@ -64,11 +64,15 @@ $(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
 # Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     $(info No custom path specified.)
-    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
     SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
 else
-    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
 endif
 

--- a/test/tap/tests_with_deps/deprecate_eof_support/Makefile
+++ b/test/tap/tests_with_deps/deprecate_eof_support/Makefile
@@ -50,40 +50,7 @@ MICROHTTPD_DIR := $(DEPS_PATH)/libmicrohttpd/libmicrohttpd/src
 MICROHTTPD_IDIR := $(MICROHTTPD_DIR)/include
 MICROHTTPD_LDIR := $(MICROHTTPD_DIR)/microhttpd/.libs
 
-CUSTOM_OPENSSL_PATH ?=
-
-OPENSSL_PACKAGE := openssl
-
-ifeq ($(DISTRO),almalinux)
-ifeq ($(CENTOSVER),8)
-    OPENSSL_PACKAGE := openssl3
-endif
-endif
-
-$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
-# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
-ifeq ($(CUSTOM_OPENSSL_PATH),)
-    $(info No custom path specified.)
-    SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
-else
-    SSL_IDIR := $(CUSTOM_OPENSSL_PATH)/include
-    SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)	
-    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
-endif
-
-# Check if required flags are set and provide feedback
-ifneq ($(SSL_IDIR),)
-    $(info SSL_IDIR: $(SSL_IDIR))
-    $(info SSL_LDIR: $(SSL_LDIR))
-else
-    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
-endif
-
+include ../../../../common_mk/openssl_flags.mk
 
 EV_DIR := $(DEPS_PATH)/libev/libev/
 EV_IDIR := $(EV_DIR)

--- a/test/tap/tests_with_deps/deprecate_eof_support/Makefile
+++ b/test/tap/tests_with_deps/deprecate_eof_support/Makefile
@@ -50,23 +50,36 @@ MICROHTTPD_DIR := $(DEPS_PATH)/libmicrohttpd/libmicrohttpd/src
 MICROHTTPD_IDIR := $(MICROHTTPD_DIR)/include
 MICROHTTPD_LDIR := $(MICROHTTPD_DIR)/microhttpd/.libs
 
-libssl_path := $(shell find /usr /usr/local /opt -name "libssl.so" 2>/dev/null | head -n 1)
+CUSTOM_OPENSSL_PATH ?=
 
-ifneq ($(libssl_path),)
-    SSL_LDIR := $(dir $(libssl_path))
-    $(info Found OpenSSL libs at $(SSL_LDIR))
-else
-    $(error Warning: OpenSSL library not found. exiting, please install openssl.)
+OPENSSL_PACKAGE := openssl
+
+ifeq ($(DISTRO),almalinux)
+ifeq ($(CENTOSVER),8)
+    OPENSSL_PACKAGE := openssl3
+endif
 endif
 
-ssl_header_path := $(shell find /usr /usr/local /opt -name "ssl.h" -path "*/openssl/*" 2>/dev/null | head -n 1)
-
-ifneq ($(ssl_header_path),)
-    SSL_IDIR := $(shell dirname $(ssl_header_path))
-    $(info Found OpenSSL headers at $(SSL_IDIR))
+$(info OPENSSL_PACKAGE: $(OPENSSL_PACKAGE))
+# Use pkg-config to get the compiler and linker flags for OpenSSL if CUSTOM_OPENSSL_PATH is not set
+ifeq ($(CUSTOM_OPENSSL_PATH),)
+    $(info No custom path specified.)
+    SSL_IDIR := $(shell pkg-config --cflags  --keep-system-cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
+    SSL_LDIR := $(shell pkg-config --variable=libdir  $(OPENSSL_PACKAGE) )
 else
-    $(error Warning: OpenSSL headers not found. exiting, please install openssl.)
+    SSL_IDIR := -I$(CUSTOM_OPENSSL_PATH)/include
+    SSL_LDIR := -L$(CUSTOM_OPENSSL_PATH)/lib -lssl -lcrypto
+    $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))
 endif
+
+# Check if required flags are set and provide feedback
+ifneq ($(SSL_IDIR),)
+    $(info SSL_IDIR: $(SSL_IDIR))
+    $(info SSL_LDIR: $(SSL_LDIR))
+else
+    $(error Warning: OpenSSL headers not found. Exiting. Please install OpenSSL version 3.)
+endif
+
 
 EV_DIR := $(DEPS_PATH)/libev/libev/
 EV_IDIR := $(EV_DIR)


### PR DESCRIPTION
1. Use pkg-config to detect all the OS.
2. Support for custom openssl path:

Steps to use custom openssl library:
Note: Tested with openssl 3.5.1 version

1. Download openssl source code.
2. ./config --prefix=/home/ysahu/project/custom_ssl/openssl_custom_ins 
3. make 
4. make install 
5. Compile ProxySQL using 

make CUSTOM_OPENSSL_PATH=/home/ysahu/project/custom_ssl/openssl_custom_ins

https://github.com/sysown/proxysql/issues/4774

 