### PR TITLE
build: add dev container for local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,58 @@
+# Development container for ProxySQL
+# Based on: https://github.com/ProxySQL/docker-images/blob/main/build-images/build-ubuntu24/Dockerfile
+
+FROM ubuntu:24.04
+LABEL authors="Miro Stauder <miro@sysown.com>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+	apt full-upgrade -y
+
+# gcc & build tools
+RUN apt install -y \
+	make cmake automake bison flex \
+	git wget \
+	gcc g++ \
+	libtool \
+	gdb gdbserver \
+	equivs \
+	python3 \
+	zstd \
+	pkg-config \
+	sudo
+
+# proxysql build dependencies
+RUN apt install -y \
+	libssl-dev gnutls-dev libgnutls28-dev \
+	libmysqlclient-dev \
+	libunwind8 libunwind-dev \
+	uuid-dev \
+	libncurses-dev \
+	libicu-dev \
+	libevent-dev \
+	libtirpc-dev
+
+# debug images need valgrind
+RUN apt install -y \
+	valgrind
+
+# mysql client for testing
+RUN apt install -y \
+	mariadb-client
+
+# clean apt cache
+RUN apt clean && \
+	rm -rf /var/cache/apt/* && \
+	rm -rf /var/lib/apt/lists/*
+
+# fetch needed include
+RUN wget -q -O /usr/include/mysql/hash.h https://raw.githubusercontent.com/mysql/mysql-server/5.7/include/hash.h
+
+# configure git safe dir
+RUN git config --global --add safe.directory '*'
+
+ENV CC=gcc
+ENV CXX=g++
+
+RUN ${CXX} --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "ProxySQL Development",
+  "dockerComposeFile": "docker-compose.yaml",
+  "service": "dev",
+  "workspaceFolder": "/proxysql",
+  "shutdownAction": "stopCompose",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/proxysql:cached
+    working_dir: /proxysql
+    init: true
+    command: sleep infinity
+
+  mariadb:
+    image: mariadb:11.4
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: testdb
+    ports:
+      - "3306:3306"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,31 @@ Reference issues: When fixing bugs or implementing requested features, mention t
 
 ## Development Setup
 
-ProxySQL provides Docker build images for development. The required packages for building are listed in the Dockerfiles at: https://github.com/ProxySQL/docker-images/tree/main/build-images
+### Using Dev Container (Recommended)
+
+The easiest way to set up a development environment is using the included [dev container](https://containers.dev/):
+
+**With a compatible IDE:**
+
+Many IDEs support dev containers natively or via extensions. Simply open the repository and follow your IDE's prompts to reopen in the container.
+
+**With Docker Compose:**
+```bash
+# Start the dev container and MariaDB
+docker compose -f .devcontainer/docker-compose.yaml up -d
+
+# Go into dev container shell
+docker compose -f .devcontainer/docker-compose.yaml exec dev bash
+
+# Build ProxySQL
+make
+```
+
+The MariaDB service is available at hostname `mariadb` for testing.
+
+### Manual Setup
+
+If you prefer to set up your environment manually, the required packages for building are listed in the Dockerfiles at: https://github.com/ProxySQL/docker-images/tree/main/build-images
 
 For example, to see packages needed for Ubuntu 24.04, check: https://github.com/ProxySQL/docker-images/blob/main/build-images/build-ubuntu24/Dockerfile
 


### PR DESCRIPTION
Add IDE compatible dev container setup for
easier local development and testing.

Files added:
- .devcontainer/Dockerfile: Build environment based on upstream docker-images/build-ubuntu24, with mariadb-client added for testing
- .devcontainer/docker-compose.yaml: Dev container + MariaDB service
- .devcontainer/devcontainer.json: IDE configuration

Usage with IDE: https://containers.dev/

Usage with docker compose:

```bash
docker compose -f .devcontainer/docker-compose.yaml up -d
docker compose -f .devcontainer/docker-compose.yaml exec bash

# Inside dev container
/proxysql# make
...
```

The MariaDB service is available at hostname "mariadb" for testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development container configuration with Docker and Docker Compose support for streamlined development environment setup.

* **Documentation**
  * Updated development setup guidance in contribution guidelines with Dev Container workflow instructions and manual setup options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->