### PR TITLE
Increase sid on caching_sha2 full authentication

### DIFF
--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -2089,6 +2089,7 @@ void MySQL_Protocol::PPHR_sha2full(
 	if ((*myds)->switching_auth_stage == 0) {
 		const unsigned char perform_full_authentication = '\4';
 		generate_one_byte_pkt(perform_full_authentication);
+		(*myds)->pkt_sid++; // increment pkt_sid by one
 		// Required to be set; later used in 'PPHR_1' for setting current 'auth_plugin_id'. E.g:
 		//  - mysql-default_authentication_plugin: 'caching_sha2_password'
 		//  - Requested authentication: 'caching_sha2_password'


### PR DESCRIPTION
caching_sha2_password full authentication is a complex task that requires a lot of packets being sent and forth between client and server (ProxySQL in this case). Every packet needs to have an increased sequence ID (sid) according to protocol. ProxySQL was incorrectly forgetting to increase the sid when requesting a full authentication.
For some clients this is not a problem, while other clients will consider the incorrect sid a serious issue and abort the connection. This commit ensures that sid is correctly increased when requesting caching_sha2_password full authentication.