### PR TITLE
Fix: return NoData for Describe (Portal) before Execute on empty statement

### DIFF
--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -495,7 +495,14 @@ handler_again:
 					break;
 				case PGRES_EMPTY_QUERY:
 					{
-						const unsigned int bytes_recv = query_result->add_empty_query_response(result.get());
+						unsigned int bytes_recv = 0;
+
+						if (fetch_result_end_st == ASYNC_STMT_EXECUTE_END) {
+							if ((query.extended_query_info->flags & PGSQL_EXTENDED_QUERY_FLAG_DESCRIBE_PORTAL) != 0) {
+								bytes_recv = query_result->add_no_data();
+							}
+						}
+						bytes_recv += query_result->add_empty_query_response(result.get());
 						update_bytes_recv(bytes_recv);
 					}
 					NEXT_IMMEDIATE(ASYNC_USE_RESULT_CONT);


### PR DESCRIPTION
### Summary
Fixes an issue where `Describe (Portal)` does not return a `NoData` response when sent before `Execute` if the prepared statement was created with an empty query string.

### Details
- Extended query flow with empty query string: `Parse (empty statement) -> Bind -> Describe (Portal) -> Execute`.
- Previously, `Describe (Portal)` returned nothing if called before `Execute`.
- Now, the server correctly returns a `NoData` response in this case, making behavior consistent with protocol expectations.
