### PR TITLE
Align DateStyle parsing with PostgreSQL

### DIFF
--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -6613,7 +6613,7 @@ PgSQL_DateStyle_t PgSQL_DateStyle_Util::parse_datestyle(std::string_view input) 
             newDateStyle = DATESTYLE_FORMAT_SQL;
             have_style = true;
         }
-        else if (strcasecmp(tok, "POSTGRES") == 0) {
+        else if (strncasecmp(tok, "POSTGRES", sizeof("POSTGRES") - 1) == 0) {
             if (have_style && newDateStyle != DATESTYLE_FORMAT_POSTGRES)
                 ok = false;     /* conflicting styles */
             newDateStyle = DATESTYLE_FORMAT_POSTGRES;
@@ -6634,8 +6634,8 @@ PgSQL_DateStyle_t PgSQL_DateStyle_Util::parse_datestyle(std::string_view input) 
             newDateOrder = DATESTYLE_ORDER_YMD;
             have_order = true;
         }
-        else if (strcasecmp(tok, "DMY") == 0 ||
-			strcasecmp(tok, "EURO") == 0) {
+        else if (strcasecmp(tok, "DMY") == 0 || 
+			strncasecmp(tok, "EURO", sizeof("EURO") - 1) == 0) {
             if (have_order && newDateOrder != DATESTYLE_ORDER_DMY)
                 ok = false;     /* conflicting orders */
             newDateOrder = DATESTYLE_ORDER_DMY;
@@ -6643,7 +6643,7 @@ PgSQL_DateStyle_t PgSQL_DateStyle_Util::parse_datestyle(std::string_view input) 
         }
         else if (strcasecmp(tok, "MDY") == 0 ||
 			strcasecmp(tok, "US") == 0 ||
-			strcasecmp(tok, "NONEURO") == 0) {
+			strncasecmp(tok, "NONEURO", sizeof("NONEURO") - 1) == 0) {
             if (have_order && newDateOrder != DATESTYLE_ORDER_MDY)
                 ok = false;     /* conflicting orders */
             newDateOrder = DATESTYLE_ORDER_MDY;

--- a/test/tap/tests/pgsql-set_parameter_validation_test-t.cpp
+++ b/test/tap/tests/pgsql-set_parameter_validation_test-t.cpp
@@ -79,6 +79,10 @@ std::vector<SetTestCase> test_cases = {
         {"SET datestyle = 'German, YMD'", true, "German, YMD"},
         {"SET datestyle = 'DMY'", true, "German, DMY"},
         {"SET datestyle = 'SQL, YMD'", true, "SQL, YMD"},
+        {"SET datestyle TO 'PostgreSQL, DMY'", true, "Postgres, DMY"},
+        {"SET datestyle TO 'PostgreSQL, NONEUROPEAN'", true, "Postgres, MDY"},
+        {"SET datestyle TO 'PostgreSQL, US'", true, "Postgres, MDY"},
+        {"SET datestyle TO 'PostgreSQL, European'", true, "Postgres, DMY"},
         // Invalid combinations
         {"SET datestyle = 'INVALID'", false, ""},
         {"SET datestyle = 'ISO, INVALID'", false, ""},


### PR DESCRIPTION
Updated `PgSQL_DateStyle_Util::parse_datestyle()` to support prefix-based matching for known tokens (`POSTGRES`, `EURO`, `NONEURO`). This allows variants like "`PostgreSQL`" and "`European`" to be recognized as valid inputs. The change improves compatibility and consistency with PostgreSQL’s DateStyle parsing behavior.

_`PostgreSQL` is treated the same as `POSTGRES`, `EURO/EUROPEAN` map to `DMY`, and `NONEURO/US` map to `MDY`_