### PR TITLE
Remove print of jemalloc conf prior to cmd options handling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1978,13 +1978,6 @@ int print_jemalloc_conf() {
 #endif
 
 int main(int argc, const char * argv[]) {
-	// Output current jemalloc conf; no action taken when disabled
-	{
-		int rc = print_jemalloc_conf();
-		if (rc) { exit(EXIT_FAILURE); }
-	}
-
-
 #ifdef DEBUG
 	{
 		// This run some ProxyProtocolInfo tests.
@@ -1993,7 +1986,6 @@ int main(int argc, const char * argv[]) {
 		ppi.run_tests();
 	}
 #endif // DEBUG
-
 
 	{
 		MYSQL *my = mysql_init(NULL);
@@ -2020,6 +2012,12 @@ int main(int argc, const char * argv[]) {
 #ifdef DEBUG
 		std::cerr << "Main init global variables completed in ";
 #endif
+	}
+
+	// Output current jemalloc conf; no action taken when disabled
+	{
+		int rc = print_jemalloc_conf();
+		if (rc) { exit(EXIT_FAILURE); }
 	}
 
 	struct rlimit nlimit;


### PR DESCRIPTION
This PR fixes always printing `MALLOC_CONF` details to `stderr`. Printing these details should always take place after command line options processing.