### PR TITLE
Add delay to let ProxySQL process mysql_stmt_close()

### DIFF
--- a/test/tap/tests/test_prepare_statement_memory_usage-t.cpp
+++ b/test/tap/tests/test_prepare_statement_memory_usage-t.cpp
@@ -90,6 +90,7 @@ int check_prepare_statement_mem_usage(MYSQL* proxysql_admin, MYSQL* proxysql, co
 		old_prep_stmt_backend_mem, new_prep_stmt_backend_mem);
 
 	mysql_stmt_close(stmt);
+	usleep(10000);
 	return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
Add delay to `test_prepare_statement_memory_usage-t` allowing ProxySQL time to process `mysql_stmt_close()`.