### PR TITLE
Correct  regex for timezone

### DIFF
--- a/lib/MySQL_Set_Stmt_Parser.cpp
+++ b/lib/MySQL_Set_Stmt_Parser.cpp
@@ -253,7 +253,7 @@ void MySQL_Set_Stmt_Parser::generateRE_parse1v2() {
 		string tzd =  "(?:(?:\\+|\\-)(?:|\\d)\\d:\\d\\d)";
 		// time_zone in string format:
 		// word / word
-		string tzw =  "(?:\\w+/\\w+)";
+		string tzw =  "(?:\\w+/\\w+(?:/\\w+)?)";
 		vp = "(?:" + tzd + "|" + tzw + ")"; // time_zone in numeric and string format
 	}
 	for (auto it = quote_symbol.begin(); it != quote_symbol.end(); it++) {


### PR DESCRIPTION
## CONTEXT

Running query with correcct timezone like this:
```sql
set time_zone='America/Argentina/Buenos_Aires';
```

trigger error in proxysql logs:
```bash
MySQL_Session.cpp:7069:handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo(): 
[ERROR] Unable to parse query. If correct, report it as a bug: SET time_zone="America/Argentina/Buenos_Aires";
```

This causes timestamps to be incorrectly written to the database if multiplexing is enabled.