### PR TITLE
v2.7 fix GH actions run name

### DIFF
--- a/.github/workflows/CI-trigger.yml
+++ b/.github/workflows/CI-trigger.yml
@@ -1,5 +1,6 @@
 name: CI-trigger
-run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+#run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+run-name: ${{ github.head_ref || github.ref_name }} ${{ github.workflow }} ${{ github.event.after || github.sha }}
 
 on:
   push:


### PR DESCRIPTION
the property used for constructing run-name - `github.ref_name`
changes for different trigger event types.

make sure its always the same, use:

`run-name: ${{ github.head_ref || github.ref_name }} ${{ github.workflow }} ${{ github.event.after || github.sha }}
`