### PR TITLE
pass WITHGCOV WITHASAN NOJEMALLOC to build container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - CURVER
       - PKG_RELEASE
       - PROXYSQL_BUILD_TYPE
+      - WITHGCOV
+      - NOJEMALLOC
+      - WITHASAN
     command: bash -l -c /opt/entrypoint/entrypoint.bash
 
 ####################################################################################################


### PR DESCRIPTION
proxysql_3p_tests are building in containers and need WITHGCOV
this was omitted before, as there was no need for it.

pass WITHGCOV WITHASAN NOJEMALLOC build env vars
to build container in docker-compose.yml
