### PR TITLE
ProxySQL crashes when client sends unknown connection parameter - v3.0

### DIFF
--- a/include/PgSQL_Backend.h
+++ b/include/PgSQL_Backend.h
@@ -12,8 +12,6 @@ class PgSQL_Backend
 	void * operator new(size_t);
 	void operator delete(void *);
 	int hostgroup_id; //< The ID of the host group this connection belongs to. Set to -1 if uninitialized
-	char gtid_uuid[128]; //< An array to store a unique identifier for each transaction : for now unused
-	uint64_t gtid_trxid; //< The ID of the current transaction : for now unused
 	PgSQL_Data_Stream *server_myds;
 	//  mysql_cp_entry_t *server_mycpe;
 	bytes_stats_t server_bytes_at_cmd; //< A structure storing the number of bytes received and sent

--- a/include/ProxySQL_Poll.h
+++ b/include/ProxySQL_Poll.h
@@ -44,6 +44,7 @@ class ProxySQL_Poll {
 	ProxySQL_Poll();
 	~ProxySQL_Poll();
 	void add(uint32_t _events, int _fd, T *_myds, unsigned long long sent_time);
+	void update_fd_at_index(unsigned int idx, int _fd);
 	void remove_index_fast(unsigned int i);
 	int find_index(int fd);
 };

--- a/lib/Base_Thread.cpp
+++ b/lib/Base_Thread.cpp
@@ -349,8 +349,13 @@ void Base_Thread::configure_pollout(DS * myds, unsigned int n) {
 	} else {
 		if (myds->DSS > STATE_MARIADB_BEGIN && myds->DSS < STATE_MARIADB_END) {
 			thr->mypolls.fds[n].events = POLLIN;
-			if (thr->mypolls.myds[n]->myconn->async_exit_status & MYSQL_WAIT_WRITE)
-				thr->mypolls.fds[n].events |= POLLOUT;
+			if constexpr (std::is_same_v<T, PgSQL_Thread>) {
+				if (thr->mypolls.myds[n]->myconn->async_exit_status & PG_EVENT_WRITE)
+					thr->mypolls.fds[n].events |= POLLOUT;
+			} else if constexpr (std::is_same_v<T, MySQL_Thread>) {
+				if (thr->mypolls.myds[n]->myconn->async_exit_status & MYSQL_WAIT_WRITE)
+					thr->mypolls.fds[n].events |= POLLOUT;
+			}
 		} else {
 			myds->set_pollout();
 		}

--- a/lib/PgSQL_Backend.cpp
+++ b/lib/PgSQL_Backend.cpp
@@ -15,8 +15,6 @@ PgSQL_Backend::PgSQL_Backend() {
 	server_myds=NULL;
 	server_bytes_at_cmd.bytes_recv=0;
 	server_bytes_at_cmd.bytes_sent=0;
-	memset(gtid_uuid,0,sizeof(gtid_uuid));
-	gtid_trxid=0;
 }
 
 PgSQL_Backend::~PgSQL_Backend() {

--- a/lib/ProxySQL_Poll.cpp
+++ b/lib/ProxySQL_Poll.cpp
@@ -127,6 +127,21 @@ void ProxySQL_Poll<T>::add(uint32_t _events, int _fd, T *_myds, unsigned long lo
 }
 
 /**
+ * @brief Updates the file descriptor (FD) at a specific index in the ProxySQL_Poll object.
+ *
+ * This function updates the file descriptor (FD) at a specific index in the ProxySQL_Poll object.
+ * It does not modify any other associated data or metadata.
+ *
+ * @param idx The index of the file descriptor (FD) to update.
+ * @param _fd The new file descriptor (FD) value.
+ */
+template<class T>
+void ProxySQL_Poll<T>::update_fd_at_index(unsigned int idx, int _fd) {
+	if ((int)idx == -1 || idx >= len) return;
+	fds[idx].fd = _fd;
+}
+
+/**
  * @brief Removes a file descriptor (FD) and its associated MySQL_Data_Stream from the ProxySQL_Poll object.
  * 
  * This function removes a file descriptor (FD) along with its associated MySQL_Data_Stream from the ProxySQL_Poll object.


### PR DESCRIPTION
### Problem
ProxySQL crashes when a client sends an unknown connection parameter. The issue occurs during the connection phase, in PQconnectPoll.

When an invalid or unknown connection parameter is passed while establishing a connection to the PostgreSQL server, and the server returns an error, libpq (the PostgreSQL client library) performs a backward compatibility check for versions prior to PostgreSQL 9.0.

One such parameter is application_name, which didn’t exist before PostgreSQL 9.0. If the server returns error code 42704 (undefined object), libpq assumes it’s connecting to a pre-9.0 server that doesn’t recognize the application_name parameter. As a result, it retries the connection—this time omitting the parameter.

However, this same error code is returned for any unknown parameter, not just application_name. So if any invalid parameter is used, libpq will silently restart the connection—closing the old socket and opening a new one.

ProxySQL was not handling this fd change, leading to a crash.

### Solution
ProxySQL now detects file descriptor changes on every PQconnectPoll call. If a change is detected, it updates the corresponding file descriptor within ProxySQL.

Closes[#4919](https://github.com/sysown/proxysql/issues/4919)