### PR TITLE
fix: fix user name and database name are swapped.

### DIFF
--- a/lib/Base_Session.cpp
+++ b/lib/Base_Session.cpp
@@ -419,8 +419,8 @@ bool Base_Session<S,DS,B,T>::handler_special_queries_STATUS(PtrSize_t* pkt) {
 			resultset->add_column_definition(SQLITE_TEXT, "DATABASE()");
 			resultset->add_column_definition(SQLITE_TEXT, "USER()");
 			char* pta[2];
-			pta[0] = client_myds->myconn->userinfo->username;
-			pta[1] = client_myds->myconn->userinfo->schemaname;
+			pta[0] = client_myds->myconn->userinfo->schemaname;
+			pta[1] = client_myds->myconn->userinfo->username;
 			resultset->add_row(pta);
 			bool deprecate_eof_active = client_myds->myconn->options.client_flag & CLIENT_DEPRECATE_EOF;
 			SQLite3_to_MySQL(resultset, NULL, 0, &client_myds->myprot, false, deprecate_eof_active);


### PR DESCRIPTION
I noticed that the displayed `Current database` and `Current user` were swapped when running the mysql status command. Consequently, I fixed the affected area.

The output before modification is as follows:

```
$ mysql -h127.0.0.1 -P6033 -uuser_name -p db_name -e'status'
Enter password:
--------------
mysql  Ver 9.2.0 for macos15.2 on arm64 (Homebrew)

Connection id:          3
Current database:       user_name
Current user:           db_name
SSL:                    Not in use
Current pager:          stdout
Using outfile:          ''
Using delimiter:        ;
Server version:         5.5.30 (ProxySQL)
Protocol version:       10
Connection:             127.0.0.1 via TCP/IP
Server characterset:    utf8
Db     characterset:    utf8
Client characterset:    utf8mb4
Conn.  characterset:    utf8mb4
TCP port:               6033
Binary data as:         Hexadecimal
Uptime:                 11 min 42 sec

Threads: 1  Questions: 14  Slow queries: 0
--------------
```