### PR TITLE
build: improve macOS compatibility and make Rust toolchain optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ endif
 export GIT_VERSION
 
 # Extract CURVER from GIT_VERSION (first 3 numbers, e.g., 3.0.6 from 3.0.6-388-ga94b7d6)
-CURVER := $(shell echo "$(GIT_VERSION)" | grep -oP '^\d+\.\d+\.\d+' | head -1)
+CURVER := $(shell echo "$(GIT_VERSION)" | sed -nE 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -1)
 
 # Validate CURVER has 3 numbers separated by dots
-CURVER_CHECK := $(shell echo "$(CURVER)" | grep -cP '^\d+\.\d+\.\d+$$')
+CURVER_CHECK := $(shell echo "$(CURVER)" | grep -cE '^[0-9]+\.[0-9]+\.[0-9]+$$')
 
 ifeq ($(CURVER_CHECK),0)
     $(error CURVER "$(CURVER)" derived from GIT_VERSION "$(GIT_VERSION)" does not have 3 numbers separated by dots (expected format: X.Y.Z)

--- a/common_mk/openssl_flags.mk
+++ b/common_mk/openssl_flags.mk
@@ -20,20 +20,12 @@ endif
 
 ifeq ($(CUSTOM_OPENSSL_PATH),)
     ifeq ($(OPENSSL_PACKAGE),openssl3)
-ifeq ($(UNAME_S),Darwin)
         SSL_IDIR := $(shell pkg-config --cflags $(OPENSSL_PACKAGE) | sed -E 's/-I/ /g' | awk '{for(i=1;i<=NF;i++) if($$i ~ /^\//) print $$i}' | head -n 1)
-else
-        SSL_IDIR := $(shell pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-endif
         SSL_LDIR := $(shell pkg-config --variable=libdir $(OPENSSL_PACKAGE))
         LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so.3" 2>/dev/null | head -n 1)
         LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so.3" 2>/dev/null | head -n 1)
     else
-ifeq ($(UNAME_S),Darwin)
         SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | sed -E 's/-I/ /g' | awk '{for(i=1;i<=NF;i++) if($$i ~ /^\//) print $$i}' | head -n 1)
-else
-        SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | grep -oP "(?<=-I)[^ ]+")
-endif
         SSL_LDIR := $(shell pkg-config --variable=libdir $(OPENSSL_PACKAGE))
 ifeq ($(UNAME_S),Darwin)
         LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.dylib" 2>/dev/null | head -n 1)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -4,14 +4,16 @@ PROXYSQL_PATH := $(shell while [ ! -f ./src/proxysql_global.cpp ]; do cd ..; don
 
 include $(PROXYSQL_PATH)/include/makefiles_vars.mk
 
-# Rust toolchain detection
+# Rust toolchain detection (only needed for PROXYSQLGENAI)
+ifeq ($(PROXYSQLGENAI),1)
 RUSTC := $(shell which rustc 2>/dev/null)
 CARGO := $(shell which cargo 2>/dev/null)
 ifndef RUSTC
-$(error "rustc not found. Please install Rust toolchain")
+$(error "rustc not found. Please install Rust toolchain (required for PROXYSQLGENAI)")
 endif
 ifndef CARGO
-$(error "cargo not found. Please install Rust toolchain")
+$(error "cargo not found. Please install Rust toolchain (required for PROXYSQLGENAI)")
+endif
 endif
 
 # SQLite environment variables for sqlite-rembed build
@@ -285,7 +287,17 @@ sqlite3/libsqlite_rembed.a: sqlite3/sqlite-rembed-0.0.1-alpha.9.tar.gz
 	cd sqlite3/sqlite-rembed-source && SQLITE3_INCLUDE_DIR=$(SQLITE3_INCLUDE_DIR) SQLITE3_LIB_DIR=$(SQLITE3_LIB_DIR) SQLITE3_STATIC=1 $(CARGO) build --release --features=sqlite-loadable/static --lib
 	cp sqlite3/sqlite-rembed-source/target/release/libsqlite_rembed.a sqlite3/libsqlite_rembed.a
 
+ifeq ($(PROXYSQLGENAI),1)
 sqlite3: sqlite3/sqlite3/sqlite3.o sqlite3/sqlite3/vec.o sqlite3/libsqlite_rembed.a
+else
+sqlite3: sqlite3/sqlite3/sqlite3.o
+endif
+
+# sqlite-vec: Vector similarity search extension (for GenAI)
+sqlite-vec: sqlite3/sqlite3/vec.o
+
+# sqlite-rembed: Remote embedding extension (Rust-based, for GenAI)
+sqlite-rembed: sqlite3/libsqlite_rembed.a
 
 
 libconfig/libconfig/out/libconfig++.a:
@@ -373,24 +385,6 @@ libscram/lib/libscram.a:postgresql/postgresql/src/interfaces/libpq/libpq.a
 	cd libscram && CC=${CC} CXX=${CXX} ${MAKE} LIBOPENSSL_DIR="$(SSL_IDIR)" POSTGRESQL_DIR="$(shell pwd)/postgresql/postgresql/"
 
 libscram: libscram/lib/libscram.a
-
-
-# sqlite-vec: Vector similarity search extension (for GenAI)
-sqlite3/sqlite3/vec.o: sqlite3/sqlite3/sqlite3.o
-	cd sqlite3/sqlite3 && cp ../sqlite-vec-source/sqlite-vec.c . && cp ../sqlite-vec-source/sqlite-vec.h .
-	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o vec.o sqlite-vec.c -DSQLITE_CORE -DSQLITE_VEC_STATIC -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DSQLITE_DLL=1
-
-sqlite-vec: sqlite3/sqlite3/vec.o
-
-# sqlite-rembed: Remote embedding extension (Rust-based, for GenAI)
-sqlite3/libsqlite_rembed.a: sqlite3/sqlite-rembed-0.0.1-alpha.9.tar.gz
-	cd sqlite3 && rm -rf sqlite-rembed-*/ sqlite-rembed-source/ || true
-	cd sqlite3 && tar -zxf sqlite-rembed-0.0.1-alpha.9.tar.gz
-	mv sqlite3/sqlite-rembed-0.0.1-alpha.9 sqlite3/sqlite-rembed-source
-	cd sqlite3/sqlite-rembed-source && SQLITE3_INCLUDE_DIR=$(SQLITE3_INCLUDE_DIR) SQLITE3_LIB_DIR=$(SQLITE3_LIB_DIR) SQLITE3_STATIC=1 $(CARGO) build --release --features=sqlite-loadable/static --lib
-	cp sqlite3/sqlite-rembed-source/target/release/libsqlite_rembed.a sqlite3/libsqlite_rembed.a
-
-sqlite-rembed: sqlite3/libsqlite_rembed.a
 
 
 ### clean targets


### PR DESCRIPTION
## Summary

This PR contains two build system improvements to enhance macOS compatibility:

1. **Replace `grep -oP` with `sed -E`** - The `-P` (Perl regex) flag is not available on macOS by default. Replaced with `sed -nE` and `grep -cE` which are POSIX-compliant and work on both Linux and macOS.

2. **Make Rust toolchain optional** - Rust/cargo are now only required when `PROXYSQLGENAI=1` is set. Previously, the build would fail if Rust wasn't installed, even when not building GenAI features. Similarly, the `sqlite3` target now only depends on GenAI extensions (`vec.o`, `libsqlite_rembed.a`) when `PROXYSQLGENAI` is enabled.

## Files changed

- `Makefile`: Replace `grep -oP` with `sed -nE` for version extraction
- `common_mk/openssl_flags.mk`: Replace `grep -oP` with `sed -E` for include path extraction
- `deps/Makefile`: Make Rust toolchain conditional and simplify sqlite3 target

## Testing

Built successfully on macOS without Rust toolchain (GenAI disabled).