### PR TITLE
Fix timezone parsing to support 3-component IANA names and hyphens

### DIFF
--- a/lib/MySQL_Set_Stmt_Parser.cpp
+++ b/lib/MySQL_Set_Stmt_Parser.cpp
@@ -244,16 +244,58 @@ void MySQL_Set_Stmt_Parser::generateRE_parse1v2() {
 	vp = "(?:| *(?:\\+|\\-) *)\\d+(?:|\\.\\d+)"; // a signed or unsigned integer or decimal , N7 = merge of N3 and N6
 	var_patterns.push_back(vp);
 
+	/**
+	 * @page time_zone_parsing MySQL time_zone Variable Parsing
+	 *
+	 * The MySQL @c time_zone system variable accepts two formats:
+	 *
+	 * @section tz_numeric_format Numeric Offset Format
+	 * Specifies timezone as an offset from UTC in the format [+|-]HH:MM.
+	 * Examples: @c '+08:00' , @c '-05:30' , @c '+00:00' (UTC)
+	 *
+	 * @section tz_iana_format IANA Timezone Name Format
+	 * Specifies timezone using IANA timezone database names.
+	 * The naming convention follows the pattern @c Area/Location or
+	 * @c Area/Country/Location.
+	 *
+	 * @subsection tz_iana_components IANA Timezone Name Components
+	 * - **Area**: Continent, ocean, or special region (e.g., America, Europe, Asia, Etc)
+	 * - **Location**: City, island, or country name
+	 *
+	 * IANA timezone names may contain:
+	 * - Word characters (letters, digits, underscores): @c [a-zA-Z0-9_]
+	 * - Hyphens in place of spaces: @c Port-au-Prince , @c Rio_Gallegos
+	 *
+	 * @subsection tz_iana_examples IANA Timezone Examples
+	 * - 2 components: @c Europe/London , @c America/New_York , @c Asia/Tokyo
+	 * - 3 components: @c America/Argentina/Buenos_Aires , @c America/Indiana/Indianapolis
+	 * - With hyphens: @c America/Port-au-Prince , @c America/Blanc-Sablon
+	 *
+	 * @subsection tz_special_values Special Values
+	 * The following special values are also supported (matched by other patterns):
+	 * - @c SYSTEM : Use the system's timezone
+	 * - @c UTC : Coordinated Universal Time
+	 *
+	 * @subsection tz_limitations Limitations
+	 * The regex pattern limits matching to 2-3 components (e.g., @c Area/Location or
+	 * @c Area/Country/Location). While IANA timezone names with 4+ components are
+	 * theoretically possible, they are extremely rare and not currently supported.
+	 *
+	 * @see https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html
+	 * @see https://www.iana.org/time-zones
+	 */
 	{
-		// time_zone in numeric format:
-		// - +/- sign
-		// 1 or 2 digits
-		// :
-		// 2 digits
+		// time_zone in numeric format: [+|-]HH:MM
+		// Examples: '+08:00', '-05:30', '+00:00'
 		string tzd =  "(?:(?:\\+|\\-)(?:|\\d)\\d:\\d\\d)";
-		// time_zone in string format:
-		// word / word
-		string tzw =  "(?:\\w+/\\w+)";
+		// time_zone in string format: IANA timezone names
+		// Supports 2-3 components with optional hyphens:
+		//   - 2 components: Area/Location (e.g., Europe/London, America/New_York)
+		//   - 3 components: Area/Country/Location (e.g., America/Argentina/Buenos_Aires)
+		//   - With hyphens: America/Port-au-Prince, America/Blanc-Sablon
+		// Note: Does not match bare words like 'SYSTEM' or 'UTC' - these are matched
+		//       by other patterns in var_patterns (e.g., vp2 at line ~197)
+		string tzw =  "(?:[\\w-]+(?:/[\\w-]+){1,2})";
 		vp = "(?:" + tzd + "|" + tzw + ")"; // time_zone in numeric and string format
 	}
 	for (auto it = quote_symbol.begin(); it != quote_symbol.end(); it++) {

--- a/test/tap/tests/setparser_test_common.h
+++ b/test/tap/tests/setparser_test_common.h
@@ -156,7 +156,7 @@ static Test time_zone[] = {
   // Timezone names with hyphens (additional fix)
   { "SET time_zone = 'America/Port-au-Prince'", { Expected("time_zone",  {"America/Port-au-Prince"}) } },
   { "SET time_zone = 'America/Blanc-Sablon'", { Expected("time_zone",  {"America/Blanc-Sablon"}) } },
-  { "SET time_zone = \"Atlantic/Canary\"", { Expected("time_zone",  {"Atlantic/Canary"}) } },
+  { "SET time_zone = \"US/East-Indiana\"", { Expected("time_zone",  {"US/East-Indiana"}) } },
   // Various numeric offsets
   { "SET time_zone = '+08:00'", { Expected("time_zone",  {"+08:00"}) } },
   { "SET time_zone = '-05:30'", { Expected("time_zone",  {"-05:30"}) } },

--- a/test/tap/tests/setparser_test_common.h
+++ b/test/tap/tests/setparser_test_common.h
@@ -136,6 +136,7 @@ static Test syntax_errors[] = {
 };
 
 static Test time_zone[] = {
+  // Original tests - 2 component timezone names
   { "SET @@time_zone = 'Europe/Paris'", { Expected("time_zone",  {"Europe/Paris"}) } },
   { "SET @@time_zone = '+00:00'", { Expected("time_zone",  {"+00:00"}) } },
   { "SET @@time_zone = \"Europe/Paris\"", { Expected("time_zone",  {"Europe/Paris"}) } },
@@ -144,6 +145,24 @@ static Test time_zone[] = {
   { "SET @@TIME_ZONE = @OLD_TIME_ZONE", { Expected("time_zone",  {"@OLD_TIME_ZONE"}) } },
   { "SET @@TIME_ZONE := 'SYSTEM'", { Expected("time_zone",  {"SYSTEM"}) } },
   { "SET time_zone := 'SYSTEM'", { Expected("time_zone",  {"SYSTEM"}) } },
+  // Special values - UTC and SYSTEM
+  { "SET time_zone = 'UTC'", { Expected("time_zone",  {"UTC"}) } },
+  { "SET time_zone = SYSTEM", { Expected("time_zone",  {"SYSTEM"}) } },
+  { "SET time_zone = UTC", { Expected("time_zone",  {"UTC"}) } },
+  // 3 component timezone names (bug fix for GitHub issue #4993)
+  { "SET time_zone = 'America/Argentina/Buenos_Aires'", { Expected("time_zone",  {"America/Argentina/Buenos_Aires"}) } },
+  { "SET time_zone = 'America/Indiana/Indianapolis'", { Expected("time_zone",  {"America/Indiana/Indianapolis"}) } },
+  { "SET time_zone = \"America/Kentucky/Louisville\"", { Expected("time_zone",  {"America/Kentucky/Louisville"}) } },
+  // Timezone names with hyphens (additional fix)
+  { "SET time_zone = 'America/Port-au-Prince'", { Expected("time_zone",  {"America/Port-au-Prince"}) } },
+  { "SET time_zone = 'America/Blanc-Sablon'", { Expected("time_zone",  {"America/Blanc-Sablon"}) } },
+  { "SET time_zone = \"Atlantic/Canary\"", { Expected("time_zone",  {"Atlantic/Canary"}) } },
+  // Various numeric offsets
+  { "SET time_zone = '+08:00'", { Expected("time_zone",  {"+08:00"}) } },
+  { "SET time_zone = '-05:30'", { Expected("time_zone",  {"-05:30"}) } },
+  { "SET time_zone = '-10:00'", { Expected("time_zone",  {"-10:00"}) } },
+  // Combined with other SET variables
+  { "SET time_zone = 'America/Argentina/Buenos_Aires', sql_mode = 'TRADITIONAL'", { Expected("time_zone",  {"America/Argentina/Buenos_Aires"}), Expected("sql_mode", {"TRADITIONAL"}) } },
 };
 
 static Test session_track_gtids[] = {


### PR DESCRIPTION
## Summary

Fixes a parsing error in the MySQL SET statement parser that occurred when processing `SET time_zone` statements with:

1. **Three-component IANA timezone names** (e.g., `America/Argentina/Buenos_Aires`, `America/Indiana/Indianapolis`)
2. **Timezone names containing hyphens** (e.g., `America/Port-au-Prince`, `America/Blanc-Sablon`)

Previously, the regex pattern `(?:\w+/\w+)` only matched 2-component timezone names and did not support hyphens. This caused parsing errors in the logs:

```
[ERROR] Unable to parse query. If correct, report it as a bug: 
SET time_zone="America/Argentina/Buenos_Aires";
```

When multiplexing is enabled, this bug causes timestamps to be incorrectly written to the database.

## Changes

### Core Fix
- **File**: `lib/MySQL_Set_Stmt_Parser.cpp:298`
- **Old regex**: `(?:\w+/\w+)` - matches only 2 components, no hyphens
- **New regex**: `(?:[\w-]+(?:/[\w-]+){1,2})` - matches 2-3 components with hyphens

### Documentation
- Added comprehensive Doxygen documentation for the timezone parsing code
- Documents both numeric offset format (`+08:00`) and IANA timezone name format
- Clearly explains the 2-3 component limitation and character set support
- References MySQL and IANA timezone documentation

### Tests
- Extended `time_zone` test array in `test/tap/tests/setparser_test_common.h`
- Added test cases for:
  - 3-component timezone names (the bug fix)
  - Timezone names with hyphens (additional improvement)
  - UTC and SYSTEM special values (already worked, now explicitly tested)
  - Various numeric offsets

## Examples of Supported Timezones

| Format | Examples |
|--------|----------|
| Numeric offset | `+08:00`, `-05:30`, `+00:00` |
| 2 components | `Europe/London`, `America/New_York`, `Asia/Tokyo` |
| 3 components | `America/Argentina/Buenos_Aires`, `America/Indiana/Indianapolis` |
| With hyphens | `America/Port-au-Prince`, `America/Blanc-Sablon` |
| Special values | `SYSTEM`, `UTC` |

## Addresses Review Feedback

This PR incorporates feedback from **gemini-code-assist** on the original #4993:
- ✅ Fixed the 3-component timezone name parsing issue
- ✅ Added support for hyphens in timezone names (e.g., `America/Port-au-Prince`)
- ✅ Updated code comments to reflect the new pattern capabilities
- ✅ Added comprehensive Doxygen documentation

## Limitations

The regex pattern limits matching to **2-3 components** (e.g., `Area/Location` or `Area/Country/Location`). While IANA timezone names with 4+ components are theoretically possible, they are extremely rare and not currently supported. This is documented in the code.

## Related

- Fixes #4993
- Addresses gemini-code-assist review comments on the original PR
- Fresh start on v3.0 branch with comprehensive documentation

Credit to @pbrydzinski for the original PR