### PR TITLE
Destroy backend connections with untracked session parameters (via options=) instead of returning them to the pool

### DIFF
--- a/lib/PgSQL_Data_Stream.cpp
+++ b/lib/PgSQL_Data_Stream.cpp
@@ -1213,7 +1213,9 @@ void PgSQL_Data_Stream::reset_connection() {
 			return_MySQL_Connection_To_Pool();
 		} else {
 			if (sess && sess->session_fast_forward == SESSION_FORWARD_TYPE_NONE) {
-				destroy_MySQL_Connection_From_Pool(true);
+				// If the startup connection includes untracked session parameters (passed via options=),
+				// the connection must be destroyed instead of returned to the pool. Issue #5102
+				destroy_MySQL_Connection_From_Pool(sess->untracked_option_parameters.empty());
 			} else {
 				destroy_MySQL_Connection_From_Pool(false);
 			}


### PR DESCRIPTION
### Summary
When a client connects with untracked session parameters using` options='-c ...'`, the session is locked to a hostgroup and a new backend connection is created. These options are applied as startup parameters on that connection. After the session ends, a connection reset (`DISCARD ALL`) is executed on that backend connection, but this does not restore the parameters to their `DEFAULT` values; instead, they revert to the **connection’s startup parameters**. If such a backend connection is returned to the pool, subsequent sessions may reuse it and unintentionally inherit those parameters, causing incorrect behavior.
Therefore, backend connections initialized with **untracked options=** must be **destroyed** rather than returned to the connection pool.

Closes #[5102](https://github.com/sysown/proxysql/issues/5102)