### PR TITLE
Fix delete connection with incorrect index

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2915,7 +2915,7 @@ void MySQL_HostGroups_Manager::drop_all_idle_connections() {
 					unsigned long long intv = mysql_thread___connection_max_age_ms;
 					intv *= 1000;
 					if (curtime > mc->creation_time + intv) {
-						mc=mscl->remove(0);
+						mc=mscl->remove(i);
 						delete mc;
 						i--;
 					}


### PR DESCRIPTION
This PR solves the problem of removing an incorrect connection.

### A clear description of the issue

The first connection in the list is always deleted when it appears that the one with index `i` is to be deleted.

### ProxySQL version
v3.0.2

### The steps to reproduce the issue
This error was detected by a manual inspection of the code, so I don't know what could be causing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected idle database connection removal logic to ensure proper selection of connections during cleanup operations, improving system stability when managing inactive connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->