### PR TITLE
revert build image versions to match next release version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   centos9_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-centos9-v4.0.0
+    image: proxysql/packaging:build-centos9-v3.0.6
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -38,7 +38,7 @@ services:
   centos9_clang_build:
     extends:
       service: centos9_build
-    image: proxysql/packaging:build-clang-centos9-v4.0.0
+    image: proxysql/packaging:build-clang-centos9-v3.0.6
     environment:
       - PKG_RELEASE=centos9-clang
 
@@ -53,7 +53,7 @@ services:
   centos10_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-centos10-v4.0.0
+    image: proxysql/packaging:build-centos10-v3.0.6
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -66,7 +66,7 @@ services:
   centos10_clang_build:
     extends:
       service: centos10_build
-    image: proxysql/packaging:build-clang-centos10-v4.0.0
+    image: proxysql/packaging:build-clang-centos10-v3.0.6
     environment:
       - PKG_RELEASE=centos10-clang
 
@@ -82,7 +82,7 @@ services:
   fedora42_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-fedora42-v3.0.3
+    image: proxysql/packaging:build-fedora42-v3.0.6
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -95,7 +95,7 @@ services:
   fedora42_clang_build:
     extends:
       service: fedora42_build
-    image: proxysql/packaging:build-clang-fedora42-v3.0.3
+    image: proxysql/packaging:build-clang-fedora42-v3.0.6
     environment:
       - PKG_RELEASE=fedora42-clang
 
@@ -139,7 +139,7 @@ services:
   debian12_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-debian12-v4.0.0
+    image: proxysql/packaging:build-debian12-v3.0.6
     volumes:
       - ./docker/images/proxysql/deb-compliant/ctl/:/root/ctl/
       - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
@@ -151,7 +151,7 @@ services:
   debian12_clang_build:
     extends:
       service: debian12_build
-    image: proxysql/packaging:build-clang-debian12-v4.0.0
+    image: proxysql/packaging:build-clang-debian12-v3.0.6
     environment:
       - PKG_RELEASE=debian12-clang
 
@@ -166,7 +166,7 @@ services:
   debian13_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-debian13-v4.0.0
+    image: proxysql/packaging:build-debian13-v3.0.6
     volumes:
       - ./docker/images/proxysql/deb-compliant/ctl/:/root/ctl/
       - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
@@ -178,7 +178,7 @@ services:
   debian13_clang_build:
     extends:
       service: debian13_build
-    image: proxysql/packaging:build-clang-debian13-v4.0.0
+    image: proxysql/packaging:build-clang-debian13-v3.0.6
     environment:
       - PKG_RELEASE=debian13-clang
 
@@ -194,7 +194,7 @@ services:
   ubuntu22_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-ubuntu22-v4.0.0
+    image: proxysql/packaging:build-ubuntu22-v3.0.6
     volumes:
       - ./docker/images/proxysql/deb-compliant/ctl/:/root/ctl/
       - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
@@ -206,7 +206,7 @@ services:
   ubuntu22_clang_build:
     extends:
       service: ubuntu22_build
-    image: proxysql/packaging:build-clang-ubuntu22-v4.0.0
+    image: proxysql/packaging:build-clang-ubuntu22-v3.0.6
     environment:
       - PKG_RELEASE=ubuntu22-clang
 
@@ -221,7 +221,7 @@ services:
   ubuntu24_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-ubuntu24-v4.0.0
+    image: proxysql/packaging:build-ubuntu24-v3.0.6
     volumes:
       - ./docker/images/proxysql/deb-compliant/ctl/:/root/ctl/
       - ./docker/images/proxysql/deb-compliant/entrypoint/:/opt/entrypoint/
@@ -233,7 +233,7 @@ services:
   ubuntu24_clang_build:
     extends:
       service: ubuntu24_build
-    image: proxysql/packaging:build-clang-ubuntu24-v4.0.0
+    image: proxysql/packaging:build-clang-ubuntu24-v3.0.6
     environment:
       - PKG_RELEASE=ubuntu24-clang
 
@@ -249,7 +249,7 @@ services:
   opensuse15_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-opensuse15-v4.0.0
+    image: proxysql/packaging:build-opensuse15-v3.0.6
     volumes:
       - ./docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/suse-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -262,7 +262,7 @@ services:
   opensuse15_clang_build:
     extends:
       service: opensuse15_build
-    image: proxysql/packaging:build-clang-opensuse15-v4.0.0
+    image: proxysql/packaging:build-clang-opensuse15-v3.0.6
     environment:
       - PKG_RELEASE=opensuse15-clang
 
@@ -277,7 +277,7 @@ services:
   opensuse16_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-opensuse16-v4.0.0
+    image: proxysql/packaging:build-opensuse16-v3.0.6
     volumes:
       - ./docker/images/proxysql/suse-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/suse-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -290,7 +290,7 @@ services:
   opensuse16_clang_build:
     extends:
       service: opensuse16_build
-    image: proxysql/packaging:build-clang-opensuse16-v4.0.0
+    image: proxysql/packaging:build-clang-opensuse16-v3.0.6
     environment:
       - PKG_RELEASE=opensuse16-clang
 
@@ -306,7 +306,7 @@ services:
   almalinux8_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-almalinux8-v4.0.0
+    image: proxysql/packaging:build-almalinux8-v3.0.6
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -319,7 +319,7 @@ services:
   almalinux8_clang_build:
     extends:
       service: almalinux8_build
-    image: proxysql/packaging:build-clang-almalinux8-v4.0.0
+    image: proxysql/packaging:build-clang-almalinux8-v3.0.6
     environment:
       - PKG_RELEASE=almalinux8-clang
 
@@ -334,7 +334,7 @@ services:
   almalinux9_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-almalinux9-v4.0.0
+    image: proxysql/packaging:build-almalinux9-v3.0.6
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -347,7 +347,7 @@ services:
   almalinux9_clang_build:
     extends:
       service: almalinux9_build
-    image: proxysql/packaging:build-clang-almalinux9-v4.0.0
+    image: proxysql/packaging:build-clang-almalinux9-v3.0.6
     environment:
       - PKG_RELEASE=almalinux9-clang
 
@@ -362,7 +362,7 @@ services:
   almalinux10_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-almalinux10-v4.0.0
+    image: proxysql/packaging:build-almalinux10-v3.0.6
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -375,7 +375,7 @@ services:
   almalinux10_clang_build:
     extends:
       service: almalinux10_build
-    image: proxysql/packaging:build-clang-almalinux10-v4.0.0
+    image: proxysql/packaging:build-clang-almalinux10-v3.0.6
     environment:
       - PKG_RELEASE=almalinux10-clang
 


### PR DESCRIPTION
revert build image versions in `docker-compose.yml` to `3.0.6`
to match the upcoming release version.

the `4.0.0` version numbers were merged from the `v4.0` branch
and would break versioning pattern of future build image updates.

push of updated `3.0.6` to docker hub is pending upon approval of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tags to v3.0.6 across all supported platform variants (CentOS, Fedora, Debian, Ubuntu, openSUSE, AlmaLinux, etc.), ensuring consistency in the containerized environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->