### PR TITLE
Ignore tracking of session_track_system_variables

### DIFF
--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -52,6 +52,8 @@ MySQL_Variables::MySQL_Variables() {
 	ignore_vars.push_back("read_rnd_buffer_size");
 	// NOTE: This variable has been temporarily ignored. Check issues #3442 and #3441.
 	ignore_vars.push_back("session_track_schema");
+	// NOTE: This variable has been temporarily ignored. Check issues #4839
+	ignore_vars.push_back("session_track_system_variables");
 	variables_regexp = "";
 	for (auto i = 0; i < SQL_NAME_LAST_HIGH_WM; i++) {
 		// we initialized all the internal_variable_name if set to NULL

--- a/lib/set_parser.cpp
+++ b/lib/set_parser.cpp
@@ -162,7 +162,7 @@ void SetParser::generateRE_parse1v2() {
 		// - variable name , with double @ (session variable) or single @ (user defiend variable)
 		// - strings that includes words, spaces and commas
 		// - single quote string
-		string  sw0  = "(?:\\w+|\"[\\w, ]+\"|\'[\\w, ]+\'|@(?:|@)\\w+|\'\')";
+		string  sw0  = "(?:\\w+|\"[\\w, ]+\"|\'[\\w, ]+\'|@(?:|@|@session\\.|@global\\.)\\w+|\'\')";
 		string  mw0  = "(?:" + sw0 + "(?: *, *" + sw0 + ")*)"; // multiple words, separated by comma and random spaces
 		string  fww  = "(?:(?:REPLACE|IFNULL|CONCAT)\\( *" + mw0 + "\\))"; // functions REPLACE|IFNULL|CONCAT having argument multiple words
 		string rfww2 = "(?:(?:REPLACE|IFNULL|CONCAT)\\( *" + fww   + " *, *" + mw0 + "\\))"; //functions REPLACE|IFNULL|CONCAT calling the same functions


### PR DESCRIPTION
Adding variable session_track_system_variables to `ignore_vars`

Also added `@@session.` and `@@global.` in the parser for SET statements (parse1v2)

See issue #4839