### PR TITLE
otel: Minimize the latency of `Tracer::StartSpan()`

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -423,6 +423,7 @@ $(OTEL_INSTALL_DIR)/lib/libopentelemetry.a: protobuf abseil curl json
 	cd opentelemetry && tar -zxf opentelemetry-cpp-1.21.0.tar.gz
 	cd opentelemetry && rm -rf opentelemetry-proto-*/ || true
 	cd opentelemetry && tar -zxf opentelemetry-proto-1.6.0.tar.gz
+	cd opentelemetry/opentelemetry-cpp && patch -p0 < ../active_span.patch
 	cd opentelemetry/opentelemetry-cpp && mkdir -p build
 	cd opentelemetry/opentelemetry-cpp/build && cmake ..                   \
 								$(CMAKE_FLAGS)                             \

--- a/deps/opentelemetry/active_span.patch
+++ b/deps/opentelemetry/active_span.patch
@@ -1,0 +1,23 @@
+--- sdk/src/trace/tracer.cc.orig	2025-07-15 15:37:39.140015261 +0530
++++ sdk/src/trace/tracer.cc	2025-07-15 15:52:52.629125745 +0530
+@@ -62,7 +62,7 @@
+   {
+     return kNoopTracer->StartSpan(name, attributes, links, options);
+   }
+-  opentelemetry::trace::SpanContext parent_context = GetCurrentSpan()->GetContext();
++  auto parent_context = opentelemetry::trace::SpanContext::GetInvalid();
+   if (nostd::holds_alternative<opentelemetry::trace::SpanContext>(options.parent))
+   {
+     auto span_context = nostd::get<opentelemetry::trace::SpanContext>(options.parent);
+@@ -89,6 +89,11 @@
+     }
+   }
+ 
++  if (!parent_context.IsValid())
++  {
++    parent_context = GetCurrentSpan()->GetContext();
++  }
++
+   IdGenerator &generator = GetIdGenerator();
+   opentelemetry::trace::TraceId trace_id;
+   opentelemetry::trace::SpanId span_id = generator.GenerateSpanId();

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -683,7 +683,7 @@ MySQL_Session::MySQL_Session() {
 	proxysql_node_address = NULL;
 	use_ldap_auth = false;
 
-	span_stack = unsafe_shared_ptr<OTelSpanStack>();
+	span_stack = unsafe_shared_ptr(new OTelSpanStack());
 	root_span = CreateSessionSpan("new_session");
 }
 

--- a/src/proxysql.cfg
+++ b/src/proxysql.cfg
@@ -62,7 +62,7 @@ otel_variables=
 	trace_enable=false
 	trace_service_name="proxysql"
 	trace_exporter_otlp_protocol="http/protobuf"
-	trace_exporter_otlp_endpoint="http://127.0.0.1:4318"
+	trace_exporter_otlp_endpoint="http://127.0.0.1:4318/v1/traces"
 	trace_exporter_otlp_compression="none"
 }
 


### PR DESCRIPTION
During `perf` analysis following #5015, it is found that `sdk::trace::Tracer::StartSpan()` is a major contributor to the latency. This PR tries to remove one of the unnecessary sub-routine calls from `StartSpan()`, which contributes to 16% of total execution time of this function.