### PR TITLE
respect ssl settings for monitor connections

### DIFF
--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -874,22 +874,15 @@ string build_conn_str(const task_st_t& task_st) {
 	const mon_srv_t& srv_info { task_st.op_st.srv_info };
 	const mon_user_t& user_info { task_st.op_st.user_info };
 
-	string conn_str = 
+	return string {
 		"host='" + srv_info.addr + "' "
 		+ "port='" + std::to_string(srv_info.port) + "' "
 		+ "user='" + user_info.user + "' "
 		+ "password='" + user_info.pass + "' "
 		+ "dbname='" + user_info.dbname + "' "
-		+ "application_name=ProxySQL-Monitor ";
-
-	// Add SSL configuration based on server's use_ssl setting
-	if (srv_info.ssl) {
-		conn_str += "sslmode=require ";
-	} else {
-		conn_str += "sslmode=disable ";
-	}
-
-	return conn_str;
+		+ "application_name=ProxySQL-Monitor "
+		+ (srv_info.ssl ? "sslmode=require " : "sslmode=disable ")
+	};
 }
 
 pgsql_conn_t create_new_conn(task_st_t& task_st) {

--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -874,14 +874,22 @@ string build_conn_str(const task_st_t& task_st) {
 	const mon_srv_t& srv_info { task_st.op_st.srv_info };
 	const mon_user_t& user_info { task_st.op_st.user_info };
 
-	return string {
+	string conn_str = 
 		"host='" + srv_info.addr + "' "
-			+ "port='" + std::to_string(srv_info.port) + "' "
-			+ "user='" + user_info.user + "' "
-			+ "password='" + user_info.pass + "' "
-			+ "dbname='" + user_info.dbname + "' "
-			+ "application_name=ProxySQL-Monitor"
-	};
+		+ "port='" + std::to_string(srv_info.port) + "' "
+		+ "user='" + user_info.user + "' "
+		+ "password='" + user_info.pass + "' "
+		+ "dbname='" + user_info.dbname + "' "
+		+ "application_name=ProxySQL-Monitor ";
+
+	// Add SSL configuration based on server's use_ssl setting
+	if (srv_info.ssl) {
+		conn_str += "sslmode=require ";
+	} else {
+		conn_str += "sslmode=disable ";
+	}
+
+	return conn_str;
 }
 
 pgsql_conn_t create_new_conn(task_st_t& task_st) {


### PR DESCRIPTION
Problem
PostgreSQL monitor connections were not respecting the `use_ssl` setting from pgsql_servers and defaulting to sslmode=prefer. This creates inconsistency between regular client connections and monitor behavior, which is not ideal.

Solution
Modified `build_conn_str()` in `PgSQL_Monitor.cpp` to explicitly set:

`sslmode=require` when `use_ssl=1`
`sslmode=disable` when `use_ssl=0`
This ensures monitor connections behave consistently with the configured SSL settings.