### PR TITLE
add fedora43, remove fedora40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensu
 amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux9-clang almalinux9-dbg almalinux10 almalinux10-clang almalinux10-dbg
 amd64-centos: centos9 centos9-clang centos9-dbg centos10 centos10-clang centos10-dbg
 amd64-debian: debian12 debian12-clang debian12-dbg debian13 debian13-clang debian13-dbg
-amd64-fedora: fedora40 fedora40-clang fedora40-dbg fedora41 fedora41-clang fedora41-dbg fedora42 fedora42-clang fedora42-dbg
+amd64-fedora: fedora41 fedora41-clang fedora41-dbg fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
@@ -329,7 +329,7 @@ arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensu
 arm64-almalinux: almalinux8 almalinux9 almalinux10
 arm64-centos: centos9 centos10
 arm64-debian: debian12 debian13
-arm64-fedora: fedora40 fedora41 fedora42
+arm64-fedora: fedora41 fedora42 fedora43
 arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensu
 amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux9-clang almalinux9-dbg almalinux10 almalinux10-clang almalinux10-dbg
 amd64-centos: centos9 centos9-clang centos9-dbg centos10 centos10-clang centos10-dbg
 amd64-debian: debian12 debian12-clang debian12-dbg debian13 debian13-clang debian13-dbg
-amd64-fedora: fedora41 fedora41-clang fedora41-dbg fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg
+amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
@@ -329,7 +329,7 @@ arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensu
 arm64-almalinux: almalinux8 almalinux9 almalinux10
 arm64-centos: centos9 centos10
 arm64-debian: debian12 debian13
-arm64-fedora: fedora41 fedora42 fedora43
+arm64-fedora: fedora42 fedora43
 arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,34 +77,6 @@ services:
 
 ####################################################################################################
 ####################################################################################################
-  fedora41_build:
-    extends:
-      service: _build
-    image: proxysql/packaging:build-fedora41-v3.0.3
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
-      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - PKG_RELEASE=fedora41
-      - PROXYSQL_BUILD_TYPE=clickhouse
-
-  fedora41_clang_build:
-    extends:
-      service: fedora41_build
-    image: proxysql/packaging:build-clang-fedora41-v3.0.3
-    environment:
-      - PKG_RELEASE=fedora41-clang
-
-  fedora41_dbg_build:
-    extends:
-      service: fedora41_build
-    environment:
-      - PKG_RELEASE=dbg-fedora41
-      - PROXYSQL_BUILD_TYPE=debug
-
-####################################################################################################
   fedora42_build:
     extends:
       service: _build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,34 +77,6 @@ services:
 
 ####################################################################################################
 ####################################################################################################
-  fedora40_build:
-    extends:
-      service: _build
-    image: proxysql/packaging:build-fedora40-v3.0.3
-    volumes:
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
-      - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
-      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
-      - ./:/opt/proxysql/
-    environment:
-      - PKG_RELEASE=fedora40
-      - PROXYSQL_BUILD_TYPE=clickhouse
-
-  fedora40_clang_build:
-    extends:
-      service: fedora40_build
-    image: proxysql/packaging:build-clang-fedora40-v3.0.3
-    environment:
-      - PKG_RELEASE=fedora40-clang
-
-  fedora40_dbg_build:
-    extends:
-      service: fedora40_build
-    environment:
-      - PKG_RELEASE=dbg-fedora40
-      - PROXYSQL_BUILD_TYPE=debug
-
-####################################################################################################
   fedora41_build:
     extends:
       service: _build
@@ -158,6 +130,34 @@ services:
       service: fedora42_build
     environment:
       - PKG_RELEASE=dbg-fedora42
+      - PROXYSQL_BUILD_TYPE=debug
+
+####################################################################################################
+  fedora43_build:
+    extends:
+      service: _build
+    image: proxysql/packaging:build-fedora43-v3.0.6
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
+      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - PKG_RELEASE=fedora43
+      - PROXYSQL_BUILD_TYPE=clickhouse
+
+  fedora43_clang_build:
+    extends:
+      service: fedora43_build
+    image: proxysql/packaging:build-clang-fedora43-v3.0.6
+    environment:
+      - PKG_RELEASE=fedora43-clang
+
+  fedora43_dbg_build:
+    extends:
+      service: fedora43_build
+    environment:
+      - PKG_RELEASE=dbg-fedora43
       - PROXYSQL_BUILD_TYPE=debug
 
 ####################################################################################################


### PR DESCRIPTION
add new package builds for fedora43
remove old fedora40



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to add Fedora 42 and Fedora 43 for amd64 and arm64.
  * Removed Fedora 40 and Fedora 41 build targets.
  * Aligned CI/service definitions and image tags to reflect Fedora 42→43 migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->