### PR TITLE
Improve fast forward replication CLIENT_DEPRECATE_EOF validation (closes #5062)

### DIFF
--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -738,8 +738,29 @@ bool MySQL_Connection::match_ff_req_options(const MySQL_Connection *c) {
 
 	// Only required to be checked for fast_forward sessions
 	if (frontend->myds && frontend->myds->sess->session_fast_forward) {
-		return (frontend->options.client_flag & CLIENT_DEPRECATE_EOF) ==
+		bool ret = (frontend->options.client_flag & CLIENT_DEPRECATE_EOF) ==
 				(backend->mysql->server_capabilities & CLIENT_DEPRECATE_EOF);
+		if (ret == false) {
+			if (frontend->myds && frontend->myds->PSarrayIN) {
+				PtrSizeArray * PSarrayIN = frontend->myds->PSarrayIN;
+				if (PSarrayIN->len == 1) {
+					PtrSize_t pkt = PSarrayIN->pdata[0];
+					if (pkt.size >= 5) {
+						unsigned char c = *reinterpret_cast<unsigned char*>(static_cast<char*>(pkt.ptr) + 4);
+						switch ((enum_mysql_command)c) {
+							case _MYSQL_COM_BINLOG_DUMP:
+							case _MYSQL_COM_BINLOG_DUMP_GTID:
+							case _MYSQL_COM_REGISTER_SLAVE:
+								ret = true;
+								break;
+							default:
+								break;
+						};
+					}
+				}
+			}
+		}
+		return ret;
 	} else {
 		return true;
 	}


### PR DESCRIPTION
## Summary

Enhance fast forward replication CLIENT_DEPRECATE_EOF validation to improve compatibility and robustness.

## Changes Made

- Improved `match_ff_req_options` function in `lib/mysql_connection.cpp`
- Enhanced CLIENT_DEPRECATE_EOF flag validation for fast forward replication scenarios
- Added special handling for binlog-related commands that should be allowed even when CLIENT_DEPRECATE_EOF flags don't match
- Implemented proper packet parsing to extract and validate MySQL command types

## Technical Details

The function now performs a more robust check by examining the actual MySQL command type when the initial CLIENT_DEPRECATE_EOF flags don't match between frontend and backend connections. Special handling is provided for:

- `_MYSQL_COM_BINLOG_DUMP`
- `_MYSQL_COM_BINLOG_DUMP_GTID` 
- `_MYSQL_COM_REGISTER_SLAVE`

These commands are now allowed even when CLIENT_DEPRECATE_EOF flags don't match, improving compatibility for fast forward replication connections with mixed deprecate EOF configurations.

## Test Coverage

This change is complemented by the new test `fast_forward_switch_replication_deprecate_eof.cpp` which validates all combinations of mysql-enable_client_deprecate_eof and mysql-enable_server_deprecate_eof settings.

## Closes

#5062