### PR TITLE
feat(pgsql): resort to servers with weight = 0 if all connections are used

### DIFF
--- a/common_mk/openssl_flags.mk
+++ b/common_mk/openssl_flags.mk
@@ -43,5 +43,5 @@ else
     $(error Warning: OpenSSL libraries directory (SSL_LDIR) not found. Exiting. Please ensure the correct path is set or install OpenSSL version 3.)
 endif
 else
-    $(error Warning: OpenSSL headers (SSL_IDIR) not found. Exiting. Please install OpenSSL version 3.)
+    $(error Warning: OpenSSL headers (SSL_IDIR) not found. Exiting. Please install OpenSSL version 3 and make sure pkg-config is present.)
 endif

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -1974,6 +1974,17 @@ PgSQL_SrvC *PgSQL_HGC::get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, 
 				}
 			}
 		}
+		if (sum==0 && num_candidates > 0) {
+			proxy_info("No available server in hostgroup %u with weight > 0, but %u candidates found. This is probably due to max_connections reached for all servers. Using candidates with weight 0\n", hid, num_candidates);
+			// Iterate on all candidates and increase their weight
+			for (j=0; j<num_candidates; j++) {
+				mysrvc = mysrvcCandidates[j];
+				// increase the weight of the server
+				mysrvc->weight++;
+				proxy_debug("Increasing weight of server %s:%d to %ld\n", mysrvc->address, mysrvc->port, mysrvc->weight);
+				sum += 1;
+			}
+		}
 		if (sum==0) {
 			// per issue #531 , we try a desperate attempt to bring back online any shunned server
 			// we do this lowering the maximum wait time to 10%

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -1974,17 +1974,6 @@ PgSQL_SrvC *PgSQL_HGC::get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, 
 				}
 			}
 		}
-		if (sum==0 && num_candidates > 0) {
-			proxy_info("No available server in hostgroup %u with weight > 0, but %u candidates found. This is probably due to max_connections reached for all servers. Using candidates with weight 0\n", hid, num_candidates);
-			// Iterate on all candidates and increase their weight
-			for (j=0; j<num_candidates; j++) {
-				mysrvc = mysrvcCandidates[j];
-				// increase the weight of the server
-				mysrvc->weight++;
-				proxy_debug("Increasing weight of server %s:%d to %ld\n", mysrvc->address, mysrvc->port, mysrvc->weight);
-				sum += 1;
-			}
-		}
 		if (sum==0) {
 			// per issue #531 , we try a desperate attempt to bring back online any shunned server
 			// we do this lowering the maximum wait time to 10%
@@ -2044,15 +2033,21 @@ PgSQL_SrvC *PgSQL_HGC::get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, 
 				}
 			}
 		}
+		bool use_index_instead_of_weight = false;
 		if (sum==0) {
-			proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 7, "Returning PgSQL_SrvC NULL because no backend ONLINE or with weight\n");
-			if (l>32) {
-				free(mysrvcCandidates);
-			}
+			if (num_candidates==0) {
+				proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 7, "Returning PgSQL_SrvC NULL because no backend ONLINE or with weight\n");
+				if (l>32) {
+					free(mysrvcCandidates);
+				}
 #ifdef TEST_AURORA
-			array_mysrvc_cands += num_candidates;
+				array_mysrvc_cands += num_candidates;
 #endif // TEST_AURORA
-			return NULL; // if we reach here, we couldn't find any target
+				return NULL; // if we reach here, we couldn't find any target
+			}
+			// All servers have weight 0, but we have some candidates - pick a random one (assume they all have weight 1)
+			proxy_info("No available server in hostgroup %u with weight > 0, but %u candidates found. This is probably due to max_connections reached for all servers. Using candidates with weight 0\n", hid, num_candidates);
+			use_index_instead_of_weight = true;
 		}
 
 /*
@@ -2077,7 +2072,7 @@ PgSQL_SrvC *PgSQL_HGC::get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, 
 		}
 */
 
-		unsigned int New_sum=sum;
+		unsigned int New_sum=use_index_instead_of_weight ? num_candidates : sum;
 
 		if (New_sum==0) {
 			proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 7, "Returning PgSQL_SrvC NULL because no backend ONLINE or with weight\n");
@@ -2125,7 +2120,7 @@ PgSQL_SrvC *PgSQL_HGC::get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, 
 					New_sum = 0;
 					for (j=0; j<num_candidates; j++) {
 						mysrvc = mysrvcCandidates[j];
-						New_sum+=mysrvc->weight;
+						New_sum+=use_index_instead_of_weight ? 1 : mysrvc->weight;
 					}
 				}
 			}
@@ -2143,7 +2138,7 @@ PgSQL_SrvC *PgSQL_HGC::get_random_MySrvC(char * gtid_uuid, uint64_t gtid_trxid, 
 
 		for (j=0; j<num_candidates; j++) {
 			mysrvc = mysrvcCandidates[j];
-			New_sum+=mysrvc->weight;
+			New_sum+=use_index_instead_of_weight ? 1 : mysrvc->weight;
 			if (k<=New_sum) {
 				proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 7, "Returning PgSQL_SrvC %p, server %s:%d\n", mysrvc, mysrvc->address, mysrvc->port);
 				if (l>32) {


### PR DESCRIPTION
Hello,

We have an Aurora PostgreSQL cluster with fixed-size instances, and sometimes have to face large traffic spikes (like 2x or 3x the usual one). Queries are hard to cache, we've come to the conclusion that RDS Serveless v2 could be a good solution for our problem as it's said to scale up very fast. Our plan is to use the fixed instance for normal traffic and send all overflow traffic (which we can detect when we reach a certain amount of running queries on the fixed size node) to the serverless instance, getting it to hopefully scale as needed and save costs as we don't have to constantly over-provision stuff.

Here's the query routing we want to implement
* If max_connections hasn't been reached on server 1, send the query there
* Else, send the query to server 2

Query rules don't work here as they are applied before the query is routed.

## Design
This Pull Request proposes to change the behavior of ProxySQL for servers with weight 0. Currently, servers with weight 0 are configured but are never selected by the load balancing algorithm. With this change, these servers can be selected if all other servers have reached `max_connections`. These server's `max_connections` values are still respected (a server reaching max_connections is not added to the candidates list).

## Alternative implementations
An alternative implementation could be to set a `priority` field on the server object and sort servers by this field when selecting them. My knowledge of the codebase is a it too limited for that though. This implementation works for me, but this could be a nice enhancement.

## Testing protocol
Spin up 2 databases in the same hostgroup, give weights 0 and 10, set max_connections to 5 and 100 then launch 20 slow queries in parallel (e.g. `select pg_sleep(2)`). The first server should process 5 of them and the other should process 15 of them.

Testing files: https://gist.github.com/TPXP/598c9135a57e957dea2cf8b495a61562

```bash
docker compose up --build
# After it started, use another terminal
docker compose exec node bash
yarn
node test.js
```

## Other notes
I've also added a small improvement to the error message if we can't locate OpenSSL headers.