### PR TITLE
bump version to 3.0.6 at the beginning of the development cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ O3 := -O3 -mtune=native
 ALL_DEBUG := $(O0) -ggdb -DDEBUG
 NO_DEBUG := $(O2) -ggdb
 DEBUG := $(ALL_DEBUG)
-CURVER ?= 3.0.5
+CURVER ?= 3.0.6
 #export DEBUG
 #export EXTRALINK
 export MAKE


### PR DESCRIPTION
bump version to 3.0.6 at the beginning of the development cycle

set `CURVER=3.0.6` in Makefile

tag merge commit with tag 3.0.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 3.0.6

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->