### PR TITLE
bump version to 3.0.5 at the beginning of the development cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ O3 := -O3 -mtune=native
 ALL_DEBUG := $(O0) -ggdb -DDEBUG
 NO_DEBUG := $(O2) -ggdb
 DEBUG := $(ALL_DEBUG)
-CURVER ?= 3.0.4
+CURVER ?= 3.0.5
 #export DEBUG
 #export EXTRALINK
 export MAKE


### PR DESCRIPTION
bump version to 3.0.5 at the beginning of the development cycle

set `CURVER=3.0.5` in Makefile

tag merge commit with tag `3.0.5`
