### PR TITLE
Fix wrong index in connection cleanup loops (MySQL and PgSQL)

### DIFF
--- a/lib/Base_HostGroups_Manager.cpp
+++ b/lib/Base_HostGroups_Manager.cpp
@@ -2600,7 +2600,7 @@ void MySQL_HostGroups_Manager::drop_all_idle_connections() {
 					unsigned long long intv = mysql_thread___connection_max_age_ms;
 					intv *= 1000;
 					if (curtime > mc->creation_time + intv) {
-						mc=mscl->remove(0);
+						mc=mscl->remove(i);
 						delete mc;
 						i--;
 					}

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2936,7 +2936,7 @@ void MySQL_HostGroups_Manager::drop_all_idle_connections() {
 					unsigned long long intv = mysql_thread___connection_max_age_ms;
 					intv *= 1000;
 					if (curtime > mc->creation_time + intv) {
-						mc=mscl->remove(0);
+						mc=mscl->remove(i);
 						delete mc;
 						i--;
 					}

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -2779,7 +2779,7 @@ void PgSQL_HostGroups_Manager::drop_all_idle_connections() {
 					unsigned long long intv = pgsql_thread___connection_max_age_ms;
 					intv *= 1000;
 					if (curtime > mc->creation_time + intv) {
-						mc=mscl->remove(0);
+						mc=mscl->remove(i);
 						delete mc;
 						i--;
 					}


### PR DESCRIPTION
## Summary

This PR fixes a bug in connection cleanup loops where the wrong connection was being removed from the pool. The loops iterate through connections by index `i` and check each one using `index(i)`, but when an expired connection was found, they were removing index `0` instead of index `i`.

### Files Changed

| File | Line | Issue |
|------|------|-------|
| `lib/Base_HostGroups_Manager.cpp` | 2603 | `remove(0)` → `remove(i)` |
| `lib/MySQL_HostGroups_Manager.cpp` | 2939 | `remove(0)` → `remove(i)` |
| `lib/PgSQL_HostGroups_Manager.cpp` | 2782 | `remove(0)` → `remove(i)` |

### Impact of the Bug

When the first connection (index 0) was fresh but a later connection was expired:
- The fresh connection at index 0 was deleted
- The expired connection remained in the pool
- This could cause connection pool corruption and resource leaks

### Example Scenario

5 connections in the pool, with connections at indices 2 and 4 expired:

| Index | Before Fix | After Fix |
|-------|------------|-----------|
| 0 (Fresh) | ❌ Deleted | ✅ Kept |
| 1 (Fresh) | ✅ Kept | ✅ Kept |
| 2 (Expired) | ✅ Kept (BUG!) | ❌ Deleted |
| 3 (Fresh) | ✅ Kept | ✅ Kept |
| 4 (Expired) | ✅ Kept (BUG!) | ❌ Deleted |

### Related PRs

- #5094: Fixes similar issue in `drop_all_idle_connections()` (MySQL)
- This PR fixes the same pattern in the `connection_max_age` cleanup code for both MySQL and PgSQL

## Test plan

- Manual code review confirms the fix is correct
- The pattern matches the fix in #5094 which was verified as correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the idle database connection cleanup process to properly remove connections when they exceed their maximum age limit. This ensures more efficient connection management across all database host groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->