### PR TITLE
Fix int overflow if the first server is invalid

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1768,7 +1768,7 @@ void MySQL_HostGroups_Manager::purge_mysql_servers_table() {
 	for (unsigned int i=0; i<MyHostGroups->len; i++) {
 		MyHGC *myhgc=(MyHGC *)MyHostGroups->index(i);
 		MySrvC *mysrvc=NULL;
-		for (unsigned int j=0; j<myhgc->mysrvs->servers->len; j++) {
+		for (int j=0; j<myhgc->mysrvs->servers->len; j++) {
 			mysrvc=myhgc->mysrvs->idx(j);
 			if (mysrvc->get_status() == MYSQL_SERVER_STATUS_OFFLINE_HARD) {
 				if (mysrvc->ConnectionsUsed->conns_length()==0 && mysrvc->ConnectionsFree->conns_length()==0) {


### PR DESCRIPTION
This PR solves the problem of integer underflow.

### A clear description of the issue

If the first connection is removed, this decreases the variable `j` by one unit, but since it is an unsigned integer, it causes it to acquire an indeterminate value and thus may cause errors if the code want to access that element.

### ProxySQL version
v3.0.2

### The steps to reproduce the issue
This error was detected by a manual inspection of the code, so I don't know what could be causing it.