### PR TITLE
Add parameterized PID support for pg_cancel_backend/pg_terminate_backend in extended query protocol

### DIFF
--- a/include/PgSQL_Session.h
+++ b/include/PgSQL_Session.h
@@ -607,7 +607,7 @@ public:
 
 private:
 	int32_t extract_pid_from_param(const PgSQL_Param_Value& param, uint16_t format) const;
-	void send_parameter_error_response(const char* error_message);
+	void send_parameter_error_response(const char* error_message, PGSQL_ERROR_CODES code = PGSQL_ERROR_CODES::ERRCODE_INVALID_TEXT_REPRESENTATION);
 	bool handle_kill_success(int32_t pid, int tki, const char* digest_text, PgSQL_Connection* mc, PtrSize_t* pkt);
 	bool handle_literal_kill_query(PtrSize_t* pkt, PgSQL_Connection* mc);
 

--- a/include/PgSQL_Session.h
+++ b/include/PgSQL_Session.h
@@ -20,6 +20,7 @@ class PgSQL_Describe_Message;
 class PgSQL_Close_Message;
 class PgSQL_Bind_Message;
 class PgSQL_Execute_Message;
+struct PgSQL_Param_Value;
 
 #ifndef PROXYJSON
 #define PROXYJSON
@@ -580,6 +581,7 @@ public:
 	void Memory_Stats();
 	void create_new_session_and_reset_connection(PgSQL_Data_Stream* _myds) override;
 	bool handle_command_query_kill(PtrSize_t*);
+
 	//void update_expired_conns(const std::vector<std::function<bool(PgSQL_Connection*)>>&);
 	/**
 	 * @brief Performs the final operations after current query has finished to be executed. It updates the session
@@ -602,6 +604,12 @@ public:
 	void generate_status_one_hostgroup(int hid, std::string& s);
 	void set_previous_status_mode3(bool allow_execute = true);
 	char* get_current_query(int max_length = -1);
+
+private:
+	int32_t extract_pid_from_param(const PgSQL_Param_Value& param, uint16_t format) const;
+	void send_parameter_error_response(const char* error_message);
+	bool handle_kill_success(int32_t pid, int tki, const char* digest_text, PgSQL_Connection* mc, PtrSize_t* pkt);
+	bool handle_literal_kill_query(PtrSize_t* pkt, PgSQL_Connection* mc);
 
 #if defined(__clang__)
 	template<typename SESS, typename DS, typename BE, typename THD>

--- a/include/gen_utils.h
+++ b/include/gen_utils.h
@@ -436,6 +436,31 @@ inline T overflow_safe_multiply(T val) {
 	return (val * FACTOR);
 }
 
+/**
+ * @brief Read a 64-bit unsigned integer from a big-endian byte buffer.
+ *
+ * Reads 8 bytes from the provided buffer and converts them from
+ * big-endian (network byte order) into host byte order.
+ *
+ * @param pkt   Pointer to at least 8 bytes of input data.
+ * @param dst_p Pointer to the destination uint64_t where the result
+ *              will be stored.
+ *
+ * @return true Always returns true.
+ */
+inline bool get_uint64be(const unsigned char* pkt, uint64_t* dst_p) {
+	*dst_p =
+		((uint64_t)pkt[0] << 56) |
+		((uint64_t)pkt[1] << 48) |
+		((uint64_t)pkt[2] << 40) |
+		((uint64_t)pkt[3] << 32) |
+		((uint64_t)pkt[4] << 24) |
+		((uint64_t)pkt[5] << 16) |
+		((uint64_t)pkt[6] << 8)  |
+		((uint64_t)pkt[7]);
+	return true;
+}
+
 /*
  * @brief Reads and converts a big endian 32-bit unsigned integer from the provided packet buffer into the destination pointer.
  *
@@ -448,9 +473,9 @@ inline T overflow_safe_multiply(T val) {
  */
 inline bool get_uint32be(const unsigned char* pkt, uint32_t* dst_p) {
 	*dst_p = ((uint32_t)pkt[0] << 24) |
-			 ((uint32_t)pkt[1] << 16) |
-			 ((uint32_t)pkt[2] << 8) |
-			 ((uint32_t)pkt[3]);
+		((uint32_t)pkt[1] << 16) |
+		((uint32_t)pkt[2] << 8) |
+		((uint32_t)pkt[3]);
 	return true;
 }
 

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5191,91 +5191,59 @@ bool PgSQL_Session::handle_command_query_kill(PtrSize_t* pkt) {
 			// Note: This simple check might have false positives if $1 appears in comments or string literals
 			// but those cases would fail later when checking bind_msg or parameter validation
 			const char* digest_text = CurrentQuery.QueryParserArgs.digest_text;
-			bool is_parameterized = strstr(digest_text, "$1") != nullptr;
+
+			// Use protocol facts (Bind) 
+			const PgSQL_Bind_Message* bind_msg = CurrentQuery.extended_query_info.bind_msg;
+			const bool is_parameterized = bind_msg && bind_msg->data().num_param_values > 0;
 			if (is_parameterized) {
-				// Check if there are multiple parameters (e.g., $1, $2)
-				// Look for $2, $3, etc. to reject multiple parameters
-				const char* p = digest_text;
-				int max_param = 0;
-				while ((p = strstr(p, "$")) != nullptr) {
-					p++; // Skip '$'
-					if (isdigit(*p)) {
-						char* end;
-						long param_num = strtol(p, &end, 10);
-						if (p != end) { // check if any digits were parsed
-							if (param_num > max_param) {
-								max_param = static_cast<int>(param_num);
-							}
-							p = end;
-							continue;
-						}
-					}
-					p++;
-				}
-				if (max_param > 1) {
-					// Multiple parameters not supported
+				// Check that we have exactly one parameter
+				if (bind_msg->data().num_param_values != 1) {
 					send_parameter_error_response("function requires exactly one parameter");
 					l_free(pkt->size, pkt->ptr);
 					return true;
 				}
-						
-				// Handle parameterized query
-				if (CurrentQuery.extended_query_info.bind_msg) {
-					const PgSQL_Bind_Message* bind_msg = CurrentQuery.extended_query_info.bind_msg;
-					auto param_reader = bind_msg->get_param_value_reader();
-					PgSQL_Param_Value param;
-							
-					// Check that we have exactly one parameter
-					if (bind_msg->data().num_param_values != 1) {
-						send_parameter_error_response("function requires exactly one parameter");
+				auto param_reader = bind_msg->get_param_value_reader();
+				PgSQL_Param_Value param;
+				if (param_reader.next(&param)) {
+					// Get parameter format (default to text format 0)
+					uint16_t param_format = 0;
+					if (bind_msg->data().num_param_formats == 1) {
+						// Single format applies to all parameters
+						auto format_reader = bind_msg->get_param_format_reader();
+						format_reader.next(&param_format);
+					}
+								
+					// Extract PID from parameter
+					int32_t pid = extract_pid_from_param(param, param_format);
+					if (pid > 0) {
+						// Determine if this is terminate or cancel
+						int tki = -1;
+						if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_TERMINATE_BACKEND) {
+							tki = 0;  // Connection terminate
+						} else if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_CANCEL_BACKEND) {
+							tki = 1;  // Query cancel
+						}
+									
+						if (tki >= 0) {
+							return handle_kill_success(pid, tki, digest_text, mc, pkt);
+						}
+					} else {
+						// Invalid parameter - send appropriate error response
+						if (pid == -2) {
+							// NULL parameter
+							send_parameter_error_response("NULL is not allowed", PGSQL_ERROR_CODES::ERRCODE_NULL_VALUE_NOT_ALLOWED);
+						} else if (pid == -1) {
+							// Invalid format (not a valid integer)
+							send_parameter_error_response("invalid input syntax for integer", PGSQL_ERROR_CODES::ERRCODE_INVALID_PARAMETER_VALUE);
+						} else if (pid == 0) {
+							// PID <= 0 (non-positive)
+							send_parameter_error_response("PID must be a positive integer", PGSQL_ERROR_CODES::ERRCODE_INVALID_PARAMETER_VALUE);
+						}
 						l_free(pkt->size, pkt->ptr);
 						return true;
 					}
-							
-					if (param_reader.next(&param)) {
-						// Get parameter format (default to text format 0)
-						uint16_t param_format = 0;
-						if (bind_msg->data().num_param_formats == 1) {
-							// Single format applies to all parameters
-							auto format_reader = bind_msg->get_param_format_reader();
-							format_reader.next(&param_format);
-						}
-								
-						// Extract PID from parameter
-						int32_t pid = extract_pid_from_param(param, param_format);
-						if (pid > 0) {
-							// Determine if this is terminate or cancel
-							int tki = -1;
-							if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_TERMINATE_BACKEND) {
-								tki = 0;  // Connection terminate
-							} else if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_CANCEL_BACKEND) {
-								tki = 1;  // Query cancel
-							}
-									
-							if (tki >= 0) {
-								return handle_kill_success(pid, tki, digest_text, mc, pkt);
-							}
-						} else {
-							// Invalid parameter - send appropriate error response
-							if (pid == -2) {
-								// NULL parameter
-								send_parameter_error_response("NULL is not allowed", PGSQL_ERROR_CODES::ERRCODE_NULL_VALUE_NOT_ALLOWED);
-							} else if (pid == -1) {
-								// Invalid format (not a valid integer)
-								send_parameter_error_response("invalid input syntax for integer", PGSQL_ERROR_CODES::ERRCODE_INVALID_PARAMETER_VALUE);
-							} else if (pid == 0) {
-								// PID <= 0 (non-positive)
-								send_parameter_error_response("PID must be a positive integer", PGSQL_ERROR_CODES::ERRCODE_INVALID_PARAMETER_VALUE);
-							}
-							l_free(pkt->size, pkt->ptr);
-							return true;
-						}
-					} else {
-						// No parameter available - this shouldn't happen
-						return false;
-					}
 				} else {
-					// No bind message available (shouldn't happen for Execute phase)
+					// No parameter available - this shouldn't happen
 					return false;
 				}
 			} else {

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -4425,11 +4425,10 @@ bool PgSQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___PGSQL_Q
 	}
 
 	// Handle KILL command
-	//if (prepared == false) {
 	if (handle_command_query_kill(pkt)) {
 		return true;
 	}
-	//
+
 	// Query cache handling
 	if (qpo->cache_ttl > 0 && stmt_type == PGSQL_EXTENDED_QUERY_TYPE_NOT_SET) {
 		const std::shared_ptr<PgSQL_QC_entry_t> pgsql_qc_entry = GloPgQC->get(
@@ -5171,55 +5170,284 @@ bool PgSQL_Session::handle_command_query_kill(PtrSize_t* pkt) {
 	if (!CurrentQuery.QueryParserArgs.digest_text)
 		return false;
 
-	if (client_myds && client_myds->myconn) {
-		PgSQL_Connection* mc = client_myds->myconn;
-		if (mc->userinfo && mc->userinfo->username) {
-			if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_CANCEL_BACKEND || 
-				CurrentQuery.PgQueryCmd == PGSQL_QUERY_TERMINATE_BACKEND) {
-				char* qu = pgsql_query_strip_comments((char*)CurrentQuery.QueryPointer, CurrentQuery.QueryLength,
-					pgsql_thread___query_digests_lowercase);
-				string nq = string(qu, strlen(qu));
-				re2::RE2::Options* opt2 = new re2::RE2::Options(RE2::Quiet);
-				opt2->set_case_sensitive(false);
-				char* pattern = (char*)"^SELECT\\s+(?:pg_catalog\\.)?PG_(TERMINATE|CANCEL)_BACKEND\\s*\\(\\s*(\\d+)\\s*\\)\\s*;?\\s*$";
-				re2::RE2* re = new RE2(pattern, *opt2);
-				string tk;
-				int id = 0;
-				RE2::FullMatch(nq, *re, &tk, &id);
-				delete re;
-				delete opt2;
-				proxy_debug(PROXY_DEBUG_MYSQL_QUERY_PROCESSOR, 2, "filtered query= \"%s\"\n", qu);
-				free(qu);
+	if (!client_myds ||
+		!client_myds->myconn ||
+		!client_myds->myconn->userinfo ||
+		!client_myds->myconn->userinfo->username) {
+		return false;
+	}
 
-				if (id) {
-					int tki = -1;
-					// Note: tk will capture "TERMINATE" or "CANCEL" (case insensitive match)
-					if (strcasecmp(tk.c_str(), "TERMINATE") == 0) {
-						tki = 0;  // Connection terminate
-					} else if (strcasecmp(tk.c_str(), "CANCEL") == 0) {
-						tki = 1;  // Query cancel
+	PgSQL_Connection* mc = client_myds->myconn;
+	if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_CANCEL_BACKEND || 
+		CurrentQuery.PgQueryCmd == PGSQL_QUERY_TERMINATE_BACKEND) {
+				
+		if (cmd == 'Q') {
+			// Simple query protocol - only handle literal values
+			// Parameterized queries in simple protocol are invalid and will be handled by PostgreSQL
+			return handle_literal_kill_query(pkt, mc);
+		} else {
+			// cmd == 'E' - Execute phase of extended query protocol
+			// Check if this is a parameterized query (contains $1)
+			// Note: This simple check might have false positives if $1 appears in comments or string literals
+			// but those cases would fail later when checking bind_msg or parameter validation
+			const char* digest_text = CurrentQuery.QueryParserArgs.digest_text;
+			bool is_parameterized = strstr(digest_text, "$1") != nullptr;
+			if (is_parameterized) {
+				// Check if there are multiple parameters (e.g., $1, $2)
+				// Look for $2, $3, etc. to reject multiple parameters
+				const char* p = digest_text;
+				int max_param = 0;
+				while ((p = strstr(p, "$")) != nullptr) {
+					p++; // Skip '$'
+					if (isdigit(*p)) {
+						int param_num = atoi(p);
+						if (param_num > max_param) max_param = param_num;
 					}
-					if (tki >= 0) {
-						proxy_debug(PROXY_DEBUG_MYSQL_QUERY_PROCESSOR, 2, "Killing %s %d\n", (tki == 0 ? "CONNECTION" : "QUERY"), id);
-						GloPTH->kill_connection_or_query(id, 0, mc->userinfo->username, (tki == 0 ? false : true));
-						client_myds->DSS = STATE_QUERY_SENT_NET;
-					
-						std::unique_ptr<SQLite3_result> resultset = std::make_unique<SQLite3_result>(1);
-						resultset->add_column_definition(SQLITE_TEXT, tki == 0 ? "pg_terminate_backend" : "pg_cancel_backend");
-						char* pta[1];
-						pta[0] = (char*)"t";
-						resultset->add_row(pta);
-						bool send_ready_packet = is_extended_query_ready_for_query();
-						unsigned int nTxn = NumActiveTransactions();
-						char txn_state = (nTxn ? 'T' : 'I');
-						SQLite3_to_Postgres(client_myds->PSarrayOUT, resultset.get(), nullptr, 0, (const char*)pkt->ptr + 5, send_ready_packet, txn_state);
-
-						RequestEnd(NULL, false);
+					p++;
+				}
+				if (max_param > 1) {
+					// Multiple parameters not supported
+					send_parameter_error_response("function requires exactly one parameter");
+					l_free(pkt->size, pkt->ptr);
+					return true;
+				}
+						
+				// Handle parameterized query
+				if (CurrentQuery.extended_query_info.bind_msg) {
+					const PgSQL_Bind_Message* bind_msg = CurrentQuery.extended_query_info.bind_msg;
+					auto param_reader = bind_msg->get_param_value_reader();
+					PgSQL_Param_Value param;
+							
+					// Check that we have exactly one parameter
+					if (bind_msg->data().num_param_values != 1) {
+						send_parameter_error_response("function requires exactly one parameter");
 						l_free(pkt->size, pkt->ptr);
 						return true;
 					}
+							
+					if (param_reader.next(&param)) {
+						// Get parameter format (default to text format 0)
+						uint16_t param_format = 0;
+						if (bind_msg->data().num_param_formats == 1) {
+							// Single format applies to all parameters
+							auto format_reader = bind_msg->get_param_format_reader();
+							format_reader.next(&param_format);
+						}
+								
+						// Extract PID from parameter
+						int32_t pid = extract_pid_from_param(param, param_format);
+						if (pid > 0) {
+							// Determine if this is terminate or cancel
+							int tki = -1;
+							if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_TERMINATE_BACKEND) {
+								tki = 0;  // Connection terminate
+							} else if (CurrentQuery.PgQueryCmd == PGSQL_QUERY_CANCEL_BACKEND) {
+								tki = 1;  // Query cancel
+							}
+									
+							if (tki >= 0) {
+								return handle_kill_success(pid, tki, digest_text, mc, pkt);
+							}
+						} else {
+							// Invalid parameter - send appropriate error response
+							if (pid == -2) {
+								// NULL parameter
+								send_parameter_error_response("NULL is not allowed");
+							} else if (pid == -1) {
+								// Invalid format (not a valid integer)
+								send_parameter_error_response("invalid input syntax for integer");
+							} else if (pid == 0) {
+								// PID <= 0 (non-positive)
+								send_parameter_error_response("PID must be a positive integer");
+							}
+							l_free(pkt->size, pkt->ptr);
+							return true;
+						}
+					} else {
+						// No parameter available - this shouldn't happen
+						return false;
+					}
+				} else {
+					// No bind message available (shouldn't happen for Execute phase)
+					return false;
 				}
+			} else {
+				// Literal query in extended protocol
+				return handle_literal_kill_query(pkt, mc);
 			}
+		}
+	}
+
+	return false;
+}
+
+int32_t PgSQL_Session::extract_pid_from_param(const PgSQL_Param_Value& param, uint16_t format) const {
+
+	if (param.len == -1) {
+		// NULL parameter
+		return -2; // Special value for NULL
+	}
+	
+	/* ---------------- TEXT FORMAT ---------------- */
+	if (format == 0) {
+		// Text format
+		if (param.len == 0) {
+			// Empty string
+			return -1;
+		}
+		
+		// Convert text to integer
+		std::string_view str_val(reinterpret_cast<const char*>(param.value), param.len);
+
+		// Validate that the string contains only digits
+		for (size_t i = 0; i < str_val.size(); i++) {
+			if (!isdigit(str_val[i])) {
+				return -1;
+			}
+		}
+		
+		// Parse the integer
+		char* endptr;
+		long pid = strtol(str_val.data(), &endptr, 10);
+		
+		// Check for conversion errors
+		if (endptr != str_val.data() + str_val.size()) {
+			return -1;
+		}
+		
+		// Check valid range
+		if (pid <= 0) {
+			return 0; // Special value for non-positive
+		}
+		if (pid > INT_MAX) {
+			return -1; // Out of range
+		}
+		
+		return static_cast<int32_t>(pid);
+	} 
+
+	/* ---------------- BINARY FORMAT ---------------- */
+	// PostgreSQL sends int4 or int8 for integer parameters
+	if (format == 1) { // Binary format (format == 1)
+		
+		if (param.len == 4) {
+			// uint32 in network byte order
+			uint32_t host_u32;
+			get_uint32be(reinterpret_cast<const unsigned char*>(param.value), &host_u32);
+			int32_t pid = static_cast<int32_t>(host_u32);
+			
+			// Validate positive PID
+			if (pid <= 0) {
+				return 0; // Special value for non-positive
+			}
+			return pid;
+		} 
+		
+		if (param.len == 8) {
+			// int64 in network byte order (PostgreSQL sends int8 for some integer types)
+			uint64_t host_u64 = 0;
+			get_uint64be(reinterpret_cast<const unsigned char*>(param.value), &host_u64);
+			int64_t pid = static_cast<int64_t>(host_u64);
+			
+			// Validate positive PID and within int32 range
+			if (pid <= 0) {
+				return 0; // Special value for non-positive
+			}
+			if (pid > INT_MAX) {
+				return -1; // Out of range
+			}
+			return static_cast<int32_t>(pid);
+		}
+
+		// Invalid integer width for Bind
+		return -1;
+	}
+
+	char buf[INET6_ADDRSTRLEN];
+	switch (client_myds->client_addr->sa_family) {
+	case AF_INET: {
+		struct sockaddr_in* ipv4 = (struct sockaddr_in*)client_myds->client_addr;
+		inet_ntop(client_myds->client_addr->sa_family, &ipv4->sin_addr, buf, INET_ADDRSTRLEN);
+		break;
+	}
+	case AF_INET6: {
+		struct sockaddr_in6* ipv6 = (struct sockaddr_in6*)client_myds->client_addr;
+		inet_ntop(client_myds->client_addr->sa_family, &ipv6->sin6_addr, buf, INET6_ADDRSTRLEN);
+		break;
+	}
+	default:
+		sprintf(buf, "localhost");
+		break;
+	}
+
+	// Unknown format code
+	proxy_error("Unknown parameter format code: %u from client %s", format, buf);
+	return -1;
+}
+
+void PgSQL_Session::send_parameter_error_response(const char* error_message) {
+	if (!client_myds) return;
+	
+	// Create proper PostgreSQL error message
+	std::string full_error = std::string("invalid input syntax for integer: \"") + 
+		(error_message ? error_message : "parameter error") + "\"";
+	client_myds->setDSS_STATE_QUERY_SENT_NET();
+	// Generate and send error packet using PostgreSQL protocol
+	client_myds->myprot.generate_error_packet(true, is_extended_query_ready_for_query(), 
+		full_error.c_str(), PGSQL_ERROR_CODES::ERRCODE_INVALID_TEXT_REPRESENTATION, false, true);
+	
+	RequestEnd(NULL, true);
+}
+
+bool PgSQL_Session::handle_kill_success(int32_t pid, int tki, const char* digest_text, PgSQL_Connection* mc, PtrSize_t* pkt) {
+
+	proxy_debug(PROXY_DEBUG_MYSQL_QUERY_PROCESSOR, 2, "Killing %s %d\n",
+		(tki == 0 ? "CONNECTION" : "QUERY"), pid);
+	GloPTH->kill_connection_or_query(pid, 0, mc->userinfo->username, (tki == 0 ? false : true));
+	client_myds->DSS = STATE_QUERY_SENT_NET;
+
+	std::unique_ptr<SQLite3_result> resultset = std::make_unique<SQLite3_result>(1);
+	resultset->add_column_definition(SQLITE_TEXT, tki == 0 ? "pg_terminate_backend" : "pg_cancel_backend");
+	char* pta[1];
+	pta[0] = (char*)"t";
+	resultset->add_row(pta);
+	bool send_ready_packet = is_extended_query_ready_for_query();
+	unsigned int nTxn = NumActiveTransactions();
+	char txn_state = (nTxn ? 'T' : 'I');
+	SQLite3_to_Postgres(client_myds->PSarrayOUT, resultset.get(), nullptr, 0, digest_text, send_ready_packet, txn_state);
+
+	RequestEnd(NULL, false);
+	l_free(pkt->size, pkt->ptr);
+	return true;
+}
+
+bool PgSQL_Session::handle_literal_kill_query(PtrSize_t* pkt, PgSQL_Connection* mc) {
+	// Handle literal query (original implementation)
+	char* qu = pgsql_query_strip_comments((char*)CurrentQuery.QueryPointer, CurrentQuery.QueryLength,
+		pgsql_thread___query_digests_lowercase);
+	std::string nq { qu, strlen(qu) };
+
+	re2::RE2::Options opt2(RE2::Quiet);
+	opt2.set_case_sensitive(false);
+	const char* pattern = "^SELECT\\s+(?:pg_catalog\\.)?PG_(TERMINATE|CANCEL)_BACKEND\\s*\\(\\s*(\\d+)\\s*\\)\\s*;?\\s*$";
+	re2::RE2 re(pattern, opt2);
+	std::string tk;
+	uint32_t id = 0;
+	RE2::FullMatch(nq, re, &tk, &id);
+	
+	proxy_debug(PROXY_DEBUG_MYSQL_QUERY_PROCESSOR, 2, "filtered query= \"%s\"\n", qu);
+	free(qu);
+
+	if (id > 0) {
+		int tki = -1;
+		// Note: tk will capture "TERMINATE" or "CANCEL" (case insensitive match)
+		if (strcasecmp(tk.c_str(), "TERMINATE") == 0) {
+			tki = 0;  // Connection terminate
+		} else if (strcasecmp(tk.c_str(), "CANCEL") == 0) {
+			tki = 1;  // Query cancel
+		}
+		if (tki >= 0) {
+			return handle_kill_success(id, tki, CurrentQuery.QueryParserArgs.digest_text, mc, pkt);
 		}
 	}
 	return false;
@@ -6123,6 +6351,17 @@ int PgSQL_Session::handle_post_sync_execute_message(PgSQL_Execute_Message* execu
 			if (handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___handle_special_commands(dig, &lock_hostgroup)) {
 				// if we are here, it means we have handled the special command
 				return 0;
+			}
+
+			PGSQL_QUERY_command pg_query_cmd = extended_query_info.stmt_info->PgQueryCmd;
+			if (pg_query_cmd == PGSQL_QUERY_CANCEL_BACKEND ||
+				pg_query_cmd == PGSQL_QUERY_TERMINATE_BACKEND) {
+				CurrentQuery.PgQueryCmd = pg_query_cmd;
+				auto execute_pkt = execute_msg->get_raw_pkt(); // detach the packet from the describe message
+				if (handle_command_query_kill(&execute_pkt)) {
+					execute_msg->detach(); // detach the packet from the execute message
+					return 0;
+				}
 			}
 		}
 		current_hostgroup = previous_hostgroup; // reset current hostgroup to previous hostgroup

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5200,8 +5200,15 @@ bool PgSQL_Session::handle_command_query_kill(PtrSize_t* pkt) {
 				while ((p = strstr(p, "$")) != nullptr) {
 					p++; // Skip '$'
 					if (isdigit(*p)) {
-						int param_num = atoi(p);
-						if (param_num > max_param) max_param = param_num;
+						char* end;
+						long param_num = strtol(p, &end, 10);
+						if (p != end) { // check if any digits were parsed
+							if (param_num > max_param) {
+								max_param = static_cast<int>(param_num);
+							}
+							p = end;
+							continue;
+						}
 					}
 					p++;
 				}
@@ -5252,13 +5259,13 @@ bool PgSQL_Session::handle_command_query_kill(PtrSize_t* pkt) {
 							// Invalid parameter - send appropriate error response
 							if (pid == -2) {
 								// NULL parameter
-								send_parameter_error_response("NULL is not allowed");
+								send_parameter_error_response("NULL is not allowed", PGSQL_ERROR_CODES::ERRCODE_NULL_VALUE_NOT_ALLOWED);
 							} else if (pid == -1) {
 								// Invalid format (not a valid integer)
-								send_parameter_error_response("invalid input syntax for integer");
+								send_parameter_error_response("invalid input syntax for integer", PGSQL_ERROR_CODES::ERRCODE_INVALID_PARAMETER_VALUE);
 							} else if (pid == 0) {
 								// PID <= 0 (non-positive)
-								send_parameter_error_response("PID must be a positive integer");
+								send_parameter_error_response("PID must be a positive integer", PGSQL_ERROR_CODES::ERRCODE_INVALID_PARAMETER_VALUE);
 							}
 							l_free(pkt->size, pkt->ptr);
 							return true;
@@ -5297,7 +5304,7 @@ int32_t PgSQL_Session::extract_pid_from_param(const PgSQL_Param_Value& param, ui
 		}
 		
 		// Convert text to integer
-		std::string_view str_val(reinterpret_cast<const char*>(param.value), param.len);
+		std::string str_val(reinterpret_cast<const char*>(param.value), param.len);
 
 		// Validate that the string contains only digits
 		for (size_t i = 0; i < str_val.size(); i++) {
@@ -5308,10 +5315,10 @@ int32_t PgSQL_Session::extract_pid_from_param(const PgSQL_Param_Value& param, ui
 		
 		// Parse the integer
 		char* endptr;
-		long pid = strtol(str_val.data(), &endptr, 10);
+		long pid = strtol(str_val.c_str(), &endptr, 10);
 		
 		// Check for conversion errors
-		if (endptr != str_val.data() + str_val.size()) {
+		if (endptr != str_val.c_str() + str_val.size()) {
 			return -1;
 		}
 		
@@ -5334,12 +5341,10 @@ int32_t PgSQL_Session::extract_pid_from_param(const PgSQL_Param_Value& param, ui
 			// uint32 in network byte order
 			uint32_t host_u32;
 			get_uint32be(reinterpret_cast<const unsigned char*>(param.value), &host_u32);
-			int32_t pid = static_cast<int32_t>(host_u32);
-			
-			// Validate positive PID
-			if (pid <= 0) {
-				return 0; // Special value for non-positive
+			if (host_u32 & 0x80000000u) { // negative int4
+				return 0;
 			}
+			int32_t pid = static_cast<int32_t>(host_u32);
 			return pid;
 		} 
 		
@@ -5347,15 +5352,13 @@ int32_t PgSQL_Session::extract_pid_from_param(const PgSQL_Param_Value& param, ui
 			// int64 in network byte order (PostgreSQL sends int8 for some integer types)
 			uint64_t host_u64 = 0;
 			get_uint64be(reinterpret_cast<const unsigned char*>(param.value), &host_u64);
+			if (host_u64 & 0x8000000000000000ull) { // negative int8
+				return 0;
+			}
+			if (host_u64 > static_cast<uint64_t>(INT32_MAX)) {
+				return -1; // out of range for PID
+			}
 			int64_t pid = static_cast<int64_t>(host_u64);
-			
-			// Validate positive PID and within int32 range
-			if (pid <= 0) {
-				return 0; // Special value for non-positive
-			}
-			if (pid > INT_MAX) {
-				return -1; // Out of range
-			}
 			return static_cast<int32_t>(pid);
 		}
 
@@ -5379,13 +5382,12 @@ int32_t PgSQL_Session::extract_pid_from_param(const PgSQL_Param_Value& param, ui
 		sprintf(buf, "localhost");
 		break;
 	}
-
 	// Unknown format code
-	proxy_error("Unknown parameter format code: %u from client %s", format, buf);
+	proxy_error("Unknown parameter format code: %u received from client %s:%d", format, buf, client_myds->addr.port);
 	return -1;
 }
 
-void PgSQL_Session::send_parameter_error_response(const char* error_message) {
+void PgSQL_Session::send_parameter_error_response(const char* error_message, PGSQL_ERROR_CODES error_code) {
 	if (!client_myds) return;
 	
 	// Create proper PostgreSQL error message
@@ -5394,7 +5396,7 @@ void PgSQL_Session::send_parameter_error_response(const char* error_message) {
 	client_myds->setDSS_STATE_QUERY_SENT_NET();
 	// Generate and send error packet using PostgreSQL protocol
 	client_myds->myprot.generate_error_packet(true, is_extended_query_ready_for_query(), 
-		full_error.c_str(), PGSQL_ERROR_CODES::ERRCODE_INVALID_TEXT_REPRESENTATION, false, true);
+		full_error.c_str(), error_code, false, true);
 	
 	RequestEnd(NULL, true);
 }
@@ -5425,7 +5427,7 @@ bool PgSQL_Session::handle_literal_kill_query(PtrSize_t* pkt, PgSQL_Connection* 
 	// Handle literal query (original implementation)
 	char* qu = pgsql_query_strip_comments((char*)CurrentQuery.QueryPointer, CurrentQuery.QueryLength,
 		pgsql_thread___query_digests_lowercase);
-	std::string nq { qu, strlen(qu) };
+	std::string nq(qu);
 
 	re2::RE2::Options opt2(RE2::Quiet);
 	opt2.set_case_sensitive(false);

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5306,19 +5306,14 @@ int32_t PgSQL_Session::extract_pid_from_param(const PgSQL_Param_Value& param, ui
 		// Convert text to integer
 		std::string str_val(reinterpret_cast<const char*>(param.value), param.len);
 
-		// Validate that the string contains only digits
-		for (size_t i = 0; i < str_val.size(); i++) {
-			if (!isdigit(str_val[i])) {
-				return -1;
-			}
-		}
-		
-		// Parse the integer
+		// Parse the integer (allow leading +/- and whitespace, then validate semantics)
 		char* endptr;
+		errno = 0;
 		long pid = strtol(str_val.c_str(), &endptr, 10);
-		
-		// Check for conversion errors
-		if (endptr != str_val.c_str() + str_val.size()) {
+
+		// Require full consumption (ignoring trailing whitespace)
+		while (endptr && *endptr && isspace(static_cast<unsigned char>(*endptr))) endptr++;
+		if (endptr == str_val.c_str() || (endptr && *endptr) || errno == ERANGE) {
 			return -1;
 		}
 		

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -244,6 +244,7 @@
   "test_ignore_min_gtid-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-query_digests_stages_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-monitor_ssl_connections_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-parameterized_kill_queries_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5284_frontend_ssl_enforcement-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5273_bind_parameter_format-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "unit-strip_schema_from_query-t": [ "unit-tests-g1" ]

--- a/test/tap/tests/pgsql-parameterized_kill_queries_test-t.cpp
+++ b/test/tap/tests/pgsql-parameterized_kill_queries_test-t.cpp
@@ -502,7 +502,7 @@ int main(int argc, char** argv) {
     {
         auto test_conn = createNewConnection(BACKEND);
         if (!test_conn || PQstatus(test_conn.get()) != CONNECTION_OK) {
-            skip(2, "Connection failed");
+            skip(1, "Connection failed");
         } else {
             // Test with SELECT pg_cancel_backend($1, $2)
             std::string stmt_name = "multi_param_" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count());
@@ -511,7 +511,6 @@ int main(int argc, char** argv) {
             PGresult* res = PQprepare(test_conn.get(), stmt_name.c_str(), "SELECT pg_cancel_backend($1, $2)", 2, NULL);
             bool prepare_failed = (PQresultStatus(res) == PGRES_FATAL_ERROR);
             PQclear(res);
-
 
             ok(prepare_failed, "Multiple parameters should return error");
 

--- a/test/tap/tests/pgsql-parameterized_kill_queries_test-t.cpp
+++ b/test/tap/tests/pgsql-parameterized_kill_queries_test-t.cpp
@@ -1,0 +1,575 @@
+/**
+ * @file pgsql-parameterized_kill_queries_test-t.cpp
+ * @brief TAP test verifying ProxySQL parameterized pg_terminate_backend and pg_cancel_backend support.
+ * 
+ */
+
+#include <unistd.h>
+#include <string>
+#include <sstream>
+#include <chrono>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <vector>
+#include <cstring>
+#include <cstdlib>
+#include <cctype>
+#include <arpa/inet.h>
+#include "libpq-fe.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+CommandLine cl;
+
+using PGConnPtr = std::unique_ptr<PGconn, decltype(&PQfinish)>;
+
+enum ConnType {
+    ADMIN,
+    BACKEND
+};
+
+PGConnPtr createNewConnection(ConnType conn_type, const std::string& options = "", bool with_ssl = false) {
+    
+    const char* host = (conn_type == BACKEND) ? cl.pgsql_host : cl.pgsql_admin_host;
+    int port = (conn_type == BACKEND) ? cl.pgsql_port : cl.pgsql_admin_port;
+    const char* username = (conn_type == BACKEND) ? cl.pgsql_username : cl.admin_username;
+    const char* password = (conn_type == BACKEND) ? cl.pgsql_password : cl.admin_password;
+
+    std::stringstream ss;
+
+    ss << "host=" << host << " port=" << port;
+    ss << " user=" << username << " password=" << password;
+    ss << (with_ssl ? " sslmode=require" : " sslmode=disable");
+
+    if (options.empty() == false) {
+		ss << " options='" << options << "'";
+    }
+
+    PGconn* conn = PQconnectdb(ss.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        fprintf(stderr, "Connection failed to '%s': %s", (conn_type == BACKEND ? "Backend" : "Admin"), PQerrorMessage(conn));
+        PQfinish(conn);
+        return PGConnPtr(nullptr, &PQfinish);
+    }
+    return PGConnPtr(conn, &PQfinish);
+}
+
+struct TestSync {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool query_started = false;
+    bool query_completed = false;
+};
+
+void execute_long_running_query(PGconn* conn, TestSync& sync, int duration_sec, bool& was_canceled) {
+    std::string query = "SELECT pg_sleep(" + std::to_string(duration_sec) + ")";
+    
+    {
+        std::lock_guard<std::mutex> lock(sync.mutex);
+        sync.query_started = true;
+    }
+    sync.cv.notify_one();
+
+    PGresult* res = PQexec(conn, query.c_str());
+    
+    {
+        std::lock_guard<std::mutex> lock(sync.mutex);
+        sync.query_completed = true;
+    }
+    sync.cv.notify_one();
+
+    if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+        if (PQresultStatus(res) == PGRES_FATAL_ERROR) {
+            const char* error = PQresultErrorMessage(res);
+            if (error && strstr(error, "canceling statement due to user request")) {
+                was_canceled = true;
+            }
+        }
+    }
+    
+    PQclear(res);
+}
+
+bool execute_prepared_statement(PGconn* conn, const std::string& stmt_name, const std::string& query, 
+                                const char* param_value, int param_len, int param_format) {
+    // Prepare the statement
+    PGresult* res = PQprepare(conn, stmt_name.c_str(), query.c_str(), 1, NULL);
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        PQclear(res);
+        return false;
+    }
+    PQclear(res);
+
+    // Bind and execute with parameter
+    const char* param_values[1] = {param_value};
+    int param_lengths[1] = {param_len};
+    int param_formats[1] = {param_format};
+    
+    res = PQexecPrepared(conn, stmt_name.c_str(), 1, param_values, param_lengths, param_formats, 0);
+    bool success = (PQresultStatus(res) == PGRES_TUPLES_OK);
+    PQclear(res);
+
+    // Clean up prepared statement
+    res = PQexec(conn, ("DEALLOCATE " + stmt_name).c_str());
+    PQclear(res);
+
+    return success;
+}
+
+bool execute_prepared_statement_binary(PGconn* conn, const std::string& stmt_name, const std::string& query,
+                                      int32_t pid_value) {
+    // Prepare the statement
+    PGresult* res = PQprepare(conn, stmt_name.c_str(), query.c_str(), 1, NULL);
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        PQclear(res);
+        return false;
+    }
+    PQclear(res);
+
+    // Convert PID to network byte order for binary format
+    uint32_t network_pid = htonl(static_cast<uint32_t>(pid_value));
+    const char* param_values[1] = {reinterpret_cast<const char*>(&network_pid)};
+    int param_lengths[1] = {4};
+    int param_formats[1] = {1};  // Binary format
+    
+    res = PQexecPrepared(conn, stmt_name.c_str(), 1, param_values, param_lengths, param_formats, 0);
+    bool success = (PQresultStatus(res) == PGRES_TUPLES_OK);
+    PQclear(res);
+
+    // Clean up prepared statement
+    res = PQexec(conn, ("DEALLOCATE " + stmt_name).c_str());
+    PQclear(res);
+
+    return success;
+}
+
+bool execute_prepared_statement_int8(PGconn* conn, const std::string& stmt_name, const std::string& query,
+                                    int64_t pid_value) {
+    // Prepare the statement
+    PGresult* res = PQprepare(conn, stmt_name.c_str(), query.c_str(), 1, NULL);
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        PQclear(res);
+        return false;
+    }
+    PQclear(res);
+
+    // Convert PID to network byte order for binary format (int8)
+    uint64_t network_pid = 0;
+    // Simple big-endian conversion for 64-bit
+    uint64_t host_pid = static_cast<uint64_t>(pid_value);
+    network_pid = 
+        ((host_pid & 0xFF00000000000000ULL) >> 56) |
+        ((host_pid & 0x00FF000000000000ULL) >> 40) |
+        ((host_pid & 0x0000FF0000000000ULL) >> 24) |
+        ((host_pid & 0x000000FF00000000ULL) >> 8) |
+        ((host_pid & 0x00000000FF000000ULL) << 8) |
+        ((host_pid & 0x0000000000FF0000ULL) << 24) |
+        ((host_pid & 0x000000000000FF00ULL) << 40) |
+        ((host_pid & 0x00000000000000FFULL) << 56);
+    
+    const char* param_values[1] = {reinterpret_cast<const char*>(&network_pid)};
+    int param_lengths[1] = {8};
+    int param_formats[1] = {1};  // Binary format
+    
+    res = PQexecPrepared(conn, stmt_name.c_str(), 1, param_values, param_lengths, param_formats, 0);
+    bool success = (PQresultStatus(res) == PGRES_TUPLES_OK);
+    PQclear(res);
+
+    // Clean up prepared statement
+    res = PQexec(conn, ("DEALLOCATE " + stmt_name).c_str());
+    PQclear(res);
+
+    return success;
+}
+
+bool test_parameterized_query_error(PGconn* conn, const std::string& query, const char* param_value, 
+                                   int param_len, int param_format, const char* expected_error) {
+    std::string stmt_name = "test_error_" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count());
+    
+    // Prepare the statement
+    PGresult* res = PQprepare(conn, stmt_name.c_str(), query.c_str(), 1, NULL);
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        PQclear(res);
+        return false;
+    }
+    PQclear(res);
+
+    // Bind and execute with parameter
+    const char* param_values[1] = {param_value};
+    int param_lengths[1] = {param_len};
+    int param_formats[1] = {param_format};
+    
+    res = PQexecPrepared(conn, stmt_name.c_str(), 1, param_values, param_lengths, param_formats, 0);
+    
+    bool has_error = (PQresultStatus(res) == PGRES_FATAL_ERROR);
+    bool error_matches = false;
+    
+    if (has_error) {
+        const char* error_msg = PQresultErrorMessage(res);
+        if (error_msg && strstr(error_msg, expected_error)) {
+            error_matches = true;
+        }
+    }
+    
+    PQclear(res);
+
+    // Clean up prepared statement
+    res = PQexec(conn, ("DEALLOCATE " + stmt_name).c_str());
+    PQclear(res);
+
+    return has_error && error_matches;
+}
+
+int main(int argc, char** argv) {
+    TestSync sync;
+    bool was_canceled = false;
+
+    if (cl.getEnv())
+        return exit_status();
+
+    plan(21); // Total number of tests
+   
+    // Test 1: Basic parameterized pg_cancel_backend with text format
+    diag("Test 1: Parameterized pg_cancel_backend with text format");
+    {
+        auto backend_conn = createNewConnection(BACKEND);
+        if (!backend_conn || PQstatus(backend_conn.get()) != CONNECTION_OK) {
+            diag("Error: failed to connect to the database");
+            skip(1, "Connection failed");
+        } else {
+            int backend_pid = PQbackendPID(backend_conn.get());
+            
+            // Start query in separate thread
+            std::thread query_thread([&]() {
+                execute_long_running_query(backend_conn.get(), sync, 10, was_canceled);
+            });
+
+            // Wait for query to start
+            {
+                std::unique_lock<std::mutex> lock(sync.mutex);
+                sync.cv.wait(lock, [&]() { return sync.query_started; });
+            }
+
+            // Create connection and cancel the query using parameterized statement
+            auto cancel_conn = createNewConnection(BACKEND);
+            if (!cancel_conn || PQstatus(cancel_conn.get()) != CONNECTION_OK) {
+                query_thread.join();
+                skip(1, "Connection failed");
+            } else {
+                std::string pid_str = std::to_string(backend_pid);
+                bool success = execute_prepared_statement(cancel_conn.get(), "cancel_stmt", 
+                    "SELECT pg_cancel_backend($1)", pid_str.c_str(), pid_str.length(), 0);
+                
+                ok(success, "Parameterized pg_cancel_backend with text format should succeed");
+
+                // Wait for query completion
+                {
+                    std::unique_lock<std::mutex> lock(sync.mutex);
+                    sync.cv.wait_for(lock, std::chrono::seconds(3), [&]() { return sync.query_completed; });
+                }
+
+                query_thread.join();
+                ok(was_canceled, "Query should be canceled via parameterized query");
+            }
+        }
+    }
+
+    // Test 2: Basic parameterized pg_terminate_backend with text format
+    diag("Test 2: Parameterized pg_terminate_backend with text format");
+    {
+        auto victim_conn = createNewConnection(BACKEND);
+        if (!victim_conn || PQstatus(victim_conn.get()) != CONNECTION_OK) {
+            skip(1, "Connection failed");
+        } else {
+            int victim_pid = PQbackendPID(victim_conn.get());
+            
+            // Create connection and terminate using parameterized statement
+            auto killer_conn = createNewConnection(BACKEND);
+            if (!killer_conn || PQstatus(killer_conn.get()) != CONNECTION_OK) {
+                skip(1, "Connection failed");
+            } else {
+                std::string pid_str = std::to_string(victim_pid);
+                bool success = execute_prepared_statement(killer_conn.get(), "terminate_stmt", 
+                    "SELECT pg_terminate_backend($1)", pid_str.c_str(), pid_str.length(), 0);
+                
+                ok(success, "Parameterized pg_terminate_backend with text format should succeed");
+
+                // Verify the connection was terminated
+                PGresult* res = PQexec(victim_conn.get(), "SELECT 1");
+                bool connection_dead = (PQresultStatus(res) != PGRES_TUPLES_OK);
+                PQclear(res);
+                
+                ok(connection_dead, "Connection should be terminated");
+            }
+        }
+    }
+
+    // Test 3: Parameterized pg_cancel_backend with binary format (int4)
+    diag("Test 3: Parameterized pg_cancel_backend with binary format (int4)");
+    {
+        auto backend_conn = createNewConnection(BACKEND);
+        if (!backend_conn || PQstatus(backend_conn.get()) != CONNECTION_OK) {
+            diag("Error: failed to connect to the database");
+            skip(1, "Connection failed");
+        } else {
+            int backend_pid = PQbackendPID(backend_conn.get());
+            
+            // Reset sync variables
+            sync.query_started = false;
+            sync.query_completed = false;
+            was_canceled = false;
+            
+            // Start query in separate thread
+            std::thread query_thread([&]() {
+                execute_long_running_query(backend_conn.get(), sync, 10, was_canceled);
+            });
+
+            // Wait for query to start
+            {
+                std::unique_lock<std::mutex> lock(sync.mutex);
+                sync.cv.wait(lock, [&]() { return sync.query_started; });
+            }
+
+            // Create connection and cancel the query using binary format
+            auto cancel_conn = createNewConnection(BACKEND);
+            if (!cancel_conn || PQstatus(cancel_conn.get()) != CONNECTION_OK) {
+                query_thread.join();
+                skip(1, "Connection failed");
+            } else {
+                bool success = execute_prepared_statement_binary(cancel_conn.get(), "cancel_binary_stmt",
+                    "SELECT pg_cancel_backend($1)", backend_pid);
+                
+                ok(success, "Parameterized pg_cancel_backend with binary format (int4) should succeed");
+
+                // Wait for query completion
+                {
+                    std::unique_lock<std::mutex> lock(sync.mutex);
+                    sync.cv.wait_for(lock, std::chrono::seconds(3), [&]() { return sync.query_completed; });
+                }
+
+                query_thread.join();
+                ok(was_canceled, "Query should be canceled via binary parameterized query");
+            }
+        }
+    }
+
+    // Test 4: Parameterized pg_terminate_backend with binary format (int4)
+    diag("Test 4: Parameterized pg_terminate_backend with binary format (int4)");
+    {
+        auto victim_conn = createNewConnection(BACKEND);
+        if (!victim_conn || PQstatus(victim_conn.get()) != CONNECTION_OK) {
+            skip(1, "Connection failed");
+        } else {
+            int victim_pid = PQbackendPID(victim_conn.get());
+            
+            // Create connection and terminate using binary format
+            auto killer_conn = createNewConnection(BACKEND);
+            if (!killer_conn || PQstatus(killer_conn.get()) != CONNECTION_OK) {
+                skip(1, "Connection failed");
+            } else {
+                bool success = execute_prepared_statement_binary(killer_conn.get(), "terminate_binary_stmt",
+                    "SELECT pg_terminate_backend($1)", victim_pid);
+                
+                ok(success, "Parameterized pg_terminate_backend with binary format (int4) should succeed");
+
+                // Verify the connection was terminated
+                PGresult* res = PQexec(victim_conn.get(), "SELECT 1");
+                bool connection_dead = (PQresultStatus(res) != PGRES_TUPLES_OK);
+                PQclear(res);
+                
+                ok(connection_dead, "Connection should be terminated with binary parameter");
+            }
+        }
+    }
+
+    // Test 5: Parameterized pg_cancel_backend with binary format (int8)
+    diag("Test 5: Parameterized pg_cancel_backend with binary format (int8)");
+    {
+        auto backend_conn = createNewConnection(BACKEND);
+        if (!backend_conn || PQstatus(backend_conn.get()) != CONNECTION_OK) {
+            diag("Error: failed to connect to the database");
+            skip(1, "Connection failed");
+        } else {
+            int backend_pid = PQbackendPID(backend_conn.get());
+            
+            // Reset sync variables
+            sync.query_started = false;
+            sync.query_completed = false;
+            was_canceled = false;
+            
+            // Start query in separate thread
+            std::thread query_thread([&]() {
+                execute_long_running_query(backend_conn.get(), sync, 10, was_canceled);
+            });
+
+            // Wait for query to start
+            {
+                std::unique_lock<std::mutex> lock(sync.mutex);
+                sync.cv.wait(lock, [&]() { return sync.query_started; });
+            }
+
+            // Create connection and cancel the query using int8 binary format
+            auto cancel_conn = createNewConnection(BACKEND);
+            if (!cancel_conn || PQstatus(cancel_conn.get()) != CONNECTION_OK) {
+                query_thread.join();
+                skip(1, "Connection failed");
+            } else {
+                bool success = execute_prepared_statement_int8(cancel_conn.get(), "cancel_int8_stmt",
+                    "SELECT pg_cancel_backend($1)", static_cast<int64_t>(backend_pid));
+                
+                ok(success, "Parameterized pg_cancel_backend with binary format (int8) should succeed");
+
+                // Wait for query completion
+                {
+                    std::unique_lock<std::mutex> lock(sync.mutex);
+                    sync.cv.wait_for(lock, std::chrono::seconds(3), [&]() { return sync.query_completed; });
+                }
+
+                query_thread.join();
+                ok(was_canceled, "Query should be canceled via int8 binary parameterized query");
+            }
+        }
+    }
+
+    // Test 6: Error handling - NULL parameter
+    diag("Test 6: Error handling - NULL parameter");
+    {
+        auto test_conn = createNewConnection(BACKEND);
+        if (!test_conn || PQstatus(test_conn.get()) != CONNECTION_OK) {
+            skip(2, "Connection failed");
+        } else {
+            bool error_occurred = test_parameterized_query_error(test_conn.get(), 
+                "SELECT pg_cancel_backend($1)", NULL, 0, 0, "NULL is not allowed");
+            ok(error_occurred, "NULL parameter should return error");
+            
+            error_occurred = test_parameterized_query_error(test_conn.get(),
+                "SELECT pg_terminate_backend($1)", NULL, 0, 0, "NULL is not allowed");
+            ok(error_occurred, "NULL parameter should return error for terminate");
+        }
+    }
+
+    // Test 7: Error handling - Invalid text (non-integer)
+    diag("Test 7: Error handling - Invalid text parameter");
+    {
+        auto test_conn = createNewConnection(BACKEND);
+        if (!test_conn || PQstatus(test_conn.get()) != CONNECTION_OK) {
+            skip(2, "Connection failed");
+        } else {
+            bool error_occurred = test_parameterized_query_error(test_conn.get(),
+                "SELECT pg_cancel_backend($1)", "not_a_number", 12, 0, "invalid input syntax for integer");
+            ok(error_occurred, "Non-integer text parameter should return error");
+            
+            error_occurred = test_parameterized_query_error(test_conn.get(),
+                "SELECT pg_terminate_backend($1)", "abc123", 6, 0, "invalid input syntax for integer");
+            ok(error_occurred, "Mixed text parameter should return error");
+        }
+    }
+    
+    // Test 8: Error handling - Negative integer
+    diag("Test 8: Error handling - Negative integer");
+    {
+        auto test_conn = createNewConnection(BACKEND);
+        if (!test_conn || PQstatus(test_conn.get()) != CONNECTION_OK) {
+            skip(2, "Connection failed");
+        } else {
+            bool error_occurred = test_parameterized_query_error(test_conn.get(),
+                "SELECT pg_cancel_backend($1)", "-123", 4, 0, "invalid input syntax for integer");
+            ok(error_occurred, "Negative integer should return error");
+            
+            error_occurred = test_parameterized_query_error(test_conn.get(),
+                "SELECT pg_terminate_backend($1)", "0", 1, 0, "PID must be a positive integer");
+            ok(error_occurred, "Zero should return error");
+        }
+    }
+
+    // Test 9: Error handling - Empty string
+    diag("Test 9: Error handling - Empty string");
+    {
+        auto test_conn = createNewConnection(BACKEND);
+        if (!test_conn || PQstatus(test_conn.get()) != CONNECTION_OK) {
+            skip(1, "Connection failed");
+        } else {
+            bool error_occurred = test_parameterized_query_error(test_conn.get(),
+                "SELECT pg_cancel_backend($1)", "", 0, 0, "invalid input syntax for integer");
+            ok(error_occurred, "Empty string should return error");
+        }
+    }
+    
+    // Test 10: Error handling - Multiple parameters
+    diag("Test 10: Error handling - Multiple parameters");
+    {
+        auto test_conn = createNewConnection(BACKEND);
+        if (!test_conn || PQstatus(test_conn.get()) != CONNECTION_OK) {
+            skip(2, "Connection failed");
+        } else {
+            // Test with SELECT pg_cancel_backend($1, $2)
+            std::string stmt_name = "multi_param_" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count());
+
+            // Prepare statement with two parameters
+            PGresult* res = PQprepare(test_conn.get(), stmt_name.c_str(), "SELECT pg_cancel_backend($1, $2)", 2, NULL);
+            bool prepare_failed = (PQresultStatus(res) == PGRES_FATAL_ERROR);
+            PQclear(res);
+
+
+            ok(prepare_failed, "Multiple parameters should return error");
+
+            // Clean up
+            res = PQexec(test_conn.get(), ("DEALLOCATE " + stmt_name).c_str());
+            PQclear(res);
+        }
+    }
+
+    // Test 11: Mixed queries (literal still works)
+    diag("Test 11: Literal queries still work");
+    {
+        auto victim_conn = createNewConnection(BACKEND);
+        if (!victim_conn || PQstatus(victim_conn.get()) != CONNECTION_OK) {
+            skip(2, "Connection failed");
+        } else {
+            int victim_pid = PQbackendPID(victim_conn.get());
+            
+            // Create connection and terminate using literal query (not parameterized)
+            auto killer_conn = createNewConnection(BACKEND);
+            if (!killer_conn || PQstatus(killer_conn.get()) != CONNECTION_OK) {
+                skip(2, "Connection failed");
+            } else {
+                std::string literal_query = "SELECT pg_terminate_backend(" + std::to_string(victim_pid) + ")";
+                PGresult* res = PQexec(killer_conn.get(), literal_query.c_str());
+                bool success = (PQresultStatus(res) == PGRES_TUPLES_OK);
+                PQclear(res);
+                
+                ok(success, "Literal pg_terminate_backend should still work");
+                
+                // Verify the connection was terminated
+                res = PQexec(victim_conn.get(), "SELECT 1");
+                bool connection_dead = (PQresultStatus(res) != PGRES_TUPLES_OK);
+                PQclear(res);
+                
+                ok(connection_dead, "Connection should be terminated via literal query");
+            }
+        }
+    }
+
+    // Test 12: Very large PID (boundary test)
+    diag("Test 12: Boundary test - large PID");
+    {
+        auto test_conn = createNewConnection(BACKEND);
+        if (!test_conn || PQstatus(test_conn.get()) != CONNECTION_OK) {
+            skip(1, "Connection failed");
+        } else {
+            // Test with maximum 32-bit integer
+            std::string max_pid = "2147483647"; // INT_MAX
+            bool error_occurred = test_parameterized_query_error(test_conn.get(),
+                "SELECT pg_cancel_backend($1)", max_pid.c_str(), max_pid.length(), 0, 
+                "invalid input syntax for integer");
+            
+            // This might succeed or fail depending on system limits
+            // We just verify it doesn't crash
+            ok(true, "Large PID should not crash the system");
+        }
+    }
+
+    return exit_status();
+}


### PR DESCRIPTION
### Summary:
This PR extends the existing support for `pg_cancel_backend()` and `pg_terminate_backend()` functions to work with parameterized queries in the extended query protocol. While literal PID values were already supported in both simple and extended query protocols, this enhancement adds support for parameterized queries like `SELECT pg_cancel_backend($1)`.

Closes [#5298](https://github.com/sysown/proxysql/issues/5298) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for parameterized terminate/cancel operations in text and binary formats, with fallback for literal queries.
  * Added helper to read 64-bit big-endian integers from buffers.

* **Bug Fixes / Validation**
  * Improved validation and explicit error responses for NULL, invalid, negative/zero, empty, and multi-parameter inputs.

* **Tests**
  * Added comprehensive tests for parameterized kills, bindings, error paths, boundary cases, and cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->