### PR TITLE
OTel span filter implementation

### DIFF
--- a/include/Base_Session.h
+++ b/include/Base_Session.h
@@ -15,25 +15,23 @@ template<typename S, typename DSi, typename B, typename T> class Base_Session;
 #include "nlohmann/json_fwd.hpp"
 #endif // PROXYJSON
 
-#include "otel_span.h"
+#include "otel_tracer.h"
 
 class MySQL_STMTs_meta;
 class StmtLongDataHandler;
 class MySQL_Session;
 class PgSQL_Session;
 
-#define STR(x)			#x
-#define TO_STRING(x)	STR(x)
-#define FILE_LINE_FUNC	(std::string(__FILE__ ":" TO_STRING(__LINE__) ":") + __func__)
+extern OTelTracer *GloOTelTracer;
 
 #define SESSION_TRACE(session) \
-	session->CreateSessionSpan(FILE_LINE_FUNC)
+	session->CreateSessionSpan(__FILE__, __LINE__, __func__)
 
 #define SESSION_TRACE_NAMED(session, name) \
-	session->CreateSessionSpan(name)
+	session->CreateSessionSpan(__FILE__, __LINE__, name)
 
 #define SESSION_TRACE_AUTO(session) \
-	auto otel_span = session->CreateSessionSpan(FILE_LINE_FUNC)
+	auto __otel_span = session->CreateSessionSpan(__FILE__, __LINE__, __func__)
 
 enum SESSION_FORWARD_TYPE : uint8_t {
 	SESSION_FORWARD_TYPE_NONE					= 0x00,
@@ -167,7 +165,13 @@ class Base_Session {
 	 */
 	int FindOneActiveTransaction(bool check_savepoint=false);
 
-	std::unique_ptr<OTelSpan> CreateSessionSpan(const std::string& span_name) { return std::make_unique<OTelSpan>(span_name, span_stack); }
+	std::unique_ptr<OTelSpan> CreateSessionSpan(
+		const char *__file,
+		int __line,
+		const char *name
+	) {
+		return GloOTelTracer->StartSpan(span_stack, __file, __line, name);
+	}
 };
 
 #endif // CLASS_BASE_SESSION_H

--- a/include/ProxySQL_Admin_Tables_Definitions.h
+++ b/include/ProxySQL_Admin_Tables_Definitions.h
@@ -304,6 +304,8 @@
 #define STATS_SQLITE_TABLE_PGSQL_QUERY_DIGEST "CREATE TABLE stats_pgsql_query_digest (hostgroup INT , database VARCHAR NOT NULL , username VARCHAR NOT NULL , client_address VARCHAR NOT NULL , digest VARCHAR NOT NULL , digest_text VARCHAR NOT NULL , count_star INTEGER NOT NULL , first_seen INTEGER NOT NULL , last_seen INTEGER NOT NULL , sum_time INTEGER NOT NULL , min_time INTEGER NOT NULL , max_time INTEGER NOT NULL , sum_rows_affected INTEGER NOT NULL , sum_rows_sent INTEGER NOT NULL , PRIMARY KEY(hostgroup, database, username, client_address, digest))"
 #define STATS_SQLITE_TABLE_PGSQL_QUERY_DIGEST_RESET "CREATE TABLE stats_pgsql_query_digest_reset (hostgroup INT , database VARCHAR NOT NULL , username VARCHAR NOT NULL , client_address VARCHAR NOT NULL , digest VARCHAR NOT NULL , digest_text VARCHAR NOT NULL , count_star INTEGER NOT NULL , first_seen INTEGER NOT NULL , last_seen INTEGER NOT NULL , sum_time INTEGER NOT NULL , min_time INTEGER NOT NULL , max_time INTEGER NOT NULL , sum_rows_affected INTEGER NOT NULL , sum_rows_sent INTEGER NOT NULL , PRIMARY KEY(hostgroup, database, username, client_address, digest))"
 
+// OpenTelemetry
+#define OTEL_SQLITE_TABLE_SPAN_FILTERS "CREATE TABLE otel_span_filters (file VARCHAR NOT NULL, line INT NOT NULL, span VARCHAR NOT NULL, PRIMARY KEY (file, line, span))"
 
 //#define STATS_SQLITE_TABLE_MEMORY_METRICS "CREATE TABLE stats_memory_metrics (Variable_Name VARCHAR NOT NULL PRIMARY KEY , Variable_Value VARCHAR NOT NULL)"
 

--- a/include/otel_span.h
+++ b/include/otel_span.h
@@ -3,12 +3,14 @@
 
 #include <memory>
 #include <signal.h>
-#include "unsafe_shared_ptr.h"
-#include "otel_tracer.h"
-#include "opentelemetry/nostd/shared_ptr.h"
-#include "opentelemetry/trace/span.h"
+#include <utility>
 
-extern OTelTracer *GloOTelTracer;
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/tracer.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_startoptions.h"
+
+#include "unsafe_shared_ptr.h"
 
 #define OTEL_SPAN_STACK_SIZE_DEFAULT	8
 
@@ -94,30 +96,48 @@ class OTelSpan {
 private:
 	otel_nostd::shared_ptr<Span> span;
 	unsafe_shared_ptr<OTelSpanStack> ctx_stack;
-	bool create_span(const string& name, const OTelSpanCtx& pctx);
+
+	bool create_span(
+		otel_trace_api::Tracer* tracer,
+		const string& name,
+		const OTelSpanCtx& pctx
+	);
+
 public:
-	OTelSpan(const string& name, const OTelSpanCtx& pctx = OTelSpanCtx::GetInvalid());
-	OTelSpan(const string& name, unsafe_shared_ptr<OTelSpanStack>& stack);
+	OTelSpan() = default;
+
+	explicit OTelSpan(
+		otel_trace_api::Tracer* tracer,
+		const string& name,
+		const OTelSpanCtx& pctx = OTelSpanCtx::GetInvalid()
+	);
+
+	explicit OTelSpan(
+		otel_trace_api::Tracer* tracer,
+		const string& name,
+		unsafe_shared_ptr<OTelSpanStack>& stack
+	);
+
 	~OTelSpan();
 
 	void SetAttribute(const string& key, OTelSpanAttrVal value);
 	void UpdateName(const string& name);
 };
 
-inline OTelSpan::OTelSpan(const string& name, const OTelSpanCtx& pctx) {
-	create_span(name, pctx);
+inline OTelSpan::OTelSpan(otel_trace_api::Tracer* tracer, const string& name, const OTelSpanCtx& pctx) {
+	create_span(tracer, name, pctx);
 }
 
-inline OTelSpan::OTelSpan(const string& name, unsafe_shared_ptr<OTelSpanStack>& stack) {
+inline OTelSpan::OTelSpan(otel_trace_api::Tracer* tracer, const string& name, unsafe_shared_ptr<OTelSpanStack>& stack) {
 	if (stack) {
-		if (create_span(name, stack->GetCurrent())) {
+		if (create_span(tracer, name, stack->GetCurrent())) {
 			stack->Attach(span->GetContext());
 			ctx_stack = stack;
 		}
 		return;
 	}
 
-	create_span(name, OTelSpanCtx::GetInvalid());
+	create_span(tracer, name, OTelSpanCtx::GetInvalid());
 }
 
 inline OTelSpan::~OTelSpan() {
@@ -138,11 +158,7 @@ inline void OTelSpan::UpdateName(const string& name) {
 	}
 }
 
-inline bool OTelSpan::create_span(const string& name, const OTelSpanCtx& pctx) {
-	auto tracer = GloOTelTracer->get();
-	if (!tracer)
-		return false;
-
+inline bool OTelSpan::create_span(otel_trace_api::Tracer* tracer, const string& name, const OTelSpanCtx& pctx) {
 	auto option = otel_trace_api::StartSpanOptions();
 	option.parent = pctx;
 	span = tracer->StartSpan(name, option);

--- a/include/otel_tracer.h
+++ b/include/otel_tracer.h
@@ -2,9 +2,14 @@
 #define __CLASS_PROXYSQL_OTEL_TRACER_H
 
 #include "proxysql.h"
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/trace/tracer.h"
+
+#include "unsafe_shared_ptr.h"
+#include "otel_span.h"
 
 namespace otel_nostd = opentelemetry::nostd;
 namespace otel_trace_api = opentelemetry::trace;
@@ -20,19 +25,30 @@ class OTelTracer {
 public:
 	OTelTracer();
 	~OTelTracer();
-	void setup();
-	otel_trace_api::Tracer* get();
-	const std::vector<string>& get_variables_list();
-	bool has_variable(const char *var);
-	char *get_variable(const char *var);
-	bool set_variable(const char *var, const char *val);
+
+	void Setup();
+
+	std::unique_ptr<OTelSpan> StartSpan(
+		unsafe_shared_ptr<OTelSpanStack>& stack,
+		const char *__file,
+		int __line,
+		const char *name
+	);
+
+	const std::vector<string>& GetVariablesList();
+	char *GetVariable(const char *var);
+	bool SetVariable(const char *var, const char *val);
+	std::set<std::string> GetFilter();
+	void SetFilter(const std::set<std::string>& filter);
 
 	void rdlock() { pthread_rwlock_rdlock(&rwlock); }
 	void wrlock() { pthread_rwlock_wrlock(&rwlock); }
 	void unlock() { pthread_rwlock_unlock(&rwlock); }
 private:
 	pthread_rwlock_t rwlock;
+
 	otel_nostd::shared_ptr<otel_trace_api::Tracer> tracer;
+
 	struct {
 		bool trace_enable;
 		string service_name;
@@ -47,6 +63,12 @@ private:
 		size_t bsp_max_queue_size;
 		size_t bsp_max_export_batch_size;
 	} variables;
+
+	bool span_filter_enable = false;
+	std::set<std::string> span_filter;
+
+	otel_trace_api::Tracer* get_tracer();
+	bool allow_span(const char *__file, int __line, const char *name);
 };
 
 #endif  // __CLASS_PROXYSQL_OTEL_TRACER_H

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -641,6 +641,8 @@ class ProxySQL_Admin {
 	void init_otel_variables();
 	void load_otel_variables_to_runtime() { flush_otel_variables___database_to_runtime(admindb, true); }
 	void save_otel_variables_from_runtime() { flush_otel_variables___runtime_to_database(admindb, true, true, false); }
+	void load_otel_filter_to_runtime();
+	void save_otel_filter_from_runtime();
 
 	void p_update_metrics();
 	void stats___mysql_query_rules();

--- a/lib/Admin_Bootstrap.cpp
+++ b/lib/Admin_Bootstrap.cpp
@@ -708,6 +708,10 @@ bool ProxySQL_Admin::init(const bootstrap_info_t& bootstrap_info) {
 	insert_into_tables_defs(tables_defs_stats,"stats_proxysql_message_metrics", STATS_SQLITE_TABLE_PROXYSQL_MESSAGE_METRICS);
 	insert_into_tables_defs(tables_defs_stats,"stats_proxysql_message_metrics_reset", STATS_SQLITE_TABLE_PROXYSQL_MESSAGE_METRICS_RESET);
 
+	// OpenTelemetry
+	insert_into_tables_defs(tables_defs_admin,"otel_span_filters", OTEL_SQLITE_TABLE_SPAN_FILTERS);
+	insert_into_tables_defs(tables_defs_config,"otel_span_filters", OTEL_SQLITE_TABLE_SPAN_FILTERS);
+
 	// init ldap here
 	init_ldap();
 

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -193,7 +193,7 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 		} else if (modname == "ldap") {
 			rc = GloMyLdapAuth->set_variable(r->fields[0],r->fields[1]);
 		} else if (modname == "otel") {
-			rc = GloOTelTracer->set_variable(r->fields[0], r->fields[1]);
+			rc = GloOTelTracer->SetVariable(r->fields[0], r->fields[1]);
 		}
 
 		const string v = string(r->fields[0]);
@@ -214,7 +214,7 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 				} else if (modname == "ldap") {
 					val = GloMyLdapAuth->get_variable(r->fields[0]);
 				} else if (modname == "otel") {
-					val = GloOTelTracer->get_variable(r->fields[0]);
+					val = GloOTelTracer->GetVariable(r->fields[0]);
 				}
 
 				char q[1000];
@@ -1138,7 +1138,7 @@ void ProxySQL_Admin::flush_otel_variables___database_to_runtime(SQLite3DB *db, b
 	}
 
 	// setup tracer after configuration change
-	GloOTelTracer->setup();
+	GloOTelTracer->Setup();
 
 	if (resultset) delete resultset;
 }
@@ -1204,9 +1204,9 @@ void ProxySQL_Admin::flush_otel_variables___runtime_to_database(SQLite3DB *db, b
 	GloOTelTracer->wrlock();
 	db->execute("BEGIN");
 
-	for (auto& var : GloOTelTracer->get_variables_list()) {
+	for (auto& var : GloOTelTracer->GetVariablesList()) {
 		const char *varname = var.c_str();
-		char *val = GloOTelTracer->get_variable(varname);
+		char *val = GloOTelTracer->GetVariable(varname);
 
 		char *qualified_name = (char *)malloc(strlen(varname) + 6);
 		sprintf(qualified_name, "otel-%s", varname);

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -277,29 +277,55 @@ const std::vector<std::string> LOAD_COREDUMP_FROM_MEMORY = {
 	"LOAD COREDUMP TO RUN" };
 
 const std::vector<std::string> LOAD_OTEL_VARIABLES_TO_MEMORY = {
-	"LOAD OTEL VARIABLES TO MEMORY" ,
-	"LOAD OTEL VARIABLES TO MEM" ,
+	"LOAD OTEL VARIABLES TO MEMORY",
+	"LOAD OTEL VARIABLES TO MEM",
 	"LOAD OTEL VARIABLES FROM DISK"
 };
 
 const std::vector<std::string> SAVE_OTEL_VARIABLES_FROM_MEMORY = {
-	"SAVE OTEL VARIABLES FROM MEMORY" ,
-	"SAVE OTEL VARIABLES FROM MEM" ,
+	"SAVE OTEL VARIABLES FROM MEMORY",
+	"SAVE OTEL VARIABLES FROM MEM",
 	"SAVE OTEL VARIABLES TO DISK"
 };
 
 const std::vector<std::string> LOAD_OTEL_VARIABLES_FROM_MEMORY = {
-	"LOAD OTEL VARIABLES FROM MEMORY" ,
-	"LOAD OTEL VARIABLES FROM MEM" ,
-	"LOAD OTEL VARIABLES TO RUNTIME" ,
+	"LOAD OTEL VARIABLES FROM MEMORY",
+	"LOAD OTEL VARIABLES FROM MEM",
+	"LOAD OTEL VARIABLES TO RUNTIME",
 	"LOAD OTEL VARIABLES TO RUN"
 };
 
 const std::vector<std::string> SAVE_OTEL_VARIABLES_TO_MEMORY = {
-	"SAVE OTEL VARIABLES TO MEMORY" ,
-	"SAVE OTEL VARIABLES TO MEM" ,
-	"SAVE OTEL VARIABLES FROM RUNTIME" ,
+	"SAVE OTEL VARIABLES TO MEMORY",
+	"SAVE OTEL VARIABLES TO MEM",
+	"SAVE OTEL VARIABLES FROM RUNTIME",
 	"SAVE OTEL VARIABLES FROM RUN"
+};
+
+const std::vector<std::string> LOAD_OTEL_FILTER_TO_MEMORY = {
+	"LOAD OTEL FILTER TO MEMORY",
+	"LOAD OTEL FILTER TO MEM",
+	"LOAD OTEL FILTER FROM DISK"
+};
+
+const std::vector<std::string> SAVE_OTEL_FILTER_FROM_MEMORY = {
+	"SAVE OTEL FILTER FROM MEMORY",
+	"SAVE OTEL FILTER FROM MEM",
+	"SAVE OTEL FILTER TO DISK"
+};
+
+const std::vector<std::string> LOAD_OTEL_FILTER_FROM_MEMORY = {
+	"LOAD OTEL FILTER FROM MEMORY",
+	"LOAD OTEL FILTER FROM MEM",
+	"LOAD OTEL FILTER TO RUNTIME",
+	"LOAD OTEL FILTER TO RUN"
+};
+
+const std::vector<std::string> SAVE_OTEL_FILTER_TO_MEMORY = {
+	"SAVE OTEL FILTER TO MEMORY",
+	"SAVE OTEL FILTER TO MEM",
+	"SAVE OTEL FILTER FROM RUNTIME",
+	"SAVE OTEL FILTER FROM RUN"
 };
 
 extern unordered_map<string,std::tuple<string, vector<string>, vector<string>>> load_save_disk_commands;
@@ -2172,6 +2198,40 @@ bool admin_handler_command_load_or_save(char *query_no_space, unsigned int query
 		if (is_admin_command_or_alias(SAVE_OTEL_VARIABLES_TO_MEMORY, query_no_space, query_no_space_length)) {
 			pa->save_otel_variables_from_runtime();
 			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Saved otel variables from RUNTIME\n");
+			pa->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+			return false;
+		}
+	}
+
+	if ((query_no_space_length > 17)
+		&& ((!strncasecmp("SAVE OTEL FILTER ", query_no_space, 17))
+			|| (!strncasecmp("LOAD OTEL FILTER ", query_no_space, 17)))) {
+		if (is_admin_command_or_alias(LOAD_OTEL_FILTER_TO_MEMORY, query_no_space, query_no_space_length)) {
+			pa->admindb->execute("DELETE FROM main.otel_span_filters");
+			pa->admindb->execute("INSERT INTO main.otel_span_filters SELECT * FROM disk.otel_span_filters");
+			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded otel span filters to MEMORY\n");
+			SPA->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+			return false;
+		}
+
+		if (is_admin_command_or_alias(SAVE_OTEL_FILTER_FROM_MEMORY, query_no_space, query_no_space_length)) {
+			pa->admindb->execute("DELETE FROM disk.otel_span_filters");
+			pa->admindb->execute("INSERT INTO disk.otel_span_filters SELECT * FROM main.otel_span_filters");
+			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Saved otel span filters to DISK\n");
+			SPA->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+			return false;
+		}
+
+		if (is_admin_command_or_alias(LOAD_OTEL_FILTER_FROM_MEMORY, query_no_space, query_no_space_length)) {
+			pa->load_otel_filter_to_runtime();
+			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded otel span filter to RUNTIME\n");
+			pa->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+			return false;
+		}
+
+		if (is_admin_command_or_alias(SAVE_OTEL_FILTER_TO_MEMORY, query_no_space, query_no_space_length)) {
+			pa->save_otel_filter_from_runtime();
+			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Saved otel span filter from RUNTIME\n");
 			pa->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
 			return false;
 		}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -684,7 +684,7 @@ MySQL_Session::MySQL_Session() {
 	use_ldap_auth = false;
 
 	span_stack = unsafe_shared_ptr(new OTelSpanStack());
-	root_span = CreateSessionSpan("new_session");
+	root_span = SESSION_TRACE(this);
 }
 
 /**

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -583,7 +583,7 @@ PgSQL_Session::PgSQL_Session() {
 	transaction_state_manager = new PgSQL_ExplicitTxnStateMgr(this);
 
 	span_stack = unsafe_shared_ptr<OTelSpanStack>();
-	root_span = CreateSessionSpan("new_session");
+	root_span = SESSION_TRACE(this);
 }
 
 void PgSQL_Session::reset() {

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2800,12 +2800,6 @@ void ProxySQL_Admin::init_pgsql_variables() {
 	flush_pgsql_variables___database_to_runtime(admindb, true);
 }
 
-void ProxySQL_Admin::init_otel_variables() {
-	flush_otel_variables___database_to_runtime(admindb, true);
-	flush_otel_variables___runtime_to_database(configdb, false, false, false);
-	flush_otel_variables___runtime_to_database(admindb, false, true, false);
-}
-
 void ProxySQL_Admin::admin_shutdown() {
 	int i;
 //	do { usleep(50); } while (main_shutdown==0);
@@ -5217,6 +5211,9 @@ void ProxySQL_Admin::__insert_or_replace_maintable_select_disktable() {
 	if (GloMyLdapAuth) {
 		admindb->execute("INSERT OR REPLACE INTO main.mysql_ldap_mapping SELECT * FROM disk.mysql_ldap_mapping");
 	}
+
+	//OpenTelemetry
+	BQE1(admindb, {"otel_span_filters"}, "", "INSERT OR REPLACE INTO main.", " SELECT * FROM disk.");
 }
 
 void ProxySQL_Admin::__insert_or_replace_disktable_select_maintable() {
@@ -8463,3 +8460,65 @@ void ProxySQL_Admin::enable_replicationlag_testing() {
 	mysql_servers_wrunlock();
 }
 #endif // TEST_REPLICATIONLAG
+
+// OpenTelemetry
+void ProxySQL_Admin::init_otel_variables() {
+	flush_otel_variables___database_to_runtime(admindb, true);
+	flush_otel_variables___runtime_to_database(configdb, false, false, false);
+	flush_otel_variables___runtime_to_database(admindb, false, true, false);
+}
+
+void ProxySQL_Admin::load_otel_filter_to_runtime() {
+	int cols = 0;
+	int affected_rows = 0;
+	char *error = NULL;
+	SQLite3_result *resultset = NULL;
+
+	std::string query = "SELECT file, line, span FROM otel_span_filters";
+	admindb->execute_statement(query.c_str(), &error , &cols , &affected_rows , &resultset);
+	if (error) {
+		// LCOV_EXCL_START
+		proxy_error("Error on %s : %s\n", query.c_str(), error);
+		// LCOV_EXCL_STOP
+	} else {
+		std::set<std::string> filters;
+
+		for (const auto& row : resultset->rows) {
+			std::string key;
+
+			// use the format file:line:span_name
+			key = row->fields[0];
+			key += ":";
+			key += row->fields[1];
+			key += ":";
+			key += row->fields[2];
+			filters.emplace(key);
+		}
+
+		GloOTelTracer->SetFilter(filters);
+	}
+
+	if (resultset)
+		delete resultset;
+}
+
+void ProxySQL_Admin::save_otel_filter_from_runtime() {
+	std::set<std::string> filters = GloOTelTracer->GetFilter();
+
+	std::string query = "DELETE FROM otel_span_filters";
+	admindb->execute(query.c_str());
+
+	for (auto& key : filters) {
+		std::vector<std::string> ret = split_str(key, ':');
+
+		query = "INSERT INTO otel_span_filters VALUES ('";
+		query += ret[0]; // file
+		query += "',";
+		query += ret[1]; // line
+		query += ",'";
+		query += ret[2]; // span_name
+		query += "')";
+
+		admindb->execute(query.c_str());
+	}
+}

--- a/lib/otel_tracer.cpp
+++ b/lib/otel_tracer.cpp
@@ -2,6 +2,8 @@
 #include <cstddef>
 #include <cstdio>
 #include <inttypes.h>
+#include <memory>
+#include <string>
 
 #include "otel_tracer.h"
 #include "opentelemetry/trace/provider.h"
@@ -11,6 +13,7 @@
 #include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
+#include "otel_span.h"
 
 #define OTEL_TRACER_NAME_DEFAULT		"proxysql"
 #define OTEL_SERVICE_NAME_DEFAULT		"proxysql"
@@ -73,7 +76,7 @@ OTelTracer::~OTelTracer() {
 	pthread_rwlock_destroy(&rwlock);
 }
 
-void OTelTracer::setup() {
+void OTelTracer::Setup() {
 	wrlock();
 
 	// reset global trace provider
@@ -118,33 +121,11 @@ void OTelTracer::setup() {
 	unlock();
 }
 
-otel_trace_api::Tracer* OTelTracer::get() {
-	otel_trace_api::Tracer* ret = nullptr;
-
-	rdlock();
-	if (variables.trace_enable) {
-		ret = tracer.get();
-	}
-	unlock();
-
-	return ret;
-}
-
-const std::vector<std::string>& OTelTracer::get_variables_list() {
+const std::vector<std::string>& OTelTracer::GetVariablesList() {
 	return otel_variables;
 }
 
-bool OTelTracer::has_variable(const char * key) {
-	for (auto& var : otel_variables) {
-		if (strcasecmp(var.c_str(), key) == 0) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-char * OTelTracer::get_variable(const char* key) {
+char * OTelTracer::GetVariable(const char* key) {
 	char buf[21];
 
 	if (strcasecmp(key,"trace_enable") == 0)
@@ -194,7 +175,7 @@ char * OTelTracer::get_variable(const char* key) {
 	return nullptr;
 }
 
-bool OTelTracer::set_variable(const char *key, const char *val) {
+bool OTelTracer::SetVariable(const char *key, const char *val) {
 	if (strcasecmp(key,"trace_enable") == 0) {
 		if (strcasecmp(val, "true") == 0 || strcasecmp(val, "1") == 0) {
 			variables.trace_enable = true;
@@ -295,4 +276,108 @@ bool OTelTracer::set_variable(const char *key, const char *val) {
 	}
 
 	return false;
+}
+
+void OTelTracer::SetFilter(const std::set<std::string>& filter) {
+	wrlock();
+
+	span_filter = filter;
+	span_filter_enable = false;
+	if(span_filter.size())
+		span_filter_enable = true;
+
+	unlock();
+}
+
+std::set<std::string> OTelTracer::GetFilter() {
+	rdlock();
+	auto ret = span_filter;
+	unlock();
+
+	return ret;
+}
+
+std::unique_ptr<OTelSpan> OTelTracer::StartSpan(
+	unsafe_shared_ptr<OTelSpanStack>& stack,
+	const char *__file,
+	int __line,
+	const char *name
+) {
+	auto inactive_span = std::make_unique<OTelSpan>();
+
+	auto tracer = get_tracer();
+	if (!tracer)
+		return inactive_span;
+
+	if(!allow_span(__file, __line, name))
+		return inactive_span;
+
+	auto span = std::make_unique<OTelSpan>(tracer, name, stack);
+	span->SetAttribute("file", __file);
+	span->SetAttribute("line", __line);
+
+	return span;
+}
+
+otel_trace_api::Tracer* OTelTracer::get_tracer() {
+	otel_trace_api::Tracer* ret = nullptr;
+
+	rdlock();
+	if (variables.trace_enable) {
+		ret = tracer.get();
+	}
+	unlock();
+
+	return ret;
+}
+
+bool OTelTracer::allow_span(const char *__file, int __line, const char *name) {
+	rdlock();
+
+	if (!span_filter_enable) {
+		unlock();
+		return true;
+	}
+
+	bool ret = false;
+	do {
+		// full search - file:line:span_name
+		std::string key(__file);
+		key += ":" + std::to_string(__line);
+		key += ":";
+		key += name;
+		if (span_filter.find(key) != span_filter.end()) {
+			ret = true;
+			break;
+		}
+
+		// partial - file:line:<empty>
+		key = __file;
+		key += ":" + std::to_string(__line);
+		key += ":";
+		if (span_filter.find(key) != span_filter.end()) {
+			ret = true;
+			break;
+		}
+
+		// partial - file:0:span_name
+		key = __file;
+		key += ":0:";
+		key += name;
+		if (span_filter.find(key) != span_filter.end()) {
+			ret = true;
+			break;
+		}
+
+		// partial - file:0:<empty>
+		key = __file;
+		key += ":0:";
+		if (span_filter.find(key) != span_filter.end()) {
+			ret = true;
+			break;
+		}
+	} while(0);
+
+	unlock();
+	return ret;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1072,8 +1072,9 @@ void ProxySQL_Main_init_ClickHouseServer() {
 
 void ProxySQL_Main_init_OTelTracer() {
 	GloOTelTracer = new OTelTracer();
-	GloOTelTracer->setup();
+	GloOTelTracer->Setup();
 	GloAdmin->init_otel_variables();
+	GloAdmin->load_otel_filter_to_runtime();
 }
 
 void ProxySQL_Main_join_all_threads() {


### PR DESCRIPTION
- Add `otel_span_filters` table and handle load/save operations.
- Handle filtering via `OTelTracer` class, treat filters as an allow list.
- Modify `OTelTracer` class to achieve the following.
    - `OTelTracer` should be the only interface other ProxySQL modules rely on to do any operation related to telemtry.
    - Spans should be created by calling `OTelTracer::StartSpan()`, instead of calling `OTelSpan`'s constructor directly.

Closes #5002.