### PR TITLE
Fix memory leak on 'ssl_params' fetch in Monitor

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1531,10 +1531,12 @@ __exit_set_wait_timeout:
 bool MySQL_Monitor_State_Data::create_new_connection() {
 		mysql=mysql_init(NULL);
 		assert(mysql);
-		MySQLServers_SslParams * ssl_params = NULL;
+		std::unique_ptr<MySQLServers_SslParams> ssl_params { nullptr };
 		if (use_ssl && port) {
-			ssl_params = MyHGM->get_Server_SSL_Params(hostname, port, mysql_thread___monitor_username);
-			MySQL_Connection::set_ssl_params(mysql,ssl_params);
+			ssl_params = std::unique_ptr<MySQLServers_SslParams>(
+				MyHGM->get_Server_SSL_Params(hostname, port, mysql_thread___monitor_username)
+			);
+			MySQL_Connection::set_ssl_params(mysql, ssl_params.get());
 			mysql_options(mysql, MARIADB_OPT_SSL_KEYLOG_CALLBACK, (void*)proxysql_keylog_write_line_callback);
 		}
 		unsigned int timeout=mysql_thread___monitor_connect_timeout/1000;


### PR DESCRIPTION
This PR fixed a leak in monitor connection creation when `ssl_params` are used for the target server.