### PR TITLE
Add comments to select @@version queries to bypass ProxySQL interception

### DIFF
--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -400,7 +400,7 @@ int set_admin_global_variable(MYSQL *mysql, const string& var_name, const string
 int get_server_version(MYSQL *mysql, string& version) {
 	char query[128];
 
-	if (mysql_query(mysql, "select @@version")) {
+	if (mysql_query(mysql, "select /* set_testing */ @@version")) {
 		fprintf(stderr, "Error %d, %s\n",
 				mysql_errno(mysql), mysql_error(mysql));
 		return exit_status();

--- a/test/tap/tests/set_testing-240.h
+++ b/test/tap/tests/set_testing-240.h
@@ -474,7 +474,7 @@ int detect_version(CommandLine& cl, bool& is_mariadb) {
 		return 1;
 	}
 
-	MYSQL_QUERY(mysql, "select @@version");
+	MYSQL_QUERY(mysql, "select /* set_testing */ @@version");
 	MYSQL_RES *result = mysql_store_result(mysql);
 	MYSQL_ROW row;
 	while ((row = mysql_fetch_row(result)))

--- a/test/tap/tests/set_testing.h
+++ b/test/tap/tests/set_testing.h
@@ -473,7 +473,7 @@ int detect_version(CommandLine& cl, bool& is_mariadb, bool& is_cluster) {
 		return 1;
 	}
 
-	MYSQL_QUERY(mysql, "select @@version");
+	MYSQL_QUERY(mysql, "select /* set_testing */ @@version");
 	MYSQL_RES *result = mysql_store_result(mysql);
 	MYSQL_ROW row;
 	while ((row = mysql_fetch_row(result)))

--- a/test/tap/tests/test_firewall-t.cpp
+++ b/test/tap/tests/test_firewall-t.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
 	MYSQL_QUERY(mysqladmin, "load mysql variables to runtime");
 	
 	// Test that firewall initialized and blocks all queries
-	if (mysql_query(mysql, "select @@version")) {
+	if (mysql_query(mysql, "select /* set_testing */ @@version")) {
 		int myerrno = mysql_errno(mysql);
 		ok(myerrno == 1148, "Any query should be blocked");
 	}


### PR DESCRIPTION
## Summary
ProxySQL now responds directly to `SELECT @@version` queries, preventing them from reaching backend MySQL servers. This PR adds `/* set_testing */` comments to these queries in test files to prevent perfect match interception and allow them to run on the backend.

## Changes
- Updated `test/tap/tap/utils.cpp` - `get_server_version()` function
- Updated `test/tap/tests/set_testing-240.h` 
- Updated `test/tap/tests/set_testing.h`
- Updated `test/tap/tests/test_firewall-t.cpp`

## Why this change is needed
With ProxySQL v3.0, exact `SELECT @@version` queries are intercepted and responded to directly by ProxySQL. This breaks tests that rely on getting the actual backend MySQL version. Adding `/* set_testing */` comments creates query digests that don't match the interception pattern, allowing the queries to reach the backend.

## Test Plan
- [x] Verify the modified tests still pass
- [x] Ensure `SELECT @@version` queries with comments reach backend
- [x] Confirm ProxySQL still intercepts uncommented `SELECT @@version` queries