### PR TITLE
Fix query digests for comments for certain query sizes - Closes #4918.

### DIFF
--- a/lib/c_tokenizer.cpp
+++ b/lib/c_tokenizer.cpp
@@ -447,7 +447,8 @@ enum p_st get_next_st(const options* opts, struct shared_st* shared_st) {
 	// cmnt type 1 - start with '/*'
 	if(
 		// v1_crashing_payload_05
-		shared_st->q_cur_pos < (shared_st->d_max_len-1) && *shared_st->q == '/' && *(shared_st->q+1) == '*'
+		shared_st->q_cur_pos < (shared_st->q_len - 2) &&
+		*shared_st->q == '/' && *(shared_st->q+1) == '*'
 	) {
 		st = st_cmnt_type_1;
 	}
@@ -458,7 +459,7 @@ enum p_st get_next_st(const options* opts, struct shared_st* shared_st) {
 	// cmnt type 3 - start with '--'
 	else if (
 		// shared_st->query isn't over, need to check next character
-		shared_st->q_cur_pos < (shared_st->d_max_len-2) &&
+		shared_st->q_cur_pos < (shared_st->q_len - 2) &&
 		// found starting pattern '-- ' (space is required)
 		*shared_st->q == '-' && *(shared_st->q+1) == '-' && is_space_char(*(shared_st->q+2))
 	) {

--- a/lib/c_tokenizer.cpp
+++ b/lib/c_tokenizer.cpp
@@ -778,14 +778,9 @@ enum p_st process_cmnt_type_2(shared_st* shared_st) {
 	if (*shared_st->q == '#' && shared_st->q_cur_pos <= (shared_st->q_len - 2)) {
 		shared_st->q += 1;
 		shared_st->q_cur_pos += 1;
-
-		if (shared_st->q_cur_pos == (shared_st->q_len - 2)) {
-			next_state = st_no_mark_found;
-			return next_state;
-		}
 	}
 
-	if (*shared_st->q == '\n' || *shared_st->q == '\r' || (shared_st->q_cur_pos == shared_st->q_len - 1)) {
+	if (*shared_st->q == '\n' || *shared_st->q == '\r' || (shared_st->q_cur_pos >= shared_st->q_len - 1)) {
 		next_state = st_no_mark_found;
 		shared_st->prev_char = ' ';
 
@@ -818,14 +813,9 @@ enum p_st process_cmnt_type_3(shared_st* shared_st) {
 	) {
 		shared_st->q += 3;
 		shared_st->q_cur_pos += 3;
-
-		if (shared_st->q_cur_pos == (shared_st->q_len - 4)) {
-			next_state = st_no_mark_found;
-			return next_state;
-		}
 	}
 
-	if (*shared_st->q == '\n' || *shared_st->q == '\r' || (shared_st->q_cur_pos == shared_st->q_len - 1)) {
+	if (*shared_st->q == '\n' || *shared_st->q == '\r' || (shared_st->q_cur_pos >= shared_st->q_len - 1)) {
 		next_state = st_no_mark_found;
 		shared_st->prev_char = ' ';
 

--- a/test/tap/tests/tokenizer_payloads/regular_tokenizer_digests.hjson
+++ b/test/tap/tests/tokenizer_payloads/regular_tokenizer_digests.hjson
@@ -24,7 +24,10 @@
 			"# random_comment\n select 1.1   #final_comment  \n  ",
 			"-- random_comment\n select 1.1 -- final_comment\n   ",
 			"-- random_comment\n select 1.1-- final_comment   \n",
-			"-- random_comment\n select 1.1   -- final_comment  \n  "
+			// NOTE: Reg check for last `-- ` comment with '4' chars
+			"select 1 -- aaaa",
+			// NOTE: Reg check for last `# ` comment with '1' chars
+			"select 1 # a"
 		],
 		"s1": "select ?",
 		"s2": "select ?",

--- a/test/tap/tests/tokenizer_payloads/regular_tokenizer_digests.hjson
+++ b/test/tap/tests/tokenizer_payloads/regular_tokenizer_digests.hjson
@@ -958,6 +958,49 @@
 		]
 	},
 	{
+		// Correct compression of final comment '--' with query exceeding 'query_digests_max_query_length'
+		"q": [
+			"insert into table (field1, field2, field3, field4, field5, field6) values ('00000000000000000000000000', null, '11111111111111111111111111', 'STOP', 1745624748961, '00000000000000000000000000') on duplicate key update field4 = 'STOP', field5 = 1745624748961, field6 = '11111111111111111111111111' -- cmt: OOOOOOOOOOOOOOOOOOOOOOOOOO:NNNNNNNNNNNNNNNNNNNNNNNNNN:N"
+		],
+		"mz": [
+			{
+				"digest_max_size": 299,
+				"grouping_limit": 3,
+				"replace_null": false,
+				"groups_grouping_limit": 10,
+				"digest": "insert into table (field1,field2,field3,field4,field5,field6) values (?,null,?,?,?,?) on duplicate key update field4 = ?,field5 = ?,field6 = ?"
+			}
+		]
+	},
+	{
+		// Correct compression of final comment '--' with query exceeding 'query_digests_max_query_length'
+		"q": [
+			"SELECT '01JSQMJPDJEF'  -- cmt: foo"
+		],
+		"mz": [
+			{
+				"digest_max_size": 25,
+				"grouping_limit": 3,
+				"groups_grouping_limit": 10,
+				"digest": "SELECT ?"
+			}
+		]
+	},
+	{
+		// Correct compression of final comment '--' with query exceeding 'query_digests_max_query_length'
+		"q": [
+			"SELECT '01JSQMJPDJEF'  /* cmt: foo */"
+		],
+		"mz": [
+			{
+				"digest_max_size": 24,
+				"grouping_limit": 3,
+				"groups_grouping_limit": 10,
+				"digest": "SELECT ?"
+			}
+		]
+	},
+	{
 		// digest_corner_cases_1.hjson - Testing the compression limits of number parsing when buffer is exceeded
 		"q": [
 			"INSERT INTO db.table (col1,col2,col3) VALUES    (  0x1bb81  ,  214957.551736 , NuLL   ,  13931.135294  , 23747.192325   ,123446.135101   ,  NULL  ,   \"qishXAQYMGjKECmKDOMPhdcAnCKsIZ\"   ,  0xdf06 )   ,  (   0xeeb2, 61634.403212  ,\"WLrEhMSFQunfdVMBlNTHuTOoJnZWXp\"  , 134001  ,0x11691   ,-117247   ,   null   , 185039.893374,0xfffffffffffdec0c   )   , (   63386.842817 ,NUll , NuLL ,'rjEesshgtPbGPhQQPPJdzShBDxgqtX', -70027.364007   ,   -33812,16088,  -55381.721224 ,    30937.841446  )  , (   -86381.060501   ,42818   , \"dWQiQvHpsqARowGWJYDfCWFfftJCQF\"  ,  \"usJPVckeqNRKoRbJhZcnjlKWxdRFqx\",   'vmHWbmdhfopTPzKzBktGDHfgAWvTjK' , -144765.876660  ,'zpUGEePzmDcktBrkWvpAjFvIYJLjJk'   ,   nuLL   ,   nulL) , (  Null  , -60588.485877,0xfffffffffffef1d8  ,   0x186f3   ,   'YRTtjWCbHXxqDAjfhqAeyOkflwUkUy'   ,   Null   ,   30300 ,   -79082   ,   -53386.660287 )   , (nuLL,  101067.756480,  'QJqcLLvbdUKvElZnitrCPiBmxttzPR'   , 82544.127490, \"pLwcmgkGEruDvPuJbjVWqigQKLtApm\" , NuLl ,\"pHCWIfigWjGHRWGbmrEYboNjNRrVle\"   ,   273.951202 , 0x1611e) ,  (  'xEqRpKSqBETVFlBrmUWDBNvXiWhLAv' ,0x2d71b   , -7610.975745 ,   49496.141605   ,  0x5a3b, 41343,   187409,  \"ogsXdRWyoxDtZIIsgbUQIBnHRPVBCr\" ,    \"OKDhJKxprZcDdKrveMoCipXkyBOWzB\")  ,(179771.894977 ,  'exEZujUOHgZlQNHbNBmzuqGvfIjSmh'   , 110148.494099  ,  0x22668,0xbb55   ,'WUAcoNyluxqJGkRXIynFEAzaHGoNUm', 99168  ,98435.675651   ,    83750.793947 ),    ( -55183.197960  ,  -209785 ,NULl  ,-131058  ,-40439.196182  , 0xfffffffffffeef1e  ,   'bOWeCuKfVyMAHgcRjonjLlHffKkVUj',-152886   ,  74587.327657 )  ON DUPLICATE KEY UPDATE col1 = VALUES(col2)"


### PR DESCRIPTION
Closes #4918.

This patches has been tested using the `AFL++` tests with the following clean results:
```
[AFL++ 81ffae2edf4f] /src/test/afl_digest_test # afl-whatsup -s output/
/usr/local/bin/afl-whatsup status check tool for afl-fuzz by Michal Zalewski

Summary stats
=============

        Fuzzers alive : 5
          Starting up : 1 (excluded from stats)
       Total run time : 1 days, 6 hours
          Total execs : 1374 millions
     Cumulative speed : 62007 execs/sec
  Total average speed : 12401 execs/sec
Current average speed : 59955 execs/sec
        Pending items : 0 faves, 0 total
   Pending per fuzzer : 0 faves, 0 total (on average)
     Coverage reached : 1.30%
        Crashes saved : 0
          Hangs saved : 0
 Cycles without finds : 37/312/73/76/65
   Time without finds : 28 minutes, 44 seconds
```