### PR TITLE
Enable to set to eventlog output to stdout and stderr

### DIFF
--- a/lib/MySQL_Logger.cpp
+++ b/lib/MySQL_Logger.cpp
@@ -1261,14 +1261,25 @@ void MySQL_Logger::audit_flush_log_unlocked() {
 }
 
 void MySQL_Logger::events_open_log_unlocked() {
-	events.log_file_id=events_find_next_id();
-	if (events.log_file_id!=0) {
-		events.log_file_id=events_find_next_id()+1;
-	} else {
-		events.log_file_id++;
+	// Check if this is a special device file like /dev/stdout or /dev/stderr
+	bool is_special_device = (strcmp(events.base_filename, "/dev/stdout") == 0 || 
+	                         strcmp(events.base_filename, "/dev/stderr") == 0);
+	
+	if (!is_special_device) {
+		events.log_file_id=events_find_next_id();
+		if (events.log_file_id!=0) {
+			events.log_file_id=events_find_next_id()+1;
+		} else {
+			events.log_file_id++;
+		}
 	}
+	
 	char *filen=NULL;
-	if (events.base_filename[0]=='/') { // absolute path
+	if (is_special_device) {
+		// For special device files, use the filename directly without rotation
+		filen=(char *)malloc(strlen(events.base_filename)+1);
+		strcpy(filen, events.base_filename);
+	} else if (events.base_filename[0]=='/') { // absolute path
 		filen=(char *)malloc(strlen(events.base_filename)+11);
 		sprintf(filen,"%s.%08d",events.base_filename,events.log_file_id);
 	} else { // relative path
@@ -1310,14 +1321,25 @@ void MySQL_Logger::events_open_log_unlocked() {
 };
 
 void MySQL_Logger::audit_open_log_unlocked() {
-	audit.log_file_id=audit_find_next_id();
-	if (audit.log_file_id!=0) {
-		audit.log_file_id=audit_find_next_id()+1;
-	} else {
-		audit.log_file_id++;
+	// Check if this is a special device file like /dev/stdout or /dev/stderr
+	bool is_special_device = (strcmp(audit.base_filename, "/dev/stdout") == 0 || 
+	                         strcmp(audit.base_filename, "/dev/stderr") == 0);
+	
+	if (!is_special_device) {
+		audit.log_file_id=audit_find_next_id();
+		if (audit.log_file_id!=0) {
+			audit.log_file_id=audit_find_next_id()+1;
+		} else {
+			audit.log_file_id++;
+		}
 	}
+	
 	char *filen=NULL;
-	if (audit.base_filename[0]=='/') { // absolute path
+	if (is_special_device) {
+		// For special device files, use the filename directly without rotation
+		filen=(char *)malloc(strlen(audit.base_filename)+1);
+		strcpy(filen, audit.base_filename);
+	} else if (audit.base_filename[0]=='/') { // absolute path
 		filen=(char *)malloc(strlen(audit.base_filename)+11);
 		sprintf(filen,"%s.%08d",audit.base_filename,audit.log_file_id);
 	} else { // relative path

--- a/test/tap/tests/test_logger_special_devices-t.cpp
+++ b/test/tap/tests/test_logger_special_devices-t.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file test_logger_special_devices-t.cpp
+ * @brief Tests for MySQL_Logger special device file handling (/dev/stdout, /dev/stderr)
+ * @details This test ensures that eventslog_filename and auditlog_filename can be set to
+ *          special device files like /dev/stdout and /dev/stderr without rotation errors.
+ */
+
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+#include <string>
+#include <fstream>
+
+#include "mysql.h"
+#include "mysqld_error.h"
+#include "proxysql.h"
+#include "cpp-dotenv/dotenv.h"
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	MYSQL* proxysql_admin = mysql_init(NULL);
+	
+	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return -1;
+	}
+
+	plan(6);
+
+	// Test 1: Set eventslog_filename to /dev/stdout (should not fail)
+	{
+		MYSQL_QUERY(proxysql_admin, "SET mysql-eventslog_filename='/dev/stdout'");
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+		ok(true, "Successfully set eventslog_filename to /dev/stdout");
+	}
+
+	// Test 2: Set eventslog_filename to /dev/stderr (should not fail)
+	{
+		MYSQL_QUERY(proxysql_admin, "SET mysql-eventslog_filename='/dev/stderr'");
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+		ok(true, "Successfully set eventslog_filename to /dev/stderr");
+	}
+
+	// Test 3: Set auditlog_filename to /dev/stdout (should not fail)
+	{
+		MYSQL_QUERY(proxysql_admin, "SET mysql-auditlog_filename='/dev/stdout'");
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+		ok(true, "Successfully set auditlog_filename to /dev/stdout");
+	}
+
+	// Test 4: Set auditlog_filename to /dev/stderr (should not fail)
+	{
+		MYSQL_QUERY(proxysql_admin, "SET mysql-auditlog_filename='/dev/stderr'");
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+		ok(true, "Successfully set auditlog_filename to /dev/stderr");
+	}
+
+	// Test 5: FLUSH LOGS with special device should work
+	{
+		MYSQL_QUERY(proxysql_admin, "SET mysql-eventslog_filename='/dev/stdout'");
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+		MYSQL_QUERY(proxysql_admin, "PROXYSQL FLUSH LOGS");
+		ok(true, "FLUSH LOGS works with /dev/stdout");
+	}
+
+	// Test 6: Verify we can switch back to regular file
+	{
+		MYSQL_QUERY(proxysql_admin, "SET mysql-eventslog_filename='/tmp/test_events.log'");
+		MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+		ok(true, "Successfully switched back to regular file");
+	}
+
+	// Cleanup
+	MYSQL_QUERY(proxysql_admin, "SET mysql-eventslog_filename=''");
+	MYSQL_QUERY(proxysql_admin, "SET mysql-auditlog_filename=''");
+	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+	mysql_close(proxysql_admin);
+
+	return exit_status();
+}


### PR DESCRIPTION
## WHAT

* enable to set event log output to /dev/stdout and /dev/stderr

## WHY

https://github.com/sysown/proxysql/issues/5038

## Tests

```
mysql_variables=
{
...
        eventslog_filename      = "/dev/stderr"
        auditlog_filename         = "/dev/stderr"
        # logging as json format
        eventslog_format           = 2
        auditlog_format         = 2
}

mysql_query_rules:
(
        {
                rule_id=1
                active=1
                match_pattern=".*"
                log=1
        }
)
```

* we can start proxysql server without error, and log works.
```
vagrant@ubuntu:~$ sudo /usr/bin/proxysql -f --reload -c /etc/proxysql.cnf --idle-threads
...
2025-07-14 06:39:27 [INFO] For information about products and services visit: https://proxysql.com/
2025-07-14 06:39:27 [INFO] For online documentation visit: https://proxysql.com/documentation/
2025-07-14 06:39:27 [INFO] For support visit: https://proxysql.com/services/support/
2025-07-14 06:39:27 [INFO] For consultancy visit: https://proxysql.com/services/consulting/
2025-07-14 06:39:27 [INFO] Started Monitor scheduler thread for PgSQL servers
2025-07-14 06:39:28 [INFO] Latest ProxySQL version available: 3.0.1-420-g2c26a42

{"client_addr":"127.0.0.1:40544","event":"MySQL_Client_Connect_OK","proxy_addr":"0.0.0.0:6033","schemaname":"information_schema","ssl":true,"thread_id":1,"time":"2025-07-14 06:39:52.038","timestamp":1752475192038,"username":"root"}
{"client":"127.0.0.1:40544","digest":"0x7AFCE30A2413DF1B","duration_us":1259,"endtime":"2025-07-14 06:39:52.040464","endtime_timestamp_us":1752475192040464,"errno":0,"event":"COM_QUERY","hostgroup_id":0,"query":"select 1 from dual","rows_affected":0,"rows_sent":1,"schemaname":"information_schema","server":"127.0.0.1:3306","starttime":"2025-07-14 06:39:52.039205","starttime_timestamp_us":1752475192039205,"thread_id":1,"username":"root"}
{"client_addr":"127.0.0.1:40544","event":"MySQL_Client_Quit","proxy_addr":"0.0.0.0:6033","schemaname":"information_schema","ssl":true,"thread_id":1,"time":"2025-07-14 06:39:52.041","timestamp":1752475192041,"username":"root"}
{"client_addr":"127.0.0.1:40544","creation_time":"2025-07-14 06:39:52.028","duration":"13.020ms","event":"MySQL_Client_Close","extra_info":"MySQL_Thread.cpp:4018:process_all_sessions()","proxy_addr":"0.0.0.0:6033","schemaname":"information_schema","ssl":true,"thread_id":1,"time":"2025-07-14 06:39:52.041","timestamp":1752475192041,"username":"root"}
```

```
vagrant@ubuntu:~/proxysql$ mysql -u root -P 6033 -h 127.0.0.1 -p -e "select 1 from dual;"
Enter password:
+---+
| 1 |
+---+
| 1 |
+---+
```

* log rotate:
```
vagrant@ubuntu:~/proxysql$ mysql -u admin -P 6032 -h 127.0.0.1 -p -e "PROXYSQL FLUSH LOGS;"
Enter password:

: proxysql log. not errored.
2025-07-14 06:45:23 [INFO] Received PROXYSQL FLUSH LOGS command
2025-07-14 06:45:23 [INFO] ProxySQL version d693e6e2d4da2d7c1b474df47510c8796be3d576
```