### PR TITLE
Enable SQLITE_ENABLE_MATH_FUNCTIONS flag in SQLite build

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -243,7 +243,7 @@ sqlite3/sqlite3/sqlite3.o:
 	cd sqlite3/sqlite3 && patch -p0 < ../from_unixtime.patch
 	cd sqlite3/sqlite3 && patch -p0 < ../sqlite3_pass_exts.patch
 	cd sqlite3/sqlite3 && patch -p0 < ../throw.patch
-	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o sqlite3.o sqlite3.c -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_DLL=1
+	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o sqlite3.o sqlite3.c -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_DLL=1 -DSQLITE_ENABLE_MATH_FUNCTIONS
 	cd sqlite3/sqlite3 && ${CC} -shared -o libsqlite3.so sqlite3.o
 
 sqlite3: sqlite3/sqlite3/sqlite3.o


### PR DESCRIPTION
## Summary
Enable `SQLITE_ENABLE_MATH_FUNCTIONS` compile flag to provide mathematical function support in SQLite queries through ProxySQL's SQLite interface.

## Changes
- Add `-DSQLITE_ENABLE_MATH_FUNCTIONS` to SQLite compilation flags in `deps/Makefile`

## Benefits
- Enables mathematical functions (`sin()`, `cos()`, `log()`, `pow()`, `sqrt()`, etc.) in SQL queries
- Enhances SQL capabilities for admin interface, query rules, and statistics
- Minimal binary size impact (~few KB)
- Fully backward compatible

## Testing
- Mathematical functions should work in admin SQLite interface
- Existing functionality remains unchanged

## Related Issue
Closes #5261

## Checklist
- [x] Code changes compile successfully
- [x] No breaking changes introduced
- [ ] Documentation updated if needed
- [ ] Tests added if applicable