### PR TITLE
remove opensuse16 builds due to rpm packaging issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux
 amd64-centos: centos9 centos9-clang centos9-dbg centos10 centos10-clang centos10-dbg
 amd64-debian: debian12 debian12-clang debian12-dbg debian13 debian13-clang debian13-dbg
 amd64-fedora: fedora40 fedora40-clang fedora40-dbg fedora41 fedora41-clang fedora41-dbg fedora42 fedora42-clang fedora42-dbg
-amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
+amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
 	@${MAKE} -nk amd64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
@@ -330,7 +330,7 @@ arm64-almalinux: almalinux8 almalinux9 almalinux10
 arm64-centos: centos9 centos10
 arm64-debian: debian12 debian13
 arm64-fedora: fedora40 fedora41 fedora42
-arm64-opensuse: opensuse15 opensuse16
+arm64-opensuse: opensuse15
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:
 	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'


### PR DESCRIPTION
new rpm v4.20.1 in opensuse16 is creating an automatic dependence on group(proxysql) during install, and triggers an error:

```
Problem: 1: nothing provides 'group(proxysql)' needed by the to be installed proxysql-3.0.3-1.x86_64
00:12:26.997  Solution 1: do not install proxysql-3.0.3-1.x86_64
00:12:26.997  Solution 2: break proxysql-3.0.3-1.x86_64 by ignoring some of its dependencies
```

attempts to sort out the issue as described bellow was not successful:
https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/HG2JKUIKDTWQQIQSA43A4VWHX7YKJQT3/
https://en.opensuse.org/openSUSE:Packaging_guidelines#Users_and_Groups

more in issue #5183 