### PR TITLE
Avoid send close in ssl connections

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -182,7 +182,7 @@ static int wait_for_mysql(MYSQL *mysql, int status) {
 }
 
 static void close_mysql(MYSQL *my) {
-	if (my->net.pvio) {
+	if (my->net.pvio && !my->options.use_ssl) {
 		char buff[5];
 		mysql_hdr myhdr;
 		myhdr.pkt_id=0;

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -2958,7 +2958,7 @@ void MySQL_Connection::optimize() {
 // if avoids that a QUIT command stops forever
 // FIXME: currently doesn't support encryption and compression
 void MySQL_Connection::close_mysql() {
-	if ((send_quit) && (mysql->net.pvio) && ret_mysql) {
+	if ((send_quit) && (mysql->net.pvio) && ret_mysql && !mysql->options.use_ssl) {
 		char buff[5];
 		mysql_hdr myhdr;
 		myhdr.pkt_id=0;


### PR DESCRIPTION
This PR avoid sending an unencrypted message to a server that uses SSL, as this will cause the backend to abruptly close the connection.

### A clear description of the issue

It seems that since the standard MySQL function is blocking, this logic has been recoded in ProxySQL to use a non blocking aproach, at least partially because it doesn't allow SSL or compression. This causes the MySQL backend to receive an incorrect message (or rather, an invalid message since it is not encrypted) and MySQL abruptly cuts the connection. This is not a serious problem since the desired result is achieved in the end, but it makes it difficult to detect real network problems since the MySQL metrics constantly show that there are problems.

Not sending anything can be worse than sending something, but it works for us, and I don't know if it works for you too.

### ProxySQL version
v3.0.2

### The steps to reproduce the issue
Anything that attempts to close a backend connection if SSL is used can be seen in the MySQL errors defining `log_error_verbosity=3` or with the global status metric `aborted_clients`.