### PR TITLE
Avoid usage of deleted connection

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -5206,6 +5206,7 @@ handler_again:
 									NEXT_IMMEDIATE(CONNECTING_SERVER);
 								return handler_ret;
 							}
+							myconn = myds->myconn;
 							handler_minus1_GenerateErrorMessage(myds, myconn, wrong_pass);
 							RequestEnd(myds, myerr);
 							handler_minus1_HandleBackendConnection(myds, myconn);


### PR DESCRIPTION
This PR fix the usage of a connection pointer to a deleted object.

### A clear description of the issue

The `handler_minus1_HandleErrorCodes` function sometimes calls `destroy_MySQL_Connection_From_Pool`, causing the pointer of the variable `myconn` to become invalid.

### ProxySQL version
v3.0.2

### The steps to reproduce the issue
Call the function that removes the connection. This has been achieved by repeatedly restarting MySQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message handling to properly reference the active database connection during error reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->