### PR TITLE
processlist: Prevent crash due to SQLITE_TOOBIG

### DIFF
--- a/include/MySQL_Session.h
+++ b/include/MySQL_Session.h
@@ -468,6 +468,7 @@ class MySQL_Session: public Base_Session<MySQL_Session, MySQL_Data_Stream, MySQL
 	void generate_status_one_hostgroup(int hid, std::string& s);
 	void reset_warning_hostgroup_flag_and_release_connection();
 	void set_previous_status_mode3(bool allow_execute=true);
+	char* get_current_query(int max_length = -1);
 
 	friend void SQLite3_Server_session_handler(MySQL_Session*, void *_pa, PtrSize_t *pkt);
 

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -6,6 +6,8 @@
 
 #include "proxysql.h"
 #include "cpp.h"
+#include "proxysql_admin.h"
+
 #include "MySQL_Variables.h"
 #ifdef IDLE_THREADS
 #include <sys/epoll.h>
@@ -441,10 +443,8 @@ class MySQL_Threads_Handler
 		int connect_timeout_server;
 		int connect_timeout_server_max;
 		int free_connections_pct;
-		int show_processlist_extended;
 #ifdef IDLE_THREADS
 		int session_idle_ms;
-		bool session_idle_show_processlist;
 #endif // IDLE_THREADS
 		bool sessions_sort;
 		char *default_schema;
@@ -561,6 +561,22 @@ class MySQL_Threads_Handler
 		int data_packets_history_size;
 		int handle_warnings;
 		int evaluate_replication_lag_on_servers_load;
+		/**
+		 *   The processlist variables are logically group under "mysql-" variables
+		 *   and they are kept under MySQL_Threads_Handler.
+		 *
+		 *   Other than configuration load/save or sync activities, these variables
+		 *   are not utilized by MTH or MySQL_Thread for any other purpose and hence
+		 *   they are not associated with thread-local variables.
+		 *
+		 *   At runtime, ProxySQL_Admin keeps a copy of these variables and uses them
+		 *   when collecting stats for stats_mysql_processlist.
+		 */
+#ifdef IDLE_THREADS
+		bool session_idle_show_processlist;
+#endif
+		int show_processlist_extended;
+		int processlist_max_query_length;
 	} variables;
 	struct {
 		unsigned int mirror_sessions_current;
@@ -678,7 +694,7 @@ class MySQL_Threads_Handler
 	void start_listeners();
 	void stop_listeners();
 	void signal_all_threads(unsigned char _c=0);
-	SQLite3_result * SQL3_Processlist();
+	SQLite3_result * SQL3_Processlist(processlist_config_t args);
 	SQLite3_result * SQL3_GlobalStatus(bool _memory);
 	bool kill_session(uint32_t _thread_session_id);
 	unsigned long long get_total_mirror_queue();

--- a/include/PgSQL_Session.h
+++ b/include/PgSQL_Session.h
@@ -627,6 +627,7 @@ public:
 	void detected_broken_connection(const char* file, unsigned int line, const char* func, const char* action, PgSQL_Connection* myconn, bool verbose = false);
 	void generate_status_one_hostgroup(int hid, std::string& s);
 	void set_previous_status_mode3(bool allow_execute = true);
+	char* get_current_query(int max_length = -1);
 
 #if defined(__clang__)
 	template<typename SESS, typename DS, typename BE, typename THD>

--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -5,6 +5,8 @@
 #include <prometheus/gauge.h>
 
 #include "proxysql.h"
+#include "proxysql_admin.h"
+
 #include "Base_Thread.h"
 #include "ProxySQL_Poll.h"
 #include "PgSQL_Variables.h"
@@ -949,10 +951,8 @@ public:
 		int connect_timeout_server;
 		int connect_timeout_server_max;
 		int free_connections_pct;
-		int show_processlist_extended;
 #ifdef IDLE_THREADS
 		int session_idle_ms;
-		bool session_idle_show_processlist;
 #endif // IDLE_THREADS
 		bool sessions_sort;
 		char* default_schema;
@@ -1058,6 +1058,22 @@ public:
 		int handle_warnings;
 		char* server_version;
 		char* server_encoding;
+		/**
+		 *   The processlist variables are logically group under "pgsql-" variables
+		 *   and they are kept under PgSQL_Threads_Handler.
+		 *
+		 *   Other than configuration load/save or sync activities, these variables
+		 *   are not utilized by PTH or PgSQL_Thread for any other purpose and hence
+		 *   they are not associated with thread-local variables.
+		 *
+		 *   At runtime, ProxySQL_Admin keeps a copy of these variables and uses them
+		 *   when collecting stats for stats_pgsql_processlist.
+		 */
+#ifdef IDLE_THREADS
+		bool session_idle_show_processlist;
+#endif
+		int show_processlist_extended;
+		int processlist_max_query_length;
 	} variables;
 	struct {
 		unsigned int mirror_sessions_current;
@@ -1507,6 +1523,8 @@ public:
 	/**
 	 * @brief Retrieves a process list for all threads in the thread pool.
 	 *
+	 * @param args Processlist configuration of PgSQL.
+	 *
 	 * @return A `SQLite3_result` object containing the process list, or `NULL` if an error
 	 * occurred.
 	 *
@@ -1519,7 +1537,7 @@ public:
 	 * object, allowing administrators to monitor active sessions and their status.
 	 *
 	 */
-	SQLite3_result* SQL3_Processlist();
+	SQLite3_result* SQL3_Processlist(processlist_config_t args);
 
 	/**
 	 * @brief Retrieves global status information for the thread pool.

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -17,6 +17,10 @@
 
 #include "proxysql_typedefs.h"
 
+#define PROCESSLIST_MAX_QUERY_LEN_DEFAULT    2 * 1024 * 1024  //  2 MiB
+#define PROCESSLIST_MAX_QUERY_LEN_MIN        1 * 1024         //  1 KiB
+#define PROCESSLIST_MAX_QUERY_LEN_MAX       32 * 1024 * 1024  // 32 MiB
+
 typedef struct { uint32_t hash; uint32_t key; } t_symstruct;
 class ProxySQL_Config;
 class ProxySQL_Restapi;
@@ -237,6 +241,13 @@ struct peer_pgsql_servers_v2_t {
 	peer_pgsql_servers_v2_t(SQLite3_result*, const pgsql_servers_v2_checksum_t&);
 };
 
+struct processlist_config_t {
+#ifdef IDLE_THREADS
+	bool show_idle_session;
+#endif
+	int show_extended;
+	int max_query_length;
+};
 
 class ProxySQL_Admin {
 	private:
@@ -317,8 +328,6 @@ class ProxySQL_Admin {
 		int stats_mysql_eventslog_sync_buffer_to_disk;
 		int stats_system_cpu;
 		int stats_system_memory;
-		int mysql_show_processlist_extended;
-		int pgsql_show_processlist_extended;
 		bool restapi_enabled;
 		bool restapi_enabled_old;
 		int restapi_port;
@@ -335,6 +344,13 @@ class ProxySQL_Admin {
 		int coredump_generation_interval_ms;
 		int coredump_generation_threshold;
 		char* ssl_keylog_file;
+		/**
+		 *   Processlist configurations are owned by MySQL/PgSQL Threads_Handlers.
+		 *   At runtime, ProxySQL_Admin keeps a copy of those variables and uses them
+		 *   for collecting stats.
+		 */
+		processlist_config_t mysql_processlist;
+		processlist_config_t pgsql_processlist;
 	} variables;
 
 	unsigned long long last_p_memory_metrics_ts;

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -1083,7 +1083,6 @@ PgSQL_HostGroups_Manager* PgHGM;
 
 // PostgreSQL thread variables
 __thread int pgsql_thread___authentication_method;
-__thread int pgsql_thread___show_processlist_extended;
 __thread char *pgsql_thread___server_version;
 __thread char *pgsql_thread___server_encoding;
 __thread bool pgsql_thread___have_ssl;
@@ -1203,7 +1202,6 @@ __thread int pgsql_thread___query_cache_size_MB;
 __thread int pgsql_thread___query_cache_soft_ttl_pct;
 __thread int pgsql_thread___query_cache_handle_warnings;
 
-__thread bool pgsql_thread___session_idle_show_processlist;
 __thread char* pgsql_thread___default_variables[PGSQL_NAME_LAST_LOW_WM];
 __thread int pgsql_thread___handle_unknown_charset;
 __thread int pgsql_thread___max_stmts_cache;
@@ -1288,11 +1286,9 @@ __thread bool mysql_thread___query_digests_keep_comment;
 __thread int mysql_thread___query_digests_max_digest_length;
 __thread int mysql_thread___query_digests_max_query_length;
 __thread bool mysql_thread___parse_failure_logs_digest;
-__thread int mysql_thread___show_processlist_extended;
 __thread int mysql_thread___session_idle_ms;
 __thread int mysql_thread___hostgroup_manager_verbose;
 __thread bool mysql_thread___default_reconnect;
-__thread bool mysql_thread___session_idle_show_processlist;
 __thread bool mysql_thread___sessions_sort;
 __thread bool mysql_thread___kill_backend_connection_when_disconnect;
 __thread bool mysql_thread___client_session_track_gtid;
@@ -1391,7 +1387,6 @@ extern PgSQL_HostGroups_Manager *PgHGM;
 
 //PostgreSQL Thread Variables
 extern __thread int pgsql_thread___authentication_method;
-extern __thread int pgsql_thread___show_processlist_extended;
 extern __thread char *pgsql_thread___server_version;
 extern __thread char* pgsql_thread___server_encoding;
 extern __thread bool pgsql_thread___have_ssl;
@@ -1509,7 +1504,6 @@ extern __thread int pgsql_thread___query_cache_size_MB;
 extern __thread int pgsql_thread___query_cache_soft_ttl_pct;
 extern __thread int pgsql_thread___query_cache_handle_warnings;
 
-extern __thread bool pgsql_thread___session_idle_show_processlist;
 extern __thread char* pgsql_thread___default_variables[PGSQL_NAME_LAST_LOW_WM];
 extern __thread int pgsql_thread___handle_unknown_charset;
 extern __thread int pgsql_thread___max_stmts_cache;
@@ -1594,11 +1588,9 @@ extern __thread bool mysql_thread___query_digests_keep_comment;
 extern __thread int mysql_thread___query_digests_max_digest_length;
 extern __thread int mysql_thread___query_digests_max_query_length;
 extern __thread bool mysql_thread___parse_failure_logs_digest;
-extern __thread int mysql_thread___show_processlist_extended;
 extern __thread int mysql_thread___session_idle_ms;
 extern __thread int mysql_thread___hostgroup_manager_verbose;
 extern __thread bool mysql_thread___default_reconnect;
-extern __thread bool mysql_thread___session_idle_show_processlist;
 extern __thread bool mysql_thread___sessions_sort;
 extern __thread bool mysql_thread___kill_backend_connection_when_disconnect;
 extern __thread bool mysql_thread___client_session_track_gtid;

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -434,7 +434,15 @@ void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, 
 		assert(previous_default_charset);
 		assert(previous_default_collation_connection);
 		flush_GENERIC_variables__process__database_to_runtime("mysql", db, resultset, false, replace, {}, {"session_debug"}, {"forward_autocommit"},
-			{"default_collation_connection", "default_charset", "show_processlist_extended"},
+			{
+				"default_collation_connection",
+				"default_charset",
+				"show_processlist_extended",
+#ifdef IDLE_THREADS
+				"session_idle_show_processlist",
+#endif // IDLE_THREADS
+				"processlist_max_query_length"
+			},
 			[](const std::string& varname, const char *varvalue, SQLite3DB* db) {
 				if (varname == "default_collation_connection" || varname == "default_charset") {
 					char *val=GloMTH->get_variable((char *)varname.c_str());
@@ -448,10 +456,16 @@ void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, 
 						free(val);
 					}
 				} else if (varname == "show_processlist_extended") {
-					GloAdmin->variables.mysql_show_processlist_extended = atoi(varvalue);
+					GloAdmin->variables.mysql_processlist.show_extended = atoi(varvalue);
+#ifdef IDLE_THREADS
+				} else if (varname == "session_idle_show_processlist") {
+					GloAdmin->variables.mysql_processlist.show_idle_session = atoi(varvalue);
+#endif // IDLE_THREADS
+				} else if (varname == "processlist_max_query_length") {
+					GloAdmin->variables.mysql_processlist.max_query_length = atoi(varvalue);
 				}
 			}
-			);
+		);
 		char q[1000];
 		char * default_charset = GloMTH->get_variable_string((char *)"default_charset");
 		char * default_collation_connection = GloMTH->get_variable_string((char *)"default_collation_connection");
@@ -795,7 +809,13 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 				}
 				proxy_debug(PROXY_DEBUG_ADMIN, 4, "Set variable %s with value \"%s\"\n", r->fields[0], value);
 				if (strcmp(r->fields[0], (char*)"show_processlist_extended") == 0) {
-					variables.pgsql_show_processlist_extended = atoi(value);
+					variables.pgsql_processlist.show_extended = atoi(value);
+#ifdef IDLE_THREADS
+				} else if (strcmp(r->fields[0], (char*)"session_idle_show_processlist") == 0) {
+					variables.pgsql_processlist.show_idle_session = atoi(value);
+#endif // IDLE_THREADS
+				} else if (strcmp(r->fields[0], (char*)"processlist_max_query_length") == 0) {
+					variables.pgsql_processlist.max_query_length = atoi(value);
 				}
 			}
 			//			}

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -3916,7 +3916,7 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 
 	if (query_no_space_length==strlen("SHOW PROCESSLIST") && !strncasecmp("SHOW PROCESSLIST",query_no_space, query_no_space_length)) {
 		l_free(query_length,query);
-		query=l_strdup("SELECT SessionID, user, db, hostgroup, command, time_ms, SUBSTR(info,0,100) info FROM stats_mysql_processlist");
+		query=l_strdup("SELECT SessionID, user, db, hostgroup, command, time_ms, info FROM stats_mysql_processlist");
 		query_length=strlen(query)+1;
 		goto __run_query;
 	}
@@ -3937,14 +3937,14 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 
 	if (query_no_space_length == strlen("SHOW PGSQL PROCESSLIST") && !strncasecmp("SHOW PGSQL PROCESSLIST", query_no_space, query_no_space_length)) {
 		l_free(query_length, query);
-		query = l_strdup("SELECT SessionID, user, database, hostgroup, backend_pid, backend_state, command, time_ms, SUBSTR(info,0,100) info FROM stats_pgsql_processlist");
+		query = l_strdup("SELECT SessionID, user, database, hostgroup, backend_pid, backend_state, command, time_ms, info FROM stats_pgsql_processlist");
 		query_length = strlen(query) + 1;
 		goto __run_query;
 	}
 
 	if (query_no_space_length == strlen("SHOW PGSQL ACTIVITY") && !strncasecmp("SHOW PGSQL ACTIVITY", query_no_space, query_no_space_length)) {
 		l_free(query_length, query);
-		query = l_strdup("SELECT datname, pid, usename, hostgroup, backend_pid, state, command, duration_ms, SUBSTR(query,0,100) query FROM stats_pgsql_stat_activity");
+		query = l_strdup("SELECT datname, pid, usename, hostgroup, backend_pid, state, command, duration_ms, query FROM stats_pgsql_stat_activity");
 		query_length = strlen(query) + 1;
 		goto __run_query;
 	}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -8116,3 +8116,42 @@ void MySQL_Session::reset_warning_hostgroup_flag_and_release_connection() {
 		warning_in_hg = -1;
 	}
 }
+
+char* MySQL_Session::get_current_query(int max_length) {
+	const char *query_ptr = NULL;
+	int query_len = 0;
+
+	if (!(mybe && mybe->server_myds && mybe->server_myds->myconn)) {
+		return NULL;
+	}
+
+	if (CurrentQuery.stmt_info == NULL) { // text protocol
+		query_ptr = mybe->server_myds->myconn->query.ptr;
+		query_len = mybe->server_myds->myconn->query.length;
+	} else { // prepared statement
+		query_ptr = CurrentQuery.stmt_info->query;
+		query_len = CurrentQuery.stmt_info->query_length;
+	}
+
+	bool trunc_query = false;
+	if (max_length > 0 && query_len > max_length) {
+		query_len = max_length;
+		trunc_query = true;
+	}
+
+	char *res = NULL;
+
+	if (query_len > 0) {
+		res = (char *) malloc(query_len + 1);
+		if (trunc_query) {
+			// for truncated queries, add three dots at the end
+			strncpy(res, query_ptr, query_len - 3);
+			strncpy(res + (query_len - 3), "...", 3);
+		} else {
+			strncpy(res, query_ptr, query_len);
+		}
+		res[query_len] = '\0';
+	}
+
+	return res;
+}

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -471,6 +471,7 @@ static char * mysql_thread_variables_names[]= {
 	(char *)"session_idle_show_processlist",
 #endif // IDLE_THREADS
 	(char *)"show_processlist_extended",
+	(char *)"processlist_max_query_length",
 	(char *)"commands_stats",
 	(char *)"query_digests",
 	(char *)"query_digests_lowercase",
@@ -1123,6 +1124,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.session_idle_show_processlist=true;
 #endif // IDLE_THREADS
 	variables.show_processlist_extended = 0;
+	variables.processlist_max_query_length = PROCESSLIST_MAX_QUERY_LEN_DEFAULT;
 	variables.servers_stats=true;
 	variables.default_reconnect=true;
 	variables.ssl_p2s_ca=NULL;
@@ -2304,6 +2306,14 @@ char ** MySQL_Threads_Handler::get_variables_list() {
 		VariablesPointers_int["session_idle_ms"]           = make_tuple(&variables.session_idle_ms,              1,        3600*1000, false);
 #endif // IDLE_THREADS
 		VariablesPointers_int["show_processlist_extended"] = make_tuple(&variables.show_processlist_extended,    0,                2, false);
+
+		VariablesPointers_int["processlist_max_query_length"] = make_tuple(
+			&variables.processlist_max_query_length,
+			PROCESSLIST_MAX_QUERY_LEN_MIN,
+			PROCESSLIST_MAX_QUERY_LEN_MAX,
+			false
+		);
+
 		VariablesPointers_int["threshold_query_length"]    = make_tuple(&variables.threshold_query_length,    1024, 1*1024*1024*1024, false);
 		VariablesPointers_int["threshold_resultset_size"]  = make_tuple(&variables.threshold_resultset_size,  1024, 1*1024*1024*1024, false);
 
@@ -4248,10 +4258,6 @@ void MySQL_Thread::refresh_variables() {
 	REFRESH_VARIABLE_BOOL(kill_backend_connection_when_disconnect);
 	REFRESH_VARIABLE_BOOL(client_session_track_gtid);
 	REFRESH_VARIABLE_BOOL(sessions_sort);
-#ifdef IDLE_THREADS
-	REFRESH_VARIABLE_BOOL(session_idle_show_processlist);
-#endif // IDLE_THREADS
-	REFRESH_VARIABLE_INT(show_processlist_extended);
 	REFRESH_VARIABLE_BOOL(servers_stats);
 	REFRESH_VARIABLE_BOOL(default_reconnect);
 	REFRESH_VARIABLE_BOOL(enable_client_deprecate_eof);
@@ -4871,7 +4877,7 @@ void MySQL_Threads_Handler::Get_Memory_Stats() {
 	}
 }
 
-SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
+SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist(processlist_config_t args) {
 	const int colnum=16;
         char port[NI_MAXSERV];
 	proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 4, "Dumping MySQL Processlist\n");
@@ -4908,7 +4914,7 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
 			thr=(MySQL_Thread *)mysql_threads[i].worker;
 #ifdef IDLE_THREADS
 		} else {
-			if (GloVars.global.idle_threads && mysql_thread___session_idle_show_processlist && mysql_threads_idles) {
+			if (GloVars.global.idle_threads && args.show_idle_session && mysql_threads_idles) {
 				thr=(MySQL_Thread *)mysql_threads_idles[i-num_threads].worker;
 			}
 #endif // IDLE_THREADS
@@ -5019,24 +5025,7 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
 					pta[9]=strdup(buf);
 					sprintf(buf,"%d", mc->parent->port);
 					pta[10]=strdup(buf);
-					if (sess->CurrentQuery.stmt_info==NULL) { // text protocol
-						if (mc->query.length) {
-							pta[13]=(char *)malloc(mc->query.length+1);
-							strncpy(pta[13],mc->query.ptr,mc->query.length);
-							pta[13][mc->query.length]='\0';
-						} else {
-							pta[13]=NULL;
-						}
-					} else { // prepared statement
-						MySQL_STMT_Global_info *si=sess->CurrentQuery.stmt_info;
-						if (si->query_length) {
-							pta[13]=(char *)malloc(si->query_length+1);
-							strncpy(pta[13],si->query,si->query_length);
-							pta[13][si->query_length]='\0';
-						} else {
-							pta[13]=NULL;
-						}
-					}
+					pta[13] = sess->get_current_query(args.max_query_length);
 					sprintf(buf,"%d", mc->status_flags);
 					pta[14]=strdup(buf);
 				} else {
@@ -5147,10 +5136,10 @@ SQLite3_result * MySQL_Threads_Handler::SQL3_Processlist() {
 				pta[12]=strdup(buf);
 
 				pta[15]=NULL;
-				if (mysql_thread___show_processlist_extended) {
+				if (args.show_extended) {
 					json j;
 					sess->generate_proxysql_internal_session_json(j);
-					if (mysql_thread___show_processlist_extended == 2) {
+					if (args.show_extended == 2) {
 						std::string s = j.dump(4, ' ', false, json::error_handler_t::replace);
 						pta[15] = strdup(s.c_str());
 					} else {

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -6453,6 +6453,45 @@ void PgSQL_Session::handler___rc0_PROCESSING_STMT_DESCRIBE_PREPARE(PgSQL_Data_St
 	}
 }*/
 
+char* PgSQL_Session::get_current_query(int max_length) {
+	const char *query_ptr = NULL;
+	int query_len = 0;
+
+	if (!(mybe && mybe->server_myds && mybe->server_myds->myconn)) {
+		return NULL;
+	}
+
+	if (CurrentQuery.extended_query_info.stmt_info == NULL) { // text protocol
+		query_ptr = mybe->server_myds->myconn->query.ptr;
+		query_len = mybe->server_myds->myconn->query.length;
+	} else { // prepared statement
+		query_ptr = CurrentQuery.extended_query_info.stmt_info->query;
+		query_len = CurrentQuery.extended_query_info.stmt_info->query_length;
+	}
+
+	bool trunc_query = false;
+	if (max_length > 0 && query_len > max_length) {
+		query_len = max_length;
+		trunc_query = true;
+	}
+
+	char *res = NULL;
+
+	if (query_len > 0) {
+		res = (char *) malloc(query_len + 1);
+		if (trunc_query) {
+			// for truncated queries, add three dots at the end
+			strncpy(res, query_ptr, query_len - 3);
+			strncpy(res + (query_len - 3), "...", 3);
+		} else {
+			strncpy(res, query_ptr, query_len);
+		}
+		res[query_len] = '\0';
+	}
+
+	return res;
+}
+
 // Optimized single‐pass parser for PostgreSQL DateStyle strings.
 // It supports input in one of these forms:
 //   - "ISO, MDY"  (two tokens separated by a comma)

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -416,6 +416,7 @@ static char* pgsql_thread_variables_names[] = {
 	(char*)"session_idle_show_processlist",
 #endif // IDLE_THREADS
 	(char*)"show_processlist_extended",
+	(char *)"processlist_max_query_length",
 	(char*)"commands_stats",
 	(char*)"query_digests",
 	(char*)"query_digests_lowercase",
@@ -1066,6 +1067,7 @@ PgSQL_Threads_Handler::PgSQL_Threads_Handler() {
 	variables.session_idle_show_processlist = true;
 #endif // IDLE_THREADS
 	variables.show_processlist_extended = 0;
+	variables.processlist_max_query_length = PROCESSLIST_MAX_QUERY_LEN_DEFAULT;
 	variables.servers_stats = true;
 	variables.default_reconnect = true;
 	variables.ssl_p2s_ca = NULL;
@@ -2191,6 +2193,14 @@ char** PgSQL_Threads_Handler::get_variables_list() {
 		VariablesPointers_int["session_idle_ms"] = make_tuple(&variables.session_idle_ms, 1, 3600 * 1000, false);
 #endif // IDLE_THREADS
 		VariablesPointers_int["show_processlist_extended"] = make_tuple(&variables.show_processlist_extended, 0, 2, false);
+
+		VariablesPointers_int["processlist_max_query_length"] = make_tuple(
+			&variables.processlist_max_query_length,
+			PROCESSLIST_MAX_QUERY_LEN_MIN,
+			PROCESSLIST_MAX_QUERY_LEN_MAX,
+			false
+		);
+
 		VariablesPointers_int["threshold_query_length"] = make_tuple(&variables.threshold_query_length, 1024, 1 * 1024 * 1024 * 1024, false);
 		VariablesPointers_int["threshold_resultset_size"] = make_tuple(&variables.threshold_resultset_size, 1024, 1 * 1024 * 1024 * 1024, false);
 
@@ -3747,7 +3757,6 @@ void PgSQL_Thread::refresh_variables() {
 	GloPTH->wrlock();
 	__thread_PgSQL_Thread_Variables_version = __global_PgSQL_Thread_Variables_version;
 	pgsql_thread___authentication_method = GloPTH->get_variable_int((char*)"authentication_method");
-	pgsql_thread___show_processlist_extended = GloPTH->get_variable_int((char*)"show_processlist_extended");
 	pgsql_thread___max_connections = GloPTH->get_variable_int((char*)"max_connections");
 	pgsql_thread___use_tcp_keepalive = (bool)GloPTH->get_variable_int((char*)"use_tcp_keepalive");
 	pgsql_thread___tcp_keepalive_time = GloPTH->get_variable_int((char*)"tcp_keepalive_time");
@@ -3799,7 +3808,6 @@ void PgSQL_Thread::refresh_variables() {
 	pgsql_thread___mirror_max_concurrency = GloPTH->get_variable_int((char*)"mirror_max_concurrency");
 	pgsql_thread___mirror_max_queue_length = GloPTH->get_variable_int((char*)"mirror_max_queue_length");
 	pgsql_thread___sessions_sort = (bool)GloPTH->get_variable_int((char*)"sessions_sort");
-	pgsql_thread___show_processlist_extended = GloPTH->get_variable_int((char*)"show_processlist_extended");
 	pgsql_thread___servers_stats = (bool)GloPTH->get_variable_int((char*)"servers_stats");
 	pgsql_thread___default_reconnect = (bool)GloPTH->get_variable_int((char*)"default_reconnect");
 	
@@ -3961,9 +3969,6 @@ void PgSQL_Thread::refresh_variables() {
 
 	variables.query_cache_stores_empty_result = (bool)GloPTH->get_variable_int((char*)"query_cache_stores_empty_result");
 
-#ifdef IDLE_THREADS
-	pgsql_thread___session_idle_show_processlist = (bool)GloPTH->get_variable_int((char*)"session_idle_show_processlist");
-#endif // IDLE_THREADS
 	/*
 	variables.min_num_servers_lantency_awareness = GloPTH->get_variable_int((char*)"min_num_servers_lantency_awareness");
 	variables.aurora_max_lag_ms_only_read_from_replicas = GloPTH->get_variable_int((char*)"aurora_max_lag_ms_only_read_from_replicas");
@@ -4539,7 +4544,7 @@ void PgSQL_Threads_Handler::Get_Memory_Stats() {
 	}
 }
 
-SQLite3_result* PgSQL_Threads_Handler::SQL3_Processlist() {
+SQLite3_result* PgSQL_Threads_Handler::SQL3_Processlist(processlist_config_t args) {
 	const int colnum = 18;
 	char port[NI_MAXSERV];
 	proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 4, "Dumping PgSQL Processlist\n");
@@ -4577,8 +4582,9 @@ SQLite3_result* PgSQL_Threads_Handler::SQL3_Processlist() {
 		if (i < num_threads && pgsql_threads) {
 			thr = (PgSQL_Thread*)pgsql_threads[i].worker;
 #ifdef IDLE_THREADS
-		} else {
-			if (GloVars.global.idle_threads && pgsql_thread___session_idle_show_processlist && pgsql_threads_idles) {
+		}
+		else {
+			if (GloVars.global.idle_threads && args.show_idle_session && pgsql_threads_idles) {
 				thr = (PgSQL_Thread*)pgsql_threads_idles[i - num_threads].worker;
 			}
 #endif // IDLE_THREADS
@@ -4677,24 +4683,7 @@ SQLite3_result* PgSQL_Threads_Handler::SQL3_Processlist() {
 					pta[9] = strdup(buf);
 					sprintf(buf, "%d", mc->parent->port);
 					pta[10] = strdup(buf);
-					if (sess->CurrentQuery.extended_query_info.stmt_info == NULL) { // text protocol
-						if (mc->query.length) {
-							pta[15] = (char*)malloc(mc->query.length + 1);
-							strncpy(pta[15], mc->query.ptr, mc->query.length);
-							pta[15][mc->query.length] = '\0';
-						} else {
-							pta[15] = NULL;
-						}
-					} else { // prepared statement
-						const PgSQL_STMT_Global_info* si = sess->CurrentQuery.extended_query_info.stmt_info;
-						if (si->query_length) {
-							pta[15] = (char*)malloc(si->query_length + 1);
-							strncpy(pta[15], si->query, si->query_length);
-							pta[15][si->query_length] = '\0';
-						} else {
-							pta[15] = NULL;
-						}
-					}
+					pta[15] = sess->get_current_query(args.max_query_length);
 					sprintf(buf, "%d", mc->status_flags);
 					pta[16] = strdup(buf);
 					sprintf(buf, "%u", mc->get_pg_backend_pid());
@@ -4798,10 +4787,10 @@ SQLite3_result* PgSQL_Threads_Handler::SQL3_Processlist() {
 				pta[14] = strdup(buf);
 
 				pta[17] = NULL;
-				if (pgsql_thread___show_processlist_extended) {
+				if (args.show_extended) {
 					json j;
 					sess->generate_proxysql_internal_session_json(j);
-					if (pgsql_thread___show_processlist_extended == 2) {
+					if (args.show_extended == 2) {
 						std::string s = j.dump(4, ' ', false, json::error_handler_t::replace);
 						pta[17] = strdup(s.c_str());
 					} else {

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2605,8 +2605,6 @@ ProxySQL_Admin::ProxySQL_Admin() :
 	variables.telnet_admin_ifaces=NULL;
 	variables.telnet_stats_ifaces=NULL;
 	variables.refresh_interval=2000;
-	variables.mysql_show_processlist_extended = false;
-	variables.pgsql_show_processlist_extended = false;
 	//variables.hash_passwords=true;	// issue #676
 	variables.vacuum_stats=true;	// issue #1011
 	variables.admin_read_only=false;	// by default, the admin interface accepts writes
@@ -2692,6 +2690,14 @@ ProxySQL_Admin::ProxySQL_Admin() :
 	init_prometheus_counter_array<admin_metrics_map_idx, p_admin_counter>(admin_metrics_map, this->metrics.p_counter_array);
 	init_prometheus_gauge_array<admin_metrics_map_idx, p_admin_gauge>(admin_metrics_map, this->metrics.p_gauge_array);
 	init_prometheus_dyn_gauge_array<admin_metrics_map_idx, p_admin_dyn_gauge>(admin_metrics_map, this->metrics.p_dyn_gauge_array);
+
+	// processlist configuration
+	variables.mysql_processlist.show_extended = 0;
+	variables.pgsql_processlist.show_extended = 0;
+	variables.mysql_processlist.show_idle_session = true;
+	variables.pgsql_processlist.show_idle_session = true;
+	variables.mysql_processlist.max_query_length = PROCESSLIST_MAX_QUERY_LEN_DEFAULT;
+	variables.pgsql_processlist.max_query_length = PROCESSLIST_MAX_QUERY_LEN_DEFAULT;
 
 	// NOTE: Imposing fixed value to 'version_info' matching 'mysqld_exporter'
 	this->metrics.p_gauge_array[p_admin_gauge::version_info]->Set(1);

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -782,8 +782,8 @@ void ProxySQL_Admin::stats___pgsql_global() {
 void ProxySQL_Admin::stats___mysql_processlist() {
 	int rc;
 	if (!GloMTH) return;
-	mysql_thread___show_processlist_extended = variables.mysql_show_processlist_extended;
-	SQLite3_result * resultset=GloMTH->SQL3_Processlist();
+
+	SQLite3_result * resultset=GloMTH->SQL3_Processlist(variables.mysql_processlist);
 	if (resultset==NULL) return;
 
 	sqlite3_stmt *statement1=NULL;
@@ -935,8 +935,8 @@ CREATE TABLE stats_mysql_processlist (
 void ProxySQL_Admin::stats___pgsql_processlist() {
 	int rc;
 	if (!GloPTH) return;
-	pgsql_thread___show_processlist_extended = variables.pgsql_show_processlist_extended;
-	SQLite3_result* resultset = GloPTH->SQL3_Processlist();
+
+	SQLite3_result* resultset = GloPTH->SQL3_Processlist(variables.pgsql_processlist);
 	if (resultset == NULL) return;
 
 	sqlite3_stmt* statement1 = NULL;


### PR DESCRIPTION
- Add new mysql/pgsql variable `processlist_max_query_length`.
    - Min: 1K
    - Max: 32M
    - Default: 2M
- Truncate current query based on the configuration before inserting into `stats_*_processlist` tables.
- Refactor/fix code related to other processlist configurations.
    1. `session_idle_show_processlist` value was not updated in `ProxySQL_Admin.variables`.
    2. Pass processlist config as an argument to `MySQL_Threads_Handler::SQL3_Processlist` instead of using thread-local variables.