### PR TITLE
Add Structured Error Format and New Verbosity Levels in libpq

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -306,6 +306,7 @@ postgresql/postgresql/src/interfaces/libpq/libpq.a:
 	cd postgresql && tar -zxf postgresql-*.tar.gz
 	cd postgresql/postgresql && patch -p0 < ../get_result_from_pgconn.patch
 	cd postgresql/postgresql && patch -p0 < ../handle_row_data.patch
+	cd postgresql/postgresql && patch -p0 < ../fmt_err_msg.patch
 	#cd postgresql/postgresql && LD_LIBRARY_PATH="$(shell pwd)/libssl/openssl" ./configure --with-ssl=openssl --with-includes="$(shell pwd)/libssl/openssl/include/" --with-libraries="$(shell pwd)/libssl/openssl/" --without-readline --enable-debug  CFLAGS="-ggdb -O0 -fno-omit-frame-pointer" CPPFLAGS="-g -O0"
 	cd postgresql/postgresql && LD_LIBRARY_PATH="$(SSL_LDIR)" ./configure --with-ssl=openssl --with-includes="$(SSL_IDIR)" --with-libraries="$(SSL_LDIR)" --without-readline
 	cd postgresql/postgresql/src/interfaces/libpq && CC=${CC} CXX=${CXX} ${MAKE} MAKELEVEL=0

--- a/deps/postgresql/fmt_err_msg.patch
+++ b/deps/postgresql/fmt_err_msg.patch
@@ -18,16 +18,15 @@ index 5a28b6f..c11f3d9 100644
  	}
  
 diff --git src/interfaces/libpq/fe-protocol3.c src/interfaces/libpq/fe-protocol3.c
-index e1fb48b..16fd8b4 100644
+index e1fb48b..7ad19ba 100644
 --- src/interfaces/libpq/fe-protocol3.c
 +++ src/interfaces/libpq/fe-protocol3.c
-@@ -1016,6 +1016,58 @@ pqBuildErrorMessage3(PQExpBuffer msg, const PGresult *res,
+@@ -1016,6 +1016,54 @@ pqBuildErrorMessage3(PQExpBuffer msg, const PGresult *res,
  		return;
  	}
  
 +	if (verbosity == PSERRORS_FORMATTED_DEFAULT || verbosity == PSERRORS_FORMATTED_VERBOSE)
 +	{
-+		static const char libErr[] = "LE:-1:";
 +		size_t i;
 +
 +		// Always included fields
@@ -62,10 +61,8 @@ index e1fb48b..16fd8b4 100644
 +				appendPQExpBuffer(msg, "%c:%d:%s", default_fields[i], (int)strlen(val), val);
 +		}
 +	
-+		if (verbosity != PSERRORS_FORMATTED_VERBOSE) {
-+			appendBinaryPQExpBuffer(msg, libErr, sizeof(libErr) - 1);
++		if (verbosity != PSERRORS_FORMATTED_VERBOSE)
 +			return;
-+		}
 +	
 +		for (i = 0; i < sizeof(verbose_fields) / sizeof(verbose_fields[0]); ++i)
 +		{
@@ -73,7 +70,6 @@ index e1fb48b..16fd8b4 100644
 +			if (val)
 +				appendPQExpBuffer(msg, "%c:%d:%s", verbose_fields[i], (int)strlen(val), val);
 +		}
-+		appendBinaryPQExpBuffer(msg, libErr, sizeof(libErr) - 1);
 +		return;
 +	}
 +

--- a/deps/postgresql/fmt_err_msg.patch
+++ b/deps/postgresql/fmt_err_msg.patch
@@ -1,0 +1,97 @@
+diff --git src/bin/psql/startup.c src/bin/psql/startup.c
+index 5a28b6f..c11f3d9 100644
+--- src/bin/psql/startup.c
++++ src/bin/psql/startup.c
+@@ -1135,9 +1135,13 @@ verbosity_hook(const char *newval)
+ 		pset.verbosity = PQERRORS_TERSE;
+ 	else if (pg_strcasecmp(newval, "sqlstate") == 0)
+ 		pset.verbosity = PQERRORS_SQLSTATE;
++	else if (pg_strcasecmp(newval, "formatted_default") == 0)
++		pset.verbosity = PSERRORS_FORMATTED_DEFAULT;
++	else if (pg_strcasecmp(newval, "formatted_verbose") == 0)
++		pset.verbosity = PSERRORS_FORMATTED_VERBOSE;
+ 	else
+ 	{
+-		PsqlVarEnumError("VERBOSITY", newval, "default, verbose, terse, sqlstate");
++		PsqlVarEnumError("VERBOSITY", newval, "default, verbose, terse, sqlstate, formatted_default, formatted_verbose");
+ 		return false;
+ 	}
+ 
+diff --git src/interfaces/libpq/fe-protocol3.c src/interfaces/libpq/fe-protocol3.c
+index e1fb48b..16fd8b4 100644
+--- src/interfaces/libpq/fe-protocol3.c
++++ src/interfaces/libpq/fe-protocol3.c
+@@ -1016,6 +1016,58 @@ pqBuildErrorMessage3(PQExpBuffer msg, const PGresult *res,
+ 		return;
+ 	}
+ 
++	if (verbosity == PSERRORS_FORMATTED_DEFAULT || verbosity == PSERRORS_FORMATTED_VERBOSE)
++	{
++		static const char libErr[] = "LE:-1:";
++		size_t i;
++
++		// Always included fields
++		static const char default_fields[] = {
++			PG_DIAG_SEVERITY,
++			PG_DIAG_SQLSTATE,
++			PG_DIAG_MESSAGE_PRIMARY
++		};
++
++		// Verbose-only fields
++		static const char verbose_fields[] = {
++			PG_DIAG_MESSAGE_DETAIL,
++			PG_DIAG_MESSAGE_HINT,
++			PG_DIAG_STATEMENT_POSITION,
++			PG_DIAG_INTERNAL_POSITION,
++			PG_DIAG_INTERNAL_QUERY,
++			PG_DIAG_CONTEXT,
++			PG_DIAG_SOURCE_FILE,
++			PG_DIAG_SOURCE_LINE,
++			PG_DIAG_SOURCE_FUNCTION,
++			PG_DIAG_SCHEMA_NAME,
++			PG_DIAG_TABLE_NAME,
++			PG_DIAG_COLUMN_NAME,
++			PG_DIAG_DATATYPE_NAME,
++			PG_DIAG_CONSTRAINT_NAME
++		};
++	
++		for (i = 0; i < sizeof(default_fields) / sizeof(default_fields[0]); ++i)
++		{
++			val = PQresultErrorField(res, default_fields[i]);
++			if (val)
++				appendPQExpBuffer(msg, "%c:%d:%s", default_fields[i], (int)strlen(val), val);
++		}
++	
++		if (verbosity != PSERRORS_FORMATTED_VERBOSE) {
++			appendBinaryPQExpBuffer(msg, libErr, sizeof(libErr) - 1);
++			return;
++		}
++	
++		for (i = 0; i < sizeof(verbose_fields) / sizeof(verbose_fields[0]); ++i)
++		{
++			val = PQresultErrorField(res, verbose_fields[i]);
++			if (val)
++				appendPQExpBuffer(msg, "%c:%d:%s", verbose_fields[i], (int)strlen(val), val);
++		}
++		appendBinaryPQExpBuffer(msg, libErr, sizeof(libErr) - 1);
++		return;
++	}
++
+ 	/* Else build error message from relevant fields */
+ 	val = PQresultErrorField(res, PG_DIAG_SEVERITY);
+ 	if (val)
+diff --git src/interfaces/libpq/libpq-fe.h src/interfaces/libpq/libpq-fe.h
+index cd2f31d..47f25e0 100644
+--- src/interfaces/libpq/libpq-fe.h
++++ src/interfaces/libpq/libpq-fe.h
+@@ -127,7 +127,9 @@ typedef enum
+ 	PQERRORS_TERSE,				/* single-line error messages */
+ 	PQERRORS_DEFAULT,			/* recommended style */
+ 	PQERRORS_VERBOSE,			/* all the facts, ma'am */
+-	PQERRORS_SQLSTATE			/* only error severity and SQLSTATE code */
++	PQERRORS_SQLSTATE,			/* only error severity and SQLSTATE code */
++	PSERRORS_FORMATTED_DEFAULT,	/* formatted default error message */
++	PSERRORS_FORMATTED_VERBOSE 	/* formatted verbose error message */
+ } PGVerbosity;
+ 
+ typedef enum

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -810,7 +810,7 @@ void PgSQL_Connection::connect_start() {
 	const std::string& conninfo_str = conninfo.str();
 	pgsql_conn = PQconnectStart(conninfo_str.c_str());
 
-	// introduce a new, formatted error verbosity type.
+	// introduced a new, formatted error verbosity type.
 	PQsetErrorVerbosity(pgsql_conn, PSERRORS_FORMATTED_DEFAULT);
 	//PQsetErrorContextVisibility(pgsql_conn, PQSHOW_CONTEXT_ERRORS);
 
@@ -2136,15 +2136,11 @@ std::map<std::string, std::vector<std::string>> PgSQL_Connection::parse_pq_error
 					size = size * 10 + digit;
 				}
 			}
-			
-
 			if (!valid_size || size < 0) {
 				pos = size_start;
 				continue;
 			}
-
 			pos++;
-
 			// Extract value
 			size_t value_start = pos;
 			size_t value_end;


### PR DESCRIPTION
- Deprecating `PQgetResultFromPGconn()` API.
- Introducing a structured, length-prefixed error format for all errors returned via PQerrorMessage().
- Adding two new error verbosity levels: `PSERRORS_FORMATTED_DEFAULT` and `PSERRORS_FORMATTED_VERBOSE`

Closes [#4948](https://github.com/sysown/proxysql/issues/4948)
