### PR TITLE
Allow only galera servers in online status

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -5410,20 +5410,12 @@ void MySQL_HostGroups_Manager::update_galera_set_writer(char *_hostname, int _po
 		}
 		pthread_mutex_unlock(&Galera_Info_mutex);
 
-		if (resultset->rows_count) {
-			for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
-				SQLite3_row *r=*it;
-				int hostgroup=atoi(r->fields[0]);
-				if (hostgroup==_writer_hostgroup) {
-					int status=atoi(r->fields[1]);
-					if (status==0)
-						found_writer=true;
-				}
-				if (read_HG>=0) {
-					if (hostgroup==read_HG) {
-						found_reader=true;
-					}
-				}
+		for (size_t i = 0, l = resultset->rows.size(); i < l; ++i) {
+			int status = atoi(resultset->rows[i]->fields[1]);
+			if (status == 0) {
+				int hostgroup = atoi(resultset->rows[i]->fields[0]);
+				found_writer |= hostgroup == _writer_hostgroup;
+				found_reader |= (read_HG >= 0) && (hostgroup == read_HG);
 			}
 		}
 


### PR DESCRIPTION
This PR fix use non online servers for galera checks.

### A clear description of the issue

Currently, it is not checked whether a galera read server is online, although this does happen with write servers. This PR is a rebase of some changes included in my https://github.com/sysown/proxysql/pull/3063 PR but using the latest version of ProxySQL.

### ProxySQL version
v3.0.2

### The steps to reproduce the issue
Since this is an rebase of some changes that I made about 5 years ago, I don't remember in which cases this error occurred but it surely prevented ProxySQL from recovering if any node in the cluster had gone down and then back to up.