### PR TITLE
Fix potential 'use-after-free' by Admin 'SHOW PROCESSLIST'

### DIFF
--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -8145,8 +8145,8 @@ char* MySQL_Session::get_current_query(int max_length) {
 		res = (char *) malloc(query_len + 1);
 		if (trunc_query) {
 			// for truncated queries, add three dots at the end
-			strncpy(res, query_ptr, query_len - 3);
-			strncpy(res + (query_len - 3), "...", 3);
+			memcpy(res, query_ptr, query_len - 3);
+			memcpy(res + (query_len - 3), "...", 3);
 		} else {
 			strncpy(res, query_ptr, query_len);
 		}

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -8126,8 +8126,8 @@ char* MySQL_Session::get_current_query(int max_length) {
 	}
 
 	if (CurrentQuery.stmt_info == NULL) { // text protocol
-		query_ptr = mybe->server_myds->myconn->query.ptr;
-		query_len = mybe->server_myds->myconn->query.length;
+		query_ptr = reinterpret_cast<const char*>(CurrentQuery.QueryPointer);
+		query_len = CurrentQuery.QueryLength;
 	} else { // prepared statement
 		query_ptr = CurrentQuery.stmt_info->query;
 		query_len = CurrentQuery.stmt_info->query_length;


### PR DESCRIPTION
## Issue

The following `use-after-free` is very simple to reproduce:

1. Start a test performing `SET statements` or any other query that is internally re-writed.
2. In parallel, issue `SHOW PROCESSLIST` to the Admin interface.

The following 'use-after-free' is likely to take place:
```
==2023703==ERROR: AddressSanitizer: heap-use-after-free on address 0x7be6e8c4b880 at pc 0x7fb6ea11b078 bp 0x7bb6bf234590 sp 0x7bb6bf233d38
READ of size 3 at 0x7be6e8c4b880 thread T48
    #0 0x7fb6ea11b077 in strncpy /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:627
    #1 0x55f68a014e40 in MySQL_Session::get_current_query(int) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:8151
    #2 0x55f689f722c8 in MySQL_Threads_Handler::SQL3_Processlist(processlist_config_t) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Thread.cpp:5028
    #3 0x55f68a4c7035 in ProxySQL_Admin::stats___mysql_processlist() /home/javjarfer/Projects/proxysql_dev/lib/ProxySQL_Admin_Stats.cpp:786
    #4 0x55f68a0c775d in ProxySQL_Admin::GenericRefreshStatistics(char const*, unsigned int, bool) /home/javjarfer/Projects/proxysql_dev/lib/ProxySQL_Admin.cpp:1470
    #5 0x55f68a53e0e3 in void admin_session_handler<MySQL_Session>(MySQL_Session*, void*, _PtrSize_t*) /home/javjarfer/Projects/proxysql_dev/lib/Admin_Handler.cpp:2812
    #6 0x55f689fd957b in MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY___not_mysql(_PtrSize_t&) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:3543
    #7 0x55f689fe1695 in MySQL_Session::get_pkts_from_client(bool&, _PtrSize_t&) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:4338
    #8 0x55f689fe8f3a in MySQL_Session::handler() /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:4952
    #9 0x55f68a0cbc5f in child_mysql(void*) /home/javjarfer/Projects/proxysql_dev/lib/ProxySQL_Admin.cpp:2046
    #10 0x7fb6ea05e11a in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:239
    #11 0x7fb6e8e969ca  (/usr/lib/libc.so.6+0x969ca) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)

0x7be6e8c4b880 is located 0 bytes inside of 26-byte region [0x7be6e8c4b880,0x7be6e8c4b89a)
freed by thread T4 here:
    #0 0x7fb6ea11f79d in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x55f689fcbced in MySQL_Session::handler_again___status_SETTING_GENERIC_VARIABLE(int*, char const*, char const*, bool, bool) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:2565
    #2 0x55f68a42c71b in update_server_variable(MySQL_Session*, int, int&) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Variables.cpp:487
    #3 0x55f68a42a2de in MySQL_Variables::update_variable(MySQL_Session*, session_status, int&) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Variables.cpp:313
    #4 0x55f689fec0f2 in MySQL_Session::handler() /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:5295
    #5 0x55f689f65e5b in MySQL_Thread::process_all_sessions() /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Thread.cpp:4028
    #6 0x55f689f5f8d4 in MySQL_Thread::run() /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Thread.cpp:3388
    #7 0x55f689cce72c in mysql_worker_thread_func(void*) /home/javjarfer/Projects/proxysql_dev/src/main.cpp:524
    #8 0x7fb6ea05e11a in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:239
    #9 0x7fb6e8e969ca  (/usr/lib/libc.so.6+0x969ca) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)

previously allocated by thread T4 here:
    #0 0x7fb6ea120cb5 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 0x55f689fcb7b4 in MySQL_Session::handler_again___status_SETTING_GENERIC_VARIABLE(int*, char const*, char const*, bool, bool) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:2533
    #2 0x55f68a42c71b in update_server_variable(MySQL_Session*, int, int&) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Variables.cpp:487
    #3 0x55f68a42a2de in MySQL_Variables::update_variable(MySQL_Session*, session_status, int&) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Variables.cpp:313
    #4 0x55f689fec0f2 in MySQL_Session::handler() /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:5295
    #5 0x55f689f65e5b in MySQL_Thread::process_all_sessions() /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Thread.cpp:4028
    #6 0x55f689f5f8d4 in MySQL_Thread::run() /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Thread.cpp:3388
    #7 0x55f689cce72c in mysql_worker_thread_func(void*) /home/javjarfer/Projects/proxysql_dev/src/main.cpp:524
    #8 0x7fb6ea05e11a in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:239
    #9 0x7fb6e8e969ca  (/usr/lib/libc.so.6+0x969ca) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)

Thread T48 created by T3 here:
    #0 0x7fb6ea11732c in pthread_create /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:250
    #1 0x55f68a0ce000 in admin_main_loop(void*) /home/javjarfer/Projects/proxysql_dev/lib/ProxySQL_Admin.cpp:2290
    #2 0x7fb6ea05e11a in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:239
    #3 0x7fb6e8e969ca  (/usr/lib/libc.so.6+0x969ca) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)

Thread T3 created by T0 here:
    #0 0x7fb6ea11732c in pthread_create /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:250
    #1 0x55f68a5ba512 in ProxySQL_Admin::init(bootstrap_info_t const&) /home/javjarfer/Projects/proxysql_dev/lib/Admin_Bootstrap.cpp:1060
    #2 0x55f689cd2bfb in ProxySQL_Main_init_Admin_module(bootstrap_info_t const&) /home/javjarfer/Projects/proxysql_dev/src/main.cpp:944
    #3 0x55f689cd68f4 in ProxySQL_Main_init_phase2___not_started(bootstrap_info_t const&) /home/javjarfer/Projects/proxysql_dev/src/main.cpp:1427
    #4 0x55f689ce6ee3 in main /home/javjarfer/Projects/proxysql_dev/src/main.cpp:2993
    #5 0x7fb6e8e27674  (/usr/lib/libc.so.6+0x27674) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)
    #6 0x7fb6e8e27728 in __libc_start_main (/usr/lib/libc.so.6+0x27728) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)
    #7 0x55f689ccc464 in _start (/home/javjarfer/Projects/proxysql_dev/src/proxysql+0x802464) (BuildId: 8de9e0b8d88c67d3575c76282cfc7693c0c2601a)

Thread T4 created by T0 here:
    #0 0x7fb6ea11732c in pthread_create /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:250
    #1 0x55f689f5624f in MySQL_Threads_Handler::create_thread(unsigned int, void* (*)(void*), bool) /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Thread.cpp:2447
    #2 0x55f689cd37f5 in ProxySQL_Main_init_MySQL_Threads_Handler_module() /home/javjarfer/Projects/proxysql_dev/src/main.cpp:992
    #3 0x55f689cd7232 in ProxySQL_Main_init_phase3___start_all() /home/javjarfer/Projects/proxysql_dev/src/main.cpp:1503
    #4 0x55f689ce6f94 in main /home/javjarfer/Projects/proxysql_dev/src/main.cpp:3004
    #5 0x7fb6e8e27674  (/usr/lib/libc.so.6+0x27674) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)
    #6 0x7fb6e8e27728 in __libc_start_main (/usr/lib/libc.so.6+0x27728) (BuildId: 4fe011c94a88e8aeb6f2201b9eb369f42b4a1e9e)
    #7 0x55f689ccc464 in _start (/home/javjarfer/Projects/proxysql_dev/src/proxysql+0x802464) (BuildId: 8de9e0b8d88c67d3575c76282cfc7693c0c2601a)

SUMMARY: AddressSanitizer: heap-use-after-free /home/javjarfer/Projects/proxysql_dev/lib/MySQL_Session.cpp:8151 in MySQL_Session::get_current_query(int)
Shadow bytes around the buggy address:
  0x7be6e8c4b600: fa fa fd fd fd fa fa fa fd fd fd fa fa fa fd fd
  0x7be6e8c4b680: fd fa fa fa fd fd fd fd fa fa fd fd fd fd fa fa
  0x7be6e8c4b700: fd fd fd fa fa fa fd fd fd fd fa fa fd fd fd fa
  0x7be6e8c4b780: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fa fa
  0x7be6e8c4b800: fa fa fa fa fd fd fd fd fa fa fd fd fd fa fa fa
=>0x7be6e8c4b880:[fd]fd fd fd fa fa fd fd fd fa fa fa fa fa fa fa
  0x7be6e8c4b900: fa fa fd fd fd fd fa fa fd fd fd fa fa fa fd fd
  0x7be6e8c4b980: fd fd fa fa fd fd fd fa fa fa fa fa fa fa fa fa
  0x7be6e8c4ba00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7be6e8c4ba80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7be6e8c4bb00: fa fa fa fa fd fd fd fa fa fa fd fd fd fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```

## Solution

Instead of using the query present in `myconn`, which could be allocated and freed from `Session` in case of rewrites. We use the query present in `Session` (`CurrentQuery`), which scope is well defined, and shouldn't point to invalid memory.

A small compilation warning was also fixed.