### PR TITLE
V3.0.6 fix package builds

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -284,7 +284,7 @@ sqlite3/libsqlite_rembed.a: sqlite3/sqlite-rembed-0.0.1-alpha.9.tar.gz
 	cd sqlite3 && rm -rf sqlite-rembed-*/ sqlite-rembed-source/ || true
 	cd sqlite3 && tar -zxf sqlite-rembed-0.0.1-alpha.9.tar.gz
 	mv sqlite3/sqlite-rembed-0.0.1-alpha.9 sqlite3/sqlite-rembed-source
-	cd sqlite3/sqlite-rembed-source && SQLITE3_INCLUDE_DIR=$(SQLITE3_INCLUDE_DIR) SQLITE3_LIB_DIR=$(SQLITE3_LIB_DIR) SQLITE3_STATIC=1 $(CARGO) build --release --features=sqlite-loadable/static --lib
+	cd sqlite3/sqlite-rembed-source && SQLITE3_INCLUDE_DIR=$(SQLITE3_INCLUDE_DIR) SQLITE3_LIB_DIR=$(SQLITE3_LIB_DIR) SQLITE3_STATIC=1 $(CARGO) build --locked --release --features=sqlite-loadable/static --lib
 	cp sqlite3/sqlite-rembed-source/target/release/libsqlite_rembed.a sqlite3/libsqlite_rembed.a
 
 ifeq ($(PROXYSQLGENAI),1)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -6,8 +6,8 @@ include $(PROXYSQL_PATH)/include/makefiles_vars.mk
 
 # Rust toolchain detection (only needed for PROXYSQLGENAI)
 ifeq ($(PROXYSQLGENAI),1)
-RUSTC := $(shell which rustc 2>/dev/null)
-CARGO := $(shell which cargo 2>/dev/null)
+RUSTC := $(shell type rustc 2>/dev/null | sed 's/.* //')
+CARGO := $(shell type cargo 2>/dev/null | sed 's/.* //')
 ifndef RUSTC
 $(error "rustc not found. Please install Rust toolchain (required for PROXYSQLGENAI)")
 endif

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -408,6 +408,7 @@ cleanall:
 	cd re2 && rm -rf re2-*/ || true
 	cd pcre && rm -rf pcre-*/ || true
 	cd sqlite3 && rm -rf sqlite-amalgamation-*/ || true
+	cd sqlite3 && rm -rf libsqlite_rembed.a sqlite-rembed-source/ sqlite-rembed-*/ || true
 	cd clickhouse-cpp/ && rm -rf clickhouse-cpp-*/ || true
 	cd lz4 && rm -rf lz4-*/ || true
 	cd libmicrohttpd && rm -rf libmicrohttpd-*/ || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
   fedora42_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-fedora42-v3.0.3
+    image: proxysql/packaging:build-fedora42-v4.0.0
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -95,7 +95,7 @@ services:
   fedora42_clang_build:
     extends:
       service: fedora42_build
-    image: proxysql/packaging:build-clang-fedora42-v3.0.3
+    image: proxysql/packaging:build-clang-fedora42-v4.0.0
     environment:
       - PKG_RELEASE=fedora42-clang
 
@@ -110,7 +110,7 @@ services:
   fedora43_build:
     extends:
       service: _build
-    image: proxysql/packaging:build-fedora43-v3.0.6
+    image: proxysql/packaging:build-fedora43-v4.0.0
     volumes:
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
       - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
@@ -123,7 +123,7 @@ services:
   fedora43_clang_build:
     extends:
       service: fedora43_build
-    image: proxysql/packaging:build-clang-fedora43-v3.0.6
+    image: proxysql/packaging:build-clang-fedora43-v4.0.0
     environment:
       - PKG_RELEASE=fedora43-clang
 

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -43,10 +43,11 @@ fi
 
 # clean is expensive, do it before, outside of container
 #${MAKE} cleanbuild
-${MAKE} ${MAKEOPT} ${deps_target}
 if [[ "${PROXYSQLGENAI:-}" == "1" ]]; then
+    ${MAKE} ${MAKEOPT} PROXYSQLGENAI=1 ${deps_target}
     ${MAKE} ${MAKEOPT} PROXYSQLGENAI=1 ${build_target}
 else
+    ${MAKE} ${MAKEOPT} ${deps_target}
     ${MAKE} ${MAKEOPT} ${build_target}
 fi
 

--- a/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
@@ -43,10 +43,11 @@ fi
 
 # clean is expensive, do it before, outside of container
 #${MAKE} cleanbuild
-${MAKE} ${MAKEOPT} ${deps_target}
 if [[ "${PROXYSQLGENAI:-}" == "1" ]]; then
+    ${MAKE} ${MAKEOPT} PROXYSQLGENAI=1 ${deps_target}
     ${MAKE} ${MAKEOPT} PROXYSQLGENAI=1 ${build_target}
 else
+    ${MAKE} ${MAKEOPT} ${deps_target}
     ${MAKE} ${MAKEOPT} ${build_target}
 fi
 

--- a/docker/images/proxysql/suse-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/suse-compliant/entrypoint/entrypoint.bash
@@ -43,10 +43,11 @@ fi
 
 # clean is expensive, do it before, outside of container
 #${MAKE} cleanbuild
-${MAKE} ${MAKEOPT} ${deps_target}
 if [[ "${PROXYSQLGENAI:-}" == "1" ]]; then
+    ${MAKE} ${MAKEOPT} PROXYSQLGENAI=1 ${deps_target}
     ${MAKE} ${MAKEOPT} PROXYSQLGENAI=1 ${build_target}
 else
+    ${MAKE} ${MAKEOPT} ${deps_target}
     ${MAKE} ${MAKEOPT} ${build_target}
 fi
 


### PR DESCRIPTION
the check for `rustc` toolchain is using `which` that is not present in some build images
we don't need `which` to check for the `rustc` command
check by using `type`:
```
RUSTC := $(shell type rustc 2>/dev/null | sed 's/.* //')
```
also:
- update fedora to use `v4.0.0` build image versions
- add sqlite3-rembed to cleanall
- add --locked to cargo build for reproducibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Rust toolchain detection in build scripts to reduce false negatives and improve reliability.
  * Enforced reproducible Rust builds for the bundled sqlite-rembed component.
  * Expanded cleanup to remove additional sqlite-rembed build artifacts.
  * Upgraded Fedora 42/43 build container images (including clang variants) to newer build tags.
  * Adjusted build entrypoint logic so a specific build flag is now propagated to dependency builds when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->