### PR TITLE
Fix memory leak in Query Processor and ProxySQL_Admin::flush_pgsql_variables___database_to_runtime

### DIFF
--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -737,9 +737,7 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 		return;
 	}
 	else {
-		GloPTH->wrlock();
-		const char* previous_default_client_encoding = GloPTH->get_variable_string((char*)"default_client_encoding");
-		assert(previous_default_client_encoding);		
+		GloPTH->wrlock();	
 		for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
 			SQLite3_row* r = *it;
 			const char* value = r->fields[1];

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -129,6 +129,10 @@ static void __delete_query_rule(QP_rule_t *qr) {
 		free(qr->username);
 	if (qr->schemaname)
 		free(qr->schemaname);
+	if (qr->client_addr)
+		free(qr->client_addr);
+	if (qr->proxy_addr)
+		free(qr->proxy_addr);
 	if (qr->match_digest)
 		free(qr->match_digest);
 	if (qr->match_pattern)


### PR DESCRIPTION
Addresses memory leaks in **Query Processing** and in **ProxySQL_Admin::flush_pgsql_variables___database_to_runtime**