### PR TITLE
bump version to 3.0.3 at the beginning of the development cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ O3 := -O3 -mtune=native
 ALL_DEBUG := $(O0) -ggdb -DDEBUG
 NO_DEBUG := $(O2) -ggdb
 DEBUG := $(ALL_DEBUG)
-CURVER ?= 3.0.2
+CURVER ?= 3.0.3
 #export DEBUG
 #export EXTRALINK
 export MAKE


### PR DESCRIPTION
needs a tag after merge to `v3.0`
`git tag -a -m "tag version 3.0.3 at the beginning of the development cycle" 3.0.3`
