### PR TITLE
Fix: pgsql_users.use_ssl not being enforced on frontend connections

### DIFF
--- a/include/PgSQL_Session.h
+++ b/include/PgSQL_Session.h
@@ -528,16 +528,6 @@ public:
 	//bool started_sending_data_to_client; // this status variable tracks if some result set was sent to the client, or if proxysql is still buffering everything
 	bool use_ssl;
 #endif // 0
-	/**
-	 * @brief This status variable tracks whether the session is performing an
-	 *   'Auth Switch' due to a 'COM_CHANGE_USER' packet.
-	 * @details It becomes 'true' when the packet is detected and processed by:
-	 *    - 'MySQL_Protocol::process_pkt_COM_CHANGE_USER'
-	 *   It's reset before sending the final response for 'Auth Switch' to the client by:
-	 *   -  'PgSQL_Session::handler___status_CONNECTING_CLIENT___STATE_SERVER_HANDSHAKE'
-	 *   This flag was introduced for issue #3504.
-	 */
-	bool change_user_auth_switch;
 
 //	MySQL_STMTs_meta* sess_STMTs_meta;
 //	StmtLongDataHandler* SLDH;

--- a/lib/PgSQL_Protocol.cpp
+++ b/lib/PgSQL_Protocol.cpp
@@ -860,6 +860,7 @@ EXECUTION_STATE PgSQL_Protocol::process_handshake_response_packet(unsigned char*
 			(*myds)->sess->session_fast_forward = fast_forward ? SESSION_FORWARD_TYPE_PERMANENT : SESSION_FORWARD_TYPE_NONE;
 		}
 		(*myds)->sess->user_max_connections = max_connections;
+		(*myds)->sess->use_ssl = _ret_use_ssl;
 	} else {
 
 		if (

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -269,7 +269,6 @@ PgSQL_Session::PgSQL_Session() {
 	active_transactions = 0;
 
 	use_ssl = false;
-	change_user_auth_switch = false;
 
 	match_regexes = NULL;
 	copy_cmd_matcher = NULL;
@@ -3475,20 +3474,7 @@ void PgSQL_Session::handler___status_CONNECTING_CLIENT___STATE_SERVER_HANDSHAKE(
 				}
 				free(addr);
 				free(client_addr);
-			}
-			else {
-				uint8_t _pid = 2;
-				if (client_myds->switching_auth_stage) _pid += 2;
-				if (is_encrypted) _pid++;
-				// If this condition is met, it means that the
-				// 'STATE_SERVER_HANDSHAKE' being performed isn't from the start of a
-				// connection, but as a consequence of a 'COM_USER_CHANGE' which
-				// requires an 'Auth Switch'. Thus, we impose a 'pid' of '3' for the
-				// response 'OK' packet. See #3504 for more context.
-				if (change_user_auth_switch) {
-					_pid = 3;
-					change_user_auth_switch = 0;
-				}
+			} else {
 				if (use_ssl == true && is_encrypted == false) {
 					*wrong_pass = true;
 					GloPgSQL_Logger->log_audit_entry(PGSQL_LOG_EVENT_TYPE::AUTH_ERR, this, NULL);
@@ -3503,8 +3489,7 @@ void PgSQL_Session::handler___status_CONNECTING_CLIENT___STATE_SERVER_HANDSHAKE(
 					__sync_add_and_fetch(&PgHGM->status.client_connections_aborted, 1);
 					free(_s);
 					__sync_fetch_and_add(&PgHGM->status.access_denied_wrong_password, 1);
-				}
-				else {
+				} else {
 					// we are good!
 					//client_myds->myprot.generate_pkt_OK(true,NULL,NULL, (is_encrypted ? 3 : 2), 0,0,0,0,NULL,false);
 					proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 8, "Session=%p , DS=%p . STATE_CLIENT_AUTH_OK\n", this, client_myds);

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -243,5 +243,6 @@
   "test_ignore_min_gtid-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-query_digests_stages_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-monitor_ssl_connections_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5284_frontend_ssl_enforcement-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "unit-strip_schema_from_query-t": [ "unit-tests-g1" ]
 }

--- a/test/tap/tests/pgsql-reg_test_5284_frontend_ssl_enforcement-t.cpp
+++ b/test/tap/tests/pgsql-reg_test_5284_frontend_ssl_enforcement-t.cpp
@@ -1,0 +1,242 @@
+/**
+ * @file pgsql-frontend_ssl_enforcement-t.cpp
+ * @brief This test validates that ProxySQL correctly enforces SSL requirement for
+ *        PostgreSQL frontend connections when use_ssl=1 is set in pgsql_users.
+ *
+ *        The test addresses the issue where setting use_ssl=1 didn't actually
+ *        enforce TLS - clients could still connect without SSL.
+ *
+ *        Test scenarios:
+ *        1. With use_ssl=1: connection without SSL should be rejected
+ *        2. With use_ssl=1: connection with SSL should succeed
+ *        3. With use_ssl=0: connection without SSL should succeed
+ *        4. With use_ssl=0: connection with SSL should succeed
+ */
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include "libpq-fe.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+CommandLine cl;
+
+using PGConnPtr = std::unique_ptr<PGconn, decltype(&PQfinish)>;
+
+enum ConnType {
+    ADMIN,
+    BACKEND
+};
+
+/**
+ * @brief Creates a new PostgreSQL connection with specified SSL mode.
+ *
+ * @param conn_type Type of connection (ADMIN or BACKEND)
+ * @param with_ssl Whether to use SSL for the connection
+ * @return PGConnPtr Smart pointer to the connection
+ */
+PGConnPtr createNewConnection(ConnType conn_type, bool with_ssl = false) {
+    const char* host = (conn_type == BACKEND) ? cl.pgsql_host : cl.pgsql_admin_host;
+    int port = (conn_type == BACKEND) ? cl.pgsql_port : cl.pgsql_admin_port;
+    const char* username = (conn_type == BACKEND) ? cl.pgsql_username : cl.admin_username;
+    const char* password = (conn_type == BACKEND) ? cl.pgsql_password : cl.admin_password;
+
+    std::stringstream ss;
+
+    ss << "host=" << host << " port=" << port;
+    ss << " user=" << username << " password=" << password;
+    ss << (with_ssl ? " sslmode=require" : " sslmode=disable");
+
+    PGconn* conn = PQconnectdb(ss.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        // For expected failures, we still return the conn so caller can check
+        return PGConnPtr(conn, &PQfinish);
+    }
+    return PGConnPtr(conn, &PQfinish);
+}
+
+/**
+ * @brief Checks if a connection uses SSL.
+ *
+ * @param conn The connection to check
+ * @return true if SSL is used, false otherwise
+ */
+bool is_connection_using_ssl(PGconn* conn) {
+    return PQsslInUse(conn) == 1;
+}
+
+/**
+ * @brief Executes a list of queries on the given connection.
+ *
+ * @param conn The connection to execute queries on
+ * @param queries List of queries to execute
+ * @return true if all queries succeeded, false otherwise
+ */
+bool executeQueries(PGconn* conn, const std::vector<std::string>& queries) {
+    for (const auto& query : queries) {
+        PGresult* res = PQexec(conn, query.c_str());
+        bool success = (PQresultStatus(res) == PGRES_COMMAND_OK) ||
+                       (PQresultStatus(res) == PGRES_TUPLES_OK);
+        if (!success) {
+            fprintf(stderr, "Query failed: %s\nError: %s\n",
+                    query.c_str(), PQresultErrorMessage(res));
+        }
+        PQclear(res);
+        if (!success) return false;
+    }
+    return true;
+}
+
+int main(int argc, char** argv) {
+
+    // We have 6 test cases:
+    // 1. Admin connection
+    // 2. Set use_ssl=1 and load to runtime
+    // 3. Connection without SSL should fail when use_ssl=1
+    // 4. Connection with SSL should succeed when use_ssl=1
+    // 5. Set use_ssl=0 and load to runtime
+    // 6. Connection without SSL should succeed when use_ssl=0
+    // 7. Connection with SSL should succeed when use_ssl=0
+    plan(7);
+
+    if (cl.getEnv())
+        return exit_status();
+
+    // ============================================
+    // Test 1: Connect to ADMIN interface
+    // ============================================
+    auto admin = createNewConnection(ADMIN, false);
+    ok(admin != nullptr && PQstatus(admin.get()) == CONNECTION_OK,
+       "ADMIN connection created");
+
+    if (!admin || PQstatus(admin.get()) != CONNECTION_OK) {
+        BAIL_OUT("Cannot proceed without admin connection");
+        return exit_status();
+    }
+
+    // ============================================
+    // Test 2: Set use_ssl=1 for the test user
+    // ============================================
+    {
+        std::stringstream q;
+        q << "UPDATE pgsql_users SET use_ssl=1 WHERE username='" << cl.pgsql_username << "';";
+        PGresult* res = PQexec(admin.get(), q.str().c_str());
+        bool update_ok = (PQresultStatus(res) == PGRES_COMMAND_OK);
+        PQclear(res);
+
+        res = PQexec(admin.get(), "LOAD PGSQL USERS TO RUNTIME;");
+        bool load_ok = (PQresultStatus(res) == PGRES_COMMAND_OK);
+        PQclear(res);
+
+        ok(update_ok && load_ok, "Set use_ssl=1 and loaded to runtime");
+
+        if (!update_ok || !load_ok) {
+            BAIL_OUT("Failed to configure pgsql_users");
+            return exit_status();
+        }
+    }
+
+    // Give ProxySQL time to load the configuration
+    usleep(100000); // 100ms
+
+    // ============================================
+    // Test 3: Connection WITHOUT SSL should FAIL when use_ssl=1
+    // ============================================
+    {
+        auto conn = createNewConnection(BACKEND, false); // sslmode=disable
+        bool conn_failed = (conn && PQstatus(conn.get()) != CONNECTION_OK);
+
+        if (conn_failed) {
+            ok(true, "Connection without SSL rejected when use_ssl=1 (as expected)");
+            diag("Connection error: %s", PQerrorMessage(conn.get()));
+        } else {
+            ok(false, "Connection without SSL should be rejected when use_ssl=1, but it succeeded");
+        }
+    }
+
+    // ============================================
+    // Test 4: Connection WITH SSL should SUCCEED when use_ssl=1
+    // ============================================
+    {
+        auto conn = createNewConnection(BACKEND, true); // sslmode=require
+        bool conn_ok = (conn && PQstatus(conn.get()) == CONNECTION_OK);
+        bool uses_ssl = conn_ok && is_connection_using_ssl(conn.get());
+
+        if (conn_ok && uses_ssl) {
+            ok(true, "Connection with SSL succeeded when use_ssl=1");
+        } else {
+            ok(false, "Connection with SSL should succeed when use_ssl=1");
+            if (!conn_ok) {
+                diag("Connection error: %s", PQerrorMessage(conn.get()));
+            } else {
+                diag("Connection succeeded but SSL not in use");
+            }
+        }
+    }
+
+    // ============================================
+    // Test 5: Set use_ssl=0 for the test user
+    // ============================================
+    {
+        std::stringstream q;
+        q << "UPDATE pgsql_users SET use_ssl=0 WHERE username='" << cl.pgsql_username << "';";
+        PGresult* res = PQexec(admin.get(), q.str().c_str());
+        bool update_ok = (PQresultStatus(res) == PGRES_COMMAND_OK);
+        PQclear(res);
+
+        res = PQexec(admin.get(), "LOAD PGSQL USERS TO RUNTIME;");
+        bool load_ok = (PQresultStatus(res) == PGRES_COMMAND_OK);
+        PQclear(res);
+
+        ok(update_ok && load_ok, "Set use_ssl=0 and loaded to runtime");
+
+        if (!update_ok || !load_ok) {
+            BAIL_OUT("Failed to configure pgsql_users");
+            return exit_status();
+        }
+    }
+
+    // Give ProxySQL time to load the configuration
+    usleep(100000); // 100ms
+
+    // ============================================
+    // Test 6: Connection WITHOUT SSL should SUCCEED when use_ssl=0
+    // ============================================
+    {
+        auto conn = createNewConnection(BACKEND, false); // sslmode=disable
+        bool conn_ok = (conn && PQstatus(conn.get()) == CONNECTION_OK);
+
+        if (conn_ok) {
+            ok(true, "Connection without SSL succeeded when use_ssl=0");
+        } else {
+            ok(false, "Connection without SSL should succeed when use_ssl=0");
+            diag("Connection error: %s", PQerrorMessage(conn.get()));
+        }
+    }
+
+    // ============================================
+    // Test 7: Connection WITH SSL should also SUCCEED when use_ssl=0
+    // (SSL is optional when use_ssl=0)
+    // ============================================
+    {
+        auto conn = createNewConnection(BACKEND, true); // sslmode=require
+        bool conn_ok = (conn && PQstatus(conn.get()) == CONNECTION_OK);
+        bool uses_ssl = conn_ok && is_connection_using_ssl(conn.get());
+
+        if (conn_ok && uses_ssl) {
+            ok(true, "Connection with SSL succeeded when use_ssl=0 (SSL is optional)");
+        } else {
+            ok(false, "Connection with SSL should succeed when use_ssl=0");
+            if (!conn_ok) {
+                diag("Connection error: %s", PQerrorMessage(conn.get()));
+            } else {
+                diag("Connection succeeded but SSL not in use");
+            }
+        }
+    }
+
+    return exit_status();
+}

--- a/test/tap/tests/pgsql-reg_test_5284_frontend_ssl_enforcement-t.cpp
+++ b/test/tap/tests/pgsql-reg_test_5284_frontend_ssl_enforcement-t.cpp
@@ -68,28 +68,6 @@ bool is_connection_using_ssl(PGconn* conn) {
     return PQsslInUse(conn) == 1;
 }
 
-/**
- * @brief Executes a list of queries on the given connection.
- *
- * @param conn The connection to execute queries on
- * @param queries List of queries to execute
- * @return true if all queries succeeded, false otherwise
- */
-bool executeQueries(PGconn* conn, const std::vector<std::string>& queries) {
-    for (const auto& query : queries) {
-        PGresult* res = PQexec(conn, query.c_str());
-        bool success = (PQresultStatus(res) == PGRES_COMMAND_OK) ||
-                       (PQresultStatus(res) == PGRES_TUPLES_OK);
-        if (!success) {
-            fprintf(stderr, "Query failed: %s\nError: %s\n",
-                    query.c_str(), PQresultErrorMessage(res));
-        }
-        PQclear(res);
-        if (!success) return false;
-    }
-    return true;
-}
-
 int main(int argc, char** argv) {
 
     // We have 6 test cases:


### PR DESCRIPTION
### Problem:
The `use_ssl` column in `pgsql_users` table was not being enforced. Clients could connect without SSL/TLS even when `use_ssl=1` was configured.

### Root Cause: 
During PostgreSQL frontend authentication, the `use_ssl` value retrieved from the database was never assigned to the session object. The SSL enforcement logic was already in place, but it evaluated a session field that remained at its default value (`false`) regardless of the database configuration.

### Solution:
Assign the retrieved `use_ssl` value to the session after successful authentication lookup, consistent with how other user properties (`default_hostgroup, transaction_persistent, fast_forward, user_max_connections`) are already being set.

### Behavior After Fix:
  | use_ssl value | SSL connection | Non-SSL connection                 |
  |---------------|----------------|------------------------------------|
  | 1 (true)      | ✅ Allowed     | ❌ Rejected with "SSL is required" |
  | 0 (false)     | ✅ Allowed     | ✅ Allowed                         |



Closes [#5284](https://github.com/sysown/proxysql/issues/5284)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite validating SSL enforcement for PostgreSQL frontend connections across multiple configuration scenarios.

* **Improvements**
  * Enhanced SSL state management in PostgreSQL sessions.
  * Streamlined authentication handshake logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->