### PR TITLE
Fix malformed Bind packets when client provides a single parameter format

### DIFF
--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -1839,7 +1839,29 @@ void PgSQL_Connection::stmt_execute_start() {
 					"Failed to read param format", false);
 				return;
 			}
-			param_formats[i] = format;
+			param_formats[i] = format; // 0 = text, 1 = binary
+		}
+	}
+
+	// Normalize param formats for libpq:
+	// According to the PostgreSQL Bind message specification:
+	// https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-BIND
+	//  - num_param_formats = 0 -> all parameters are TEXT
+	//  - num_param_formats = 1 -> the single format applies to all parameters
+	//  - num_param_formats = num_param_values -> formats are applied per-parameter in order
+	// Any other number of parameter formats is a protocol error.
+	if (!param_formats.empty()) {
+		if (param_formats.size() == 1 && param_values.size() > 1) {
+			// PostgreSQL protocol allows 1 format for all params,
+			// libpq DOES NOT, we must expand
+			int fmt = param_formats[0];
+			param_formats.resize(param_values.size(), fmt);
+		} else if (param_formats.size() != param_values.size()) {
+			proxy_error("Invalid param format count: got %zu, expected %zu\n",
+				param_formats.size(), param_values.size());
+			set_error(PGSQL_ERROR_CODES::ERRCODE_INVALID_PARAMETER_VALUE,
+				"Invalid parameter format count", false);
+			return;
 		}
 	}
 
@@ -1858,8 +1880,13 @@ void PgSQL_Connection::stmt_execute_start() {
 		}
 	}
 
+	// If the client did not send any parameter formats (num_param_formats = 0),
+	// PostgreSQL protocol defines this as "all parameters are TEXT".
+	// libpq represents this case by passing paramFormats = nullptr.
+	const int* param_formats_data = (param_formats.empty() == false ? param_formats.data() : nullptr);
+
 	if (PQsendQueryPrepared(pgsql_conn, query.backend_stmt_name, param_values.size(),
-		param_values.data(), param_lengths.data(), param_formats.data(),
+		param_values.data(), param_lengths.data(), param_formats_data,
 		(result_formats.size() > 0) ? result_formats[0] : 0) == 0) {
 		set_error_from_PQerrorMessage();
 		proxy_error("Failed to send execute prepared statement. %s\n", get_error_code_with_message().c_str());

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -243,5 +243,6 @@
   "test_ignore_min_gtid-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-query_digests_stages_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-monitor_ssl_connections_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5273_bind_parameter_format-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "unit-strip_schema_from_query-t": [ "unit-tests-g1" ]
 }

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -285,6 +285,9 @@ test_wexecvp_syscall_failures-t: test_wexecvp_syscall_failures-t.cpp $(TAP_LDIR)
 pgsql-extended_query_protocol_test-t: pgsql-extended_query_protocol_test-t.cpp pg_lite_client.cpp $(TAP_LDIR)/libtap.so
 	$(CXX) $< pg_lite_client.cpp $(IDIRS) $(LDIRS) $(OPT) $(MYLIBS) $(STATIC_LIBS) -o $@
 
+pgsql-reg_test_5273_bind_parameter_format-t: pgsql-reg_test_5273_bind_parameter_format-t.cpp pg_lite_client.cpp $(TAP_LDIR)/libtap.so
+	$(CXX) $< pg_lite_client.cpp $(IDIRS) $(LDIRS) $(OPT) $(MYLIBS) $(STATIC_LIBS) -o $@
+
 ### clean targets
 
 .SILENT: clean

--- a/test/tap/tests/pg_lite_client.cpp
+++ b/test/tap/tests/pg_lite_client.cpp
@@ -562,25 +562,34 @@ void PgConnection::bindStatement(
     // Statement name
     writeStringToBuffer(packet, stmtName);
 
-    // Parameter formats
-    bool any_binary_format = false;
+    
+   // Check if all parameters have the same format
+   bool all_same_format = true;
+   int16_t first_format = params.empty() ? 0 : params[0].format;
 
     for (const auto& param : params) {
-        if (param.format == 1) {
-			any_binary_format = true;
-			break;  // At least one binary format
-       }
+        if (param.format != first_format) {
+            all_same_format = false;
+            break;
+        }
     }
 
-    if (any_binary_format) {
+    if (params.empty()) {
+        writeInt16ToBuffer(packet, 0); // No parameters
+    } else if (all_same_format && first_format == 0) {
+        // All text format - send 0 formats (default)
+        writeInt16ToBuffer(packet, 0);
+    } else if (all_same_format) {
+        // All same non-text format - send single format
+        writeInt16ToBuffer(packet, 1);
+        writeInt16ToBuffer(packet, first_format);
+    } else {
+        // Mixed formats - send format for each parameter
         writeInt16ToBuffer(packet, params.size());
         for (const auto& param : params) {
             writeInt16ToBuffer(packet, param.format);
         }
-    } else {
-        writeInt16ToBuffer(packet, 0); // Default: all text
-	}
-
+    }
   
     // Parameters
     writeInt16ToBuffer(packet, params.size());
@@ -624,6 +633,82 @@ void PgConnection::bindStatement(
         sendSync();
 		waitForMessage(BIND_COMPLETE, "bind", sync);
     }
+}
+
+// Extended bind with explicit format control
+void PgConnection::bindStatementEx(
+    const std::string& stmtName,
+    const std::string& portalName,
+    const std::vector<Param>& params,
+    const std::vector<int16_t>& paramFormats,
+    const std::vector<int16_t>& resultFormats,
+    bool sync
+) {
+    std::vector<uint8_t> packet;
+
+    // Portal name
+    writeStringToBuffer(packet, portalName);
+    // Statement name
+    writeStringToBuffer(packet, stmtName);
+    
+    // Parameter formats (explicit array)
+    writeInt16ToBuffer(packet, paramFormats.size());
+    for (int16_t fmt : paramFormats) {
+        writeInt16ToBuffer(packet, fmt);
+    }
+    
+    // Parameters
+    writeInt16ToBuffer(packet, params.size());
+    for (const auto& param : params) {
+        if (std::holds_alternative<std::monostate>(param.value)) {
+            writeInt32ToBuffer(packet, -1); // NULL
+        } else if (std::holds_alternative<std::string>(param.value)) {
+            const std::string & s = std::get<std::string>(param.value);
+            writeInt32ToBuffer(packet, s.size());
+            packet.insert(packet.end(), s.begin(), s.end());
+            
+        } else if (std::holds_alternative<std::vector<uint8_t>>(param.value)) {
+            const std::vector<uint8_t>&v = std::get<std::vector<uint8_t>>(param.value);
+            writeInt32ToBuffer(packet, v.size());
+            packet.insert(packet.end(), v.begin(), v.end());  
+         } else if (std::holds_alternative<int32_t>(param.value)) {
+            const int32_t & v = std::get<int32_t>(param.value);
+            writeInt32ToBuffer(packet, sizeof(int32_t));
+            packet.push_back((v >> 24) & 0xFF);
+            packet.push_back((v >> 16) & 0xFF);
+            packet.push_back((v >> 8) & 0xFF);
+            packet.push_back(v & 0xFF);
+        }
+    }
+    // Result formats
+    if (resultFormats.empty()) {
+        writeInt16ToBuffer(packet, 0); // Default: all text
+    } else {
+        writeInt16ToBuffer(packet, resultFormats.size());
+        for (int16_t fmt : resultFormats) {
+            writeInt16ToBuffer(packet, fmt);
+        }
+    }
+    
+    sendMessage('B', packet);
+    if (sync) {
+        sendSync();
+        waitForMessage(BIND_COMPLETE, "bind", sync);
+    }
+}
+
+// Helper for single format case
+void PgConnection::bindStatementSingleFormat(
+    const std::string& stmtName,
+    const std::string& portalName,
+    const std::vector<Param>& params,
+    int16_t singleFormat,
+    const std::vector<int16_t>& resultFormats,
+    bool sync
+) {
+    // Create a format array with single element
+    std::vector<int16_t> paramFormats = { singleFormat };
+    bindStatementEx(stmtName, portalName, params, paramFormats, resultFormats, sync);
 }
 
 void PgConnection::executePortal(

--- a/test/tap/tests/pg_lite_client.h
+++ b/test/tap/tests/pg_lite_client.h
@@ -162,6 +162,26 @@ public:
         const std::vector<int16_t>& resultFormats = {},
 		bool sync = false
     );
+    // Extended bind with explicit format control
+    void bindStatementEx(
+        const std::string & stmtName,
+        const std::string & portalName,
+        const std::vector<Param>&params,
+        const std::vector<int16_t>&paramFormats,  // Explicit format array
+        const std::vector<int16_t>&resultFormats = {},
+        bool sync = false
+    );
+        
+    // Helper for single format case
+    void bindStatementSingleFormat(
+        const std::string & stmtName,
+        const std::string & portalName,
+        const std::vector<Param>&params,
+        int16_t singleFormat,  // Applied to all parameters
+        const std::vector<int16_t>&resultFormats = {},
+        bool sync = false
+    );
+
     void executePortal(
         const std::string& portalName,
         int maxRows = 0,  // 0 = all rows

--- a/test/tap/tests/pgsql-extended_query_protocol_test-t.cpp
+++ b/test/tap/tests/pgsql-extended_query_protocol_test-t.cpp
@@ -5048,6 +5048,9 @@ void test_empty_query_without_describe_portal() {
 }
 
 int main(int argc, char** argv) {
+
+	plan(1061); // Adjust based on number of tests
+
 	if (cl.getEnv())
 		return exit_status();
 
@@ -5056,8 +5059,6 @@ int main(int argc, char** argv) {
 	if (of_err != EXIT_SUCCESS) {
 		return exit_status();
 	}
-
-	plan(1061); // Adjust based on number of tests
 
 	auto admin_conn = createNewConnection(ConnType::ADMIN, "", false);
 

--- a/test/tap/tests/pgsql-reg_test_5273_bind_parameter_format-t.cpp
+++ b/test/tap/tests/pgsql-reg_test_5273_bind_parameter_format-t.cpp
@@ -1,0 +1,617 @@
+/**
+ * @file pgsql-reg_test_5273_bind_parameter_format-t.cpp
+ * @brief Comprehensive test suite for PostgreSQL BIND message parameter format handling
+ * 
+ * This test verifies the fix for PostgreSQL Extended Query Protocol BIND message
+ * parameter format handling according to PostgreSQL protocol specification:
+ * - num_param_formats = 0: All parameters use default format (text)
+ * - num_param_formats = 1: Single format applies to ALL parameters
+ * - num_param_formats = num_params: Each parameter gets explicit format
+ */
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include "libpq-fe.h"
+#include "pg_lite_client.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+// CommandLine is defined elsewhere, we'll declare it extern
+CommandLine cl;
+
+int test_count = 1;
+
+using PGConnPtr = std::unique_ptr<PGconn, decltype(&PQfinish)>;
+using PGResultPtr = std::unique_ptr<PGresult, decltype(&PQclear)>;
+
+enum ConnType {
+    ADMIN,
+    BACKEND
+};
+
+PGConnPtr createNewConnection(ConnType conn_type, const std::string& options = "", bool with_ssl = false) {
+
+    const char* host = (conn_type == BACKEND) ? cl.pgsql_host : cl.pgsql_admin_host;
+    int port = (conn_type == BACKEND) ? cl.pgsql_port : cl.pgsql_admin_port;
+    const char* username = (conn_type == BACKEND) ? cl.pgsql_username : cl.admin_username;
+    const char* password = (conn_type == BACKEND) ? cl.pgsql_password : cl.admin_password;
+
+    std::stringstream ss;
+
+    ss << "host=" << host << " port=" << port;
+    ss << " user=" << username << " password=" << password;
+    ss << (with_ssl ? " sslmode=require" : " sslmode=disable");
+
+    if (options.empty() == false) {
+        ss << " options='" << options << "'";
+    }
+
+    PGconn* conn = PQconnectdb(ss.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        fprintf(stderr, "Connection failed to '%s': %s", (conn_type == BACKEND ? "Backend" : "Admin"), PQerrorMessage(conn));
+        PQfinish(conn);
+        return PGConnPtr(nullptr, &PQfinish);
+    }
+    return PGConnPtr(conn, &PQfinish);
+}
+
+bool executeQueries(PGconn* conn, const std::vector<std::string>& queries) {
+    auto fnResultType = [](const char* query) -> int {
+        const char* fs = strchr(query, ' ');
+        // NOSONAR: strlen is safe here as we control the input
+        size_t qtlen = strlen(query); // NOSONAR
+        if (fs != NULL) {
+            qtlen = (fs - query) + 1;
+        }
+        char buf[qtlen];
+        memcpy(buf, query, qtlen - 1);
+        buf[qtlen - 1] = 0;
+
+        if (strncasecmp(buf, "SELECT", sizeof("SELECT") - 1) == 0) {
+            return PGRES_TUPLES_OK;
+        }
+        else if (strncasecmp(buf, "COPY", sizeof("COPY") - 1) == 0) {
+            return PGRES_COPY_OUT;
+        }
+
+        return PGRES_COMMAND_OK;
+        };
+
+
+    for (const auto& query : queries) {
+        diag("Running: %s", query.c_str());
+        PGresult* res = PQexec(conn, query.c_str());
+        bool success = PQresultStatus(res) == fnResultType(query.c_str());
+        if (!success) {
+            fprintf(stderr, "Failed to execute query '%s': %s\n",
+                query.c_str(), PQerrorMessage(conn));
+            PQclear(res);
+            return false;
+        }
+        PQclear(res);
+    }
+    return true;
+}
+
+// Connection creation helper
+std::shared_ptr<PgConnection> create_connection() {
+    auto conn = std::make_shared<PgConnection>(5000);
+    try {
+        conn->connect(cl.pgsql_host, cl.pgsql_port, cl.pgsql_username, cl.pgsql_username, cl.pgsql_password);
+    } catch (const PgException& e) {
+        diag("Connection failed: %s", e.what());
+        return nullptr;
+    }
+    return conn;
+}
+
+std::vector<uint8_t> stringToBytes(const std::string& str) {
+    return std::vector<uint8_t>(str.begin(), str.end());
+}
+
+// ===== Test Case Implementations =====
+void test_zero_param_formats() {
+    diag("Test %d: Zero parameter formats (default text)", test_count++);
+    auto conn = create_connection();
+    if (!conn) return;
+
+    try {
+        // Prepare statement with 4 parameters
+        conn->prepareStatement("stmt_zero_fmt",
+            "SELECT $1::int, $2::text, $3::bool, $4::bytea",
+            true);
+        
+        // Bind with zero parameter formats (all text by default)
+        std::vector<PgConnection::Param> params = {
+            {"123", 0},           // text format
+            {"hello", 0},         // text format  
+            {"true", 0},          // text format
+            {"\\xDEADBEEF", 0}    // text format (hex string)
+        };
+        
+        conn->bindStatement("stmt_zero_fmt", "", params, {}, false);
+        conn->describePortal("", false);
+
+        // Execute
+        conn->executePortal("", 0, true);
+        
+        // Read result
+        auto result = conn->readResult();
+        ok(result != nullptr, "Result received");
+        if (result) {
+            ok(result->rowCount() == 1, "One row returned");
+            ok(result->columnCount() == 4, "Four columns returned");
+            
+            // Verify values
+            if (result->rowCount() > 0 && result->columnCount() >= 4) {
+                auto val1 = result->getValue(0, 0);
+                auto val2 = result->getValue(0, 1);
+                auto val3 = result->getValue(0, 2);
+                auto val4 = result->getValue(0, 3);
+                
+                bool ok1 = std::holds_alternative<std::string>(val1) && 
+                          std::get<std::string>(val1) == "123";
+                bool ok2 = std::holds_alternative<std::string>(val2) && 
+                          std::get<std::string>(val2) == "hello";
+                bool ok3 = std::holds_alternative<std::string>(val3) && 
+                          std::get<std::string>(val3) == "t";
+                // PostgreSQL returns hex in lowercase
+                bool ok4 = std::holds_alternative<std::string>(val4) && 
+                          (std::get<std::string>(val4) == "\\xdeadbeef" ||
+                           std::get<std::string>(val4).find("deadbeef") != std::string::npos);
+                
+                ok(ok1, "Integer value correct");
+                ok(ok2, "Text value correct");
+                ok(ok3, "Boolean value correct");
+                ok(ok4, "Binary value correct (hex representation)");
+            }
+        }
+        
+        // Cleanup
+        conn->closeStatement("stmt_zero_fmt", true);
+        
+    } catch (const PgException& e) {
+        ok(false, "Zero parameter formats test failed: %s", e.what());
+    }
+}
+
+void test_single_param_format_for_all() {
+    diag("Test %d: Single parameter format for all parameters", test_count++);
+    auto conn = create_connection();
+    if (!conn) return;
+
+    try {
+        // Prepare statement with 4 parameters
+        conn->prepareStatement("stmt_single_fmt",
+            "SELECT $1::int, $2::text, $3::bool, $4::bytea",
+            true);
+        
+        // Bind with single parameter format (all text)
+        std::vector<PgConnection::Param> params = {
+            {"456", 0},           // text format
+            {"world", 0},         // text format  
+            {"false", 0},         // text format
+            {"\\xCAFEBABE", 0}    // text format (hex string)
+        };
+        
+        // Use new bindStatementSingleFormat method
+        conn->bindStatementSingleFormat("stmt_single_fmt", "", params, 0, {}, false);
+        conn->describePortal("", false);
+
+        // Execute
+        conn->executePortal("", 0, true);
+        
+        // Read result
+        auto result = conn->readResult();
+        ok(result != nullptr, "Result received");
+        if (result) {
+            ok(result->rowCount() == 1, "One row returned");
+            
+            // Verify values
+            if (result->rowCount() > 0 && result->columnCount() >= 4) {
+                auto val1 = result->getValue(0, 0);
+                auto val2 = result->getValue(0, 1);
+                auto val3 = result->getValue(0, 2);
+                auto val4 = result->getValue(0, 3);
+                
+                bool ok1 = std::holds_alternative<std::string>(val1) && 
+                          std::get<std::string>(val1) == "456";
+                bool ok2 = std::holds_alternative<std::string>(val2) && 
+                          std::get<std::string>(val2) == "world";
+                bool ok3 = std::holds_alternative<std::string>(val3) && 
+                          std::get<std::string>(val3) == "f";
+                bool ok4 = std::holds_alternative<std::string>(val4) && 
+                          (std::get<std::string>(val4) == "\\xcafebabe" ||
+                           std::get<std::string>(val4).find("cafebabe") != std::string::npos);
+                
+                ok(ok1, "Integer value correct with single format");
+                ok(ok2, "Text value correct with single format");
+                ok(ok3, "Boolean value correct with single format");
+                ok(ok4, "Binary value correct with single format");
+            }
+        }
+        
+        // Cleanup
+        conn->closeStatement("stmt_single_fmt", true);
+        
+    } catch (const PgException& e) {
+        ok(false, "Single parameter format test failed: %s", e.what());
+    }
+}
+
+void test_single_binary_format_for_all() {
+    diag("Test %d: Single binary format for all parameters", test_count++);
+    auto conn = create_connection();
+    if (!conn) return;
+
+    try {
+        // Prepare statement with 3 parameters (bytea doesn't work well with binary int)
+        conn->prepareStatement("stmt_single_bin",
+            "SELECT $1::int, $2::text, $3::bool",
+            true);
+        
+        // Bind with single binary format
+        std::vector<PgConnection::Param> params = {
+            {789, 1},                   // binary integer
+            {stringToBytes("binary"), 1}, // binary text
+            {std::vector<uint8_t>{1}, 1}  // binary boolean (true)
+        };
+        
+        // Use bindStatementEx with single format
+        std::vector<int16_t> paramFormats = {1}; // single binary format
+        conn->bindStatementEx("stmt_single_bin", "", params, paramFormats, {}, false);
+        conn->describePortal("", false);
+
+        // Execute
+        conn->executePortal("", 0, true);
+        
+        // Read result
+        auto result = conn->readResult();
+        ok(result != nullptr, "Result received for binary format");
+        if (result) {
+            ok(result->rowCount() == 1, "One row returned for binary format");
+            
+            // Verify values - they will be returned in text format unless we specify result formats
+            if (result->rowCount() > 0 && result->columnCount() >= 3) {
+                auto val1 = result->getValue(0, 0);
+                auto val2 = result->getValue(0, 1);
+                auto val3 = result->getValue(0, 2);
+                
+                // Results come back as text by default
+                bool ok1 = std::holds_alternative<std::string>(val1) && 
+                          std::get<std::string>(val1) == "789";
+                bool ok2 = std::holds_alternative<std::string>(val2) && 
+                          std::get<std::string>(val2) == "binary";
+                bool ok3 = std::holds_alternative<std::string>(val3) && 
+                          std::get<std::string>(val3) == "t";
+                
+                ok(ok1, "Binary integer parsed correctly");
+                ok(ok2, "Binary text parsed correctly");
+                ok(ok3, "Binary boolean parsed correctly");
+            }
+        }
+        
+        // Cleanup
+        conn->closeStatement("stmt_single_bin", true);
+        
+    } catch (const PgException& e) {
+        ok(false, "Single binary format test failed: %s", e.what());
+    }
+}
+
+void test_mixed_param_formats() {
+    diag("Test %d: Explicit format per parameter", test_count++);
+    auto conn = create_connection();
+    if (!conn) return;
+
+    try {
+        // Prepare statement
+        conn->prepareStatement("stmt_mixed_fmt",
+            "SELECT $1::int, $2::text, $3::bool",
+            true);
+        
+        // Bind with mixed formats
+        std::vector<PgConnection::Param> params = {
+            {999, 1},                    // binary integer
+            {"mixed", 0},                // text string
+            {std::vector<uint8_t>{0}, 1} // binary boolean (false)
+        };
+        
+        // Use bindStatementEx with explicit format array
+        std::vector<int16_t> paramFormats = {1, 0, 1};
+        conn->bindStatementEx("stmt_mixed_fmt", "", params, paramFormats, {}, false);
+        conn->describePortal("", false);
+
+        // Execute
+        conn->executePortal("", 0, true);
+        
+        // Read result
+        auto result = conn->readResult();
+        ok(result != nullptr, "Result received for mixed formats");
+        if (result) {
+            ok(result->rowCount() == 1, "One row returned for mixed formats");
+            
+            // Verify values
+            if (result->rowCount() > 0 && result->columnCount() >= 3) {
+                auto val1 = result->getValue(0, 0);
+                auto val2 = result->getValue(0, 1);
+                auto val3 = result->getValue(0, 2);
+                
+                bool ok1 = std::holds_alternative<std::string>(val1) && 
+                          std::get<std::string>(val1) == "999";
+                bool ok2 = std::holds_alternative<std::string>(val2) && 
+                          std::get<std::string>(val2) == "mixed";
+                bool ok3 = std::holds_alternative<std::string>(val3) && 
+                          std::get<std::string>(val3) == "f";
+                
+                ok(ok1, "Binary integer (mixed format) parsed correctly");
+                ok(ok2, "Text string (mixed format) parsed correctly");
+                ok(ok3, "Binary boolean (mixed format) parsed correctly");
+            }
+        }
+        
+        // Cleanup
+        conn->closeStatement("stmt_mixed_fmt", true);
+        
+    } catch (const PgException& e) {
+        ok(false, "Mixed parameter formats test failed: %s", e.what());
+    }
+}
+
+void test_insert_with_zero_formats() {
+    diag("Test %d: INSERT with zero parameter formats", test_count++);
+    auto conn = create_connection();
+    if (!conn) return;
+
+    try {
+        // Create test table
+        conn->execute("DROP TABLE IF EXISTS test_insert_formats_1");
+        conn->waitForReady();
+
+        conn->execute("CREATE TABLE test_insert_formats_1 ("
+                     "id SERIAL PRIMARY KEY, "
+                     "int_val INTEGER, "
+                     "text_val TEXT, "
+                     "bool_val BOOLEAN, "
+                     "bytea_val BYTEA)");
+        conn->waitForReady();
+        
+        // Prepare INSERT statement
+        conn->prepareStatement("insert_zero_fmt",
+            "INSERT INTO test_insert_formats_1 (int_val, text_val, bool_val, bytea_val) "
+            "VALUES ($1, $2, $3, $4)",
+            false);
+        
+        // Bind with zero parameter formats (all text)
+        std::vector<PgConnection::Param> params = {
+            {"1000", 0},
+            {"insert_test", 0},
+            {"true", 0},
+            {"\\x11223344", 0}
+        };
+        
+        conn->bindStatement("insert_zero_fmt", "", params, {}, false);
+
+        // Execute INSERT
+        conn->executePortal("", 0, true);
+        
+        // Read result
+        char type;
+        std::vector<uint8_t> buffer;
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::PARSE_COMPLETE, "PARSE command completed");
+
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::BIND_COMPLETE, "BIND command completed");
+
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::COMMAND_COMPLETE, "Binary INSERT command completed");
+
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::READY_FOR_QUERY, "READY FOR QUERY");
+        
+        // Verify data was actually inserted
+        conn->execute("SELECT int_val, text_val, bool_val, bytea_val FROM test_insert_formats_1");
+        auto result = conn->readResult();
+        ok(result != nullptr, "SELECT result received after INSERT");
+        if (result) {
+            ok(result->rowCount() == 1, "One row inserted");
+            
+            if (result->rowCount() > 0 && result->columnCount() >= 4) {
+                auto val1 = result->getValue(0, 0);
+                auto val2 = result->getValue(0, 1);
+                auto val3 = result->getValue(0, 2);
+                auto val4 = result->getValue(0, 3);
+                
+                bool ok1 = std::holds_alternative<std::string>(val1) && 
+                          std::get<std::string>(val1) == "1000";
+                bool ok2 = std::holds_alternative<std::string>(val2) && 
+                          std::get<std::string>(val2) == "insert_test";
+                bool ok3 = std::holds_alternative<std::string>(val3) && 
+                          std::get<std::string>(val3) == "t";
+                bool ok4 = std::holds_alternative<std::string>(val4) && 
+                          (std::get<std::string>(val4) == "\\x11223344" ||
+                           std::get<std::string>(val4).find("11223344") != std::string::npos);
+                
+                ok(ok1, "INSERT integer value correct");
+                ok(ok2, "INSERT text value correct");
+                ok(ok3, "INSERT boolean value correct");
+                ok(ok4, "INSERT binary value correct");
+            }
+        }
+        
+        // Cleanup
+        conn->closeStatement("insert_zero_fmt", true);
+        
+    } catch (const PgException& e) {
+        ok(false, "INSERT with zero formats test failed: %s", e.what());
+    }
+}
+
+void test_insert_with_single_binary_format() {
+    diag("Test %d: INSERT with single binary format", test_count++);
+    auto conn = create_connection();
+    if (!conn) return;
+
+    try {
+        // Create test table
+        conn->execute("DROP TABLE IF EXISTS test_insert_formats_2");
+        conn->waitForReady();
+
+        conn->execute("CREATE TABLE test_insert_formats_2 ("
+                     "id SERIAL PRIMARY KEY, "
+                     "int_val INTEGER, "
+                     "text_val TEXT)");
+        conn->waitForReady();
+
+        // Prepare INSERT statement
+        conn->prepareStatement("insert_single_bin",
+            "INSERT INTO test_insert_formats_2 (int_val, text_val) VALUES ($1, $2)",
+            false);
+
+        // Bind with single binary format
+        std::vector<PgConnection::Param> params = {
+            {2000, 1},                    // binary integer
+            {stringToBytes("binary_insert"), 1} // binary text
+        };
+        
+        std::vector<int16_t> paramFormats = {1}; // single binary format
+        conn->bindStatementEx("insert_single_bin", "", params, paramFormats, {}, false);
+
+        // Execute INSERT
+        conn->executePortal("", 0, true);
+        
+        // Read result
+        char type;
+        std::vector<uint8_t> buffer;
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::PARSE_COMPLETE, "PARSE command completed");
+
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::BIND_COMPLETE, "BIND command completed");
+
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::COMMAND_COMPLETE, "Binary INSERT command completed");
+
+        conn->readMessage(type, buffer);
+        ok(type == PgConnection::READY_FOR_QUERY, "READY FOR QUERY");
+        
+        // Verify data
+        conn->execute("SELECT int_val, text_val FROM test_insert_formats_2");
+        auto result = conn->readResult();
+        ok(result != nullptr, "SELECT result received after binary INSERT");
+        if (result) {
+            ok(result->rowCount() == 1, "One row inserted with binary format");
+            
+            if (result->rowCount() > 0 && result->columnCount() >= 2) {
+                auto val1 = result->getValue(0, 0);
+                auto val2 = result->getValue(0, 1);
+                
+                bool ok1 = std::holds_alternative<std::string>(val1) && 
+                          std::get<std::string>(val1) == "2000";
+                bool ok2 = std::holds_alternative<std::string>(val2) && 
+                          std::get<std::string>(val2) == "binary_insert";
+                
+                ok(ok1, "Binary INSERT integer value correct");
+                ok(ok2, "Binary INSERT text value correct");
+            }
+        }
+        
+        // Cleanup
+        conn->closeStatement("insert_single_bin", true);
+        
+    } catch (const PgException& e) {
+        ok(false, "INSERT with single binary format test failed: %s", e.what());
+    }
+}
+
+void test_null_parameter_handling() {
+    diag("Test %d: NULL parameter handling with formats", test_count++);
+    auto conn = create_connection();
+    if (!conn) return;
+
+    try {
+        // Prepare statement
+        conn->prepareStatement("stmt_null_test",
+            "SELECT $1::int, $2::text, $3::bool",
+            true);
+        
+        // Bind with NULL parameters
+        std::vector<PgConnection::Param> params = {
+            {123, 0},                    // integer
+            {std::monostate{}, 0},  // NULL text (default constructed)
+            {std::vector<uint8_t>{1}, 1} // binary boolean
+        };
+        params[1].value = std::monostate{}; // Explicit NULL
+        
+        // Use single format
+        conn->bindStatementSingleFormat("stmt_null_test", "", params, 1, {}, false);
+        conn->describePortal("", false);
+
+        // Execute
+        conn->executePortal("", 0, true);
+        
+        // Read result
+        auto result = conn->readResult();
+        ok(result != nullptr, "Result received with NULL parameters");
+        if (result) {
+            ok(result->rowCount() == 1, "One row returned with NULL");
+            
+            if (result->rowCount() > 0 && result->columnCount() >= 3) {
+                auto val1 = result->getValue(0, 0);
+                auto val2 = result->getValue(0, 1);
+                auto val3 = result->getValue(0, 2);
+                
+                bool ok1 = std::holds_alternative<std::string>(val1) && 
+                          std::get<std::string>(val1) == "123";
+                bool ok2 = result->isNull(0, 1); // Should be NULL
+                bool ok3 = std::holds_alternative<std::string>(val3) && 
+                          std::get<std::string>(val3) == "t";
+                
+                ok(ok1, "Non-NULL integer value correct");
+                ok(ok2, "NULL parameter handled correctly");
+                ok(ok3, "Binary boolean with NULL in middle handled");
+            }
+        }
+        
+        // Cleanup
+        conn->closeStatement("stmt_null_test", true);
+        
+    } catch (const PgException& e) {
+        ok(false, "NULL parameter handling test failed: %s", e.what());
+    }
+}
+
+int main() {
+    plan(46); // Total number of checks we'll perform
+
+    if (cl.getEnv())
+        return exit_status();
+
+    auto admin_conn = createNewConnection(ConnType::ADMIN, "", false);
+
+    if (!admin_conn || PQstatus(admin_conn.get()) != CONNECTION_OK) {
+        BAIL_OUT("Error: failed to connect to the database in file %s, line %d", __FILE__, __LINE__);
+        return exit_status();
+    }
+
+
+    if (executeQueries(admin_conn.get(), { "SET pgsql-authentication_method=1",
+                                           "LOAD PGSQL VARIABLES TO RUNTIME" }) == false) {
+        BAIL_OUT("Error: failed to set pgsql-authentication_method=1 in file %s, line %d", __FILE__, __LINE__);
+        return exit_status();
+    }
+    
+    // Run tests
+    test_zero_param_formats();
+    test_single_param_format_for_all();
+    test_single_binary_format_for_all();
+    test_mixed_param_formats();
+    test_insert_with_zero_formats();
+    test_insert_with_single_binary_format();
+    test_null_parameter_handling();
+    
+    return exit_status();
+}


### PR DESCRIPTION
### Background

In the PostgreSQL extended query protocol, the Bind message supports the
following semantics for parameter formats:

- `num_param_formats = 0`: all parameters use the default text format
- `num_param_formats = 1`: a single format applies to all parameters
- `num_param_formats = num_params`: each parameter has an explicit format

Any other combination is invalid.

While PostgreSQL correctly applies the single provided format to all parameters,
ProxySQL previously did not replicate this behavior.

### Issue

When a client sent a Bind message with:
- num_param_formats = 1
- num_params > 1

ProxySQL forwarded uninitialized (garbage) values for the remaining parameter
formats (_`libpq` has a limitation where it expects a parameter format entry for each
parameter_). This resulted in malformed Bind packets and protocol errors.

### Fix

This PR updates ProxySQL’s Bind handling to match PostgreSQL behavior:
- When exactly one parameter format is provided, ProxySQL now applies that
  format to all parameters.

This prevents malformed packets and ensures compatibility with libpq and compliance with the PostgreSQL specification.

### Impact

- Aligns ProxySQL with PostgreSQL extended query protocol semantics
- Prevents malformed Bind packets

No behavior change occurs for valid cases where all parameter formats are
explicitly provided.

Closes [#5273](https://github.com/sysown/proxysql/issues/5273)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parameter format handling for PostgreSQL prepared statements, now supporting default text, single-format, and per-parameter format specifications.

* **Tests**
  * Added comprehensive regression test suite for PostgreSQL parameter format binding, covering text/binary formats, mixed formats, and NULL parameter scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->