### PR TITLE
exit if database file is not writable

### DIFF
--- a/lib/Admin_Bootstrap.cpp
+++ b/lib/Admin_Bootstrap.cpp
@@ -520,6 +520,10 @@ bool ProxySQL_Admin::init(const bootstrap_info_t& bootstrap_info) {
 	bool admindb_file_exists=Proxy_file_exists(GloVars.admindb);
 
 	configdb=new SQLite3DB();
+	if (access(GloVars.admindb, W_OK) != 0) {
+		proxy_error("Database file '%s' is not writable\n", GloVars.admindb);
+		exit(EXIT_SUCCESS);
+	}
 	configdb->open((char *)GloVars.admindb, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
 	// Fully synchronous is not required. See to #1055
 	// https://sqlite.org/pragma.html#pragma_synchronous

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1134,6 +1134,10 @@ void ProxySQL_Admin::flush_configdb() { // see #923
 	admindb->execute((char *)"DETACH DATABASE disk");
 	delete configdb;
 	configdb=new SQLite3DB();
+	if (access(GloVars.admindb, W_OK) != 0) {
+		proxy_error("Database file '%s' is not writable\n", GloVars.admindb);
+		exit(EXIT_SUCCESS);
+	}
 	configdb->open((char *)GloVars.admindb, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
 	__attach_db(admindb, configdb, (char *)"disk");
 	// Fully synchronous is not required. See to #1055


### PR DESCRIPTION
If database file (proxysql.db) is not writable, exit immediately instead of crashing because it is not writable.

See issue #4893