### PR TITLE
fix: Resolve openSUSE RPM packaging issue with automatic group dependency

### DIFF
--- a/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.conf
+++ b/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.conf
@@ -1,0 +1,2 @@
+# Type Name ID GECOS Home directory Shell
+u    proxysql - "ProxySQL Server" /var/lib/proxysql /bin/false

--- a/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -4,7 +4,7 @@
 
 # systemd-sysusers macros for proper user/group handling
 %sysusers_requires
-%sysusers_generate_pre %{name}.conf $name %{name}
+%sysusers_generate_pre %{name}.conf %{name} %{name}
 
 Summary: A high-performance MySQL and PostgreSQL proxy
 Name: proxysql
@@ -91,7 +91,7 @@ fi
 %{_bindir}/*
 %{_sysconfdir}/systemd/system/%{name}.service
 %{_sysconfdir}/systemd/system/%{name}-initial.service
-%{_sysusersdir}/%{name}.conf
+%config(noreplace) %{_sysusersdir}/%{name}.conf
 /usr/share/proxysql/tools/proxysql_galera_checker.sh
 /usr/share/proxysql/tools/proxysql_galera_writer.pl
 

--- a/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -2,12 +2,17 @@
 %define          debug_package %{nil}
 %define        __os_install_post %{_dbpath}/brp-compress
 
+# systemd-sysusers macros for proper user/group handling
+%sysusers_requires
+%sysusers_generate_pre %{name}.conf $name %{name}
+
 Summary: A high-performance MySQL and PostgreSQL proxy
 Name: proxysql
 Version: %{version}
 Release: 1
 License: GPL-3.0-only
 Source: %{name}-%{version}.tar.gz
+Source1: %{name}.conf
 URL: https://proxysql.com/
 Requires: gnutls, (openssl >= 3.0.0 or openssl3 >= 3.0.0)
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -32,15 +37,17 @@ fi
 /bin/rm -rf %{buildroot}
 /bin/mkdir -p %{buildroot}
 /bin/cp -a * %{buildroot}
+# Install sysusers file
+mkdir -p %{buildroot}%{_sysusersdir}
+install -m 644 %{SOURCE1} %{buildroot}%{_sysusersdir}/%{name}.conf
 
 %clean
 /bin/rm -rf %{buildroot}
 
 %post
-# Create relevant user, directories and configuration files
+# Create relevant directories and configuration files
 if [ ! -d /var/run/%{name} ]; then /bin/mkdir /var/run/%{name} ; fi
 if [ ! -d /var/lib/%{name} ]; then /bin/mkdir /var/lib/%{name} ; fi
-if ! id -u %{name} > /dev/null 2>&1; then useradd -r -U -s /bin/false -d /var/lib/%{name} -c "ProxySQL Server" %{name}; fi
 /bin/chown -R %{name}: /var/lib/%{name} /var/run/%{name}
 /bin/chown root:%{name} /etc/%{name}.cnf
 /bin/chmod 640 /etc/%{name}.cnf
@@ -84,6 +91,7 @@ fi
 %{_bindir}/*
 %{_sysconfdir}/systemd/system/%{name}.service
 %{_sysconfdir}/systemd/system/%{name}-initial.service
+%{_sysusersdir}/%{name}.conf
 /usr/share/proxysql/tools/proxysql_galera_checker.sh
 /usr/share/proxysql/tools/proxysql_galera_writer.pl
 


### PR DESCRIPTION
## Summary

Fixes the RPM packaging issue in openSUSE 16 where RPM v4.20.1 automatically generates a `group(proxysql)` dependency, causing installation failures.

## Problem

The RPM spec file used `useradd -r -U` in the `%post` scriptlet, which triggered automatic `group(proxysql)` dependency generation in newer RPM versions. Since no package provides this virtual dependency, installation fails with:

```
Problem: 1: nothing provides 'group(proxysql)' needed by the to be installed proxysql-3.0.3-1.x86_64
```

## Solution

Migrated to systemd-sysusers approach following openSUSE packaging guidelines:

- **Added systemd-sysusers configuration** (`proxysql.conf`) for proper user/group creation
- **Updated RPM spec** with correct macros:
  - Added `%sysusers_requires` and `%sysusers_generate_pre` macros  
  - Modified `%install` section to install sysusers file
  - Removed manual `useradd` command from `%post` scriptlet
  - Added sysusers file to `%files` section

## Changes

- **New file**: `docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.conf`
- **Modified**: `docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec`

This ensures compatibility with openSUSE 16's stricter dependency management while maintaining the same functionality.

Fixes: #5183