### PR TITLE
rework spec files, use rpm macros to handle systemd

### DIFF
--- a/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -1,6 +1,10 @@
+# we don't want separate debuginfo packages
+%global        _enable_debug_package 0
+%define        debug_package %{nil}
+# do not strip binaries
+%global        __strip /bin/true
 %define        __spec_install_post %{nil}
-%define          debug_package %{nil}
-%define        __os_install_post %{_dbpath}/brp-compress
+%define        __os_install_post %{_dbpath}/brp-compress %{nil}
 
 Summary: A high-performance MySQL and PostgreSQL proxy
 Name: proxysql
@@ -9,8 +13,12 @@ Release: 1
 License: GPL-3.0-only
 Source: %{name}-%{version}.tar.gz
 URL: https://proxysql.com/
-Requires: gnutls, (openssl >= 3.0.0 or openssl3 >= 3.0.0)
+Requires: gnutls
+Requires: (openssl >= 3.0.0 or openssl3 >= 3.0.0)
+#BuildRequires: systemd-rpm-macros
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+Provides: user(%{name})
+Provides: group(%{name})
 
 %description
 %{summary}
@@ -19,72 +27,56 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 %setup -q
 
 %pre
-# Cleanup artifacts
-if [ -f /var/lib/%{name}/PROXYSQL_UPGRADE ]; then 
-    rm -fr /var/lib/%{name}/PROXYSQL_UPGRADE
-fi
+# setup user, group
+getent passwd %{name} &>/dev/null || useradd -r -U -s /bin/false -d /var/lib/%{name} -c "ProxySQL Server" %{name}
 
 %build
 # Packages are pre-built, nothing to do
 
 %install
+export DONT_STRIP=1
 # Clean buildroot and install files
-/bin/rm -rf %{buildroot}
-/bin/mkdir -p %{buildroot}
-/bin/cp -a * %{buildroot}
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+mkdir -p %{buildroot}/var/run/%{name}
+mkdir -p %{buildroot}/var/lib/%{name}
 
 %clean
-/bin/rm -rf %{buildroot}
+rm -rf %{buildroot}
 
 %post
-# Create relevant user, directories and configuration files
-if [ ! -d /var/run/%{name} ]; then /bin/mkdir /var/run/%{name} ; fi
-if [ ! -d /var/lib/%{name} ]; then /bin/mkdir /var/lib/%{name} ; fi
-if ! id -u %{name} > /dev/null 2>&1; then useradd -r -U -s /bin/false -d /var/lib/%{name} -c "ProxySQL Server" %{name}; fi
-/bin/chown -R %{name}: /var/lib/%{name} /var/run/%{name}
-/bin/chown root:%{name} /etc/%{name}.cnf
-/bin/chmod 640 /etc/%{name}.cnf
-# Configure systemd appropriately.
-/bin/systemctl daemon-reload
-/bin/systemctl enable %{name}.service
-# Notify that a package update is in progress in order to start service.
-if [ $1 -eq 2 ]; then /bin/touch /var/lib/%{name}/PROXYSQL_UPGRADE ; fi
+# install service
+%systemd_post %{name}.service
+#%systemd_post_with_reload %{name}.service
 
 %preun
-# When uninstalling always try stop the service, ignore failures
-/bin/systemctl stop %{name} || true
+# remove service
+%systemd_preun %{name}.service
 
 %postun
-if [ $1 -eq 0 ]; then
-    # This is a pure uninstall, systemd unit file removed
-    # only daemon-reload is needed.
-    /bin/systemctl daemon-reload
-else
-    # This is an upgrade, ProxySQL should be started. This
-    # logic works for packages newer than 2.0.7 and ensures
-    # a faster restart time.
-    /bin/systemctl start %{name}.service
-    /bin/rm -fr /var/lib/%{name}/PROXYSQL_UPGRADE
-fi
+# remove user, group on uninstall
+# dont, its against the recommended practice
+#if [ "$1" == "0" ]; then
+#	groupdel %{name}
+#	userdel %{name}
+#fi
 
 %posttrans
-if [ -f /var/lib/%{name}/PROXYSQL_UPGRADE ]; then
-    # This is a safeguard to start the service after an update
-    # which supports legacy "preun" / "postun" logic and will
-    # only execute for packages before 2.0.7.
-    /bin/systemctl start %{name}.service
-    /bin/rm -fr /var/lib/%{name}/PROXYSQL_UPGRADE
-fi
+# reload, restart service
+#%systemd_posttrans_with_reload %{name}.service
+#%systemd_posttrans_with_restart %{name}.service
 
 %files
 %defattr(-,root,root,-)
-%config(noreplace) %{_sysconfdir}/%{name}.cnf
-%attr(640,root,%{name}) %{_sysconfdir}/%{name}.cnf
+%config(noreplace) %attr(640,root,%{name}) %{_sysconfdir}/%{name}.cnf
 %config(noreplace) %attr(640,root,%{name}) %{_sysconfdir}/logrotate.d/%{name}
 %{_bindir}/*
 %{_sysconfdir}/systemd/system/%{name}.service
 %{_sysconfdir}/systemd/system/%{name}-initial.service
 /usr/share/proxysql/tools/proxysql_galera_checker.sh
 /usr/share/proxysql/tools/proxysql_galera_writer.pl
+%config(noreplace) %attr(750,%{name},%{name}) /var/run/%{name}/
+%config(noreplace) %attr(750,%{name},%{name}) /var/lib/%{name}/
 
 %changelog

--- a/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
+++ b/docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/SPECS/proxysql.spec
@@ -1,6 +1,10 @@
+# we don't want separate debuginfo packages
+%global        _enable_debug_package 0
+%define        debug_package %{nil}
+# do not strip binaries
+%global        __strip /bin/true
 %define        __spec_install_post %{nil}
-%define          debug_package %{nil}
-%define        __os_install_post %{_dbpath}/brp-compress
+%define        __os_install_post %{_dbpath}/brp-compress %{nil}
 
 Summary: A high-performance MySQL and PostgreSQL proxy
 Name: proxysql
@@ -9,8 +13,11 @@ Release: 1
 License: GPL-3.0-only
 Source: %{name}-%{version}.tar.gz
 URL: https://proxysql.com/
-Requires: gnutls, (openssl >= 3.0.0 or openssl3 >= 3.0.0)
+Requires: gnutls
+Requires: (openssl >= 3.0.0 or openssl3 >= 3.0.0)
+#BuildRequires: systemd-rpm-macros
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+Provides: user(%{name})
 Provides: group(%{name})
 
 %description
@@ -20,72 +27,56 @@ Provides: group(%{name})
 %setup -q
 
 %pre
-# Cleanup artifacts
-if [ -f /var/lib/%{name}/PROXYSQL_UPGRADE ]; then
-    rm -fr /var/lib/%{name}/PROXYSQL_UPGRADE
-fi
-if ! id -u %{name} > /dev/null 2>&1; then useradd -r -U -s /bin/false -d /var/lib/%{name} -c "ProxySQL Server" %{name}; fi
+# setup user, group
+getent passwd %{name} &>/dev/null || useradd -r -U -s /bin/false -d /var/lib/%{name} -c "ProxySQL Server" %{name}
 
 %build
 # Packages are pre-built, nothing to do
 
 %install
+export DONT_STRIP=1
 # Clean buildroot and install files
-/bin/rm -rf %{buildroot}
-/bin/mkdir -p %{buildroot}
-/bin/cp -a * %{buildroot}
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+mkdir -p %{buildroot}/var/run/%{name}
+mkdir -p %{buildroot}/var/lib/%{name}
 
 %clean
-/bin/rm -rf %{buildroot}
+rm -rf %{buildroot}
 
 %post
-# Create relevant user, directories and configuration files
-if [ ! -d /var/run/%{name} ]; then /bin/mkdir /var/run/%{name} ; fi
-if [ ! -d /var/lib/%{name} ]; then /bin/mkdir /var/lib/%{name} ; fi
-/bin/chown -R %{name}: /var/lib/%{name} /var/run/%{name}
-/bin/chown root:%{name} /etc/%{name}.cnf
-/bin/chmod 640 /etc/%{name}.cnf
-# Configure systemd appropriately.
-/bin/systemctl daemon-reload
-/bin/systemctl enable %{name}.service
-# Notify that a package update is in progress in order to start service.
-if [ $1 -eq 2 ]; then /bin/touch /var/lib/%{name}/PROXYSQL_UPGRADE ; fi
+# install service
+%systemd_post %{name}.service
+#%systemd_post_with_reload %{name}.service
 
 %preun
-# When uninstalling always try stop the service, ignore failures
-/bin/systemctl stop %{name} || true
+# remove service
+%systemd_preun %{name}.service
 
 %postun
-if [ $1 -eq 0 ]; then
-    # This is a pure uninstall, systemd unit file removed
-    # only daemon-reload is needed.
-    /bin/systemctl daemon-reload
-else
-    # This is an upgrade, ProxySQL should be started. This
-    # logic works for packages newer than 2.0.7 and ensures
-    # a faster restart time.
-    /bin/systemctl start %{name}.service
-    /bin/rm -fr /var/lib/%{name}/PROXYSQL_UPGRADE
-fi
+# remove user, group on uninstall
+# dont, its against the recommended practice
+#if [ "$1" == "0" ]; then
+#	groupdel %{name}
+#	userdel %{name}
+#fi
 
 %posttrans
-if [ -f /var/lib/%{name}/PROXYSQL_UPGRADE ]; then
-    # This is a safeguard to start the service after an update
-    # which supports legacy "preun" / "postun" logic and will
-    # only execute for packages before 2.0.7.
-    /bin/systemctl start %{name}.service
-    /bin/rm -fr /var/lib/%{name}/PROXYSQL_UPGRADE
-fi
+# reload, restart service
+#%systemd_posttrans_with_reload %{name}.service
+#%systemd_posttrans_with_restart %{name}.service
 
 %files
 %defattr(-,root,root,-)
-%config(noreplace) %{_sysconfdir}/%{name}.cnf
-%attr(640,root,%{name}) %{_sysconfdir}/%{name}.cnf
+%config(noreplace) %attr(640,root,%{name}) %{_sysconfdir}/%{name}.cnf
 %config(noreplace) %attr(640,root,%{name}) %{_sysconfdir}/logrotate.d/%{name}
 %{_bindir}/*
 %{_sysconfdir}/systemd/system/%{name}.service
 %{_sysconfdir}/systemd/system/%{name}-initial.service
 /usr/share/proxysql/tools/proxysql_galera_checker.sh
 /usr/share/proxysql/tools/proxysql_galera_writer.pl
+%config(noreplace) %attr(750,%{name},%{name}) /var/run/%{name}/
+%config(noreplace) %attr(750,%{name},%{name}) /var/lib/%{name}/
 
 %changelog


### PR DESCRIPTION
address systemd related issues during package install

docker container images generally don't use systemd, this means:
- any systemd commands are unavailable
- any systemd units are unusable
- errors and misconfiguration due to above

use rpm macros which automatically handle systemd/no-systemd cases
