### PR TITLE
Improve speed of debug logging to disk

### DIFF
--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -61,8 +61,8 @@ void sync_log_buffer_to_disk(SQLite3DB *db) {
 	int rc;
 	db->execute("BEGIN TRANSACTION");
 	for (const auto& entry : log_buffer) {
-		rc=(*proxy_sqlite3_bind_int64)64(statement1, 1, entry.time); ASSERT_SQLITE_OK(rc, db);
-		rc=(*proxy_sqlite3_bind_int64)64(statement1, 2, entry.lapse);ASSERT_SQLITE_OK(rc, db);
+		rc=(*proxy_sqlite3_bind_int64)(statement1, 1, entry.time); ASSERT_SQLITE_OK(rc, db);
+		rc=(*proxy_sqlite3_bind_int64)(statement1, 2, entry.lapse);ASSERT_SQLITE_OK(rc, db);
 		rc=(*proxy_sqlite3_bind_int64)(statement1, 3, entry.thr); ASSERT_SQLITE_OK(rc, db);
 		rc=(*proxy_sqlite3_bind_text)(statement1, 4, entry.file.c_str(), -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		rc=(*proxy_sqlite3_bind_int64)(statement1, 5, entry.line); ASSERT_SQLITE_OK(rc, db);

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -267,7 +267,7 @@ void proxy_debug_func(
 		}
 		if (write_to_disk == true) {
 			// Create a DebugLogEntry
-			LogEntry entry;
+			DebugLogEntry entry;
 			entry.time = curtime;
 			entry.lapse = curtime - pretime;
 			entry.thr = thr;


### PR DESCRIPTION
This commit introduces multiple changes in debug.cpp:
* new struct DebugLogEntry
* entries are not written directly to database, but in a vector (`log_buffer`)
* when a threshold is reached (currently hardcoded) all entries are saved to database