### PR TITLE
[v3.0] Add scram.c.diff patch reference for security fix

### DIFF
--- a/deps/libscram/scram.c.diff
+++ b/deps/libscram/scram.c.diff
@@ -1,0 +1,24 @@
+--- /tmp/scram.c	2026-02-07 13:03:15
++++ src/scram.c	2026-02-07 13:04:12
+@@ -271,15 +271,16 @@
+ 	s = strdup(secret);
+ 	if (!s)
+ 		goto invalid_secret;
+-	if ((scheme_str = strtok(s, "$")) == NULL)
++	char *saveptr;
++	if ((scheme_str = strtok_r(s, "$", &saveptr)) == NULL)
+ 		goto invalid_secret;
+-	if ((iterations_str = strtok(NULL, ":")) == NULL)
++	if ((iterations_str = strtok_r(NULL, ":", &saveptr)) == NULL)
+ 		goto invalid_secret;
+-	if ((salt_str = strtok(NULL, "$")) == NULL)
++	if ((salt_str = strtok_r(NULL, "$", &saveptr)) == NULL)
+ 		goto invalid_secret;
+-	if ((storedkey_str = strtok(NULL, ":")) == NULL)
++	if ((storedkey_str = strtok_r(NULL, ":", &saveptr)) == NULL)
+ 		goto invalid_secret;
+-	if ((serverkey_str = strtok(NULL, "")) == NULL)
++	if ((serverkey_str = strtok_r(NULL, "", &saveptr)) == NULL)
+ 		goto invalid_secret;
+ 
+ 	/* Parse the fields */

--- a/deps/libscram/src/scram.c
+++ b/deps/libscram/src/scram.c
@@ -271,15 +271,16 @@ static bool parse_scram_secret(const char *secret, int *iterations, char **salt,
 	s = strdup(secret);
 	if (!s)
 		goto invalid_secret;
-	if ((scheme_str = strtok(s, "$")) == NULL)
+	char *saveptr;
+	if ((scheme_str = strtok_r(s, "$", &saveptr)) == NULL)
 		goto invalid_secret;
-	if ((iterations_str = strtok(NULL, ":")) == NULL)
+	if ((iterations_str = strtok_r(NULL, ":", &saveptr)) == NULL)
 		goto invalid_secret;
-	if ((salt_str = strtok(NULL, "$")) == NULL)
+	if ((salt_str = strtok_r(NULL, "$", &saveptr)) == NULL)
 		goto invalid_secret;
-	if ((storedkey_str = strtok(NULL, ":")) == NULL)
+	if ((storedkey_str = strtok_r(NULL, ":", &saveptr)) == NULL)
 		goto invalid_secret;
-	if ((serverkey_str = strtok(NULL, "")) == NULL)
+	if ((serverkey_str = strtok_r(NULL, "", &saveptr)) == NULL)
 		goto invalid_secret;
 
 	/* Parse the fields */


### PR DESCRIPTION
## Summary

This PR adds the `scram.c.diff` patch file as a reference for the security fix addressing the `strtok` vulnerability in SCRAM authentication code.

## Related PRs

- References PR #5348 on `v2.x`: "[Security] Fix HIGH vulnerability: c.lang.security.insecure-use-strtok-fn.insecure-use-strtok-fn"

## Context

This is the v3.0 counterpart to the security fix merged in PR #5348. The diff file documents the changes needed to address the `c.lang.security.insecure-use-strtok-fn.insecure-use-strtok-fn` vulnerability.

## Changes

- Added `deps/libscram/scram.c.diff` - patch file documenting the security fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SCRAM authentication parsing to use thread-safe tokenization methods, improving stability in concurrent environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->