### PR TITLE
macOS: add support for executable SHA1 calculation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,10 @@ using json = nlohmann::json;
 
 #include <sys/mman.h>
 
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
 #include <uuid/uuid.h>
 #include <atomic>
 
@@ -3007,7 +3011,18 @@ int main(int argc, const char * argv[]) {
 		int fd = -1;
 		char buff[PATH_MAX+1];
 		ssize_t len = -1;
-#if defined(__FreeBSD__)
+#if defined(__APPLE__)
+		uint32_t bufsize = sizeof(buff) - 1;
+		if (_NSGetExecutablePath(buff, &bufsize) == 0) {
+			len = bufsize;
+			// Resolve symlinks to get the real path
+			char resolved[PATH_MAX];
+			if (realpath(buff, resolved) != NULL) {
+				strncpy(buff, resolved, sizeof(buff) - 1);
+				len = strlen(buff);
+			}
+		}
+#elif defined(__FreeBSD__)
 		len = readlink("/proc/curproc/file", buff, sizeof(buff)-1);
 #else
 		len = readlink("/proc/self/exe", buff, sizeof(buff)-1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3012,15 +3012,15 @@ int main(int argc, const char * argv[]) {
 		char buff[PATH_MAX+1];
 		ssize_t len = -1;
 #if defined(__APPLE__)
-		uint32_t bufsize = sizeof(buff) - 1;
+		uint32_t bufsize = sizeof(buff);
 		if (_NSGetExecutablePath(buff, &bufsize) == 0) {
-			len = bufsize;
 			// Resolve symlinks to get the real path
 			char resolved[PATH_MAX];
 			if (realpath(buff, resolved) != NULL) {
 				strncpy(buff, resolved, sizeof(buff) - 1);
-				len = strlen(buff);
+				buff[sizeof(buff) - 1] = '\0';
 			}
+			len = strlen(buff);
 		}
 #elif defined(__FreeBSD__)
 		len = readlink("/proc/curproc/file", buff, sizeof(buff)-1);


### PR DESCRIPTION
## Summary
This PR adds macOS support for calculating the SHA1 hash of the ProxySQL executable, which is used for internal identification purposes.

## Changes
- Modified `src/main.cpp` to include macOS-specific code for executable SHA1 calculation
- The implementation uses `_NSGetExecutablePath()` along with `realpath()` to get and resolve the executable path

## Test plan
- [ ] Tested on macOS
- [ ] Verified SHA1 calculation works correctly
- [ ] No regression on Linux builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable path resolution on Apple platforms (including symlink handling and consistent resolution across multiple code paths) for more reliable startup and compatibility.
  * No changes to public APIs or exported function/type signatures; behavior and external interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->