### PR TITLE
[skip-ci] Update installation documentation for ProxySQL 3.0.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,30 +3,31 @@ How to install ProxySQL
 
 ProxySQL offers multiple ways of install:
 - install deb or rpm packages - https://github.com/sysown/proxysql/releases
-- install from the package repo - https://repo.proxysql.com/
-- build from git repo any taged or dev version - https://github.com/sysown/proxysql.git
+- install from the package repository - https://repo.proxysql.com/
+- build from git repo using docker - https://github.com/sysown/proxysql.git
 - build from source code archives - https://github.com/sysown/proxysql/releases
 
 
-Instaling using native installer packages
-----------------------------------------
+Installing using native installer packages
+------------------------------------------
 
 The list of currently supported operating systems for native packaging is:
+
 - AMD64
-  - CentOS 6,7,8
-  - Debian 8,9,0,11
-  - Ubuntu 14,16,18,20,22
-  - Fedora 27,28,33,34
-  - OpenSUSE 15
-  - AlmaLinux 8,9
+  - AlmaLinux 8, 9, 10
+  - CentOS Stream 9, 10
+  - Debian 12 (bookworm), 13 (trixie)
+  - Fedora 40, 41, 42
+  - OpenSUSE Leap 15, 16
+  - Ubuntu 22.04 (jammy), 24.04 (noble)
 - ARM64
-  - CentOS 7,8
-  - Debian 9,10,11
-  - Ubuntu 16,18,20,22
-  - Fedora 33,24
-  - OpenSUSE 15
-  - AlmaLinux 8,9
- 
+  - AlmaLinux 8, 9, 10
+  - CentOS Stream 9, 10
+  - Debian 12, 13
+  - Fedora 40, 41, 42
+  - OpenSUSE Leap 15, 16
+  - Ubuntu 22.04, 24.04
+
 Download a __deb__ or __rpm__ installer file for your OS and architecture from:
 
 https://github.com/sysown/proxysql/releases
@@ -36,9 +37,80 @@ There is also a choice of debug packages and CLang compiled packages.
 
 Installing from package repository
 ----------------------------------
-Please follow the intructions how to configure a repository:
+Please follow the instructions how to configure a repository:
 
 https://repo.proxysql.com/
+
+For ProxySQL 3.0.x, the repository URLs are:
+
+#### Ubuntu / Debian:
+```bash
+apt-get update && apt-get install -y --no-install-recommends lsb-release wget apt-transport-https ca-certificates
+wget -nv -O /etc/apt/trusted.gpg.d/proxysql-3.0.x-keyring.gpg 'https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key.gpg'
+echo "deb https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/$(lsb_release -sc)/ ./" | tee /etc/apt/sources.list.d/proxysql.list
+```
+
+#### Red Hat / CentOS / AlmaLinux:
+```bash
+cat > /etc/yum.repos.d/proxysql.repo << EOF
+[proxysql]
+name=ProxySQL YUM repository
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/centos/\$releasever
+gpgcheck=1
+gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
+EOF
+```
+
+#### Amazon Linux:
+```bash
+cat > /etc/yum.repos.d/proxysql.repo << EOF
+[proxysql]
+name=ProxySQL YUM repository
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/centos/8
+gpgcheck=1
+gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
+EOF
+```
+
+#### OpenSUSE:
+```bash
+cat > /etc/zypp/repos.d/proxysql.repo << EOF
+[proxysql]
+name=ProxySQL Zypper repository
+enabled=1
+autorefresh=0
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/opensuse/\$releasever_major
+gpgcheck=1
+EOF
+```
+or
+```bash
+zypper addrepo -g -n 'ProxySQL Zypper repository' 'https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/opensuse/$releasever_major' proxysql
+```
+
+#### FreeBSD:
+Installing (via pkg):
+```bash
+pkg install proxysql
+```
+Installing (via ports):
+```bash
+cd /usr/ports/databases/proxysql/ && make install clean
+```
+
+After configuring the repository, install ProxySQL with your package manager:
+
+```bash
+# Debian/Ubuntu
+apt-get update
+apt-get install proxysql
+
+# RHEL/CentOS/AlmaLinux/Fedora/Amazon Linux
+yum install proxysql
+
+# OpenSUSE
+zypper install proxysql
+```
 
 
 Building and installing from git repo using docker
@@ -49,11 +121,11 @@ Make sure you have docker installed, best from upstream docker.io
 
 https://docs.docker.com/engine/install/
 
-```
+```bash
 git clone https://github.com/sysown/proxysql.git
 cd proxysql
-git checkout -d v2.4.2
-make ubuntu22
+git checkout v3.0.3
+make ubuntu24   # or other target: ubuntu22, debian12, debian13, centos9, centos10, fedora40, fedora41, fedora42, opensuse15, opensuse16, almalinux8, almalinux9, almalinux10
 ```
 This will checkout the chosen version tag, pull the latest build image from DockerHub and build binaries and packages for the target distro.
 
@@ -72,32 +144,35 @@ https://github.com/sysown/proxysql/releases
 
 or get the latest development sources from:
 
-https://github.com/sysown/proxysql/archive/refs/heads/v2.x.zip
+https://github.com/sysown/proxysql/archive/refs/heads/v3.x.zip
 
 Make sure you have installed the equivalent for each of these packages for your operating system:
-- automake
-- bzip2
-- cmake
-- make
-- g++
-- gcc
-- git
-- patch
-- openssl
-- openssl-devel   # Only for RHEL / CentOS based
-- libssl-dev      # Only for Debian / Ubuntu based
-- uuid-dev
 
-Shortcut commands for installing pre-requisites:
+### Debian / Ubuntu based:
+```bash
+apt-get install -y automake bzip2 cmake make g++ gcc git openssl libssl-dev libgnutls28-dev libmysqlclient-dev libunwind8 libunwind-dev uuid-dev libncurses-dev libicu-dev libevent-dev libtirpc-dev
 ```
-# RHEL / CentOS < 7:
-yum install -y automake bzip2 cmake make g++ gcc git openssl openssl-devel gnutls libtool patch libuuid-devel
 
-# CentOS 7.4+ / Fedora 28+:
-yum install -y automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel gnutls gnutls-devel libtool patch libuuid-devel
+### RHEL / CentOS / AlmaLinux based:
+```bash
+yum install -y epel-release
+yum install -y automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel gnutls gnutls-devel libunwind libunwind-devel perl-IPC-Cmd perl-FindBin perl-Time-Piece libuuid-devel zlib-devel libicu-devel libevent-devel ncurses-devel
+yum install -y --enablerepo=crb libtirpc-devel rpcgen
+```
 
-# Debian / Ubuntu Based:
-apt-get install -y automake bzip2 cmake make g++ gcc git openssl libssl-dev libgnutls28-dev libtool patch uuid-dev
+### Fedora based:
+```bash
+dnf install -y automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel gnutls gnutls-devel libunwind libunwind-devel perl-FindBin perl-IPC-Cmd perl-Time-Piece libuuid-devel libicu-devel libevent-devel ncurses-devel libtirpc-devel rpcgen
+```
+
+### OpenSUSE based:
+```bash
+zypper install -y automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel gnutls gnutls-devel libunwind libunwind-devel perl-IPC-Cmd perl-FindBin perl-Time-Piece libuuid-devel libicu-devel libevent-devel ncurses-devel libtirpc-devel rpcgen
+```
+
+### macOS (using Homebrew):
+```bash
+brew install automake bzip2 cmake make git gpatch gnutls ossp-uuid
 ```
 
 For more details, inspect the docker build images:
@@ -107,12 +182,6 @@ https://github.com/ProxySQL/docker-images/tree/main/build-images
 For CLang builds, inspect the docker build-clang images:
 
 https://github.com/ProxySQL/docker-images/tree/main/build-clang-images
-
-On modern Mac OSX, ProxySQL's dependencies are not fully satisfied by the tools included with the XCode/clang toolkit. Using the [Homebrew](https://brew.sh/) OSX package manager, dependencies can be installed and located on OSX like this:
-
-```bash
-brew install automake bzip2 cmake make git gpatch gnutls ossp-uuid
-```
 
 Go to the directory where you cloned the repo (or unpacked the tarball) and run:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@ The list of currently supported operating systems for native packaging is:
 
 - AMD64
   - AlmaLinux 8, 9, 10
+  - Amazon Linux 2
   - CentOS Stream 9, 10
   - Debian 12 (bookworm), 13 (trixie)
   - Fedora 40, 41, 42
@@ -22,6 +23,7 @@ The list of currently supported operating systems for native packaging is:
   - Ubuntu 22.04 (jammy), 24.04 (noble)
 - ARM64
   - AlmaLinux 8, 9, 10
+  - Amazon Linux 2
   - CentOS Stream 9, 10
   - Debian 12, 13
   - Fedora 40, 41, 42
@@ -50,7 +52,7 @@ wget -nv -O /etc/apt/trusted.gpg.d/proxysql-3.0.x-keyring.gpg 'https://repo.prox
 echo "deb https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/$(lsb_release -sc)/ ./" | tee /etc/apt/sources.list.d/proxysql.list
 ```
 
-#### Red Hat / CentOS / AlmaLinux:
+#### Red Hat / CentOS:
 ```bash
 cat > /etc/yum.repos.d/proxysql.repo << EOF
 [proxysql]
@@ -67,6 +69,17 @@ cat > /etc/yum.repos.d/proxysql.repo << EOF
 [proxysql]
 name=ProxySQL YUM repository
 baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/centos/8
+gpgcheck=1
+gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
+EOF
+```
+
+#### AlmaLinux:
+```bash
+cat > /etc/yum.repos.d/proxysql.repo << EOF
+[proxysql]
+name=ProxySQL YUM repository
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/almalinux/\$releasever
 gpgcheck=1
 gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
 EOF
@@ -105,8 +118,11 @@ After configuring the repository, install ProxySQL with your package manager:
 apt-get update
 apt-get install proxysql
 
-# RHEL/CentOS/AlmaLinux/Fedora/Amazon Linux
+# RHEL/CentOS/AlmaLinux/Amazon Linux
 yum install proxysql
+
+# Fedora
+dnf install proxysql
 
 # OpenSUSE
 zypper install proxysql

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Released packages can be found here: https://github.com/sysown/proxysql/releases
 
 Just download a package and use your systems package manager to install it:
 ```bash
-wget https://github.com/sysown/proxysql/releases/download/v2.4.2/proxysql_2.4.2-ubuntu20_amd64.deb
-dpkg -i proxysql_2.4.2-ubuntu20_amd64.deb
+wget https://github.com/sysown/proxysql/releases/download/v3.0.3/proxysql_3.0.3-ubuntu24_amd64.deb
+dpkg -i proxysql_3.0.3-ubuntu24_amd64.deb
 ```
 
 Alternatively you can also use the available repositories:
@@ -45,8 +45,8 @@ Alternatively you can also use the available repositories:
 Adding repository:
 ```bash
 apt-get update && apt-get install -y --no-install-recommends lsb-release wget apt-transport-https ca-certificates
-wget -nv -O /etc/apt/trusted.gpg.d/proxysql-2.4.x-keyring.gpg 'https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/repo_pub_key.gpg'
-echo "deb https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/$(lsb_release -sc)/ ./" | tee /etc/apt/sources.list.d/proxysql.list
+wget -nv -O /etc/apt/trusted.gpg.d/proxysql-3.0.x-keyring.gpg 'https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key.gpg'
+echo "deb https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/$(lsb_release -sc)/ ./" | tee /etc/apt/sources.list.d/proxysql.list
 ```
 
 Installing:
@@ -62,9 +62,9 @@ Adding repository:
 cat > /etc/yum.repos.d/proxysql.repo << EOF
 [proxysql]
 name=ProxySQL YUM repository
-baseurl=https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/centos/\$releasever
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/centos/\$releasever
 gpgcheck=1
-gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/repo_pub_key
+gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
 EOF
 ```
 
@@ -80,9 +80,9 @@ Adding repository:
 cat > /etc/yum.repos.d/proxysql.repo << EOF
 [proxysql]
 name=ProxySQL YUM repository
-baseurl=https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/centos/8
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/centos/8
 gpgcheck=1
-gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/repo_pub_key
+gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
 EOF
 ```
 
@@ -98,9 +98,9 @@ Adding repository:
 cat > /etc/yum.repos.d/proxysql.repo << EOF
 [proxysql]
 name=ProxySQL YUM repository
-baseurl=https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/almalinux/\$releasever
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/almalinux/\$releasever
 gpgcheck=1
-gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/repo_pub_key
+gpgkey=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/repo_pub_key
 EOF
 ```
 
@@ -118,13 +118,13 @@ cat > /etc/zypp/repos.d/proxysql.repo << EOF
 name=ProxySQL Zypper repository
 enabled=1
 autorefresh=0
-baseurl=https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/opensuse/\$releasever_major
+baseurl=https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/opensuse/\$releasever_major
 gpgcheck=1
 EOF
 ```
 or
 ```bash
-zypper addrepo -g -n 'ProxySQL Zypper repository' 'https://repo.proxysql.com/ProxySQL/proxysql-2.4.x/opensuse/$releasever_major' proxysql
+zypper addrepo -g -n 'ProxySQL Zypper repository' 'https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/opensuse/$releasever_major' proxysql
 ```
 
 Installing:
@@ -215,8 +215,8 @@ service proxysql-initial start
 ### Upgrades
 Just install the new package and restart ProxySQL:
 ```bash
-wget https://github.com/sysown/proxysql/releases/download/v2.1.0/proxysql_2.1.0-ubuntu16_amd64.deb
-dpkg -i proxysql_2.1.0-ubuntu16_amd64.deb
+wget https://github.com/sysown/proxysql/releases/download/v3.0.3/proxysql_3.0.3-ubuntu24_amd64.deb
+dpkg -i proxysql_3.0.3-ubuntu24_amd64.deb
 service proxysql restart
 ```
 
@@ -225,7 +225,7 @@ service proxysql restart
 $ proxysql --version
 ```
 ```bash
-ProxySQL version 2.1.0-544-g17a4b4a7, codename Truls
+ProxySQL version 3.0.3-291-gcce161b, codename Truls
 ```
 A debug version has `_DEBUG` in its version string.
 It is slower than non-debug version, but easier to debug in case of failures.
@@ -233,8 +233,7 @@ It is slower than non-debug version, but easier to debug in case of failures.
 $ proxysql --version
 ```
 ```bash
-Main init phase0 completed in 0.000146 secs.
-ProxySQL version 2.1.0-544-g17a4b4a7_DEBUG, codename Truls
+ProxySQL version 3.0.3-291-gcce161b_DEBUG, codename Truls
 ```
 
 ### Configuring ProxySQL via the `admin interface`


### PR DESCRIPTION
## Summary
- Updated README.md and INSTALL.md to reflect ProxySQL 3.0.3 release
- Updated version references from 2.4.2 to 3.0.3 throughout documentation
- Updated repository URLs from proxysql-2.4.x to proxysql-3.0.x
- Updated supported OS list to current distributions (AlmaLinux 8-10, CentOS Stream 9-10, Debian 12-13, Fedora 40-42, OpenSUSE Leap 15-16, Ubuntu 22.04-24.04)
- Completely rewrote build dependency sections based on actual Dockerfiles from ProxySQL/docker-images repository
- Removed outdated "shortcut commands" that were incorrect
- Added accurate package lists for Debian/Ubuntu, RHEL/CentOS/AlmaLinux, Fedora, OpenSUSE, and macOS

## Test Plan
- [ ] Verify all version references are updated to 3.0.3
- [ ] Check repository URLs point to proxysql-3.0.x
- [ ] Validate supported OS list matches current packaging targets
- [ ] Review build dependency lists against Dockerfiles in docker-images repository
- [ ] Ensure documentation formatting is correct (markdown, code blocks)
- [ ] Test example commands for syntax errors
- [ ] Verify links to external resources (repo.proxysql.com, github.com releases) are valid

The documentation now accurately reflects how to install and build ProxySQL 3.0.3 on modern operating systems.