### PR TITLE
Include "information_schema_stats_expiry" as a known setting

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -98,6 +98,7 @@ static const std::set<std::string> mysql_variables_numeric = {
 	"auto_increment_increment",
 	"auto_increment_offset",
 	"group_concat_max_len",
+	"information_schema_stats_expiry",
 	"innodb_lock_wait_timeout",
 	"join_buffer_size",
 	"lock_wait_timeout",


### PR DESCRIPTION
Setting "information_schema_stats_expiry" blocks mysql_query_rules changing hostgroup routing.

https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_information_schema_stats_expiry

This change includes "information_schema_stats_expiry" as a known setting.