### PR TITLE
Add OS information that supports riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,17 @@ arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:
 	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
 
+riscv64-%: SYS_ARCH := riscv64
+riscv64-packages: riscv64-centos riscv64-debian riscv64-ubuntu riscv64-fedora riscv64-opensuse 
+riscv64-almalinux: almalinux10
+riscv64-centos: centos10
+riscv64-debian: debian13
+riscv64-fedora: fedora42
+riscv64-opensuse: opensuse16
+riscv64-ubuntu: ubuntu24 ubuntu25
+riscv64-pkglist:
+	@${MAKE} -nk riscv64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
+
 almalinux%: build-almalinux% ;
 centos%: build-centos% ;
 debian%: build-debian% ;


### PR DESCRIPTION
This PR collects and add supported operating system versions for riscv64 architecture compilation based on publicly available information.
