### PR TITLE
Fix incorrect ParameterStatus key casing for DateStyle, TimeZone, and IntervalStyle

### DIFF
--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -1817,10 +1817,10 @@ extern const pgsql_variable_validator pgsql_variable_validator_client_encoding;
 
 pgsql_variable_st pgsql_tracked_variables[]{
 	{ PGSQL_CLIENT_ENCODING,       SETTING_VARIABLE,	"client_encoding", "client_encoding", "UTF8", (PGTRACKED_VAR_OPT_QUOTE | PGTRACKED_VAR_OPT_PARAM_STATUS), &pgsql_variable_validator_client_encoding, { "names", nullptr } },
-	{ PGSQL_DATESTYLE,			   SETTING_VARIABLE,	"datestyle", "datestyle", "ISO, MDY" , (PGTRACKED_VAR_OPT_QUOTE | PGTRACKED_VAR_OPT_PARAM_STATUS), &pgsql_variable_validator_datestyle, nullptr },
-	{ PGSQL_INTERVALSTYLE,		   SETTING_VARIABLE,	"intervalstyle", "intervalstyle", "postgres" , (PGTRACKED_VAR_OPT_QUOTE | PGTRACKED_VAR_OPT_PARAM_STATUS), &pgsql_variable_validator_intervalstyle, nullptr },
+	{ PGSQL_DATESTYLE,			   SETTING_VARIABLE,	"DateStyle", "datestyle", "ISO, MDY" , (PGTRACKED_VAR_OPT_QUOTE | PGTRACKED_VAR_OPT_PARAM_STATUS), &pgsql_variable_validator_datestyle, nullptr },
+	{ PGSQL_INTERVALSTYLE,		   SETTING_VARIABLE,	"IntervalStyle", "intervalstyle", "postgres" , (PGTRACKED_VAR_OPT_QUOTE | PGTRACKED_VAR_OPT_PARAM_STATUS), &pgsql_variable_validator_intervalstyle, nullptr },
 	{ PGSQL_STANDARD_CONFORMING_STRINGS, SETTING_VARIABLE, "standard_conforming_strings", "standard_conforming_strings", "on", (PGTRACKED_VAR_OPT_PARAM_STATUS), &pgsql_variable_validator_bool, nullptr },
-	{ PGSQL_TIMEZONE,			   SETTING_VARIABLE,	"timezone", "timezone", "GMT" , (PGTRACKED_VAR_OPT_QUOTE | PGTRACKED_VAR_OPT_PARAM_STATUS), nullptr, { "TIME ZONE", nullptr } },
+	{ PGSQL_TIMEZONE,			   SETTING_VARIABLE,	"TimeZone", "timezone", "GMT" , (PGTRACKED_VAR_OPT_QUOTE | PGTRACKED_VAR_OPT_PARAM_STATUS), nullptr, { "TIME ZONE", nullptr } },
 	{ PGSQL_NAME_LAST_LOW_WM,      session_status___NONE, "placeholder", "placeholder", "0" , 0, nullptr, nullptr },  // this is just a placeholder to separate the previous index from the next block
 	{ PGSQL_ALLOW_IN_PLACE_TABLESPACES,	   SETTING_VARIABLE,	"allow_in_place_tablespaces", "allow_in_place_tablespaces", "off", (0), &pgsql_variable_validator_bool, nullptr },
 	{ PGSQL_BYTEA_OUTPUT,		   SETTING_VARIABLE,	"bytea_output", "bytea_output", "hex", (PGTRACKED_VAR_OPT_QUOTE), &pgsql_variable_validator_bytea_output,  nullptr },

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -129,15 +129,13 @@ bool PgSQL_Connection_userinfo::set_dbname(const char* db) {
 	const int new_db_len = db ? strlen(db) : 0;
 	const int old_db_len = dbname ? strlen(dbname) : 0;
 
-	if (old_db_len == 0 ||
-		old_db_len != new_db_len ||
-		strncmp(db, dbname, new_db_len)) {
+	if (old_db_len == 0 || old_db_len != new_db_len || strcmp(db, dbname)) {
 		if (dbname) {
 			free(dbname);
 		}
 		dbname = (char*)malloc(new_db_len + 1);
-		memcpy(dbname, db, new_db_len);
-		dbname[new_db_len] = 0;
+		// Copy string including null terminator
+		memcpy(dbname, db, new_db_len + 1);
 		compute_hash();
 		return true;
 	}

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -20,11 +20,11 @@ extern char * binary_sha1;
 #include "proxysql_find_charset.h"
 
 void PgSQL_Variable::fill_server_internal_session(json &j, int conn_num, int idx) {
-	j[conn_num]["conn"][pgsql_tracked_variables[idx].internal_variable_name] = std::string(value?value:"");
+	j[conn_num]["conn"][pgsql_tracked_variables[idx].set_variable_name] = std::string(value?value:"");
 }
 
 void PgSQL_Variable::fill_client_internal_session(json &j, int idx) {
-	j["conn"][pgsql_tracked_variables[idx].internal_variable_name] = value?value:"";
+	j["conn"][pgsql_tracked_variables[idx].set_variable_name] = value?value:"";
 }
 
 PgSQL_Connection_userinfo::PgSQL_Connection_userinfo() {

--- a/lib/PgSQL_Protocol.cpp
+++ b/lib/PgSQL_Protocol.cpp
@@ -1097,8 +1097,7 @@ EXECUTION_STATE PgSQL_Protocol::process_handshake_response_packet(unsigned char*
 				if (i == PGSQL_NAME_LAST_LOW_WM)
 					continue;
 				// using internal_variable_name because it follows the lowercase naming convention
-				if (strncmp(param_key.c_str(), pgsql_tracked_variables[i].internal_variable_name,
-					strlen(pgsql_tracked_variables[i].internal_variable_name)) == 0) {
+				if (strcmp(param_key.c_str(), pgsql_tracked_variables[i].internal_variable_name) == 0) {
 					idx = i;
 					break;
 				}

--- a/lib/PgSQL_Protocol.cpp
+++ b/lib/PgSQL_Protocol.cpp
@@ -1096,8 +1096,9 @@ EXECUTION_STATE PgSQL_Protocol::process_handshake_response_packet(unsigned char*
 			for (int i = 0; i < PGSQL_NAME_LAST_HIGH_WM; i++) {
 				if (i == PGSQL_NAME_LAST_LOW_WM)
 					continue;
-				if (strncmp(param_key.c_str(), pgsql_tracked_variables[i].set_variable_name, 
-					strlen(pgsql_tracked_variables[i].set_variable_name)) == 0) {
+				// using internal_variable_name because it follows the lowercase naming convention
+				if (strncmp(param_key.c_str(), pgsql_tracked_variables[i].internal_variable_name,
+					strlen(pgsql_tracked_variables[i].internal_variable_name)) == 0) {
 					idx = i;
 					break;
 				}
@@ -1248,7 +1249,7 @@ void PgSQL_Protocol::welcome_client() {
 
 		const char* val = pgsql_variables.client_get_value(sess, idx);
 		if (val)
-			pgpkt.write_ParameterStatus(pgsql_tracked_variables[idx].internal_variable_name, val);
+			pgpkt.write_ParameterStatus(pgsql_tracked_variables[idx].set_variable_name, val);
 	}
 
 	if (pgsql_thread___server_version)

--- a/lib/PgSQL_Variables.cpp
+++ b/lib/PgSQL_Variables.cpp
@@ -36,10 +36,8 @@ PgSQL_Variables::PgSQL_Variables() {
 			assert(strcmp(pgsql_tracked_variables[i].set_variable_name, pgsql_tracked_variables[i - 1].set_variable_name) > 0);
 		}
 
-		// we initialized all the internal_variable_name if set to NULL
-		if (pgsql_tracked_variables[i].internal_variable_name == NULL) {
-			pgsql_tracked_variables[i].internal_variable_name = pgsql_tracked_variables[i].set_variable_name;
-		}
+		// internal_variable_name should not be null
+		assert(pgsql_tracked_variables[i].internal_variable_name != NULL);
 
 		PgSQL_Variables::verifiers[i] = verify_server_variable;
 		PgSQL_Variables::updaters[i] = update_server_variable;


### PR DESCRIPTION
### Summary

PostgreSQL clients treat `ParameterStatus` message names as **case-sensitive** and expect canonical capitalization for certain parameters.  
Three parameters in PostgreSQL use **capitalized names** instead of lowercase for historical reasons:

- `DateStyle`
- `TimeZone`
- `IntervalStyle`

These parameters predate the unified GUC (Grand Unified Configuration) system and retained their mixed-case names for backward compatibility.  
Because ProxySQL previously sent them as `datestyle`, `timezone`, and `intervalstyle`, some PostgreSQL clients failed to recognize them and ignored their values.  

### Fix
- Updated ProxySQL to send **canonical capitalization** for `DateStyle`, `TimeZone`, and `IntervalStyle`.
- All other `ParameterStatus` keys continue to use lowercase names, consistent with PostgreSQL.

Closes #[5145](https://github.com/sysown/proxysql/issues/5145)