### PR TITLE
Prevent unnecessary VACUUM executions for SQLite3 stats database - Closes #4856

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -4048,7 +4048,7 @@ __get_pkts_from_client:
 									const uint32_t recv_query_sz { pkt.size - 5 };
 
 									proxy_debug(PROXY_DEBUG_MYSQL_COM, 5, "Processing received query"
-										"   session=%p session_type=%d schemaname=%s query=%.*s\n",
+										"   session=%p session_type=%d schemaname=\"%s\" query=\"%.*s\"\n",
 										this, session_type, schemaname ? schemaname : "", recv_query_sz, recv_query
 									);
 								}

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1682,20 +1682,24 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 		}
 		//pthread_mutex_unlock(&admin_mutex);
 	}
-	if (
-		stats_mysql_processlist || stats_mysql_connection_pool || stats_mysql_connection_pool_reset ||
-		stats_mysql_query_digest || stats_mysql_query_digest_reset || stats_mysql_errors ||
-		stats_mysql_errors_reset || stats_mysql_global || stats_memory_metrics || 
-		stats_mysql_commands_counters || stats_mysql_query_rules || stats_mysql_users ||
-		stats_mysql_gtid_executed || stats_mysql_free_connections || 
-		stats_pgsql_global || stats_pgsql_connection_pool || stats_pgsql_connection_pool_reset ||
-		stats_pgsql_free_connections || stats_pgsql_users || stats_pgsql_processlist ||
-		stats_pgsql_errors || stats_pgsql_errors_reset || stats_pgsql_query_rules || stats_pgsql_commands_counters ||
-		stats_pgsql_query_digest || stats_pgsql_query_digest_reset
-	) {
-		ret = true;
+
+	int freelist_count = statsdb->return_one_int("PRAGMA freelist_count");
+	if (freelist_count < 1000) {
+		ret = false;
+	} else {
+		int page_count  = statsdb->return_one_int("PRAGMA page_count");
+		ret = (freelist_count * 100 / page_count) > 20;
+
+#ifdef DEBUG
+		if (ret) {
+			proxy_debug(PROXY_DEBUG_ADMIN, 4,
+				"VACUUM required for 'stats_db'   page_count=%d freelist_count=%d\n",
+				page_count, freelist_count
+			);
+		}
+#endif
 	}
-	
+
 	return ret;
 }
 

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -1114,8 +1114,11 @@ int get_proxysql_cpu_usage(const CommandLine& cl, double& cpu_usage, uint32_t in
 		sleep(1);
 	}
 
-	MYSQL_QUERY(admin, "SELECT * FROM system_cpu ORDER BY timestamp DESC LIMIT 2");
-	MYSQL_RES* admin_res = mysql_store_result(admin);
+	MYSQL_QUERY(admin, "SELECT * FROM system_cpu ORDER BY timestamp DESC LIMIT 5");
+	MYSQL_RES* admin_res { mysql_store_result(admin) };
+	const string sys_cpu_str { dump_as_table(admin_res) };
+	diag("Dumping latest 5 entries from 'system_cpu':\n%s", sys_cpu_str.c_str());
+
 	MYSQL_ROW row = mysql_fetch_row(admin_res);
 
 	double s_clk = (1000.0 / sysconf(_SC_CLK_TCK));


### PR DESCRIPTION
## Description / Main work

This PR introduces a generic approach for performing `VACUUM` operations over `stats` database, performing them only when these operations could result in space optimization for the database. The PR also introduces other optimization, substituting simple query executions with prepared statements for `SQLite`. These optimizations alone should be enough to solve the increase on `CPU` usage that was affecting test `reg_test_3765_ssl_pollout-t`, described in issue #4828, other changes required in that issue description are also included in this PR.

The load used for getting the `perf` data was just a loop of the query `SELECT Variable_Name, Variable_Value FROM stats_mysql_global`. After the two main optimizations introduced, we can see how `perf` report has changed:

`original`:
```
-   94.28%     0.02%  Admin            proxysql              [.] void admin_session_handler<MySQL_Session>(MySQL_Session*, void*, _PtrSize_t*)
   - 94.26% void admin_session_handler<MySQL_Session>(MySQL_Session*, void*, _PtrSize_t*)
      + 45.66% ProxySQL_Admin::vacuum_stats(bool)
      - 34.65% SQLite3DB::execute_statement(char const*, char**, int*, int*, SQLite3_result**)
         + 33.72% sqlite3_prepare_v2
         + 0.93% SQLite3_result::SQLite3_result(sqlite3_stmt*)
      + 13.39% ProxySQL_Admin::GenericRefreshStatistics(char const*, unsigned int, bool)
```

`patched`:
```
-   84.69%     0.05%  Admin            proxysql              [.] void admin_session_handler<MySQL_Session>(MySQL_Session*, void*, _PtrSize_t*)                                                                                                                                             
   - 84.63% void admin_session_handler<MySQL_Session>(MySQL_Session*, void*, _PtrSize_t*)                                                                                                                                                                                                  
      + 63.83% ProxySQL_Admin::GenericRefreshStatistics(char const*, unsigned int, bool)                                                                                                                                                                                                   
      - 13.67% SQLite3DB::execute_statement(char const*, char**, int*, int*, SQLite3_result**)                                                                                                                                                                                             
         + 12.34% SQLite3_result::SQLite3_result(sqlite3_stmt*)                                                                                                                                                                                                                            
         + 1.24% sqlite3_prepare_v2                                                                                                                                                                                                                                                        
      + 3.86% SQLite3_result::~SQLite3_result()                                                                                                                                                                                                                                            
      + 2.77% MySQL_Session::SQLite3_to_MySQL(SQLite3_result*, char*, int, MySQL_Protocol*, bool, bool)
```

These optimizations are enough to keep most of the CPU time on the actual query result computation.
