### PR TITLE
add opensuse16 packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux
 amd64-centos: centos9 centos9-clang centos9-dbg centos10 centos10-clang centos10-dbg
 amd64-debian: debian12 debian12-clang debian12-dbg debian13 debian13-clang debian13-dbg
 amd64-fedora: fedora40 fedora40-clang fedora40-dbg fedora41 fedora41-clang fedora41-dbg fedora42 fedora42-clang fedora42-dbg
-amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg
+amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
 	@${MAKE} -nk amd64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
@@ -330,7 +330,7 @@ arm64-almalinux: almalinux8 almalinux9 almalinux10
 arm64-centos: centos9 centos10
 arm64-debian: debian12 debian13
 arm64-fedora: fedora40 fedora41 fedora42
-arm64-opensuse: opensuse15
+arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:
 	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'

--- a/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -11,6 +11,7 @@ Source: %{name}-%{version}.tar.gz
 URL: https://proxysql.com/
 Requires: gnutls, (openssl >= 3.0.0 or openssl3 >= 3.0.0)
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+Provides: group(%{name})
 
 %description
 %{summary}
@@ -23,6 +24,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 if [ -f /var/lib/%{name}/PROXYSQL_UPGRADE ]; then
     rm -fr /var/lib/%{name}/PROXYSQL_UPGRADE
 fi
+if ! id -u %{name} > /dev/null 2>&1; then useradd -r -U -s /bin/false -d /var/lib/%{name} -c "ProxySQL Server" %{name}; fi
 
 %build
 # Packages are pre-built, nothing to do
@@ -40,7 +42,6 @@ fi
 # Create relevant user, directories and configuration files
 if [ ! -d /var/run/%{name} ]; then /bin/mkdir /var/run/%{name} ; fi
 if [ ! -d /var/lib/%{name} ]; then /bin/mkdir /var/lib/%{name} ; fi
-if ! id -u %{name} > /dev/null 2>&1; then useradd -r -U -s /bin/false -d /var/lib/%{name} -c "ProxySQL Server" %{name}; fi
 /bin/chown -R %{name}: /var/lib/%{name} /var/run/%{name}
 /bin/chown root:%{name} /etc/%{name}.cnf
 /bin/chmod 640 /etc/%{name}.cnf


### PR DESCRIPTION
fixes issue #5183
this issue was a blocker for adding OpenSUSE 16 packaging

- added directive `Provides: groups(proxysql)` to satisfy dependency parser during rpm install
- moved `proxysql` user/group creation to %pre section to ensure correct execution order
- added relevant distro entries in `Makefile`
