### PR TITLE
refactor: migrate RSA key generation to OpenSSL 3.0 EVP_PKEY API

### DIFF
--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -228,9 +228,9 @@ public:
 #ifdef IDLE_THREADS
 	PtrArray* idle_mysql_sessions;
 	PtrArray* resume_mysql_sessions;
-	CopyCmdMatcher *copy_cmd_matcher;
 	pgsql_conn_exchange_t myexchange;
 #endif // IDLE_THREADS
+	CopyCmdMatcher *copy_cmd_matcher;
 
 	int pipefd[2];
 	PgSQL_Session_Interrupt_Queue_t sess_intrpt_queue;

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -332,17 +332,16 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 		a = (char*)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 	}
 	int rc;
-	//sqlite3 *mydb3=db->get_db();
-	auto [rc1, statement1_unique] = db->prepare_v2(a);
-	ASSERT_SQLITE_OK(rc1, db);
-	sqlite3_stmt* statement1 = statement1_unique.get();
+	sqlite3_stmt* statement1 = NULL;
 	sqlite3_stmt* statement2 = NULL;
+	//sqlite3 *mydb3=db->get_db();
+	rc = db->prepare_v2(a, &statement1);
+	ASSERT_SQLITE_OK(rc, db);
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'pgsql-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		auto [rc2, statement2_unique] = db->prepare_v2(b);
-		ASSERT_SQLITE_OK(rc2, db);
-		statement2 = statement2_unique.get();
+		rc = db->prepare_v2(b, &statement2);
+		ASSERT_SQLITE_OK(rc, db);
 	}
 	if (use_lock) {
 		GloPTH->wrlock();
@@ -373,6 +372,9 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 		db->execute("COMMIT");
 		GloPTH->wrunlock();
 	}
+	(*proxy_sqlite3_finalize)(statement1);
+	if (runtime)
+		(*proxy_sqlite3_finalize)(statement2);
 	for (int i = 0; varnames[i]; i++) {
 		free(varnames[i]);
 	}
@@ -1005,16 +1007,15 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 		a = (char*)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 	}
 	int rc;
-	auto [rc1, statement1_unique] = db->prepare_v2(a);
-	ASSERT_SQLITE_OK(rc1, db);
-	sqlite3_stmt* statement1 = statement1_unique.get();
+	sqlite3_stmt* statement1 = NULL;
 	sqlite3_stmt* statement2 = NULL;
+	rc = db->prepare_v2(a, &statement1);
+	ASSERT_SQLITE_OK(rc, db);
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'genai-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		auto [rc2, statement2_unique] = db->prepare_v2(b);
-		ASSERT_SQLITE_OK(rc2, db);
-		statement2 = statement2_unique.get();
+		rc = db->prepare_v2(b, &statement2);
+		ASSERT_SQLITE_OK(rc, db);
 	}
 	if (use_lock) {
 		GloGATH->wrlock();
@@ -1045,6 +1046,9 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 		db->execute("COMMIT");
 		GloGATH->wrunlock();
 	}
+	(*proxy_sqlite3_finalize)(statement1);
+	if (runtime)
+		(*proxy_sqlite3_finalize)(statement2);
 	for (int i = 0; varnames[i]; i++) {
 		free(varnames[i]);
 	}
@@ -1138,17 +1142,16 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 		a=(char *)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 	}
 	int rc;
-	auto [rc1, statement1_unique] = db->prepare_v2(a);
-	ASSERT_SQLITE_OK(rc1, db);
-	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement1 = NULL;
 	sqlite3_stmt *statement2 = NULL;
+	rc = db->prepare_v2(a, &statement1);
+	ASSERT_SQLITE_OK(rc, db);
 	if (runtime)  {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'mysql-%'");
 		b=(char *)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 
-		auto [rc2, statement2_unique] = db->prepare_v2(b);
-		ASSERT_SQLITE_OK(rc2, db);
-		statement2 = statement2_unique.get();
+		rc = db->prepare_v2(b, &statement2);
+		ASSERT_SQLITE_OK(rc, db);
 	}
 	if (use_lock) {
 		GloMTH->wrlock();
@@ -1179,6 +1182,9 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 		db->execute("COMMIT");
 		GloMTH->wrunlock();
 	}
+	(*proxy_sqlite3_finalize)(statement1);
+	if (runtime)
+		(*proxy_sqlite3_finalize)(statement2);
 	for (int i=0; varnames[i]; i++) {
 		free(varnames[i]);
 	}

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -660,18 +660,19 @@ void ProxySQL_Admin::flush_sqliteserver_variables___runtime_to_database(SQLite3D
   } else {
     a=(char *)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(\"sqliteserver-%s\",\"%s\")";
   }
-  int l=strlen(a)+200;
 	GloSQLite3Server->wrlock();
 	char **varnames=GloSQLite3Server->get_variables_list();
 	for (int i=0; varnames[i]; i++) {
 		char *val=GloSQLite3Server->get_variable(varnames[i]);
-		l+=( varnames[i] ? strlen(varnames[i]) : 6);
-		l+=( val ? strlen(val) : 6);
+		const char* safe_val = (val ? val : "(null)");
+		size_t l = strlen(a) + 200;
+		l += (varnames[i] ? strlen(varnames[i]) : 6);
+		l += strlen(safe_val);
 		char *query=(char *)malloc(l);
-		sprintf(query, a, varnames[i], val);
+		snprintf(query, l, a, varnames[i], safe_val);
 		if (runtime) {
 			db->execute(query);
-			sprintf(query, b, varnames[i], val);
+			snprintf(query, l, b, varnames[i], safe_val);
 		}
 		db->execute(query);
 		if (val)
@@ -1259,18 +1260,19 @@ void ProxySQL_Admin::flush_ldap_variables___runtime_to_database(SQLite3DB *db, b
   } else {
     a=(char *)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(\"ldap-%s\",\"%s\")";
   }
-  int l=strlen(a)+200;
 	GloMyLdapAuth->wrlock();
 	char **varnames=GloMyLdapAuth->get_variables_list();
 	for (int i=0; varnames[i]; i++) {
 		char *val=GloMyLdapAuth->get_variable(varnames[i]);
-		l+=( varnames[i] ? strlen(varnames[i]) : 6);
-		l+=( val ? strlen(val) : 6);
+		const char* safe_val = (val ? val : "(null)");
+		size_t l = strlen(a) + 200;
+		l += (varnames[i] ? strlen(varnames[i]) : 6);
+		l += strlen(safe_val);
 		char *query=(char *)malloc(l);
-		sprintf(query, a, varnames[i], val);
+		snprintf(query, l, a, varnames[i], safe_val);
 		if (runtime) {
 			db->execute(query);
-			sprintf(query, b, varnames[i], val);
+			snprintf(query, l, b, varnames[i], safe_val);
 		}
 		db->execute(query);
 		if (val)
@@ -1323,18 +1325,18 @@ void ProxySQL_Admin::flush_admin_variables___runtime_to_database(SQLite3DB *db, 
   } else {
     a=(char *)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(\"admin-%s\",\"%s\")";
   }
-  int l=strlen(a)+200;
-
 	char **varnames=get_variables_list();
 	for (int i=0; varnames[i]; i++) {
 		char *val=get_variable(varnames[i]);
-		l+=( varnames[i] ? strlen(varnames[i]) : 6);
-		l+=( val ? strlen(val) : 6);
+		const char* safe_val = (val ? val : "(null)");
+		size_t l = strlen(a) + 200;
+		l += (varnames[i] ? strlen(varnames[i]) : 6);
+		l += strlen(safe_val);
 		char *query=(char *)malloc(l);
-		sprintf(query, a, varnames[i], val);
+		snprintf(query, l, a, varnames[i], safe_val);
 		db->execute(query);
 		if (runtime) {
-			sprintf(query, b, varnames[i], val);
+			snprintf(query, l, b, varnames[i], safe_val);
 			db->execute(query);
 		}
 		if (val)

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -225,30 +225,30 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 					val = GloMyLdapAuth->get_variable(r->fields[0]);
 				}
 				char q[1000];
-				if (val) {
-					if (variables_read_only.count(v) > 0) {
-						proxy_warning("Impossible to set read-only variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0],r->fields[1], val);
-					} else {
-						proxy_warning("Impossible to set variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0],r->fields[1], val);
-					}
-					sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"%s-%s\",\"%s\")", modname.c_str(), r->fields[0],val);
-					db->execute(q);
-					free(val);
-				} else {
-					if (variables_to_delete_silently.count(v) > 0) {
-						sprintf(q,"DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
+					if (val) {
+						if (variables_read_only.count(v) > 0) {
+							proxy_warning("Impossible to set read-only variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0],r->fields[1], val);
+						} else {
+							proxy_warning("Impossible to set variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0],r->fields[1], val);
+						}
+						snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"%s-%s\",\"%s\")", modname.c_str(), r->fields[0], val);
 						db->execute(q);
-					} else if (variables_deprecated.count(v) > 0) {
-						proxy_error("Global variable %s-%s is deprecated.\n", modname.c_str(), r->fields[0]);
-						sprintf(q,"DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
-						db->execute(q);
+						free(val);
 					} else {
-						proxy_warning("Impossible to set not existing variable %s with value \"%s\". Deleting. If the variable name is correct, this version doesn't support it\n", r->fields[0],r->fields[1]);
+						if (variables_to_delete_silently.count(v) > 0) {
+							snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
+							db->execute(q);
+						} else if (variables_deprecated.count(v) > 0) {
+							proxy_error("Global variable %s-%s is deprecated.\n", modname.c_str(), r->fields[0]);
+							snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
+							db->execute(q);
+						} else {
+							proxy_warning("Impossible to set not existing variable %s with value \"%s\". Deleting. If the variable name is correct, this version doesn't support it\n", r->fields[0],r->fields[1]);
+						}
+						snprintf(q, sizeof(q), "DELETE FROM global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
+						db->execute(q);
 					}
-					sprintf(q,"DELETE FROM global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
-					db->execute(q);
 				}
-			}
 		} else {
 			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Set variable %s with value \"%s\"\n", r->fields[0],r->fields[1]);
 			if (variables_special_values.count(v) > 0) {
@@ -355,8 +355,9 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 	char** varnames = GloPTH->get_variables_list();
 	for (int i = 0; varnames[i]; i++) {
 		char* val = GloPTH->get_variable(varnames[i]);
-		char* qualified_name = (char*)malloc(strlen(varnames[i]) + 12);
-		sprintf(qualified_name, "pgsql-%s", varnames[i]);
+		size_t qualified_name_len = strlen(varnames[i]) + sizeof("pgsql-");
+		char* qualified_name = (char*)malloc(qualified_name_len);
+		snprintf(qualified_name, qualified_name_len, "pgsql-%s", varnames[i]);
 		rc = (*proxy_sqlite3_bind_text)(statement1, 1, qualified_name, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		rc = (*proxy_sqlite3_bind_text)(statement1, 2, (val ? val : (char*)""), -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		SAFE_SQLITE3_STEP2(statement1);
@@ -406,7 +407,7 @@ void ProxySQL_Admin::flush_GENERIC_variables__checksum__database_to_runtime(cons
 	uint32_t d32[2];
 	char buf[20];
 	memcpy(&d32, &hash1, sizeof(hash1));
-	sprintf(buf,"0x%0X%0X", d32[0], d32[1]);
+	snprintf(buf, sizeof(buf), "0x%0X%0X", d32[0], d32[1]);
 	ProxySQL_Checksum_Value *checkvar = NULL;
 	if (modname == "admin") {
 		checkvar = &GloVars.checksums_values.admin_variables;
@@ -462,12 +463,12 @@ void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, 
 				if (varname == "default_collation_connection" || varname == "default_charset") {
 					char *val=GloMTH->get_variable((char *)varname.c_str());
 					if (val) {
-						if (strcmp(val,varvalue)) {
-							char q[1000];
-							proxy_warning("Variable %s with value \"%s\" is being replaced with value \"%s\".\n", varname.c_str(), varvalue, val);
-							sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"mysql-%s\",\"%s\")", varname.c_str() ,val);
-							db->execute(q);
-						}
+							if (strcmp(val,varvalue)) {
+								char q[1000];
+								proxy_warning("Variable %s with value \"%s\" is being replaced with value \"%s\".\n", varname.c_str(), varvalue, val);
+								snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"mysql-%s\",\"%s\")", varname.c_str(), val);
+								db->execute(q);
+							}
 						free(val);
 					}
 				} else if (varname == "show_processlist_extended") {
@@ -495,33 +496,33 @@ void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, 
 			ci = proxysql_find_charset_collate(default_collation_connection);
 			if (ci == NULL) {
 				proxy_error("Found an incorrect value for mysql-default_collation_connection: %s\n", default_collation_connection);
-				const char *p = mysql_tracked_variables[SQL_CHARACTER_SET].default_value;
-				ci = proxysql_find_charset_name(p);
-				assert(ci);
-				proxy_info("Resetting mysql-default_charset to hardcoded default value: %s\n", ci->csname);
-				sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_charset\",\"%s\")", ci->csname);
-				db->execute(q);
-				GloMTH->set_variable((char *)"default_charset",ci->csname);
-				proxy_info("Resetting mysql-default_collation_connection to hardcoded default value: %s\n", ci->name);
-				sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_collation_connection\",\"%s\")", ci->name);
-				db->execute(q);
-				GloMTH->set_variable((char *)"default_collation_connection",ci->name);
-			} else {
-				proxy_info("Changing mysql-default_charset to %s using configured mysql-default_collation_connection %s\n", ci->csname, ci->name);
-				sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_charset\",\"%s\")", ci->csname);
-				db->execute(q);
-				GloMTH->set_variable((char *)"default_charset",ci->csname);
-			}
+					const char *p = mysql_tracked_variables[SQL_CHARACTER_SET].default_value;
+					ci = proxysql_find_charset_name(p);
+					assert(ci);
+					proxy_info("Resetting mysql-default_charset to hardcoded default value: %s\n", ci->csname);
+					snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_charset\",\"%s\")", ci->csname);
+					db->execute(q);
+					GloMTH->set_variable((char *)"default_charset",ci->csname);
+					proxy_info("Resetting mysql-default_collation_connection to hardcoded default value: %s\n", ci->name);
+					snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_collation_connection\",\"%s\")", ci->name);
+					db->execute(q);
+					GloMTH->set_variable((char *)"default_collation_connection",ci->name);
+				} else {
+					proxy_info("Changing mysql-default_charset to %s using configured mysql-default_collation_connection %s\n", ci->csname, ci->name);
+					snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_charset\",\"%s\")", ci->csname);
+					db->execute(q);
+					GloMTH->set_variable((char *)"default_charset",ci->csname);
+				}
 		} else {
 			MARIADB_CHARSET_INFO * cic = NULL;
 			cic = proxysql_find_charset_collate(default_collation_connection);
-			if (cic == NULL) {
-				proxy_error("Found an incorrect value for mysql-default_collation_connection: %s\n", default_collation_connection);
-				proxy_info("Changing mysql-default_collation_connection to %s using configured mysql-default_charset: %s\n", ci->name, ci->csname);
-				sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_collation_connection\",\"%s\")", ci->name);
-				db->execute(q);
-				GloMTH->set_variable((char *)"default_collation_connection",ci->name);
-			} else {
+				if (cic == NULL) {
+					proxy_error("Found an incorrect value for mysql-default_collation_connection: %s\n", default_collation_connection);
+					proxy_info("Changing mysql-default_collation_connection to %s using configured mysql-default_charset: %s\n", ci->name, ci->csname);
+					snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_collation_connection\",\"%s\")", ci->name);
+					db->execute(q);
+					GloMTH->set_variable((char *)"default_collation_connection",ci->name);
+				} else {
 				if (strcmp(cic->csname,ci->csname)==0) {
 					// mysql-default_collation_connection and mysql-default_charset are compatible
 				} else {
@@ -533,18 +534,18 @@ void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, 
 							// we use charset as source of truth
 							use_collation = false;
 						}
-					}
-					if (use_collation) {
-						proxy_info("Changing mysql-default_charset to %s using configured mysql-default_collation_connection %s\n", cic->csname, cic->name);
-						sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_charset\",\"%s\")", cic->csname);
-						db->execute(q);
-						GloMTH->set_variable((char *)"default_charset",cic->csname);
-					} else {
-						proxy_info("Changing mysql-default_collation_connection to %s using configured mysql-default_charset: %s\n", ci->name, ci->csname);
-						sprintf(q,"INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_collation_connection\",\"%s\")", ci->name);
-						db->execute(q);
-						GloMTH->set_variable((char *)"default_collation_connection",ci->name);
-					}
+						}
+						if (use_collation) {
+							proxy_info("Changing mysql-default_charset to %s using configured mysql-default_collation_connection %s\n", cic->csname, cic->name);
+							snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_charset\",\"%s\")", cic->csname);
+							db->execute(q);
+							GloMTH->set_variable((char *)"default_charset",cic->csname);
+						} else {
+							proxy_info("Changing mysql-default_collation_connection to %s using configured mysql-default_charset: %s\n", ci->name, ci->csname);
+							snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"mysql-default_collation_connection\",\"%s\")", ci->name);
+							db->execute(q);
+							GloMTH->set_variable((char *)"default_collation_connection",ci->name);
+						}
 				}
 			}
 		}
@@ -766,10 +767,10 @@ void ProxySQL_Admin::flush_clickhouse_variables___runtime_to_database(SQLite3DB 
 		l+=( varnames[i] ? strlen(varnames[i]) : 6);
 		l+=( val ? strlen(val) : 6);
 		char *query=(char *)malloc(l);
-		sprintf(query, a, varnames[i], val);
+		snprintf(query, l, a, varnames[i], val);
 		if (runtime) {
 			db->execute(query);
-			sprintf(query, b, varnames[i], val);
+			snprintf(query, l, b, varnames[i], val);
 		}
 		db->execute(query);
 		if (val)
@@ -807,35 +808,35 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 				if (replace) {
 					char* val = GloPTH->get_variable(r->fields[0]);
 					char q[1000];
-					if (val) {
-						if (strcmp(val, value)) {
-							proxy_warning("Impossible to set variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0], value, val);
-							sprintf(q, "INSERT OR REPLACE INTO global_variables VALUES(\"pgsql-%s\",\"%s\")", r->fields[0], val);
-							db->execute(q);
-						}
-						free(val);
+						if (val) {
+							if (strcmp(val, value)) {
+								proxy_warning("Impossible to set variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0], value, val);
+								snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"pgsql-%s\",\"%s\")", r->fields[0], val);
+								db->execute(q);
+							}
+							free(val);
 					}
-					else {
-						if (strcmp(r->fields[0], (char*)"session_debug") == 0) {
-							sprintf(q, "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
-							db->execute(q);
-						}
 						else {
-							if (strcmp(r->fields[0], (char*)"forward_autocommit") == 0) {
-								if (strcasecmp(value, "true") == 0 || strcasecmp(value, "1") == 0) {
-									proxy_error("Global variable pgsql-forward_autocommit is deprecated. See issue #3253\n");
-								}
-								sprintf(q, "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
+							if (strcmp(r->fields[0], (char*)"session_debug") == 0) {
+								snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
 								db->execute(q);
 							}
 							else {
+								if (strcmp(r->fields[0], (char*)"forward_autocommit") == 0) {
+									if (strcasecmp(value, "true") == 0 || strcasecmp(value, "1") == 0) {
+										proxy_error("Global variable pgsql-forward_autocommit is deprecated. See issue #3253\n");
+									}
+									snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
+									db->execute(q);
+								}
+							else {
 								proxy_warning("Impossible to set not existing variable %s with value \"%s\". Deleting. If the variable name is correct, this version doesn't support it\n", r->fields[0], r->fields[1]);
+								}
 							}
+							snprintf(q, sizeof(q), "DELETE FROM global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
+							db->execute(q);
 						}
-						sprintf(q, "DELETE FROM global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
-						db->execute(q);
 					}
-				}
 			}
 			else {
 				if (
@@ -844,13 +845,13 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 					) {
 					char* val = GloPTH->get_variable(r->fields[0]);
 					char q[1000];
-					if (val) {
-						if (strcmp(val, value)) {
-							proxy_warning("Variable %s with value \"%s\" is being replaced with value \"%s\".\n", r->fields[0], value, val);
-							sprintf(q, "INSERT OR REPLACE INTO global_variables VALUES(\"pgsql-%s\",\"%s\")", r->fields[0], val);
-							db->execute(q);
-						}
-						free(val);
+						if (val) {
+							if (strcmp(val, value)) {
+								proxy_warning("Variable %s with value \"%s\" is being replaced with value \"%s\".\n", r->fields[0], value, val);
+								snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"pgsql-%s\",\"%s\")", r->fields[0], val);
+								db->execute(q);
+							}
+							free(val);
 					}
 				}
 				proxy_debug(PROXY_DEBUG_ADMIN, 4, "Set variable %s with value \"%s\"\n", r->fields[0], value);
@@ -876,13 +877,13 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 		if (charset_encoding == -1) {
 			// invalid charset_encoding
 			proxy_error("Found an incorrect value for pgsql-default_client_encoding: %s\n", default_client_encoding);
-			const char* p = pgsql_tracked_variables[PGSQL_CLIENT_ENCODING].default_value;
-			charset_encoding = PgSQL_Connection::char_to_encoding(p);
-			assert(charset_encoding != -1);
-			proxy_info("Resetting pgsql-default_client_encoding to hardcoded default value: %s\n", p);
-			sprintf(q, "INSERT OR REPLACE INTO global_variables VALUES(\"pgsql-default_client_encoding\",\"%s\")", p);
-			db->execute(q);
-			GloPTH->set_variable((char*)"default_client_encoding", p);
+				const char* p = pgsql_tracked_variables[PGSQL_CLIENT_ENCODING].default_value;
+				charset_encoding = PgSQL_Connection::char_to_encoding(p);
+				assert(charset_encoding != -1);
+				proxy_info("Resetting pgsql-default_client_encoding to hardcoded default value: %s\n", p);
+				snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"pgsql-default_client_encoding\",\"%s\")", p);
+				db->execute(q);
+				GloPTH->set_variable((char*)"default_client_encoding", p);
 		}
 		free(default_client_encoding);
 		GloPTH->commit();
@@ -910,7 +911,7 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 			uint32_t d32[2];
 			char buf[20];
 			memcpy(&d32, &hash1, sizeof(hash1));
-			sprintf(buf, "0x%0X%0X", d32[0], d32[1]);
+			snprintf(buf, sizeof(buf), "0x%0X%0X", d32[0], d32[1]);
 			GloVars.checksums_values.mysql_variables.set_checksum(buf);
 			GloVars.checksums_values.mysql_variables.version++;
 			time_t t = time(NULL);
@@ -1033,8 +1034,9 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 	char** varnames = GloGATH->get_variables_list();
 	for (int i = 0; varnames[i]; i++) {
 		char* val = GloGATH->get_variable(varnames[i]);
-		char* qualified_name = (char*)malloc(strlen(varnames[i]) + 10);
-		sprintf(qualified_name, "genai-%s", varnames[i]);
+		size_t qualified_name_len = strlen(varnames[i]) + sizeof("genai-");
+		char* qualified_name = (char*)malloc(qualified_name_len);
+		snprintf(qualified_name, qualified_name_len, "genai-%s", varnames[i]);
 		rc = (*proxy_sqlite3_bind_text)(statement1, 1, qualified_name, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		rc = (*proxy_sqlite3_bind_text)(statement1, 2, (val ? val : (char*)""), -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		SAFE_SQLITE3_STEP2(statement1);
@@ -1172,8 +1174,9 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 	char **varnames=GloMTH->get_variables_list();
 	for (int i=0; varnames[i]; i++) {
 		char *val=GloMTH->get_variable(varnames[i]);
-		char *qualified_name=(char *)malloc(strlen(varnames[i])+7);
-		sprintf(qualified_name, "mysql-%s", varnames[i]);
+		size_t qualified_name_len = strlen(varnames[i]) + sizeof("mysql-");
+		char *qualified_name=(char *)malloc(qualified_name_len);
+		snprintf(qualified_name, qualified_name_len, "mysql-%s", varnames[i]);
 		rc=(*proxy_sqlite3_bind_text)(statement1, 1, qualified_name, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		rc=(*proxy_sqlite3_bind_text)(statement1, 2, (val ? val : (char *)""), -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		SAFE_SQLITE3_STEP2(statement1);
@@ -1468,8 +1471,9 @@ void ProxySQL_Admin::flush_mcp_variables___runtime_to_database(SQLite3DB* db, bo
 	for (int i = 0; varnames[i]; i++) {
 		char val[256];
 		GloMCPH->get_variable(varnames[i], val);
-		char* qualified_name = (char*)malloc(strlen(varnames[i]) + 8);
-		sprintf(qualified_name, "mcp-%s", varnames[i]);
+		size_t qualified_name_len = strlen(varnames[i]) + sizeof("mcp-");
+		char* qualified_name = (char*)malloc(qualified_name_len);
+		snprintf(qualified_name, qualified_name_len, "mcp-%s", varnames[i]);
 		rc = (*proxy_sqlite3_bind_text)(statement1, 1, qualified_name, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		rc = (*proxy_sqlite3_bind_text)(statement1, 2, (val ? val : (char*)""), -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, db);
 		SAFE_SQLITE3_STEP2(statement1);
@@ -1483,7 +1487,7 @@ void ProxySQL_Admin::flush_mcp_variables___runtime_to_database(SQLite3DB* db, bo
 			// qualified_name already contains the mcp- prefix, so we use %s without prefix
 			int l = strlen(qualified_name) + strlen(val) + 100;
 			char* query = (char*)malloc(l);
-			sprintf(query, b, qualified_name, val);
+			snprintf(query, l, b, qualified_name, val);
 			if (i < 3) {
 				proxy_info("MCP: Executing SQL: %s\n", query);
 			}

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -336,12 +336,14 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 	auto [rc1, statement1_unique] = db->prepare_v2(a);
 	ASSERT_SQLITE_OK(rc1, db);
 	sqlite3_stmt* statement1 = statement1_unique.get();
+	SQLite3DB::stmt_unique_ptr statement2_unique;  // Function scope to avoid dangling pointer
 	sqlite3_stmt* statement2 = NULL;
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'pgsql-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		auto [rc2, statement2_unique] = db->prepare_v2(b);
+		auto [rc2, stmt_temp] = db->prepare_v2(b);
 		ASSERT_SQLITE_OK(rc2, db);
+		statement2_unique = std::move(stmt_temp);
 		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {
@@ -1008,12 +1010,14 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 	auto [rc1, statement1_unique] = db->prepare_v2(a);
 	ASSERT_SQLITE_OK(rc1, db);
 	sqlite3_stmt* statement1 = statement1_unique.get();
+	SQLite3DB::stmt_unique_ptr statement2_unique;  // Function scope to avoid dangling pointer
 	sqlite3_stmt* statement2 = NULL;
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'genai-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		auto [rc2, statement2_unique] = db->prepare_v2(b);
+		auto [rc2, stmt_temp] = db->prepare_v2(b);
 		ASSERT_SQLITE_OK(rc2, db);
+		statement2_unique = std::move(stmt_temp);
 		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {
@@ -1141,13 +1145,15 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 	auto [rc1, statement1_unique] = db->prepare_v2(a);
 	ASSERT_SQLITE_OK(rc1, db);
 	sqlite3_stmt *statement1 = statement1_unique.get();
+	SQLite3DB::stmt_unique_ptr statement2_unique;  // Function scope to avoid dangling pointer
 	sqlite3_stmt *statement2 = NULL;
 	if (runtime)  {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'mysql-%'");
 		b=(char *)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 
-		auto [rc2, statement2_unique] = db->prepare_v2(b);
+		auto [rc2, stmt_temp] = db->prepare_v2(b);
 		ASSERT_SQLITE_OK(rc2, db);
+		statement2_unique = std::move(stmt_temp);
 		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -332,18 +332,17 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 		a = (char*)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 	}
 	int rc;
-	sqlite3_stmt* statement1 = NULL;
-	sqlite3_stmt* statement2 = NULL;
 	//sqlite3 *mydb3=db->get_db();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, a, -1, &statement1, 0);
-	rc = db->prepare_v2(a, &statement1);
-	ASSERT_SQLITE_OK(rc, db);
+	auto [rc1, statement1_unique] = db->prepare_v2(a);
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt* statement1 = statement1_unique.get();
+	sqlite3_stmt* statement2 = NULL;
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'pgsql-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, b, -1, &statement2, 0);
-		rc = db->prepare_v2(b, &statement2);
-		ASSERT_SQLITE_OK(rc, db);
+		auto [rc2, statement2_unique] = db->prepare_v2(b);
+		ASSERT_SQLITE_OK(rc2, db);
+		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {
 		GloPTH->wrlock();
@@ -374,9 +373,6 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 		db->execute("COMMIT");
 		GloPTH->wrunlock();
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	if (runtime)
-		(*proxy_sqlite3_finalize)(statement2);
 	for (int i = 0; varnames[i]; i++) {
 		free(varnames[i]);
 	}
@@ -1009,15 +1005,16 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 		a = (char*)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 	}
 	int rc;
-	sqlite3_stmt* statement1 = NULL;
+	auto [rc1, statement1_unique] = db->prepare_v2(a);
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt* statement1 = statement1_unique.get();
 	sqlite3_stmt* statement2 = NULL;
-	rc = db->prepare_v2(a, &statement1);
-	ASSERT_SQLITE_OK(rc, db);
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'genai-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		rc = db->prepare_v2(b, &statement2);
-		ASSERT_SQLITE_OK(rc, db);
+		auto [rc2, statement2_unique] = db->prepare_v2(b);
+		ASSERT_SQLITE_OK(rc2, db);
+		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {
 		GloGATH->wrlock();
@@ -1048,9 +1045,6 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 		db->execute("COMMIT");
 		GloGATH->wrunlock();
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	if (runtime)
-		(*proxy_sqlite3_finalize)(statement2);
 	for (int i = 0; varnames[i]; i++) {
 		free(varnames[i]);
 	}
@@ -1144,17 +1138,17 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 		a=(char *)"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 	}
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement2=NULL;
-
-	rc=db->prepare_v2(a, &statement1);
-	ASSERT_SQLITE_OK(rc, db);
+	auto [rc1, statement1_unique] = db->prepare_v2(a);
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement2 = NULL;
 	if (runtime)  {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'mysql-%'");
 		b=(char *)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 
-		rc=db->prepare_v2(b, &statement2);
-		ASSERT_SQLITE_OK(rc, db);
+		auto [rc2, statement2_unique] = db->prepare_v2(b);
+		ASSERT_SQLITE_OK(rc2, db);
+		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {
 		GloMTH->wrlock();
@@ -1185,9 +1179,6 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 		db->execute("COMMIT");
 		GloMTH->wrunlock();
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	if (runtime)
-		(*proxy_sqlite3_finalize)(statement2);
 	for (int i=0; varnames[i]; i++) {
 		free(varnames[i]);
 	}
@@ -1442,9 +1433,9 @@ void ProxySQL_Admin::flush_mcp_variables___runtime_to_database(SQLite3DB* db, bo
 	}
 	b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(\"%s\",\"%s\")";
 	int rc;
-	sqlite3_stmt* statement1 = NULL;
-	rc = db->prepare_v2("REPLACE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)", &statement1);
-	ASSERT_SQLITE_OK(rc, db);
+	auto [rc1, statement1_unique] = db->prepare_v2("REPLACE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)");
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt* statement1 = statement1_unique.get();
 
 	if (use_lock) {
 		GloMCPH->wrlock();
@@ -1491,7 +1482,6 @@ void ProxySQL_Admin::flush_mcp_variables___runtime_to_database(SQLite3DB* db, bo
 		proxy_info("MCP: Releasing lock\n");
 		GloMCPH->wrunlock();
 	}
-	(*proxy_sqlite3_finalize)(statement1);
 	for (int i = 0; varnames[i]; i++) {
 		free(varnames[i]);
 	}

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -336,14 +336,12 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 	auto [rc1, statement1_unique] = db->prepare_v2(a);
 	ASSERT_SQLITE_OK(rc1, db);
 	sqlite3_stmt* statement1 = statement1_unique.get();
-	SQLite3DB::stmt_unique_ptr statement2_unique;  // Function scope to avoid dangling pointer
 	sqlite3_stmt* statement2 = NULL;
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'pgsql-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		auto [rc2, stmt_temp] = db->prepare_v2(b);
+		auto [rc2, statement2_unique] = db->prepare_v2(b);
 		ASSERT_SQLITE_OK(rc2, db);
-		statement2_unique = std::move(stmt_temp);
 		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {
@@ -1010,14 +1008,12 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 	auto [rc1, statement1_unique] = db->prepare_v2(a);
 	ASSERT_SQLITE_OK(rc1, db);
 	sqlite3_stmt* statement1 = statement1_unique.get();
-	SQLite3DB::stmt_unique_ptr statement2_unique;  // Function scope to avoid dangling pointer
 	sqlite3_stmt* statement2 = NULL;
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'genai-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		auto [rc2, stmt_temp] = db->prepare_v2(b);
+		auto [rc2, statement2_unique] = db->prepare_v2(b);
 		ASSERT_SQLITE_OK(rc2, db);
-		statement2_unique = std::move(stmt_temp);
 		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {
@@ -1145,15 +1141,13 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 	auto [rc1, statement1_unique] = db->prepare_v2(a);
 	ASSERT_SQLITE_OK(rc1, db);
 	sqlite3_stmt *statement1 = statement1_unique.get();
-	SQLite3DB::stmt_unique_ptr statement2_unique;  // Function scope to avoid dangling pointer
 	sqlite3_stmt *statement2 = NULL;
 	if (runtime)  {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'mysql-%'");
 		b=(char *)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 
-		auto [rc2, stmt_temp] = db->prepare_v2(b);
+		auto [rc2, statement2_unique] = db->prepare_v2(b);
 		ASSERT_SQLITE_OK(rc2, db);
-		statement2_unique = std::move(stmt_temp);
 		statement2 = statement2_unique.get();
 	}
 	if (use_lock) {

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -334,13 +334,18 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 	int rc;
 	sqlite3_stmt* statement1 = NULL;
 	sqlite3_stmt* statement2 = NULL;
-	//sqlite3 *mydb3=db->get_db();
-	rc = db->prepare_v2(a, &statement1);
+	auto [rc1, statement1_unique] = db->prepare_v2(a);
+	rc = rc1;
+	statement1 = statement1_unique.get();
 	ASSERT_SQLITE_OK(rc, db);
+	stmt_unique_ptr statement2_unique {};
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'pgsql-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		rc = db->prepare_v2(b, &statement2);
+		auto [rc2, prepared_statement2] = db->prepare_v2(b);
+		rc = rc2;
+		statement2_unique = std::move(prepared_statement2);
+		statement2 = statement2_unique.get();
 		ASSERT_SQLITE_OK(rc, db);
 	}
 	if (use_lock) {
@@ -372,9 +377,6 @@ void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, 
 		db->execute("COMMIT");
 		GloPTH->wrunlock();
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	if (runtime)
-		(*proxy_sqlite3_finalize)(statement2);
 	for (int i = 0; varnames[i]; i++) {
 		free(varnames[i]);
 	}
@@ -1010,12 +1012,18 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 	int rc;
 	sqlite3_stmt* statement1 = NULL;
 	sqlite3_stmt* statement2 = NULL;
-	rc = db->prepare_v2(a, &statement1);
+	auto [rc1, statement1_unique] = db->prepare_v2(a);
+	rc = rc1;
+	statement1 = statement1_unique.get();
 	ASSERT_SQLITE_OK(rc, db);
+	stmt_unique_ptr statement2_unique {};
 	if (runtime) {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'genai-%'");
 		b = (char*)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-		rc = db->prepare_v2(b, &statement2);
+		auto [rc2, prepared_statement2] = db->prepare_v2(b);
+		rc = rc2;
+		statement2_unique = std::move(prepared_statement2);
+		statement2 = statement2_unique.get();
 		ASSERT_SQLITE_OK(rc, db);
 	}
 	if (use_lock) {
@@ -1047,9 +1055,6 @@ void ProxySQL_Admin::flush_genai_variables___runtime_to_database(SQLite3DB* db, 
 		db->execute("COMMIT");
 		GloGATH->wrunlock();
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	if (runtime)
-		(*proxy_sqlite3_finalize)(statement2);
 	for (int i = 0; varnames[i]; i++) {
 		free(varnames[i]);
 	}
@@ -1145,13 +1150,19 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 	int rc;
 	sqlite3_stmt *statement1 = NULL;
 	sqlite3_stmt *statement2 = NULL;
-	rc = db->prepare_v2(a, &statement1);
+	auto [rc1, statement1_unique] = db->prepare_v2(a);
+	rc = rc1;
+	statement1 = statement1_unique.get();
 	ASSERT_SQLITE_OK(rc, db);
+	stmt_unique_ptr statement2_unique {};
 	if (runtime)  {
 		db->execute("DELETE FROM runtime_global_variables WHERE variable_name LIKE 'mysql-%'");
 		b=(char *)"INSERT INTO runtime_global_variables(variable_name, variable_value) VALUES(?1, ?2)";
 
-		rc = db->prepare_v2(b, &statement2);
+		auto [rc2, prepared_statement2] = db->prepare_v2(b);
+		rc = rc2;
+		statement2_unique = std::move(prepared_statement2);
+		statement2 = statement2_unique.get();
 		ASSERT_SQLITE_OK(rc, db);
 	}
 	if (use_lock) {
@@ -1183,9 +1194,6 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 		db->execute("COMMIT");
 		GloMTH->wrunlock();
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	if (runtime)
-		(*proxy_sqlite3_finalize)(statement2);
 	for (int i=0; varnames[i]; i++) {
 		free(varnames[i]);
 	}

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -901,14 +901,26 @@ bool admin_handler_command_proxysql(char *query_no_space, unsigned int query_no_
 
 	if (query_no_space_length==strlen("PROXYSQL KILL") && !strncasecmp("PROXYSQL KILL",query_no_space, query_no_space_length)) {
 		proxy_info("Received PROXYSQL KILL command\n");
+	#ifdef DEBUG
+		// In debug builds prefer coordinated shutdown to avoid teardown races.
+		__sync_bool_compare_and_swap(&glovars.shutdown,0,1);
+		return false;
+	#else
 		exit(EXIT_SUCCESS);
+	#endif
 	}
 
 	if (query_no_space_length==strlen("PROXYSQL SHUTDOWN") && !strncasecmp("PROXYSQL SHUTDOWN",query_no_space, query_no_space_length)) {
 		// in 2.1 , PROXYSQL SHUTDOWN behaves like PROXYSQL KILL : quick exit
 		// the former PROXYQL SHUTDOWN is now replaced with PROXYSQL SHUTDOWN SLOW
 		proxy_info("Received PROXYSQL SHUTDOWN command\n");
+	#ifdef DEBUG
+		// In debug builds prefer coordinated shutdown to avoid teardown races.
+		__sync_bool_compare_and_swap(&glovars.shutdown,0,1);
+		return false;
+	#else
 		exit(EXIT_SUCCESS);
+	#endif
 	}
 
 	return true;
@@ -4526,4 +4538,3 @@ __run_query:
 // Explicitly instantiate the required template class and member functions
 template void admin_session_handler<MySQL_Session>(MySQL_Session* sess, void *_pa, PtrSize_t *pkt);
 template void admin_session_handler<PgSQL_Session>(PgSQL_Session* sess, void *_pa, PtrSize_t *pkt);
-

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -1033,7 +1033,7 @@ bool admin_handler_command_set(char *query_no_space, unsigned int query_no_space
 			size_t buff_len = strlen(err_msg_fmt) + strlen(var_name) + 1;
 			char *buff = (char *) malloc(buff_len);
 			snprintf(buff, buff_len, err_msg_fmt, var_name);
-			SPA->send_ok_msg_to_client(sess, buff, 0, query_no_space);
+			SPA->send_error_msg_to_client(sess, buff);
 			free(buff);
 			run_query = false;
 		} else {

--- a/lib/Base_HostGroups_Manager.cpp
+++ b/lib/Base_HostGroups_Manager.cpp
@@ -868,11 +868,13 @@ int MySQL_HostGroups_Manager::servers_add(SQLite3_result *resultset) {
 	char *query1=(char *)"INSERT INTO mysql_servers_incoming VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 	std::string query32s = "INSERT INTO mysql_servers_incoming VALUES " + generate_multi_rows_query(32,12);
 	char *query32 = (char *)query32s.c_str();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = mydb->prepare_v2(query1, &statement1);
+	auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+	rc = rc1;
+	statement1 = statement1_unique.get();
 	ASSERT_SQLITE_OK(rc, mydb);
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = mydb->prepare_v2(query32, &statement32);
+	auto [rc2, statement32_unique] = mydb->prepare_v2(query32);
+	rc = rc2;
+	statement32 = statement32_unique.get();
 	ASSERT_SQLITE_OK(rc, mydb);
 	MySerStatus status1=MYSQL_SERVER_STATUS_ONLINE;
 	int row_idx=0;
@@ -932,8 +934,6 @@ int MySQL_HostGroups_Manager::servers_add(SQLite3_result *resultset) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	return 0;
 }
 #endif // 0
@@ -1402,12 +1402,14 @@ bool MySQL_HostGroups_Manager::commit(
 		sqlite3_stmt *statement2=NULL;
 		//sqlite3 *mydb3=mydb->get_db();
 		char *query1=(char *)"UPDATE mysql_servers SET mem_pointer = ?1 WHERE hostgroup_id = ?2 AND hostname = ?3 AND port = ?4";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = mydb->prepare_v2(query1, &statement1);
+		auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+		rc = rc1;
+		statement1 = statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, mydb);
 		char *query2=(char *)"UPDATE mysql_servers SET weight = ?1 , status = ?2 , compression = ?3 , max_connections = ?4 , max_replication_lag = ?5 , use_ssl = ?6 , max_latency_ms = ?7 , comment = ?8 , gtid_port = ?9 WHERE hostgroup_id = ?10 AND hostname = ?11 AND port = ?12";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query2, -1, &statement2, 0);
-		rc = mydb->prepare_v2(query2, &statement2);
+		auto [rc2, statement2_unique] = mydb->prepare_v2(query2);
+		rc = rc2;
+		statement2 = statement2_unique.get();
 		ASSERT_SQLITE_OK(rc, mydb);
 
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
@@ -1537,8 +1539,6 @@ bool MySQL_HostGroups_Manager::commit(
 				}
 			}
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement2);
 	}
 	if (use_gtid) {
 		has_gtid_port = true;
@@ -1731,13 +1731,15 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_table(int *_onlyhg) {
 	PtrArray *lst=new PtrArray();
 	//sqlite3 *mydb3=mydb->get_db();
 	char *query1=(char *)"INSERT INTO mysql_servers VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)";
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = mydb->prepare_v2(query1, &statement1);
+	auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+	rc = rc1;
+	statement1 = statement1_unique.get();
 	ASSERT_SQLITE_OK(rc, mydb);
 	std::string query32s = "INSERT INTO mysql_servers VALUES " + generate_multi_rows_query(32,13);
 	char *query32 = (char *)query32s.c_str();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = mydb->prepare_v2(query32, &statement32);
+	auto [rc2, statement32_unique] = mydb->prepare_v2(query32);
+	rc = rc2;
+	statement32 = statement32_unique.get();
 	ASSERT_SQLITE_OK(rc, mydb);
 
 	if (mysql_thread___hostgroup_manager_verbose) {
@@ -1828,8 +1830,6 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_table(int *_onlyhg) {
 		rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, mydb);
 		rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, mydb);
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	if (mysql_thread___hostgroup_manager_verbose) {
 		char *error=NULL;
 		int cols=0;
@@ -4306,8 +4306,9 @@ void MySQL_HostGroups_Manager::generate_mysql_hostgroup_attributes_table() {
 		"ignore_session_variables, hostgroup_settings, servers_defaults, comment) VALUES "
 		"(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
-	rc = mydb->prepare_v2(query, &statement);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, mydb);
 	proxy_info("New mysql_hostgroup_attributes table\n");
 	bool current_configured[MyHostGroups->len];
@@ -4411,7 +4412,6 @@ void MySQL_HostGroups_Manager::generate_mysql_hostgroup_attributes_table() {
 		}
 	}
 
-	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_hostgroup_attributes;
 	incoming_hostgroup_attributes=NULL;
 }
@@ -4428,7 +4428,9 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_ssl_params_table() {
 		"ssl_crl, ssl_crlpath, ssl_cipher, tls_version, comment) VALUES "
 		"(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
-	rc = mydb->prepare_v2(query, &statement);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, mydb);
 	proxy_info("New mysql_servers_ssl_params table\n");
 	std::lock_guard<std::mutex> lock(Servers_SSL_Params_map_mutex);
@@ -4466,7 +4468,6 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_ssl_params_table() {
 		string MapKey = MSSP.getMapKey(rand_del);
 		Servers_SSL_Params_map.emplace(MapKey, MSSP);
 	}
-	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_mysql_servers_ssl_params;
 	incoming_mysql_servers_ssl_params=NULL;
 }

--- a/lib/Base_Thread.cpp
+++ b/lib/Base_Thread.cpp
@@ -43,9 +43,7 @@ void Base_Thread::register_session(T thr, S _sess, bool up_start) {
 //	}
 	_sess->match_regexes=match_regexes;
 	if constexpr (std::is_same_v<T, PgSQL_Thread*>) {
-#ifdef IDLE_THREADS
 		_sess->copy_cmd_matcher = (static_cast<PgSQL_Thread*>(this))->copy_cmd_matcher;
-#endif
 	}
 
 	if (up_start)

--- a/lib/Discovery_Schema.cpp
+++ b/lib/Discovery_Schema.cpp
@@ -656,7 +656,8 @@ int Discovery_Schema::create_run(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "INSERT INTO runs(source_dsn, mysql_version, notes) VALUES(?1, ?2 ,  ?3);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_text)(stmt, 1, source_dsn.c_str(), -1, SQLITE_TRANSIENT);
@@ -665,7 +666,6 @@ int Discovery_Schema::create_run(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int run_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return run_id;
 }
@@ -674,14 +674,14 @@ int Discovery_Schema::finish_run(int run_id, const std::string& notes) {
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "UPDATE runs SET finished_at = datetime('now') ,  notes = ?1 WHERE run_id = ?2;";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_text)(stmt, 1, notes.c_str(), -1, SQLITE_TRANSIENT);
 	(*proxy_sqlite3_bind_int)(stmt, 2, run_id);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return 0;
 }
@@ -727,7 +727,8 @@ int Discovery_Schema::create_agent_run(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "INSERT INTO agent_runs(run_id, model_name, prompt_hash, budget_json) VALUES(?1, ?2, ?3 ,  ?4);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) {
 		proxy_error("Failed to prepare agent_runs insert: %s\n", (*proxy_sqlite3_errstr)(rc));
 		return -1;
@@ -747,8 +748,6 @@ int Discovery_Schema::create_agent_run(
 		}
 	} while (step_rc == SQLITE_LOCKED || step_rc == SQLITE_BUSY);
 
-	(*proxy_sqlite3_finalize)(stmt);
-
 	if (step_rc != SQLITE_DONE) {
 		proxy_error("Failed to insert into agent_runs (run_id=%d): %s\n", run_id, (*proxy_sqlite3_errstr)(step_rc));
 		return -1;
@@ -767,7 +766,8 @@ int Discovery_Schema::finish_agent_run(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "UPDATE agent_runs SET finished_at = datetime('now'), status = ?1 ,  error = ?2 WHERE agent_run_id = ?3;";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_text)(stmt, 1, status.c_str(), -1, SQLITE_TRANSIENT);
@@ -775,7 +775,6 @@ int Discovery_Schema::finish_agent_run(
 	(*proxy_sqlite3_bind_int)(stmt, 3, agent_run_id);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return 0;
 }
@@ -848,7 +847,8 @@ int Discovery_Schema::insert_schema(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "INSERT INTO schemas(run_id, schema_name, charset, collation) VALUES(?1, ?2, ?3 ,  ?4);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, run_id);
@@ -858,7 +858,6 @@ int Discovery_Schema::insert_schema(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int schema_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return schema_id;
 }
@@ -888,7 +887,8 @@ int Discovery_Schema::insert_object(
 		"  data_length, index_length, create_time, update_time, object_comment ,  definition_sql"
 		") VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11 ,  ?12);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, run_id);
@@ -906,7 +906,6 @@ int Discovery_Schema::insert_object(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int object_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return object_id;
 }
@@ -937,7 +936,8 @@ int Discovery_Schema::insert_column(
 		"  is_indexed, is_time ,  is_id_like"
 		") VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15 ,  ?16);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, object_id);
@@ -959,7 +959,6 @@ int Discovery_Schema::insert_column(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int column_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return column_id;
 }
@@ -977,7 +976,8 @@ int Discovery_Schema::insert_index(
 		"INSERT INTO indexes(object_id, index_name, is_unique, is_primary, index_type ,  cardinality) "
 		"VALUES(?1, ?2, ?3, ?4, ?5 ,  ?6);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, object_id);
@@ -989,7 +989,6 @@ int Discovery_Schema::insert_index(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int index_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return index_id;
 }
@@ -1006,7 +1005,8 @@ int Discovery_Schema::insert_index_column(
 		"INSERT INTO index_columns(index_id, seq_in_index, column_name, sub_part ,  collation) "
 		"VALUES(?1, ?2, ?3, ?4 ,  ?5);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, index_id);
@@ -1016,7 +1016,6 @@ int Discovery_Schema::insert_index_column(
 	(*proxy_sqlite3_bind_text)(stmt, 5, collation.c_str(), -1, SQLITE_TRANSIENT);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return 0;
 }
@@ -1035,7 +1034,8 @@ int Discovery_Schema::insert_foreign_key(
 		"INSERT INTO foreign_keys(run_id, child_object_id, fk_name, parent_schema_name, parent_object_name, on_update ,  on_delete) "
 		"VALUES(?1, ?2, ?3, ?4, ?5, ?6 ,  ?7);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, run_id);
@@ -1048,7 +1048,6 @@ int Discovery_Schema::insert_foreign_key(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int fk_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return fk_id;
 }
@@ -1064,7 +1063,8 @@ int Discovery_Schema::insert_foreign_key_column(
 		"INSERT INTO foreign_key_columns(fk_id, seq, child_column ,  parent_column) "
 		"VALUES(?1, ?2, ?3 ,  ?4);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, fk_id);
@@ -1073,7 +1073,6 @@ int Discovery_Schema::insert_foreign_key_column(
 	(*proxy_sqlite3_bind_text)(stmt, 4, parent_column.c_str(), -1, SQLITE_TRANSIENT);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return 0;
 }
@@ -1113,7 +1112,8 @@ int Discovery_Schema::upsert_profile(
 		"ON CONFLICT(run_id, object_id ,  profile_kind) DO UPDATE SET "
 		"  profile_json = ?4 ,  updated_at = datetime('now');";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, run_id);
@@ -1122,7 +1122,6 @@ int Discovery_Schema::upsert_profile(
 	(*proxy_sqlite3_bind_text)(stmt, 4, profile_json.c_str(), -1, SQLITE_TRANSIENT);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return 0;
 }
@@ -1232,13 +1231,13 @@ int Discovery_Schema::rebuild_fts_index(int run_id) {
 			}
 
 			// Insert into FTS
-			int rc;
 			sqlite3_stmt* fts_stmt = NULL;
 			const char* fts_sql =
 				"INSERT INTO fts_objects(object_key, schema_name, object_name, object_type, comment, columns_blob, definition_sql ,  tags) "
 				"VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7 ,  ?8);";
 
-			rc = db->prepare_v2(fts_sql, &fts_stmt);
+			auto [rc, fts_stmt_unique] = db->prepare_v2(fts_sql);
+			fts_stmt = fts_stmt_unique.get();
 			if (rc == SQLITE_OK) {
 				(*proxy_sqlite3_bind_text)(fts_stmt, 1, object_key.c_str(), -1, SQLITE_TRANSIENT);
 				(*proxy_sqlite3_bind_text)(fts_stmt, 2, schema_name.c_str(), -1, SQLITE_TRANSIENT);
@@ -1250,7 +1249,6 @@ int Discovery_Schema::rebuild_fts_index(int run_id) {
 				(*proxy_sqlite3_bind_text)(fts_stmt, 8, tags.c_str(), -1, SQLITE_TRANSIENT);
 
 				SAFE_SQLITE3_STEP2(fts_stmt);
-				(*proxy_sqlite3_finalize)(fts_stmt);
 			}
 		}
 		delete resultset;
@@ -1668,7 +1666,8 @@ int Discovery_Schema::append_agent_event(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "INSERT INTO agent_events(agent_run_id, event_type, payload_json) VALUES(?1, ?2 ,  ?3);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, agent_run_id);
@@ -1677,7 +1676,6 @@ int Discovery_Schema::append_agent_event(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int event_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return event_id;
 }
@@ -1698,7 +1696,8 @@ int Discovery_Schema::upsert_llm_summary(
 		"ON CONFLICT(agent_run_id ,  object_id) DO UPDATE SET "
 		"  summary_json = ?4, confidence = ?5, status = ?6 ,  sources_json = ?7;";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, agent_run_id);
@@ -1710,13 +1709,13 @@ int Discovery_Schema::upsert_llm_summary(
 	(*proxy_sqlite3_bind_text)(stmt, 7, sources_json.c_str(), -1, SQLITE_TRANSIENT);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	// Insert into FTS index (use INSERT OR REPLACE for upsert semantics)
 	stmt = NULL;
 	sql = "INSERT OR REPLACE INTO fts_llm(rowid, kind, key, title, body, tags) VALUES(?1, 'summary', ?2, 'Object Summary', ?3, '');";
-	rc = db->prepare_v2(sql, &stmt);
-	if (rc == SQLITE_OK) {
+	auto [fts_rc, fts_stmt_unique] = db->prepare_v2(sql);
+	stmt = fts_stmt_unique.get();
+	if (fts_rc == SQLITE_OK) {
 		// Create composite key for unique identification
 		char key_buf[64];
 		snprintf(key_buf, sizeof(key_buf), "summary_%d_%d", agent_run_id, object_id);
@@ -1727,7 +1726,6 @@ int Discovery_Schema::upsert_llm_summary(
 		(*proxy_sqlite3_bind_text)(stmt, 2, key_buf, -1, SQLITE_TRANSIENT);
 		(*proxy_sqlite3_bind_text)(stmt, 3, summary_json.c_str(), -1, SQLITE_TRANSIENT);
 		SAFE_SQLITE3_STEP2(stmt);
-		(*proxy_sqlite3_finalize)(stmt);
 	}
 
 	return 0;
@@ -1792,7 +1790,8 @@ int Discovery_Schema::upsert_llm_relationship(
 		"ON CONFLICT(agent_run_id, child_object_id, child_column, parent_object_id, parent_column ,  rel_type) "
 		"DO UPDATE SET confidence = ?8 ,  evidence_json = ?9;";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, agent_run_id);
@@ -1806,7 +1805,6 @@ int Discovery_Schema::upsert_llm_relationship(
 	(*proxy_sqlite3_bind_text)(stmt, 9, evidence_json.c_str(), -1, SQLITE_TRANSIENT);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return 0;
 }
@@ -1826,7 +1824,8 @@ int Discovery_Schema::upsert_llm_domain(
 		"ON CONFLICT(agent_run_id ,  domain_key) DO UPDATE SET "
 		"  title = ?4, description = ?5 ,  confidence = ?6;";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, agent_run_id);
@@ -1838,13 +1837,13 @@ int Discovery_Schema::upsert_llm_domain(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int domain_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	// Insert into FTS index (use INSERT OR REPLACE for upsert semantics)
 	stmt = NULL;
 	sql = "INSERT OR REPLACE INTO fts_llm(rowid, kind, key, title, body, tags) VALUES(?1, 'domain', ?2, ?3, ?4, '');";
-	rc = db->prepare_v2(sql, &stmt);
-	if (rc == SQLITE_OK) {
+	auto [fts_rc, fts_stmt_unique] = db->prepare_v2(sql);
+	stmt = fts_stmt_unique.get();
+	if (fts_rc == SQLITE_OK) {
 		// Use domain_id or a hash of domain_key as rowid
 		int rowid = domain_id > 0 ? domain_id : std::hash<std::string>{}(domain_key) % 1000000000;
 		(*proxy_sqlite3_bind_int)(stmt, 1, rowid);
@@ -1852,7 +1851,6 @@ int Discovery_Schema::upsert_llm_domain(
 		(*proxy_sqlite3_bind_text)(stmt, 3, title.c_str(), -1, SQLITE_TRANSIENT);
 		(*proxy_sqlite3_bind_text)(stmt, 4, description.c_str(), -1, SQLITE_TRANSIENT);
 		SAFE_SQLITE3_STEP2(stmt);
-		(*proxy_sqlite3_finalize)(stmt);
 	}
 
 	return domain_id;
@@ -1899,7 +1897,8 @@ int Discovery_Schema::set_domain_members(
 			sqlite3_stmt* stmt = NULL;
 			const char* ins_sql = "INSERT INTO llm_domain_members(domain_id, object_id, role, confidence) VALUES(?1, ?2, ?3 ,  ?4);";
 
-			int rc = db->prepare_v2(ins_sql, &stmt);
+			auto [rc, stmt_unique] = db->prepare_v2(ins_sql);
+			stmt = stmt_unique.get();
 			if (rc == SQLITE_OK) {
 				(*proxy_sqlite3_bind_int)(stmt, 1, domain_id);
 				(*proxy_sqlite3_bind_int)(stmt, 2, object_id);
@@ -1907,7 +1906,6 @@ int Discovery_Schema::set_domain_members(
 				(*proxy_sqlite3_bind_double)(stmt, 4, confidence);
 
 				SAFE_SQLITE3_STEP2(stmt);
-				(*proxy_sqlite3_finalize)(stmt);
 			}
 		}
 	} catch (...) {
@@ -1937,7 +1935,8 @@ int Discovery_Schema::upsert_llm_metric(
 		"ON CONFLICT(agent_run_id ,  metric_key) DO UPDATE SET "
 		"  title = ?4, description = ?5, domain_key = ?6, grain = ?7, unit = ?8, sql_template = ?9, depends_json = ?10 ,  confidence = ?11;";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, agent_run_id);
@@ -1954,13 +1953,13 @@ int Discovery_Schema::upsert_llm_metric(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int metric_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	// Insert into FTS index (use INSERT OR REPLACE for upsert semantics)
 	stmt = NULL;
 	sql = "INSERT OR REPLACE INTO fts_llm(rowid, kind, key, title, body, tags) VALUES(?1, 'metric', ?2, ?3, ?4, ?5);";
-	rc = db->prepare_v2(sql, &stmt);
-	if (rc == SQLITE_OK) {
+	auto [fts_rc, fts_stmt_unique] = db->prepare_v2(sql);
+	stmt = fts_stmt_unique.get();
+	if (fts_rc == SQLITE_OK) {
 		// Use metric_id or a hash of metric_key as rowid
 		int rowid = metric_id > 0 ? metric_id : std::hash<std::string>{}(metric_key) % 1000000000;
 		(*proxy_sqlite3_bind_int)(stmt, 1, rowid);
@@ -1969,7 +1968,6 @@ int Discovery_Schema::upsert_llm_metric(
 		(*proxy_sqlite3_bind_text)(stmt, 4, description.c_str(), -1, SQLITE_TRANSIENT);
 		(*proxy_sqlite3_bind_text)(stmt, 5, domain_key.c_str(), -1, SQLITE_TRANSIENT);
 		SAFE_SQLITE3_STEP2(stmt);
-		(*proxy_sqlite3_finalize)(stmt);
 	}
 
 	return metric_id;
@@ -1990,7 +1988,8 @@ int Discovery_Schema::add_question_template(
 		"INSERT INTO llm_question_templates(agent_run_id, run_id, title, question_nl, template_json, example_sql, related_objects, confidence) "
 		"VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, agent_run_id);
@@ -2004,20 +2003,19 @@ int Discovery_Schema::add_question_template(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int template_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	// Insert into FTS index
 	stmt = NULL;
 	sql = "INSERT INTO fts_llm(rowid, kind, key, title, body, tags) VALUES(?1, 'question_template', ?2, ?3, ?4, '');";
-	rc = db->prepare_v2(sql, &stmt);
-	if (rc == SQLITE_OK) {
+	auto [fts_rc, fts_stmt_unique] = db->prepare_v2(sql);
+	stmt = fts_stmt_unique.get();
+	if (fts_rc == SQLITE_OK) {
 		std::string key_str = std::to_string(template_id);
 		(*proxy_sqlite3_bind_int)(stmt, 1, template_id);
 		(*proxy_sqlite3_bind_text)(stmt, 2, key_str.c_str(), -1, SQLITE_TRANSIENT);
 		(*proxy_sqlite3_bind_text)(stmt, 3, title.c_str(), -1, SQLITE_TRANSIENT);
 		(*proxy_sqlite3_bind_text)(stmt, 4, question_nl.c_str(), -1, SQLITE_TRANSIENT);
 		SAFE_SQLITE3_STEP2(stmt);
-		(*proxy_sqlite3_finalize)(stmt);
 	}
 
 	return template_id;
@@ -2038,7 +2036,8 @@ int Discovery_Schema::add_llm_note(
 		"INSERT INTO llm_notes(agent_run_id, run_id, scope, object_id, domain_key, title, body ,  tags_json) "
 		"VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7 ,  ?8);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) return -1;
 
 	(*proxy_sqlite3_bind_int)(stmt, 1, agent_run_id);
@@ -2056,13 +2055,13 @@ int Discovery_Schema::add_llm_note(
 
 	SAFE_SQLITE3_STEP2(stmt);
 	int note_id = (int)(*proxy_sqlite3_last_insert_rowid)(db->get_db());
-	(*proxy_sqlite3_finalize)(stmt);
 
 	// Insert into FTS index
 	stmt = NULL;
 	sql = "INSERT INTO fts_llm(rowid, kind, key, title, body, tags) VALUES(?1, 'note', ?2, ?3, ?4, ?5);";
-	rc = db->prepare_v2(sql, &stmt);
-	if (rc == SQLITE_OK) {
+	auto [fts_rc, fts_stmt_unique] = db->prepare_v2(sql);
+	stmt = fts_stmt_unique.get();
+	if (fts_rc == SQLITE_OK) {
 		std::string key_str = std::to_string(note_id);
 		(*proxy_sqlite3_bind_int)(stmt, 1, note_id);
 		(*proxy_sqlite3_bind_text)(stmt, 2, key_str.c_str(), -1, SQLITE_TRANSIENT);
@@ -2070,7 +2069,6 @@ int Discovery_Schema::add_llm_note(
 		(*proxy_sqlite3_bind_text)(stmt, 4, body.c_str(), -1, SQLITE_TRANSIENT);
 		(*proxy_sqlite3_bind_text)(stmt, 5, tags_json.c_str(), -1, SQLITE_TRANSIENT);
 		SAFE_SQLITE3_STEP2(stmt);
-		(*proxy_sqlite3_finalize)(stmt);
 	}
 
 	return note_id;
@@ -2285,7 +2283,8 @@ int Discovery_Schema::log_llm_search(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "INSERT INTO llm_search_log(run_id, query, lmt) VALUES(?1, ?2 ,  ?3);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK || !stmt) {
 		proxy_error("Failed to prepare llm_search_log insert: %d\n", rc);
 		return -1;
@@ -2296,7 +2295,6 @@ int Discovery_Schema::log_llm_search(
 	(*proxy_sqlite3_bind_int)(stmt, 3, lmt);
 
 	rc = (*proxy_sqlite3_step)(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	if (rc != SQLITE_DONE) {
 		proxy_error("Failed to insert llm_search_log: %d\n", rc);
@@ -2314,7 +2312,8 @@ int Discovery_Schema::log_rag_search_fts(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "INSERT INTO rag_search_log(query, k, filters) VALUES(?1, ?2 ,  ?3);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK || !stmt) {
 		proxy_error("Failed to prepare rag_search_log insert: %d\n", rc);
 		return -1;
@@ -2325,7 +2324,6 @@ int Discovery_Schema::log_rag_search_fts(
 	(*proxy_sqlite3_bind_text)(stmt, 3, filters.c_str(), -1, SQLITE_TRANSIENT);
 
 	rc = (*proxy_sqlite3_step)(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	if (rc != SQLITE_DONE) {
 		proxy_error("Failed to insert rag_search_log: %d\n", rc);
@@ -2346,7 +2344,8 @@ int Discovery_Schema::log_query_tool_call(
 	sqlite3_stmt* stmt = NULL;
 	const char* sql = "INSERT INTO query_tool_calls(tool_name, schema, run_id, start_time, execution_time, error) VALUES(?1, ?2, ?3, ?4, ?5, ?6);";
 
-	int rc = db->prepare_v2(sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK || !stmt) {
 		proxy_error("Failed to prepare query_tool_calls insert: %d\n", rc);
 		return -1;
@@ -2372,7 +2371,6 @@ int Discovery_Schema::log_query_tool_call(
 	}
 
 	rc = (*proxy_sqlite3_step)(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	if (rc != SQLITE_DONE) {
 		proxy_error("Failed to insert query_tool_calls: %d\n", rc);

--- a/lib/MySQL_Catalog.cpp
+++ b/lib/MySQL_Catalog.cpp
@@ -202,7 +202,8 @@ int MySQL_Catalog::upsert(
 		"  links = ?6 , "
 		"  updated_at = strftime('%s' ,  'now')";
 
-	int rc = db->prepare_v2(upsert_sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(upsert_sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) {
 		proxy_error("Failed to prepare catalog upsert: %d\n", rc);
 		return -1;
@@ -216,7 +217,6 @@ int MySQL_Catalog::upsert(
 	(*proxy_sqlite3_bind_text)(stmt, 6, links.c_str(), -1, SQLITE_TRANSIENT);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	proxy_debug(PROXY_DEBUG_GENERIC, 3, "Catalog upsert: schema=%s, kind=%s ,  key=%s\n", schema.c_str(), kind.c_str(), key.c_str());
 	return 0;
@@ -244,7 +244,8 @@ int MySQL_Catalog::get(
 		"SELECT document FROM catalog "
 		"WHERE schema = ?1 AND kind = ?2 AND key = ?3";
 
-	int rc = db->prepare_v2(get_sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(get_sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) {
 		proxy_error("Failed to prepare catalog get: %d\n", rc);
 		return -1;
@@ -261,11 +262,9 @@ int MySQL_Catalog::get(
 		if (doc) {
 			document = doc;
 		}
-		(*proxy_sqlite3_finalize)(stmt);
 		return 0;
 	}
 
-	(*proxy_sqlite3_finalize)(stmt);
 	return -1;
 }
 
@@ -339,7 +338,8 @@ std::string MySQL_Catalog::search(
 
 	// Prepare the statement
 	sqlite3_stmt* stmt = NULL;
-	int rc = db->prepare_v2(sql.str().c_str(), &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql.str().c_str());
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) {
 		proxy_error("Failed to prepare catalog search: %d\n", rc);
 		return "[]";
@@ -394,8 +394,6 @@ std::string MySQL_Catalog::search(
 		results.push_back(entry);
 	}
 
-	(*proxy_sqlite3_finalize)(stmt);
-
 	if (step_rc != SQLITE_DONE) {
 		proxy_error("Catalog search error: step_rc=%d\n", step_rc);
 	}
@@ -433,10 +431,11 @@ std::string MySQL_Catalog::list(
 		count_sql << " AND kind = ?";
 	}
 
-	sqlite3_stmt* count_stmt = NULL;
 	int total = 0;
-	int rc = db->prepare_v2(count_sql.str().c_str(), &count_stmt);
-	if (rc == SQLITE_OK) {
+	sqlite3_stmt* count_stmt = NULL;
+	auto [count_rc, count_stmt_unique] = db->prepare_v2(count_sql.str().c_str());
+	count_stmt = count_stmt_unique.get();
+	if (count_rc == SQLITE_OK) {
 		int param_idx = 1;
 		if (has_schema) {
 			(*proxy_sqlite3_bind_text)(count_stmt, param_idx++, schema.c_str(), -1, SQLITE_TRANSIENT);
@@ -448,7 +447,6 @@ std::string MySQL_Catalog::list(
 		if ((*proxy_sqlite3_step)(count_stmt) == SQLITE_ROW) {
 			total = (*proxy_sqlite3_column_int)(count_stmt, 0);
 		}
-		(*proxy_sqlite3_finalize)(count_stmt);
 	}
 
 	// Build main query with prepared statement to prevent SQL injection
@@ -463,7 +461,8 @@ std::string MySQL_Catalog::list(
 	sql << " ORDER BY schema, kind ,  key ASC LIMIT ? OFFSET ?";
 
 	sqlite3_stmt* stmt = NULL;
-	rc = db->prepare_v2(sql.str().c_str(), &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql.str().c_str());
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) {
 		proxy_error("Failed to prepare catalog list: %d\n", rc);
 		nlohmann::json result;
@@ -515,8 +514,6 @@ std::string MySQL_Catalog::list(
 
 		results.push_back(entry);
 	}
-
-	(*proxy_sqlite3_finalize)(stmt);
 
 	if (step_rc != SQLITE_DONE) {
 		proxy_error("Catalog list error: step_rc=%d\n", step_rc);
@@ -597,7 +594,8 @@ int MySQL_Catalog::remove(
 	sql << " AND kind = ? AND key = ?";
 
 	sqlite3_stmt* stmt = NULL;
-	int rc = db->prepare_v2(sql.str().c_str(), &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(sql.str().c_str());
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) {
 		proxy_error("Failed to prepare catalog remove: %d\n", rc);
 		return -1;
@@ -612,7 +610,6 @@ int MySQL_Catalog::remove(
 	(*proxy_sqlite3_bind_text)(stmt, param_idx++, key.c_str(), -1, SQLITE_TRANSIENT);
 
 	SAFE_SQLITE3_STEP2(stmt);
-	(*proxy_sqlite3_finalize)(stmt);
 
 	return 0;
 }

--- a/lib/MySQL_FTS.cpp
+++ b/lib/MySQL_FTS.cpp
@@ -174,7 +174,8 @@ bool MySQL_FTS::index_exists(const std::string& schema, const std::string& table
 		"SELECT COUNT(*) FROM fts_indexes "
 		"WHERE schema_name = ?1 AND table_name = ?2";
 
-	int rc = db->prepare_v2(check_sql, &stmt);
+	auto [rc, stmt_unique] = db->prepare_v2(check_sql);
+	stmt = stmt_unique.get();
 	if (rc != SQLITE_OK) {
 		proxy_error("Failed to prepare index check: %d\n", rc);
 		return false;
@@ -190,7 +191,6 @@ bool MySQL_FTS::index_exists(const std::string& schema, const std::string& table
 		exists = (count > 0);
 	}
 
-	(*proxy_sqlite3_finalize)(stmt);
 	return exists;
 }
 

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1789,7 +1789,7 @@ void MySQL_HostGroups_Manager::purge_mysql_servers_table() {
 	for (unsigned int i=0; i<MyHostGroups->len; i++) {
 		MyHGC *myhgc=(MyHGC *)MyHostGroups->index(i);
 		MySrvC *mysrvc=NULL;
-		for (int j=0; j<myhgc->mysrvs->servers->len; j++) {
+		for (unsigned int j=0; j<myhgc->mysrvs->servers->len; j++) {
 			mysrvc=myhgc->mysrvs->idx(j);
 			if (mysrvc->get_status() == MYSQL_SERVER_STATUS_OFFLINE_HARD) {
 				if (mysrvc->ConnectionsUsed->conns_length()==0 && mysrvc->ConnectionsFree->conns_length()==0) {

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -838,18 +838,15 @@ int MySQL_HostGroups_Manager::servers_add(SQLite3_result *resultset) {
 	}
 	int rc;
 	mydb->execute("DELETE FROM mysql_servers_incoming");
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
-	//sqlite3 *mydb3=mydb->get_db();
 	char *query1=(char *)"INSERT INTO mysql_servers_incoming VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 	std::string query32s = "INSERT INTO mysql_servers_incoming VALUES " + generate_multi_rows_query(32,12);
 	char *query32 = (char *)query32s.c_str();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = mydb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, mydb);
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = mydb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	auto [rc2, statement32_unique] = mydb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, mydb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	MySerStatus status1=MYSQL_SERVER_STATUS_ONLINE;
 	int row_idx=0;
 	int max_bulk_row_idx=resultset->rows_count/32;
@@ -908,8 +905,6 @@ int MySQL_HostGroups_Manager::servers_add(SQLite3_result *resultset) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	return 0;
 }
 
@@ -1348,17 +1343,15 @@ bool MySQL_HostGroups_Manager::commit(
 		}
 		// optimization #829
 		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement2=NULL;
 		//sqlite3 *mydb3=mydb->get_db();
 		char *query1=(char *)"UPDATE mysql_servers SET mem_pointer = ?1 WHERE hostgroup_id = ?2 AND hostname = ?3 AND port = ?4";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = mydb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, mydb);
 		char *query2=(char *)"UPDATE mysql_servers SET weight = ?1 , status = ?2 , compression = ?3 , max_connections = ?4 , max_replication_lag = ?5 , use_ssl = ?6 , max_latency_ms = ?7 , comment = ?8 , gtid_port = ?9 WHERE hostgroup_id = ?10 AND hostname = ?11 AND port = ?12";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query2, -1, &statement2, 0);
-		rc = mydb->prepare_v2(query2, &statement2);
-		ASSERT_SQLITE_OK(rc, mydb);
+		auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, mydb);
+		auto [rc2, statement2_unique] = mydb->prepare_v2(query2);
+		ASSERT_SQLITE_OK(rc2, mydb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement2 = statement2_unique.get();
 
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 			SQLite3_row *r=*it;
@@ -1487,8 +1480,6 @@ bool MySQL_HostGroups_Manager::commit(
 				}
 			}
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement2);
 	}
 	if (use_gtid) {
 		has_gtid_port = true;
@@ -1809,20 +1800,17 @@ void MySQL_HostGroups_Manager::purge_mysql_servers_table() {
 
 void MySQL_HostGroups_Manager::generate_mysql_servers_table(int *_onlyhg) {
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 
 	PtrArray *lst=new PtrArray();
-	//sqlite3 *mydb3=mydb->get_db();
 	char *query1=(char *)"INSERT INTO mysql_servers VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)";
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = mydb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, mydb);
 	std::string query32s = "INSERT INTO mysql_servers VALUES " + generate_multi_rows_query(32,13);
 	char *query32 = (char *)query32s.c_str();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = mydb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	auto [rc2, statement32_unique] = mydb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, mydb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	if (mysql_thread___hostgroup_manager_verbose) {
 		if (_onlyhg==NULL) {
@@ -1912,8 +1900,6 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_table(int *_onlyhg) {
 		rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, mydb);
 		rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, mydb);
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	if (mysql_thread___hostgroup_manager_verbose) {
 		char *error=NULL;
 		int cols=0;
@@ -1995,12 +1981,11 @@ void MySQL_HostGroups_Manager::generate_mysql_group_replication_hostgroups_table
 		return;
 	}
 	int rc;
-	sqlite3_stmt *statement=NULL;
 	//sqlite3 *mydb3=mydb->get_db();
 	char *query=(char *)"INSERT INTO mysql_group_replication_hostgroups(writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
-	rc = mydb->prepare_v2(query, &statement);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	sqlite3_stmt *statement = statement_unique.get();
 	proxy_info("New mysql_group_replication_hostgroups table\n");
 	pthread_mutex_lock(&Group_Replication_Info_mutex);
 	for (std::map<int , Group_Replication_Info *>::iterator it1 = Group_Replication_Info_Map.begin() ; it1 != Group_Replication_Info_Map.end(); ++it1) {
@@ -2048,7 +2033,6 @@ void MySQL_HostGroups_Manager::generate_mysql_group_replication_hostgroups_table
 			Group_Replication_Info_Map.insert(Group_Replication_Info_Map.begin(), std::pair<int, Group_Replication_Info *>(writer_hostgroup,info));
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_group_replication_hostgroups;
 	incoming_group_replication_hostgroups=NULL;
 
@@ -2096,12 +2080,11 @@ void MySQL_HostGroups_Manager::generate_mysql_galera_hostgroups_table() {
 		return;
 	}
 	int rc;
-	sqlite3_stmt *statement=NULL;
 	//sqlite3 *mydb3=mydb->get_db();
 	char *query=(char *)"INSERT INTO mysql_galera_hostgroups(writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
-	rc = mydb->prepare_v2(query, &statement);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	sqlite3_stmt *statement = statement_unique.get();
 	proxy_info("New mysql_galera_hostgroups table\n");
 	pthread_mutex_lock(&Galera_Info_mutex);
 	for (std::map<int , Galera_Info *>::iterator it1 = Galera_Info_Map.begin() ; it1 != Galera_Info_Map.end(); ++it1) {
@@ -2149,7 +2132,6 @@ void MySQL_HostGroups_Manager::generate_mysql_galera_hostgroups_table() {
 			Galera_Info_Map.insert(Galera_Info_Map.begin(), std::pair<int, Galera_Info *>(writer_hostgroup,info));
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_galera_hostgroups;
 	incoming_galera_hostgroups=NULL;
 
@@ -5977,7 +5959,6 @@ void MySQL_HostGroups_Manager::generate_mysql_hostgroup_attributes_table() {
 		return;
 	}
 	int rc;
-	sqlite3_stmt *statement=NULL;
 
 	const char * query=(const char *)"INSERT INTO mysql_hostgroup_attributes ( "
 		"hostgroup_id, max_num_online_servers, autocommit, free_connections_pct, "
@@ -5985,9 +5966,9 @@ void MySQL_HostGroups_Manager::generate_mysql_hostgroup_attributes_table() {
 		"ignore_session_variables, hostgroup_settings, servers_defaults, comment) VALUES "
 		"(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
-	rc = mydb->prepare_v2(query, &statement);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	sqlite3_stmt *statement = statement_unique.get();
 	proxy_info("New mysql_hostgroup_attributes table\n");
 	bool current_configured[MyHostGroups->len];
 	// set configured = false to all
@@ -6090,7 +6071,6 @@ void MySQL_HostGroups_Manager::generate_mysql_hostgroup_attributes_table() {
 		}
 	}
 
-	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_hostgroup_attributes;
 	incoming_hostgroup_attributes=NULL;
 }
@@ -6100,15 +6080,15 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_ssl_params_table() {
 		return;
 	}
 	int rc;
-	sqlite3_stmt *statement=NULL;
 
 	const char * query = (const char *)"INSERT INTO mysql_servers_ssl_params ("
 		"hostname, port, username, ssl_ca, ssl_cert, ssl_key, ssl_capath, "
 		"ssl_crl, ssl_crlpath, ssl_cipher, tls_version, comment) VALUES "
 		"(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
-	rc = mydb->prepare_v2(query, &statement);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	sqlite3_stmt *statement = statement_unique.get();
 	proxy_info("New mysql_servers_ssl_params table\n");
 	std::lock_guard<std::mutex> lock(Servers_SSL_Params_map_mutex);
 	Servers_SSL_Params_map.clear();
@@ -6145,7 +6125,6 @@ void MySQL_HostGroups_Manager::generate_mysql_servers_ssl_params_table() {
 		string MapKey = MSSP.getMapKey(rand_del);
 		Servers_SSL_Params_map.emplace(MapKey, MSSP);
 	}
-	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_mysql_servers_ssl_params;
 	incoming_mysql_servers_ssl_params=NULL;
 }
@@ -6155,14 +6134,13 @@ void MySQL_HostGroups_Manager::generate_mysql_aws_aurora_hostgroups_table() {
 		return;
 	}
 	int rc;
-	sqlite3_stmt *statement=NULL;
 	//sqlite3 *mydb3=mydb->get_db();
 	char *query=(char *)"INSERT INTO mysql_aws_aurora_hostgroups(writer_hostgroup,reader_hostgroup,active,aurora_port,domain_name,max_lag_ms,check_interval_ms,"
 					    "check_timeout_ms,writer_is_also_reader,new_reader_weight,add_lag_ms,min_lag_ms,lag_num_checks,comment) VALUES "
 					    "(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)";
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
-	rc = mydb->prepare_v2(query, &statement);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	sqlite3_stmt *statement = statement_unique.get();
 	proxy_info("New mysql_aws_aurora_hostgroups table\n");
 	pthread_mutex_lock(&AWS_Aurora_Info_mutex);
 	for (std::map<int , AWS_Aurora_Info *>::iterator it1 = AWS_Aurora_Info_Map.begin() ; it1 != AWS_Aurora_Info_Map.end(); ++it1) {
@@ -6220,7 +6198,6 @@ void MySQL_HostGroups_Manager::generate_mysql_aws_aurora_hostgroups_table() {
 			AWS_Aurora_Info_Map.insert(AWS_Aurora_Info_Map.begin(), std::pair<int, AWS_Aurora_Info *>(writer_hostgroup,info));
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement);
 	delete incoming_aws_aurora_hostgroups;
 	incoming_aws_aurora_hostgroups=NULL;
 

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -3783,8 +3783,8 @@ void MySQL_HostGroups_Manager::set_Readyset_status(char *hostname, int port, enu
 				if (mysrvc->port==port && strcmp(mysrvc->address,hostname)==0) {
 					enum MySerStatus prev_status = mysrvc->get_status();
 					if (prev_status != status) {
-						char *src_status = "?"; // this shouldn't display
-						char *dst_status = "?"; // this shouldn't display
+						const char *src_status = "?"; // this shouldn't display
+						const char *dst_status = "?"; // this shouldn't display
 						if (prev_status == MYSQL_SERVER_STATUS_ONLINE) { src_status = "ONLINE"; }
 						else if (prev_status == MYSQL_SERVER_STATUS_OFFLINE_SOFT) { src_status = "OFFLINE_SOFT"; }
 						else if (prev_status == MYSQL_SERVER_STATUS_SHUNNED) { src_status = "SHUNNED"; };

--- a/lib/MySQL_Logger.cpp
+++ b/lib/MySQL_Logger.cpp
@@ -1859,8 +1859,6 @@ void MySQL_Logger_CircularBuffer::setBufferSize(size_t newSize) {
 
 void MySQL_Logger::insertMysqlEventsIntoDb(SQLite3DB * db, const std::string& tableName, size_t numEvents, std::vector<MySQL_Event*>::const_iterator begin){
 	int rc = 0;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 	char *query1=NULL;
 	char *query32=NULL;
 	const int numcols = 19;
@@ -1873,10 +1871,12 @@ void MySQL_Logger::insertMysqlEventsIntoDb(SQLite3DB * db, const std::string& ta
 	query32s = "INSERT INTO " + tableName + coldefs + " VALUES " + generate_multi_rows_query(32, numcols);
 	query1  = (char *)query1s.c_str();
 	query32 = (char *)query32s.c_str();
-	rc = db->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, db);
-	rc = db->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, db);
+	auto [rc1, statement1_unique] = db->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, db);
+	auto [rc2, statement32_unique] = db->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, db);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	char digest_hex_str[20]; // 2+sizeof(unsigned long long)*2+2
 
@@ -1944,8 +1944,6 @@ void MySQL_Logger::insertMysqlEventsIntoDb(SQLite3DB * db, const std::string& ta
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	db->execute("COMMIT");
 }
 

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -105,7 +105,7 @@ class ConsumerThread : public Thread {
 	int thrn;
 	char thr_name[16];
 	public:
-	ConsumerThread(wqueue<WorkItem<T>*>& queue, int _n, char thread_name[16]=NULL) : m_queue(queue) {
+	ConsumerThread(wqueue<WorkItem<T>*>& queue, int _n, const char *thread_name=NULL) : m_queue(queue) {
 		thrn=_n;
 		if (thread_name && thread_name[0]) {
 			snprintf(thr_name, sizeof(thr_name), "%.16s", thread_name);

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1232,17 +1232,16 @@ void MySQL_Monitor::update_monitor_mysql_servers(SQLite3_result* resultset) {
 
 		monitordb->execute("DELETE FROM monitor_internal.mysql_servers");
 
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement32=NULL;
-
 		std::string query32s = "INSERT INTO monitor_internal.mysql_servers VALUES " + generate_multi_rows_query(32,4);
 		char* query1 = const_cast<char*>("INSERT INTO monitor_internal.mysql_servers VALUES (?1,?2,?3,?4)");
 		char* query32 = (char *)query32s.c_str();
 
-		rc = monitordb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, monitordb);
-		rc = monitordb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, monitordb);
+		auto [rc1, statement1_unique] = monitordb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, monitordb);
+		auto [rc2, statement32_unique] = monitordb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, monitordb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement32 = statement32_unique.get();
 
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/32;
@@ -1275,9 +1274,6 @@ void MySQL_Monitor::update_monitor_mysql_servers(SQLite3_result* resultset) {
 			}
 			row_idx++;
 		}
-
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 
 	pthread_mutex_unlock(&GloMyMon->mysql_servers_mutex);
@@ -1291,17 +1287,16 @@ void MySQL_Monitor::update_monitor_proxysql_servers(SQLite3_result* resultset) {
 
 		monitordb->execute("DELETE FROM monitor_internal.proxysql_servers");
 
-		sqlite3_stmt* statement1 = NULL;
-		sqlite3_stmt* statement32 = NULL;
-
 		std::string query32s = "INSERT INTO monitor_internal.proxysql_servers VALUES " + generate_multi_rows_query(32, 4);
 		char* query1 = const_cast<char*>("INSERT INTO monitor_internal.proxysql_servers VALUES (?1,?2,?3,?4)");
 		char* query32 = (char*)query32s.c_str();
 
-		rc = monitordb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, monitordb);
-		rc = monitordb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, monitordb);
+		auto [rc1, statement1_unique] = monitordb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, monitordb);
+		auto [rc2, statement32_unique] = monitordb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, monitordb);
+		sqlite3_stmt* statement1 = statement1_unique.get();
+		sqlite3_stmt* statement32 = statement32_unique.get();
 
 		int row_idx = 0;
 		int max_bulk_row_idx = resultset->rows_count / 32;
@@ -1335,9 +1330,6 @@ void MySQL_Monitor::update_monitor_proxysql_servers(SQLite3_result* resultset) {
 			}
 			row_idx++;
 		}
-
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 
 	pthread_mutex_unlock(&GloMyMon->proxysql_servers_mutex);
@@ -1359,14 +1351,12 @@ void * monitor_connect_thread(const std::vector<MySQL_Monitor_State_Data*>& mmsd
 	mmsd->t1=start_time;
 	mmsd->t2=monotonic_time();
 
-	sqlite3_stmt *statement=NULL;
-	//sqlite3 *mondb=mmsd->mondb->get_db();
-	int rc;
 	char *query=NULL;
 	query=(char *)"INSERT OR REPLACE INTO mysql_server_connect_log VALUES (?1 , ?2 , ?3 , ?4 , ?5)";
-	//rc=(*proxy_sqlite3_prepare_v2)(mondb, query, -1, &statement, 0);
-	rc = mmsd->mondb->prepare_v2(query, &statement);
-	ASSERT_SQLITE_OK(rc, mmsd->mondb);
+	auto [rc1, statement_unique] = mmsd->mondb->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, mmsd->mondb);
+	sqlite3_stmt *statement = statement_unique.get();
+	int rc;
 	rc=(*proxy_sqlite3_bind_text)(statement, 1, mmsd->hostname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 	rc=(*proxy_sqlite3_bind_int)(statement, 2, mmsd->port); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 	unsigned long long time_now=realtime_time();
@@ -1377,7 +1367,6 @@ void * monitor_connect_thread(const std::vector<MySQL_Monitor_State_Data*>& mmsd
 	SAFE_SQLITE3_STEP2(statement);
 	rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 	rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
-	(*proxy_sqlite3_finalize)(statement);
 	if (mmsd->mysql_error_msg) {
 		if (
 			(strncmp(mmsd->mysql_error_msg,"Access denied for user",strlen("Access denied for user"))==0)
@@ -1471,17 +1460,12 @@ void * monitor_ping_thread(const std::vector<MySQL_Monitor_State_Data*>& mmsds) 
 __exit_monitor_ping_thread:
 	mmsd->t2=monotonic_time();
 	{
-		sqlite3_stmt *statement=NULL;
-		//sqlite3 *mondb=mmsd->mondb->get_db();
-		int rc;
-#ifdef TEST_AURORA
-//		if ((rand() % 10) ==0) {
-#endif // TEST_AURORA
 		char *query=NULL;
 		query=(char *)"INSERT OR REPLACE INTO mysql_server_ping_log VALUES (?1 , ?2 , ?3 , ?4 , ?5)";
-		//rc=(*proxy_sqlite3_prepare_v2)(mondb, query, -1, &statement, 0);
-		rc = mmsd->mondb->prepare_v2(query, &statement);
-		ASSERT_SQLITE_OK(rc, mmsd->mondb);
+		auto [rc1, statement_unique] = mmsd->mondb->prepare_v2(query);
+		ASSERT_SQLITE_OK(rc1, mmsd->mondb);
+		sqlite3_stmt *statement = statement_unique.get();
+		int rc;
 		rc=(*proxy_sqlite3_bind_text)(statement, 1, mmsd->hostname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 		rc=(*proxy_sqlite3_bind_int)(statement, 2, mmsd->port); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 		unsigned long long time_now=realtime_time();
@@ -1492,7 +1476,6 @@ __exit_monitor_ping_thread:
 		SAFE_SQLITE3_STEP2(statement);
 		rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 		rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
-		(*proxy_sqlite3_finalize)(statement);
 		if (mmsd->mysql_error_msg == NULL) {
 			ping_success = true;
 		}
@@ -1767,14 +1750,12 @@ void * monitor_read_only_thread(const std::vector<MySQL_Monitor_State_Data*>& da
 __exit_monitor_read_only_thread:
 	mmsd->t2=monotonic_time();
 	{
-		sqlite3_stmt *statement=NULL;
-		//sqlite3 *mondb=mmsd->mondb->get_db();
-		int rc;
 		char *query=NULL;
 		query=(char *)"INSERT OR REPLACE INTO mysql_server_read_only_log VALUES (?1 , ?2 , ?3 , ?4 , ?5 , ?6)";
-		//rc=(*proxy_sqlite3_prepare_v2)(mondb, query, -1, &statement, 0);
-		rc = mmsd->mondb->prepare_v2(query, &statement);
-		ASSERT_SQLITE_OK(rc, mmsd->mondb);
+		auto [rc1, statement_unique] = mmsd->mondb->prepare_v2(query);
+		ASSERT_SQLITE_OK(rc1, mmsd->mondb);
+		sqlite3_stmt *statement = statement_unique.get();
+		int rc;
 		int read_only=1; // as a safety mechanism , read_only=1 is the default
 		rc=(*proxy_sqlite3_bind_text)(statement, 1, mmsd->hostname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 		rc=(*proxy_sqlite3_bind_int)(statement, 2, mmsd->port); ASSERT_SQLITE_OK(rc, mmsd->mondb);
@@ -1829,7 +1810,6 @@ VALGRIND_ENABLE_ERROR_REPORTING;
 		SAFE_SQLITE3_STEP2(statement);
 		rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 		rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
-		(*proxy_sqlite3_finalize)(statement);
 
 		if (mmsd->mysql_error_msg == NULL) {
 			read_only_success = true;
@@ -2825,16 +2805,14 @@ void * monitor_replication_lag_thread(const std::vector<MySQL_Monitor_State_Data
 __exit_monitor_replication_lag_thread:
 	mmsd->t2=monotonic_time();
 	{
-		sqlite3_stmt *statement=NULL;
-		//sqlite3 *mondb=mmsd->mondb->get_db();
 		int rc;
 		char *query=NULL;
 
 		if (strcasestr(server_version.c_str(), (const char *)SERVER_VERSION_READYSET) == NULL) {
 			query=(char *)"INSERT OR REPLACE INTO mysql_server_replication_lag_log VALUES (?1 , ?2 , ?3 , ?4 , ?5 , ?6)";
-			//rc=(*proxy_sqlite3_prepare_v2)(mondb, query, -1, &statement, 0);
-			rc = mmsd->mondb->prepare_v2(query, &statement);
-			ASSERT_SQLITE_OK(rc, mmsd->mondb);
+			auto [rc1, statement_unique] = mmsd->mondb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc1, mmsd->mondb);
+			sqlite3_stmt *statement = statement_unique.get();
 				// 'replication_lag' to be feed to 'replication_lag_action'
 				int repl_lag=-2;
 				bool override_repl_lag = true;
@@ -2909,14 +2887,14 @@ __exit_monitor_replication_lag_thread:
 				MyHGM->replication_lag_action( std::list<replication_lag_server_t> {
 												replication_lag_server_t {mmsd->hostgroup_id, mmsd->hostname, mmsd->port, repl_lag, override_repl_lag }
 												} );
-			(*proxy_sqlite3_finalize)(statement);
 			if (mmsd->mysql_error_msg == NULL) {
 				replication_lag_success = true;
 			}
 		} else { // readyset
 			query=(char *)"INSERT OR REPLACE INTO readyset_status_log VALUES (?1 , ?2 , ?3 , ?4 , ?5 , ?6)";
-			rc = mmsd->mondb->prepare_v2(query, &statement);
-			ASSERT_SQLITE_OK(rc, mmsd->mondb);
+			auto [rc2, statement_unique2] = mmsd->mondb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc2, mmsd->mondb);
+			sqlite3_stmt *statement = statement_unique2.get();
 			unordered_map<string,string> status_output = {};
 			enum MySerStatus status = MYSQL_SERVER_STATUS_SHUNNED; // default status
 			rc=(*proxy_sqlite3_bind_text)(statement, 1, mmsd->hostname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, mmsd->mondb);
@@ -2965,7 +2943,6 @@ __exit_monitor_replication_lag_thread:
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 			MyHGM->set_Readyset_status(mmsd->hostname, mmsd->port, status);
-			(*proxy_sqlite3_finalize)(statement);
 			if (mmsd->mysql_error_msg == NULL) {
 				replication_lag_success = true;
 			}
@@ -3127,14 +3104,12 @@ void * MySQL_Monitor::monitor_connect() {
 
 __end_monitor_connect_loop:
 		if (mysql_thread___monitor_enabled==true) {
-			sqlite3_stmt *statement=NULL;
-			//sqlite3 *mondb=monitordb->get_db();
-			int rc;
 			char *query=NULL;
 			query=(char *)"DELETE FROM mysql_server_connect_log WHERE time_start_us < ?1";
-			//rc=(*proxy_sqlite3_prepare_v2)(mondb, query, -1, &statement, 0);
-			rc = monitordb->prepare_v2(query, &statement);
-			ASSERT_SQLITE_OK(rc, monitordb);
+			auto [rc1, statement_unique] = monitordb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc1, monitordb);
+			sqlite3_stmt *statement = statement_unique.get();
+			int rc;
 			if (mysql_thread___monitor_history < mysql_thread___monitor_ping_interval * (mysql_thread___monitor_ping_max_failures + 1 )) { // issue #626
 				if (mysql_thread___monitor_ping_interval < 3600000)
 					mysql_thread___monitor_history = mysql_thread___monitor_ping_interval * (mysql_thread___monitor_ping_max_failures + 1 );
@@ -3144,7 +3119,6 @@ __end_monitor_connect_loop:
 			SAFE_SQLITE3_STEP2(statement);
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, monitordb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, monitordb);
-			(*proxy_sqlite3_finalize)(statement);
 		}
 		if (resultset)
 			delete resultset;
@@ -3231,14 +3205,12 @@ void * MySQL_Monitor::monitor_ping() {
 
 __end_monitor_ping_loop:
 		if (mysql_thread___monitor_enabled==true) {
-			sqlite3_stmt *statement=NULL;
-			//sqlite3 *mondb=monitordb->get_db();
-			int rc;
 			char *query=NULL;
 			query=(char *)"DELETE FROM mysql_server_ping_log WHERE time_start_us < ?1";
-			//rc=(*proxy_sqlite3_prepare_v2)(mondb, query, -1, &statement, 0);
-			rc = monitordb->prepare_v2(query, &statement);
-			ASSERT_SQLITE_OK(rc, monitordb);
+			auto [rc1, statement_unique] = monitordb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc1, monitordb);
+			sqlite3_stmt *statement = statement_unique.get();
+			int rc;
 			if (mysql_thread___monitor_history < mysql_thread___monitor_ping_interval * (mysql_thread___monitor_ping_max_failures + 1 )) { // issue #626
 				if (mysql_thread___monitor_ping_interval < 3600000)
 					mysql_thread___monitor_history = mysql_thread___monitor_ping_interval * (mysql_thread___monitor_ping_max_failures + 1 );
@@ -3248,7 +3220,6 @@ __end_monitor_ping_loop:
 			SAFE_SQLITE3_STEP2(statement);
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, monitordb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, monitordb);
-			(*proxy_sqlite3_finalize)(statement);
 		}
 
 		if (resultset) {
@@ -3587,14 +3558,12 @@ void * MySQL_Monitor::monitor_read_only() {
 
 __end_monitor_read_only_loop:
 		if (mysql_thread___monitor_enabled==true) {
-			sqlite3_stmt *statement=NULL;
-			//sqlite3 *mondb=monitordb->get_db();
-			int rc;
 			char *query=NULL;
 			query=(char *)"DELETE FROM mysql_server_read_only_log WHERE time_start_us < ?1";
-			//rc=(*proxy_sqlite3_prepare_v2)(mondb, query, -1, &statement, 0);
-			rc = monitordb->prepare_v2(query, &statement);
-			ASSERT_SQLITE_OK(rc, monitordb);
+			auto [rc1, statement_unique] = monitordb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc1, monitordb);
+			sqlite3_stmt *statement = statement_unique.get();
+			int rc;
 			if (mysql_thread___monitor_history < mysql_thread___monitor_read_only_interval * (mysql_thread___monitor_read_only_max_timeout_count + 1 )) { // issue #626
 				if (mysql_thread___monitor_read_only_interval < 3600000)
 					mysql_thread___monitor_history = mysql_thread___monitor_read_only_interval * (mysql_thread___monitor_read_only_max_timeout_count + 1 );
@@ -3604,7 +3573,6 @@ __end_monitor_read_only_loop:
 			SAFE_SQLITE3_STEP2(statement);
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, monitordb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, monitordb);
-			(*proxy_sqlite3_finalize)(statement);
 		}
 
 		if (resultset)
@@ -4635,17 +4603,16 @@ void * MySQL_Monitor::monitor_replication_lag() {
 
 __end_monitor_replication_lag_loop:
 		if (mysql_thread___monitor_enabled==true) {
-			sqlite3_stmt *statement1=NULL;
-			sqlite3_stmt *statement2=NULL;
-			//sqlite3 *mondb=monitordb->get_db();
-			int rc;
 			char *query=NULL;
 			query=(char *)"DELETE FROM mysql_server_replication_lag_log WHERE time_start_us < ?1";
-			rc = monitordb->prepare_v2(query, &statement1);
-			ASSERT_SQLITE_OK(rc, monitordb);
+			auto [rc1, statement1_unique] = monitordb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc1, monitordb);
+			sqlite3_stmt *statement1 = statement1_unique.get();
 			query=(char *)"DELETE FROM readyset_status_log WHERE time_start_us < ?1";
-			rc = monitordb->prepare_v2(query, &statement2);
-			ASSERT_SQLITE_OK(rc, monitordb);
+			auto [rc2, statement2_unique] = monitordb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc2, monitordb);
+			sqlite3_stmt *statement2 = statement2_unique.get();
+			int rc;
 			if (mysql_thread___monitor_history < mysql_thread___monitor_ping_interval * (mysql_thread___monitor_ping_max_failures + 1 )) { // issue #626
 				if (mysql_thread___monitor_ping_interval < 3600000)
 					mysql_thread___monitor_history = mysql_thread___monitor_ping_interval * (mysql_thread___monitor_ping_max_failures + 1 );
@@ -4655,12 +4622,10 @@ __end_monitor_replication_lag_loop:
 			SAFE_SQLITE3_STEP2(statement1);
 			rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, monitordb);
 			rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, monitordb);
-			(*proxy_sqlite3_finalize)(statement1);
 			rc=(*proxy_sqlite3_bind_int64)(statement2, 1, time_now-(unsigned long long)mysql_thread___monitor_history*1000); ASSERT_SQLITE_OK(rc, monitordb);
 			SAFE_SQLITE3_STEP2(statement2);
 			rc=(*proxy_sqlite3_clear_bindings)(statement2); ASSERT_SQLITE_OK(rc, monitordb);
 			rc=(*proxy_sqlite3_reset)(statement2); ASSERT_SQLITE_OK(rc, monitordb);
-			(*proxy_sqlite3_finalize)(statement2);
 		}
 
 		if (resultset)
@@ -5624,16 +5589,13 @@ bool Galera_monitor_node::add_entry(unsigned long long _st, unsigned long long _
 }
 
 void MySQL_Monitor::populate_monitor_mysql_server_group_replication_log() {
-	//sqlite3 *mondb=monitordb->get_db();
-	int rc;
-	//char *query=NULL;
 	char *query1=NULL;
 	query1=(char *)"INSERT INTO mysql_server_group_replication_log VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
-	sqlite3_stmt *statement1=NULL;
 	pthread_mutex_lock(&GloMyMon->group_replication_mutex);
-	//rc=(*proxy_sqlite3_prepare_v2)(mondb, query1, -1, &statement1, 0);
-	rc = monitordb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, monitordb);
+	auto [rc1, statement1_unique] = monitordb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, monitordb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	int rc;
 	monitordb->execute((char *)"DELETE FROM mysql_server_group_replication_log");
 	std::map<std::string, MyGR_monitor_node *>::iterator it2;
 	MyGR_monitor_node *node=NULL;
@@ -5660,21 +5622,17 @@ void MySQL_Monitor::populate_monitor_mysql_server_group_replication_log() {
 			}
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement1);
 	pthread_mutex_unlock(&GloMyMon->group_replication_mutex);
 }
 
 void MySQL_Monitor::populate_monitor_mysql_server_galera_log() {
-	//sqlite3 *mondb=monitordb->get_db();
-	int rc;
-	//char *query=NULL;
 	char *query1=NULL;
 	query1=(char *)"INSERT OR IGNORE INTO mysql_server_galera_log VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)";
-	sqlite3_stmt *statement1=NULL;
 	pthread_mutex_lock(&GloMyMon->galera_mutex);
-	//rc=(*proxy_sqlite3_prepare_v2)(mondb, query1, -1, &statement1, 0);
-	rc = monitordb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, monitordb);
+	auto [rc1, statement1_unique] = monitordb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, monitordb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	int rc;
 	monitordb->execute((char *)"DELETE FROM mysql_server_galera_log");
 	std::map<std::string, Galera_monitor_node *>::iterator it2;
 	Galera_monitor_node *node=NULL;
@@ -5706,7 +5664,6 @@ void MySQL_Monitor::populate_monitor_mysql_server_galera_log() {
 			}
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement1);
 	pthread_mutex_unlock(&GloMyMon->galera_mutex);
 }
 

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -5759,21 +5759,17 @@ std::vector<string> * MySQL_Monitor::galera_find_possible_last_nodes(int writer_
 }
 
 void MySQL_Monitor::populate_monitor_mysql_server_aws_aurora_log() {
-	//sqlite3 *mondb=monitordb->get_db();
-	int rc;
-	//char *query=NULL;
 	char *query1=NULL;
 	query1=(char *)"INSERT OR IGNORE INTO mysql_server_aws_aurora_log VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)";
-	sqlite3_stmt *statement1=NULL;
 	char *query2=NULL;
 	query2=(char *)"INSERT OR IGNORE INTO mysql_server_aws_aurora_log (hostname, port, time_start_us, success_time_us, error) VALUES (?1, ?2, ?3, ?4, ?5)";
-	sqlite3_stmt *statement2=NULL;
-	//rc=(*proxy_sqlite3_prepare_v2)(mondb, query1, -1, &statement1, 0);
-	rc = monitordb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, monitordb);
-	//rc=(*proxy_sqlite3_prepare_v2)(mondb, query2, -1, &statement2, 0);
-	rc = monitordb->prepare_v2(query2, &statement2);
-	ASSERT_SQLITE_OK(rc, monitordb);
+	auto [rc1, statement1_unique] = monitordb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, monitordb);
+	auto [rc2, statement2_unique] = monitordb->prepare_v2(query2);
+	ASSERT_SQLITE_OK(rc2, monitordb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement2 = statement2_unique.get();
+	int rc;
 	pthread_mutex_lock(&GloMyMon->aws_aurora_mutex);
 	monitordb->execute((char *)"DELETE FROM mysql_server_aws_aurora_log");
 	std::map<std::string, AWS_Aurora_monitor_node *>::iterator it2;
@@ -5821,21 +5817,16 @@ void MySQL_Monitor::populate_monitor_mysql_server_aws_aurora_log() {
 			}
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement2);
 	pthread_mutex_unlock(&GloMyMon->aws_aurora_mutex);
 }
 
 void MySQL_Monitor::populate_monitor_mysql_server_aws_aurora_check_status() {
-	//sqlite3 *mondb=monitordb->get_db();
-	int rc;
-	//char *query=NULL;
 	char *query1=NULL;
 	query1=(char *)"INSERT OR IGNORE INTO mysql_server_aws_aurora_check_status VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
-	sqlite3_stmt *statement1=NULL;
-	//rc=(*proxy_sqlite3_prepare_v2)(mondb, query1, -1, &statement1, 0);
-	rc = monitordb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, monitordb);
+	auto [rc1, statement1_unique] = monitordb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, monitordb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	int rc;
 	pthread_mutex_lock(&GloMyMon->aws_aurora_mutex);
 	monitordb->execute((char *)"DELETE FROM mysql_server_aws_aurora_check_status");
 	std::map<std::string, AWS_Aurora_monitor_node *>::iterator it2;
@@ -5895,7 +5886,6 @@ void MySQL_Monitor::populate_monitor_mysql_server_aws_aurora_check_status() {
 		}
 */
 	}
-	(*proxy_sqlite3_finalize)(statement1);
 	pthread_mutex_unlock(&GloMyMon->aws_aurora_mutex);
 }
 
@@ -7301,19 +7291,17 @@ void* monitor_ping_process_ready_task_thread(const std::vector<MySQL_Monitor_Sta
 	if (ready_mmsds.empty()) return NULL;
 
 	SQLite3DB* monitor_db = ready_mmsds.front()->mondb;
-	int rc;
-	sqlite3_stmt* statement1 = NULL;
-	sqlite3_stmt* statement32 = NULL;
-
 	const char* query1 = "INSERT OR REPLACE INTO mysql_server_ping_log VALUES (?1, ?2, ?3, ?4, ?5)";
 	std::string query32s = "INSERT OR REPLACE INTO mysql_server_ping_log VALUES " + generate_multi_rows_query(32, 5);
 	const char* query32 = query32s.c_str();
 
-	rc = monitor_db->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, monitor_db);
-
-	rc = monitor_db->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, monitor_db);
+	auto [rc1, statement1_unique] = monitor_db->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, monitor_db);
+	auto [rc2, statement32_unique] = monitor_db->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, monitor_db);
+	sqlite3_stmt* statement1 = statement1_unique.get();
+	sqlite3_stmt* statement32 = statement32_unique.get();
+	int rc;
 
 	size_t row_idx = 0;
 	size_t max_bulk_row_idx = (ready_mmsds.size() / 32) * 32;
@@ -7391,9 +7379,6 @@ void* monitor_ping_process_ready_task_thread(const std::vector<MySQL_Monitor_Sta
 
 		row_idx++;
 	}
-
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 
 	return NULL;
 }
@@ -7585,10 +7570,11 @@ bool MySQL_Monitor::monitor_read_only_process_ready_tasks(const std::vector<MySQ
 			return false;
 		}
 
-		sqlite3_stmt* statement = NULL;
 		const char* query = (char*)"INSERT OR REPLACE INTO mysql_server_read_only_log VALUES (?1 , ?2 , ?3 , ?4 , ?5 , ?6)";
-		int rc = mmsd->mondb->prepare_v2(query, &statement);
-		ASSERT_SQLITE_OK(rc, mmsd->mondb);
+		auto [rc1, statement_unique] = mmsd->mondb->prepare_v2(query);
+		ASSERT_SQLITE_OK(rc1, mmsd->mondb);
+		sqlite3_stmt* statement = statement_unique.get();
+		int rc;
 		int read_only = 1; // as a safety mechanism , read_only=1 is the default
 		rc = (*proxy_sqlite3_bind_text)(statement, 1, mmsd->hostname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 		rc = (*proxy_sqlite3_bind_int)(statement, 2, mmsd->port); ASSERT_SQLITE_OK(rc, mmsd->mondb);
@@ -7672,7 +7658,6 @@ VALGRIND_ENABLE_ERROR_REPORTING;
 		SAFE_SQLITE3_STEP2(statement);
 		rc = (*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 		rc = (*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
-		(*proxy_sqlite3_finalize)(statement);
 
 		if (task_result == MySQL_Monitor_State_Data_Task_Result::TASK_RESULT_SUCCESS) {
 			//MyHGM->read_only_action_v2(mmsd->hostname, mmsd->port, read_only); // default behavior
@@ -8057,10 +8042,11 @@ bool MySQL_Monitor::monitor_replication_lag_process_ready_tasks(const std::vecto
 		}
 
 		if (strcasestr(server_version.c_str(), (const char *)SERVER_VERSION_READYSET) == NULL) {
-			sqlite3_stmt* statement = NULL;
 			const char* query = (char*)"INSERT OR REPLACE INTO mysql_server_replication_lag_log VALUES (?1 , ?2 , ?3 , ?4 , ?5 , ?6)";
-			int rc = mmsd->mondb->prepare_v2(query, &statement);
-			ASSERT_SQLITE_OK(rc, mmsd->mondb);
+			auto [rc1, statement_unique] = mmsd->mondb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc1, mmsd->mondb);
+			sqlite3_stmt* statement = statement_unique.get();
+			int rc;
 			// 'replication_lag' to be feed to 'replication_lag_action'
 			int repl_lag = -2;
 			bool override_repl_lag = true;
@@ -8133,13 +8119,13 @@ bool MySQL_Monitor::monitor_replication_lag_process_ready_tasks(const std::vecto
 			rc = (*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 			rc = (*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 			//MyHGM->replication_lag_action(mmsd->hostgroup_id, mmsd->hostname, mmsd->port, repl_lag);
-			(*proxy_sqlite3_finalize)(statement);
 			mysql_servers.push_back( replication_lag_server_t { mmsd->hostgroup_id, mmsd->hostname, mmsd->port, repl_lag, override_repl_lag });
 		} else { // readyset
-			sqlite3_stmt* statement = NULL;
 			const char* query = (char*)"INSERT OR REPLACE INTO readyset_status_log VALUES (?1 , ?2 , ?3 , ?4 , ?5 , ?6)";
-			int rc = mmsd->mondb->prepare_v2(query, &statement);
-			ASSERT_SQLITE_OK(rc, mmsd->mondb);
+			auto [rc2, statement_unique2] = mmsd->mondb->prepare_v2(query);
+			ASSERT_SQLITE_OK(rc2, mmsd->mondb);
+			sqlite3_stmt* statement = statement_unique2.get();
+			int rc;
 			unordered_map<string,string> status_output = {};
 			enum MySerStatus status = MYSQL_SERVER_STATUS_SHUNNED; // default status
 			rc = (*proxy_sqlite3_bind_text)(statement, 1, mmsd->hostname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, mmsd->mondb);
@@ -8188,7 +8174,6 @@ bool MySQL_Monitor::monitor_replication_lag_process_ready_tasks(const std::vecto
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, mmsd->mondb);
 			MyHGM->set_Readyset_status(mmsd->hostname, mmsd->port, status);
-			(*proxy_sqlite3_finalize)(statement);
 		}
 	}
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -4354,7 +4354,7 @@ void MySQL_Thread::refresh_variables() {
 	REFRESH_VARIABLE_INT(eventslog_buffer_history_size);
 	{
 		int elmhs = mysql_thread___eventslog_buffer_history_size;
-		if (GloMyLogger->MyLogCB->getBufferSize() != elmhs) {
+		if (GloMyLogger->MyLogCB->getBufferSize() != static_cast<size_t>(elmhs)) {
 			GloMyLogger->MyLogCB->setBufferSize(elmhs);
 		}
 	}

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -1363,17 +1363,14 @@ bool PgSQL_HostGroups_Manager::commit(
 		}
 		// optimization #829
 		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement2=NULL;
-		//sqlite3 *mydb3=mydb->get_db();
 		char *query1=(char *)"UPDATE pgsql_servers SET mem_pointer = ?1 WHERE hostgroup_id = ?2 AND hostname = ?3 AND port = ?4";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = mydb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, mydb);
+		auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, mydb);
 		char *query2=(char *)"UPDATE pgsql_servers SET weight = ?1 , status = ?2 , compression = ?3 , max_connections = ?4 , max_replication_lag = ?5 , use_ssl = ?6 , max_latency_ms = ?7 , comment = ?8 WHERE hostgroup_id = ?9 AND hostname = ?10 AND port = ?11";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query2, -1, &statement2, 0);
-		rc = mydb->prepare_v2(query2, &statement2);
-		ASSERT_SQLITE_OK(rc, mydb);
+		auto [rc2, statement2_unique] = mydb->prepare_v2(query2);
+		ASSERT_SQLITE_OK(rc2, mydb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement2 = statement2_unique.get();
 
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 			SQLite3_row *r=*it;
@@ -1470,8 +1467,7 @@ bool PgSQL_HostGroups_Manager::commit(
 				}
 			}
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement2);
+		// RAII auto-finalizes statement1 and statement2
 	}
 	if (resultset) { delete resultset; resultset=NULL; }
 	proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 4, "DELETE FROM pgsql_servers_incoming\n");

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -3829,17 +3829,15 @@ void PgSQL_HostGroups_Manager::generate_pgsql_hostgroup_attributes_table() {
 		return;
 	}
 	int rc;
-	sqlite3_stmt *statement=NULL;
-
 	const char * query=(const char *)"INSERT INTO pgsql_hostgroup_attributes ( "
 		"hostgroup_id, max_num_online_servers, autocommit, free_connections_pct, "
 		"init_connect, multiplex, connection_warming, throttle_connections_per_sec, "
 		"ignore_session_variables, hostgroup_settings, servers_defaults, comment) VALUES "
 		"(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
-	rc = mydb->prepare_v2(query, &statement);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement_unique] = mydb->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	sqlite3_stmt *statement = statement_unique.get();
 	proxy_info("New pgsql_hostgroup_attributes table\n");
 	bool current_configured[MyHostGroups->len];
 	// set configured = false to all

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -918,18 +918,15 @@ int PgSQL_HostGroups_Manager::servers_add(SQLite3_result *resultset) {
 	}
 	int rc;
 	mydb->execute("DELETE FROM pgsql_servers_incoming");
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
-	//sqlite3 *mydb3=mydb->get_db();
 	char *query1=(char *)"INSERT INTO pgsql_servers_incoming VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)";
 	std::string query32s = "INSERT INTO pgsql_servers_incoming VALUES " + generate_multi_rows_query(32,11);
 	char *query32 = (char *)query32s.c_str();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = mydb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, mydb);
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = mydb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, mydb);
+	auto [rc2, statement32_unique] = mydb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, mydb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	MySerStatus status1=MYSQL_SERVER_STATUS_ONLINE;
 	int row_idx=0;
 	int max_bulk_row_idx=resultset->rows_count/32;
@@ -986,8 +983,6 @@ int PgSQL_HostGroups_Manager::servers_add(SQLite3_result *resultset) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	return 0;
 }
 
@@ -1616,20 +1611,17 @@ void PgSQL_HostGroups_Manager::purge_pgsql_servers_table() {
 
 void PgSQL_HostGroups_Manager::generate_pgsql_servers_table(int *_onlyhg) {
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
-
 	PtrArray *lst=new PtrArray();
 	//sqlite3 *mydb3=mydb->get_db();
 	char *query1=(char *)"INSERT INTO pgsql_servers VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = mydb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc1, statement1_unique] = mydb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, mydb);
 	std::string query32s = "INSERT INTO pgsql_servers VALUES " + generate_multi_rows_query(32,12);
 	char *query32 = (char *)query32s.c_str();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = mydb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, mydb);
+	auto [rc2, statement32_unique] = mydb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, mydb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	if (pgsql_thread___hostgroup_manager_verbose) {
 		if (_onlyhg==NULL) {
@@ -1717,8 +1709,6 @@ void PgSQL_HostGroups_Manager::generate_pgsql_servers_table(int *_onlyhg) {
 		rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, mydb);
 		rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, mydb);
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	if (pgsql_thread___hostgroup_manager_verbose) {
 		char *error=NULL;
 		int cols=0;

--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -1463,7 +1463,7 @@ const char CHECK_HOST_ERR_LIMIT_QUERY[] {
 		" COUNT(*) = ?"
 };
 
-thread_local sqlite3_stmt* CHECK_HOST_ERR_LIMIT_STMT { nullptr };
+thread_local stmt_unique_ptr CHECK_HOST_ERR_LIMIT_STMT {};
 
 void shunn_non_resp_srv(SQLite3DB* db, state_t& state) {
 	ping_params_t* params { static_cast<ping_params_t*>(state.task.op_st.op_params.get()) };
@@ -1473,17 +1473,20 @@ void shunn_non_resp_srv(SQLite3DB* db, state_t& state) {
 	int port { srv.port };
 	int32_t max_fails { params->max_failures };
 
-	if (CHECK_HOST_ERR_LIMIT_STMT == nullptr) {
-		int rc = db->prepare_v2(CHECK_HOST_ERR_LIMIT_QUERY, &CHECK_HOST_ERR_LIMIT_STMT);
+	if (!CHECK_HOST_ERR_LIMIT_STMT) {
+		auto [rc, stmt_unique] = db->prepare_v2(CHECK_HOST_ERR_LIMIT_QUERY);
 		ASSERT_SQLITE_OK(rc, db);
+		CHECK_HOST_ERR_LIMIT_STMT = std::move(stmt_unique);
 	}
 
-	sqlite_bind_text(CHECK_HOST_ERR_LIMIT_STMT, 1, addr);
-	sqlite_bind_int(CHECK_HOST_ERR_LIMIT_STMT, 2, port);
-	sqlite_bind_int(CHECK_HOST_ERR_LIMIT_STMT, 3, max_fails);
-	sqlite_bind_int(CHECK_HOST_ERR_LIMIT_STMT, 4, max_fails);
+	sqlite3_stmt* check_host_err_limit_stmt = CHECK_HOST_ERR_LIMIT_STMT.get();
 
-	unique_ptr<SQLite3_result> limit_set { sqlite_fetch_and_clear(CHECK_HOST_ERR_LIMIT_STMT) };
+	sqlite_bind_text(check_host_err_limit_stmt, 1, addr);
+	sqlite_bind_int(check_host_err_limit_stmt, 2, port);
+	sqlite_bind_int(check_host_err_limit_stmt, 3, max_fails);
+	sqlite_bind_int(check_host_err_limit_stmt, 4, max_fails);
+
+	unique_ptr<SQLite3_result> limit_set { sqlite_fetch_and_clear(check_host_err_limit_stmt) };
 
 	if (limit_set && limit_set->rows_count) {
 		bool shunned { PgHGM->shun_and_killall(addr, port) };
@@ -1512,22 +1515,25 @@ const char HOST_FETCH_UPD_LATENCY_QUERY[] {
 	" GROUP BY hostname, port"
 };
 
-thread_local sqlite3_stmt* FETCH_HOST_LATENCY_STMT { nullptr };
+thread_local stmt_unique_ptr FETCH_HOST_LATENCY_STMT {};
 
 void update_srv_latency(SQLite3DB* db, state_t& state) {
 	const mon_srv_t& srv { state.task.op_st.srv_info };
 	char* addr { const_cast<char*>(srv.addr.c_str()) };
 	int port { srv.port };
 
-	if (FETCH_HOST_LATENCY_STMT == nullptr) {
-		int rc = db->prepare_v2(HOST_FETCH_UPD_LATENCY_QUERY, &FETCH_HOST_LATENCY_STMT);
+	if (!FETCH_HOST_LATENCY_STMT) {
+		auto [rc, stmt_unique] = db->prepare_v2(HOST_FETCH_UPD_LATENCY_QUERY);
 		ASSERT_SQLITE_OK(rc, db);
+		FETCH_HOST_LATENCY_STMT = std::move(stmt_unique);
 	}
 
-	sqlite_bind_text(FETCH_HOST_LATENCY_STMT, 1, addr);
-	sqlite_bind_int(FETCH_HOST_LATENCY_STMT, 2, port);
+	sqlite3_stmt* fetch_host_latency_stmt = FETCH_HOST_LATENCY_STMT.get();
 
-	unique_ptr<SQLite3_result> resultset { sqlite_fetch_and_clear(FETCH_HOST_LATENCY_STMT) };
+	sqlite_bind_text(fetch_host_latency_stmt, 1, addr);
+	sqlite_bind_int(fetch_host_latency_stmt, 2, port);
+
+	unique_ptr<SQLite3_result> resultset { sqlite_fetch_and_clear(fetch_host_latency_stmt) };
 
 	if (resultset && resultset->rows_count) {
 		for (const SQLite3_row* srv : resultset->rows) {
@@ -1928,8 +1934,8 @@ void* worker_thread(void* args) {
 		}
 	}
 
-	sqlite_finalize_statement(CHECK_HOST_ERR_LIMIT_STMT);
-	sqlite_finalize_statement(FETCH_HOST_LATENCY_STMT);
+	CHECK_HOST_ERR_LIMIT_STMT.reset();
+	FETCH_HOST_LATENCY_STMT.reset();
 
 	return NULL;
 }

--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -210,19 +210,18 @@ void update_monitor_pgsql_servers(SQLite3_result* rs, SQLite3DB* db) {
 	if (rs != nullptr) {
 		db->execute("DELETE FROM monitor_internal.pgsql_servers");
 
-		sqlite3_stmt* stmt1 = nullptr;
-		int rc = db->prepare_v2(
-			"INSERT INTO monitor_internal.pgsql_servers VALUES (?, ?, ?, ?)", &stmt1
+		auto [rc1, stmt1_unique] = db->prepare_v2(
+			"INSERT INTO monitor_internal.pgsql_servers VALUES (?, ?, ?, ?)"
 		);
-		ASSERT_SQLITE_OK(rc, db);
+		ASSERT_SQLITE_OK(rc1, db);
 
-		sqlite3_stmt* stmt32 = nullptr;
-		rc = db->prepare_v2(
+		auto [rc2, stmt32_unique] = db->prepare_v2(
 			("INSERT INTO monitor_internal.pgsql_servers VALUES " +
-				generate_multi_rows_query(32, 4)).c_str(),
-			&stmt32
+				generate_multi_rows_query(32, 4)).c_str()
 		);
-		ASSERT_SQLITE_OK(rc, db);
+		ASSERT_SQLITE_OK(rc2, db);
+		sqlite3_stmt* stmt1 = stmt1_unique.get();
+		sqlite3_stmt* stmt32 = stmt32_unique.get();
 
 		// Iterate through rows
 		int row_idx = 0;
@@ -255,9 +254,7 @@ void update_monitor_pgsql_servers(SQLite3_result* rs, SQLite3DB* db) {
 			row_idx++;
 		}
 
-		// Finalize statements
-		sqlite_finalize_statement(stmt1);
-		sqlite_finalize_statement(stmt32);
+		// RAII auto-finalizes stmt1 and stmt32
 	}
 }
 
@@ -1302,11 +1299,11 @@ bool is_task_finish(pgsql_conn_t& c, task_st_t& st) {
 }
 
 void update_connect_table(SQLite3DB* db, state_t& state) {
-	sqlite3_stmt* stmt = nullptr;
-	int rc = db->prepare_v2(
-		"INSERT OR REPLACE INTO pgsql_server_connect_log VALUES (?1 , ?2 , ?3 , ?4 , ?5)", &stmt
+	auto [rc1, stmt_unique] = db->prepare_v2(
+		"INSERT OR REPLACE INTO pgsql_server_connect_log VALUES (?1 , ?2 , ?3 , ?4 , ?5)"
 	);
-	ASSERT_SQLITE_OK(rc, db);
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt* stmt = stmt_unique.get();
 
 	uint64_t op_dur_us { state.task.end - state.task.start };
 
@@ -1324,7 +1321,7 @@ void update_connect_table(SQLite3DB* db, state_t& state) {
 
 	sqlite_clear_bindings(stmt);
 	sqlite_reset_statement(stmt);
-	sqlite_finalize_statement(stmt);
+	// RAII auto-finalizes stmt
 
 	if (state.conn.err) {
 		const mon_srv_t& srv { state.task.op_st.srv_info };
@@ -1347,11 +1344,11 @@ void update_connect_table(SQLite3DB* db, state_t& state) {
 }
 
 void update_ping_table(SQLite3DB* db, state_t& state) {
-	sqlite3_stmt* stmt = nullptr;
-	int rc = db->prepare_v2(
-		"INSERT OR REPLACE INTO pgsql_server_ping_log VALUES (?1, ?2, ?3, ?4, ?5)", &stmt
+	auto [rc1, stmt_unique] = db->prepare_v2(
+		"INSERT OR REPLACE INTO pgsql_server_ping_log VALUES (?1, ?2, ?3, ?4, ?5)"
 	);
-	ASSERT_SQLITE_OK(rc, db);
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt* stmt = stmt_unique.get();
 
 	uint64_t op_dur_us { state.task.end - state.task.start };
 
@@ -1369,7 +1366,7 @@ void update_ping_table(SQLite3DB* db, state_t& state) {
 
 	sqlite_clear_bindings(stmt);
 	sqlite_reset_statement(stmt);
-	sqlite_finalize_statement(stmt);
+	// RAII auto-finalizes stmt
 
 	if (state.conn.err) {
 		const mon_srv_t& srv { state.task.op_st.srv_info };
@@ -1396,11 +1393,11 @@ void update_readonly_table(SQLite3DB* db, state_t& state) {
 		static_cast<readonly_res_t*>(state.task.op_st.op_result.get())
 	};
 
-	sqlite3_stmt* stmt = nullptr;
-	int rc = db->prepare_v2(
-		"INSERT OR REPLACE INTO pgsql_server_read_only_log VALUES (?1, ?2, ?3, ?4, ?5, ?6)", &stmt
+	auto [rc1, stmt_unique] = db->prepare_v2(
+		"INSERT OR REPLACE INTO pgsql_server_read_only_log VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
 	);
-	ASSERT_SQLITE_OK(rc, db);
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt* stmt = stmt_unique.get();
 
 	uint64_t op_dur_us { state.task.end - state.task.start };
 
@@ -1425,7 +1422,7 @@ void update_readonly_table(SQLite3DB* db, state_t& state) {
 
 	sqlite_clear_bindings(stmt);
 	sqlite_reset_statement(stmt);
-	sqlite_finalize_statement(stmt);
+	// RAII auto-finalizes stmt
 
 	if (state.conn.err) {
 		const mon_srv_t& srv { state.task.op_st.srv_info };
@@ -1938,9 +1935,9 @@ void* worker_thread(void* args) {
 }
 
 void maint_monitor_table(SQLite3DB* db, const char query[], const ping_params_t& params) {
-	sqlite3_stmt* stmt { nullptr };
-	int rc = db->prepare_v2(query, &stmt);
-	ASSERT_SQLITE_OK(rc, db);
+	auto [rc1, stmt_unique] = db->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc1, db);
+	sqlite3_stmt* stmt = stmt_unique.get();
 
 	if (pgsql_thread___monitor_history < (params.interval * (params.max_failures + 1)) / 1000) {
 		if (static_cast<uint64_t>(params.interval) < uint64_t(3600000) * 1000) {
@@ -1954,7 +1951,7 @@ void maint_monitor_table(SQLite3DB* db, const char query[], const ping_params_t&
 
 	sqlite_clear_bindings(stmt);
 	sqlite_reset_statement(stmt);
-	sqlite_finalize_statement(stmt);
+	// RAII auto-finalizes stmt
 }
 
 const char MAINT_PING_LOG_QUERY[] {

--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -1299,10 +1299,10 @@ bool is_task_finish(pgsql_conn_t& c, task_st_t& st) {
 }
 
 void update_connect_table(SQLite3DB* db, state_t& state) {
-	auto [rc1, stmt_unique] = db->prepare_v2(
+	auto [rc, stmt_unique] = db->prepare_v2(
 		"INSERT OR REPLACE INTO pgsql_server_connect_log VALUES (?1 , ?2 , ?3 , ?4 , ?5)"
 	);
-	ASSERT_SQLITE_OK(rc1, db);
+	ASSERT_SQLITE_OK(rc, db);
 	sqlite3_stmt* stmt = stmt_unique.get();
 
 	uint64_t op_dur_us { state.task.end - state.task.start };
@@ -1344,10 +1344,10 @@ void update_connect_table(SQLite3DB* db, state_t& state) {
 }
 
 void update_ping_table(SQLite3DB* db, state_t& state) {
-	auto [rc1, stmt_unique] = db->prepare_v2(
+	auto [rc, stmt_unique] = db->prepare_v2(
 		"INSERT OR REPLACE INTO pgsql_server_ping_log VALUES (?1, ?2, ?3, ?4, ?5)"
 	);
-	ASSERT_SQLITE_OK(rc1, db);
+	ASSERT_SQLITE_OK(rc, db);
 	sqlite3_stmt* stmt = stmt_unique.get();
 
 	uint64_t op_dur_us { state.task.end - state.task.start };
@@ -1393,10 +1393,10 @@ void update_readonly_table(SQLite3DB* db, state_t& state) {
 		static_cast<readonly_res_t*>(state.task.op_st.op_result.get())
 	};
 
-	auto [rc1, stmt_unique] = db->prepare_v2(
+	auto [rc, stmt_unique] = db->prepare_v2(
 		"INSERT OR REPLACE INTO pgsql_server_read_only_log VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
 	);
-	ASSERT_SQLITE_OK(rc1, db);
+	ASSERT_SQLITE_OK(rc, db);
 	sqlite3_stmt* stmt = stmt_unique.get();
 
 	uint64_t op_dur_us { state.task.end - state.task.start };
@@ -1935,8 +1935,8 @@ void* worker_thread(void* args) {
 }
 
 void maint_monitor_table(SQLite3DB* db, const char query[], const ping_params_t& params) {
-	auto [rc1, stmt_unique] = db->prepare_v2(query);
-	ASSERT_SQLITE_OK(rc1, db);
+	auto [rc, stmt_unique] = db->prepare_v2(query);
+	ASSERT_SQLITE_OK(rc, db);
 	sqlite3_stmt* stmt = stmt_unique.get();
 
 	if (pgsql_thread___monitor_history < (params.interval * (params.max_failures + 1)) / 1000) {

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -2709,12 +2709,10 @@ PgSQL_Thread::~PgSQL_Thread() {
 		match_regexes = NULL;
 	}
 
-#ifdef IDLE_THREADS
 	if (copy_cmd_matcher) {
 		delete copy_cmd_matcher;
 		copy_cmd_matcher = NULL;
 	}
-#endif
 
 	if (thr_SetParser != NULL) {
 		delete thr_SetParser;
@@ -2769,9 +2767,7 @@ bool PgSQL_Thread::init() {
 	match_regexes[2] = new Session_Regex((char*)"^SET(?: +)(|SESSION +)TRANSACTION(?: +)(?:(?:(ISOLATION(?: +)LEVEL)(?: +)(REPEATABLE(?: +)READ|READ(?: +)COMMITTED|READ(?: +)UNCOMMITTED|SERIALIZABLE))|(?:(READ)(?: +)(WRITE|ONLY)))");
 	match_regexes[3] = new Session_Regex((char*)"^SET(?: +)(|SESSION +)`?(client_encoding|names)`?( *)(|=|TO)( *)");
 
-#ifdef IDLE_THREADS
 	copy_cmd_matcher = new CopyCmdMatcher();
-#endif
 
 	return true;
 }
@@ -4014,9 +4010,7 @@ PgSQL_Thread::PgSQL_Thread() {
 		status_variables.stvar[i] = 0;
 	}
 	match_regexes = NULL;
-#ifdef IDLE_THREADS
 	copy_cmd_matcher = NULL;
-#endif
 
 	variables.min_num_servers_lantency_awareness = 1000;
 	variables.aurora_max_lag_ms_only_read_from_replicas = 2;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -6670,10 +6670,6 @@ void ProxySQL_Admin::save_pgsql_ldap_mapping_runtime_to_database(bool _runtime) 
 	admindb->execute(query);
 	resultset = GloMyLdapAuth->dump_table_pgsql_ldap_mapping();
 	if (resultset) {
-		int rc;
-		sqlite3_stmt* statement1 = NULL;
-		sqlite3_stmt* statement8 = NULL;
-		//sqlite3 *mydb3=admindb->get_db();
 		char* query1 = NULL;
 		char* query8 = NULL;
 		std::string query8s = "";
@@ -6687,12 +6683,13 @@ void ProxySQL_Admin::save_pgsql_ldap_mapping_runtime_to_database(bool _runtime) 
 			query8s = "INSERT INTO pgsql_ldap_mapping VALUES " + generate_multi_rows_query(8, 4);
 			query8 = (char*)query8s.c_str();
 		}
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query8, -1, &statement8, 0);
-		rc = admindb->prepare_v2(query8, &statement8);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement8_unique] = admindb->prepare_v2(query8);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt* statement1 = statement1_unique.get();
+		sqlite3_stmt* statement8 = statement8_unique.get();
+		int rc;
 		int row_idx = 0;
 		int max_bulk_row_idx = resultset->rows_count / 8;
 		max_bulk_row_idx = max_bulk_row_idx * 8;
@@ -6721,8 +6718,6 @@ void ProxySQL_Admin::save_pgsql_ldap_mapping_runtime_to_database(bool _runtime) 
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement8);
 	}
 	if (resultset) delete resultset;
 	resultset = NULL;
@@ -6912,10 +6907,6 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 	admindb->execute(query);
 	resultset=MyHGM->dump_table_mysql("mysql_servers");
 	if (resultset) {
-		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement32=NULL;
-
 		char *query1=NULL;
 		char *query32=NULL;
 		std::string query32s = "";
@@ -6929,11 +6920,13 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			query32 = (char *)query32s.c_str();
 		}
 
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
-
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement32 = statement32_unique.get();
+		int rc;
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/32;
 		max_bulk_row_idx=max_bulk_row_idx*32;
@@ -6977,8 +6970,6 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 	if(resultset) delete resultset;
 	resultset=NULL;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -953,8 +953,6 @@ int ProxySQL_Admin::FlushDigestTableToDisk(SQLite3DB *_db) {
 	SQLite3DB * sdb = _db;
 	sdb->execute("BEGIN");
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 	char *query1=NULL;
 	char *query32=NULL;
 	std::string query32s = "";
@@ -968,10 +966,12 @@ int ProxySQL_Admin::FlushDigestTableToDisk(SQLite3DB *_db) {
 	}
 
 	query32 = (char *)query32s.c_str();
-	rc = sdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, sdb);
-	rc = sdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, sdb);
+	auto [rc1, statement1_unique] = sdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, sdb);
+	auto [rc2, statement32_unique] = sdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, sdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx=0;
 	int max_bulk_row_idx=r/32;
 	max_bulk_row_idx=max_bulk_row_idx*32;
@@ -1069,8 +1069,7 @@ int ProxySQL_Admin::FlushDigestTableToDisk(SQLite3DB *_db) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	sdb->execute("COMMIT");
 
 	for (std::unordered_map<uint64_t, void *>::iterator it=uqd.begin(); it!=uqd.end(); ++it) {

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -5061,9 +5061,6 @@ void ProxySQL_Admin::save_pgsql_firewall_whitelist_users_from_runtime(bool _runt
 void ProxySQL_Admin::save_mysql_firewall_whitelist_rules_from_runtime(bool _runtime, SQLite3_result *resultset) {
 	// NOTE: this function doesn't delete resultset. The caller must do it
 	if (resultset) {
-		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement32=NULL;
 		char *query1=NULL;
 		char *query32=NULL;
 		std::string query32s = "";
@@ -5076,10 +5073,13 @@ void ProxySQL_Admin::save_mysql_firewall_whitelist_rules_from_runtime(bool _runt
 			query32s = "INSERT INTO mysql_firewall_whitelist_rules VALUES " + generate_multi_rows_query(32,7);
 			query32 = (char *)query32s.c_str();
 		}
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement32 = statement32_unique.get();
+		int rc;
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/32;
 		max_bulk_row_idx=max_bulk_row_idx*32;
@@ -5113,17 +5113,12 @@ void ProxySQL_Admin::save_mysql_firewall_whitelist_rules_from_runtime(bool _runt
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 }
 
 void ProxySQL_Admin::save_pgsql_firewall_whitelist_rules_from_runtime(bool _runtime, SQLite3_result* resultset) {
 	// NOTE: this function doesn't delete resultset. The caller must do it
 	if (resultset) {
-		int rc;
-		sqlite3_stmt* statement1 = NULL;
-		sqlite3_stmt* statement32 = NULL;
 		char* query1 = NULL;
 		char* query32 = NULL;
 		std::string query32s = "";
@@ -5137,10 +5132,13 @@ void ProxySQL_Admin::save_pgsql_firewall_whitelist_rules_from_runtime(bool _runt
 			query32s = "INSERT INTO pgsql_firewall_whitelist_rules VALUES " + generate_multi_rows_query(32, 7);
 			query32 = (char*)query32s.c_str();
 		}
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt* statement1 = statement1_unique.get();
+		sqlite3_stmt* statement32 = statement32_unique.get();
+		int rc;
 		int row_idx = 0;
 		int max_bulk_row_idx = resultset->rows_count / 32;
 		max_bulk_row_idx = max_bulk_row_idx * 32;
@@ -5175,8 +5173,6 @@ void ProxySQL_Admin::save_pgsql_firewall_whitelist_rules_from_runtime(bool _runt
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 }
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1202,11 +1202,13 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 	bool stats_memory_metrics=false;
 	bool stats_mysql_commands_counters=false;
 	bool stats_pgsql_commands_counters = false;
+#ifdef PROXYSQLGENAI
 	bool stats_mcp_query_tools_counters = false;
 	bool stats_mcp_query_tools_counters_reset = false;
 	bool stats_mcp_query_digest = false;
 	bool stats_mcp_query_digest_reset = false;
 	bool stats_mcp_query_rules = false;
+#endif
 	bool stats_mysql_query_rules=false;
 	bool stats_pgsql_query_rules = false;
 	bool stats_mysql_users=false;
@@ -1234,7 +1236,9 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 	bool runtime_pgsql_query_rules = false;
 	bool runtime_pgsql_query_rules_fast_routing = false;
 
+#ifdef PROXYSQLGENAI
 	bool runtime_mcp_query_rules = false;
+#endif
 
 	bool stats_pgsql_global = false;
 	bool stats_pgsql_connection_pool = false;
@@ -1398,6 +1402,7 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 		{ stats_proxysql_message_metrics=true; refresh=true; }
 	if (strstr(query_no_space,"stats_proxysql_message_metrics_reset"))
 		{ stats_proxysql_message_metrics_reset=true; refresh=true; }
+#ifdef PROXYSQLGENAI
 	if (strstr(query_no_space,"stats_mcp_query_tools_counters"))
 		{ stats_mcp_query_tools_counters=true; refresh=true; }
 	if (strstr(query_no_space,"stats_mcp_query_tools_counters_reset"))
@@ -1408,6 +1413,7 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 		{ stats_mcp_query_digest=true; refresh=true; }
 	if (strstr(query_no_space,"stats_mcp_query_rules"))
 		{ stats_mcp_query_rules=true; refresh=true; }
+#endif
 
 	// temporary disabled because not implemented
 /*
@@ -1494,9 +1500,11 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 			if (strstr(query_no_space, "runtime_pgsql_query_rules_fast_routing")) {
 				runtime_pgsql_query_rules_fast_routing = true; refresh = true;
 			}
+#ifdef PROXYSQLGENAI
 			if (strstr(query_no_space, "runtime_mcp_query_rules")) {
 				runtime_mcp_query_rules = true; refresh = true;
 			}
+#endif
 			if (strstr(query_no_space,"runtime_scheduler")) {
 				runtime_scheduler=true; refresh=true;
 			}

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -4560,10 +4560,6 @@ void ProxySQL_Admin::save_mysql_query_rules_fast_routing_from_runtime(bool _runt
 	}
 	SQLite3_result * resultset=GloMyQPro->get_current_query_rules_fast_routing();
 	if (resultset) {
-		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement32=NULL;
-
 		char *query1=NULL;
 		char *query32=NULL;
 		std::string query32s = "";
@@ -4577,10 +4573,13 @@ void ProxySQL_Admin::save_mysql_query_rules_fast_routing_from_runtime(bool _runt
 			query32 = (char *)query32s.c_str();
 		}
 
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement32 = statement32_unique.get();
+		int rc;
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/32;
 		max_bulk_row_idx=max_bulk_row_idx*32;
@@ -4610,8 +4609,6 @@ void ProxySQL_Admin::save_mysql_query_rules_fast_routing_from_runtime(bool _runt
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 	if(resultset) delete resultset;
 	resultset = NULL;
@@ -4626,10 +4623,6 @@ void ProxySQL_Admin::save_pgsql_query_rules_fast_routing_from_runtime(bool _runt
 	}
 	SQLite3_result* resultset = GloPgQPro->get_current_query_rules_fast_routing();
 	if (resultset) {
-		int rc;
-		sqlite3_stmt* statement1 = NULL;
-		sqlite3_stmt* statement32 = NULL;
-		//sqlite3 *mydb3=admindb->get_db();
 		char* query1 = NULL;
 		char* query32 = NULL;
 		std::string query32s = "";
@@ -4643,12 +4636,13 @@ void ProxySQL_Admin::save_pgsql_query_rules_fast_routing_from_runtime(bool _runt
 			query32s = "INSERT INTO pgsql_query_rules_fast_routing VALUES " + generate_multi_rows_query(32, 5);
 			query32 = (char*)query32s.c_str();
 		}
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt* statement1 = statement1_unique.get();
+		sqlite3_stmt* statement32 = statement32_unique.get();
+		int rc;
 		int row_idx = 0;
 		int max_bulk_row_idx = resultset->rows_count / 32;
 		max_bulk_row_idx = max_bulk_row_idx * 32;
@@ -4679,8 +4673,6 @@ void ProxySQL_Admin::save_pgsql_query_rules_fast_routing_from_runtime(bool _runt
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 	if (resultset) delete resultset;
 	resultset = NULL;
@@ -4860,9 +4852,6 @@ void ProxySQL_Admin::save_pgsql_query_rules_from_runtime(bool _runtime) {
 void ProxySQL_Admin::save_mysql_firewall_whitelist_sqli_fingerprints_from_runtime(bool _runtime, SQLite3_result *resultset) {
 	// NOTE: this function doesn't delete resultset. The caller must do it
 	if (resultset) {
-		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement32=NULL;
 		char *query1=NULL;
 		char *query32=NULL;
 		std::string query32s = "";
@@ -4875,10 +4864,13 @@ void ProxySQL_Admin::save_mysql_firewall_whitelist_sqli_fingerprints_from_runtim
 			query32s = "INSERT INTO mysql_firewall_whitelist_sqli_fingerprints VALUES " + generate_multi_rows_query(32,2);
 			query32 = (char *)query32s.c_str();
 		}
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement32 = statement32_unique.get();
+		int rc;
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/32;
 		max_bulk_row_idx=max_bulk_row_idx*32;
@@ -4902,17 +4894,12 @@ void ProxySQL_Admin::save_mysql_firewall_whitelist_sqli_fingerprints_from_runtim
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 }
 
 void ProxySQL_Admin::save_pgsql_firewall_whitelist_sqli_fingerprints_from_runtime(bool _runtime, SQLite3_result* resultset) {
 	// NOTE: this function doesn't delete resultset. The caller must do it
 	if (resultset) {
-		int rc;
-		sqlite3_stmt* statement1 = NULL;
-		sqlite3_stmt* statement32 = NULL;
 		char* query1 = NULL;
 		char* query32 = NULL;
 		std::string query32s = "";
@@ -4926,10 +4913,13 @@ void ProxySQL_Admin::save_pgsql_firewall_whitelist_sqli_fingerprints_from_runtim
 			query32s = "INSERT INTO pgsql_firewall_whitelist_sqli_fingerprints VALUES " + generate_multi_rows_query(32, 2);
 			query32 = (char*)query32s.c_str();
 		}
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt* statement1 = statement1_unique.get();
+		sqlite3_stmt* statement32 = statement32_unique.get();
+		int rc;
 		int row_idx = 0;
 		int max_bulk_row_idx = resultset->rows_count / 32;
 		max_bulk_row_idx = max_bulk_row_idx * 32;
@@ -4954,17 +4944,12 @@ void ProxySQL_Admin::save_pgsql_firewall_whitelist_sqli_fingerprints_from_runtim
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 }
 
 void ProxySQL_Admin::save_mysql_firewall_whitelist_users_from_runtime(bool _runtime, SQLite3_result *resultset) {
 	// NOTE: this function doesn't delete resultset. The caller must do it
 	if (resultset) {
-		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement32=NULL;
 		char *query1=NULL;
 		char *query32=NULL;
 		std::string query32s = "";
@@ -4977,10 +4962,13 @@ void ProxySQL_Admin::save_mysql_firewall_whitelist_users_from_runtime(bool _runt
 			query32s = "INSERT INTO mysql_firewall_whitelist_users VALUES " + generate_multi_rows_query(32,5);
 			query32 = (char *)query32s.c_str();
 		}
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement32 = statement32_unique.get();
+		int rc;
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/32;
 		max_bulk_row_idx=max_bulk_row_idx*32;
@@ -5010,17 +4998,12 @@ void ProxySQL_Admin::save_mysql_firewall_whitelist_users_from_runtime(bool _runt
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 }
 
 void ProxySQL_Admin::save_pgsql_firewall_whitelist_users_from_runtime(bool _runtime, SQLite3_result* resultset) {
 	// NOTE: this function doesn't delete resultset. The caller must do it
 	if (resultset) {
-		int rc;
-		sqlite3_stmt* statement1 = NULL;
-		sqlite3_stmt* statement32 = NULL;
 		char* query1 = NULL;
 		char* query32 = NULL;
 		std::string query32s = "";
@@ -5034,10 +5017,13 @@ void ProxySQL_Admin::save_pgsql_firewall_whitelist_users_from_runtime(bool _runt
 			query32s = "INSERT INTO pgsql_firewall_whitelist_users VALUES " + generate_multi_rows_query(32, 5);
 			query32 = (char*)query32s.c_str();
 		}
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt* statement1 = statement1_unique.get();
+		sqlite3_stmt* statement32 = statement32_unique.get();
+		int rc;
 		int row_idx = 0;
 		int max_bulk_row_idx = resultset->rows_count / 32;
 		max_bulk_row_idx = max_bulk_row_idx * 32;
@@ -5068,8 +5054,6 @@ void ProxySQL_Admin::save_pgsql_firewall_whitelist_users_from_runtime(bool _runt
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 }
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -6511,8 +6511,6 @@ void ProxySQL_Admin::save_pgsql_users_runtime_to_database(bool _runtime) {
 	if (num_users == 0) return;
 	char* q_stmt1_f = NULL;
 	char* q_stmt1_b = NULL;
-	sqlite3_stmt* f_statement1 = NULL;
-	sqlite3_stmt* b_statement1 = NULL;
 	//sqlite3 *mydb3=admindb->get_db();
 	if (_runtime) {
 		q_stmt1_f = qfr_stmt1;
@@ -6522,12 +6520,13 @@ void ProxySQL_Admin::save_pgsql_users_runtime_to_database(bool _runtime) {
 		q_stmt1_f = qf_stmt1;
 		q_stmt1_b = qb_stmt1;
 	}
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, q_stmt1_f, -1, &f_statement1, 0);
-	rc = admindb->prepare_v2(q_stmt1_f, &f_statement1);
-	ASSERT_SQLITE_OK(rc, admindb);
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, q_stmt1_b, -1, &b_statement1, 0);
-	rc = admindb->prepare_v2(q_stmt1_b, &b_statement1);
-	ASSERT_SQLITE_OK(rc, admindb);
+	auto [rc1, f_statement1_unique] = admindb->prepare_v2(q_stmt1_f);
+	ASSERT_SQLITE_OK(rc1, admindb);
+	auto [rc2, b_statement1_unique] = admindb->prepare_v2(q_stmt1_b);
+	ASSERT_SQLITE_OK(rc2, admindb);
+	sqlite3_stmt* f_statement1 = f_statement1_unique.get();
+	sqlite3_stmt* b_statement1 = b_statement1_unique.get();
+	int rc;
 	for (i = 0; i < num_users; i++) {
 		//fprintf(stderr,"%s %d\n", ads[i]->username, ads[i]->default_hostgroup);
 		pgsql_account_details_t* ad = ads[i];
@@ -6586,10 +6585,6 @@ void ProxySQL_Admin::save_pgsql_users_runtime_to_database(bool _runtime) {
 		free(ad->attributes);
 		free(ad);
 	}
-	if (_runtime) {
-		(*proxy_sqlite3_finalize)(f_statement1);
-		(*proxy_sqlite3_finalize)(b_statement1);
-	}
 	free(ads);
 }
 
@@ -6608,10 +6603,6 @@ void ProxySQL_Admin::save_mysql_ldap_mapping_runtime_to_database(bool _runtime) 
 	admindb->execute(query);
 	resultset=GloMyLdapAuth->dump_table_mysql_ldap_mapping();
 	if (resultset) {
-		int rc;
-		sqlite3_stmt *statement1=NULL;
-		sqlite3_stmt *statement8=NULL;
-		//sqlite3 *mydb3=admindb->get_db();
 		char *query1=NULL;
 		char *query8=NULL;
 		std::string query8s = "";
@@ -6624,10 +6615,13 @@ void ProxySQL_Admin::save_mysql_ldap_mapping_runtime_to_database(bool _runtime) 
 			query8s = "INSERT INTO mysql_ldap_mapping VALUES " + generate_multi_rows_query(8,4);
 			query8 = (char *)query8s.c_str();
 		}
-		rc = admindb->prepare_v2(query1, &statement1);
-		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query8, &statement8);
-		ASSERT_SQLITE_OK(rc, admindb);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		ASSERT_SQLITE_OK(rc1, admindb);
+		auto [rc2, statement8_unique] = admindb->prepare_v2(query8);
+		ASSERT_SQLITE_OK(rc2, admindb);
+		sqlite3_stmt *statement1 = statement1_unique.get();
+		sqlite3_stmt *statement8 = statement8_unique.get();
+		int rc;
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/8;
 		max_bulk_row_idx=max_bulk_row_idx*8;
@@ -6655,8 +6649,6 @@ void ProxySQL_Admin::save_mysql_ldap_mapping_runtime_to_database(bool _runtime) 
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement8);
 	}
 	if(resultset) delete resultset;
 	resultset=NULL;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -6777,13 +6777,20 @@ void ProxySQL_Admin::save_clickhouse_users_runtime_to_database(bool _runtime) {
 	char *q_stmt1_b=NULL;
 	sqlite3_stmt *f_statement1=NULL;
 	sqlite3_stmt *b_statement1=NULL;
+	stmt_unique_ptr f_statement1_unique {};
+	stmt_unique_ptr b_statement1_unique {};
 	if (_runtime) {
-		int rc;
 		q_stmt1_f=qfr_stmt1;
 		q_stmt1_b=qbr_stmt1;
-		rc = admindb->prepare_v2(q_stmt1_f, &f_statement1);
+		auto [rc_f, prepared_f_statement1] = admindb->prepare_v2(q_stmt1_f);
+		rc = rc_f;
+		f_statement1_unique = std::move(prepared_f_statement1);
+		f_statement1 = f_statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(q_stmt1_b, &b_statement1);
+		auto [rc_b, prepared_b_statement1] = admindb->prepare_v2(q_stmt1_b);
+		rc = rc_b;
+		b_statement1_unique = std::move(prepared_b_statement1);
+		b_statement1 = b_statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 	}
 	for (i=0; i<num_users; i++) {
@@ -6826,10 +6833,6 @@ void ProxySQL_Admin::save_clickhouse_users_runtime_to_database(bool _runtime) {
 		free(ad->password); // this is not initialized with dump_all_users( , false)
 		free(ad->default_schema); // this is not initialized with dump_all_users( , false)
 		free(ad);
-	}
-	if (_runtime) {
-		(*proxy_sqlite3_finalize)(f_statement1);
-		(*proxy_sqlite3_finalize)(b_statement1);
 	}
 	free(ads);
 }
@@ -7056,7 +7059,9 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			query=(char *)"INSERT INTO mysql_group_replication_hostgroups(writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
 		}
 
-		rc = admindb->prepare_v2(query, &statement);
+		auto [rc1, statement_unique] = admindb->prepare_v2(query);
+		rc = rc1;
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
@@ -7075,7 +7080,6 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, admindb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
-		(*proxy_sqlite3_finalize)(statement);
 	}
 	if(resultset) delete resultset;
 	resultset = NULL;
@@ -7100,7 +7104,9 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			query=(char *)"INSERT INTO mysql_galera_hostgroups(writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
 		}
 
-		rc = admindb->prepare_v2(query, &statement);
+		auto [rc1, statement_unique] = admindb->prepare_v2(query);
+		rc = rc1;
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
@@ -7119,7 +7125,6 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, admindb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
-		(*proxy_sqlite3_finalize)(statement);
 	}
 	if(resultset) delete resultset;
 	resultset = NULL;
@@ -7145,7 +7150,9 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			query=(char *)"INSERT INTO mysql_aws_aurora_hostgroups(writer_hostgroup,reader_hostgroup,active,aurora_port,domain_name,max_lag_ms,check_interval_ms,check_timeout_ms,writer_is_also_reader,new_reader_weight,add_lag_ms,min_lag_ms,lag_num_checks,comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)";
 		}
 
-		rc = admindb->prepare_v2(query, &statement);
+		auto [rc1, statement_unique] = admindb->prepare_v2(query);
+		rc = rc1;
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
@@ -7169,7 +7176,6 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, admindb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
-		(*proxy_sqlite3_finalize)(statement);
 	}
 	if(resultset) delete resultset;
 	resultset=NULL;
@@ -7190,7 +7196,9 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 		if (_runtime)
 			StrQuery += "runtime_";
 		StrQuery += "mysql_hostgroup_attributes (hostgroup_id, max_num_online_servers, autocommit, free_connections_pct, init_connect, multiplex, connection_warming, throttle_connections_per_sec, ignore_session_variables, hostgroup_settings, servers_defaults, comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
-		rc = admindb->prepare_v2(StrQuery.c_str(), &statement);
+		auto [rc1, statement_unique] = admindb->prepare_v2(StrQuery.c_str());
+		rc = rc1;
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 			SQLite3_row *r=*it;
@@ -7211,7 +7219,6 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, admindb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
-		(*proxy_sqlite3_finalize)(statement);
 	}
 	if(resultset) delete resultset;
 	resultset=NULL;
@@ -7232,7 +7239,9 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 		if (_runtime)
 			StrQuery += "runtime_";
 		StrQuery += "mysql_servers_ssl_params (hostname, port, username, ssl_ca, ssl_cert, ssl_key, ssl_capath, ssl_crl, ssl_crlpath, ssl_cipher, tls_version, comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
-		rc = admindb->prepare_v2(StrQuery.c_str(), &statement);
+		auto [rc1, statement_unique] = admindb->prepare_v2(StrQuery.c_str());
+		rc = rc1;
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
@@ -7254,7 +7263,6 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, admindb);
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
-		(*proxy_sqlite3_finalize)(statement);
 	}
 	if(resultset) delete resultset;
 	resultset=NULL;
@@ -7293,11 +7301,13 @@ void ProxySQL_Admin::save_pgsql_servers_runtime_to_database(bool _runtime) {
 			query32s = "INSERT INTO pgsql_servers VALUES " + generate_multi_rows_query(32, 11);
 			query32 = (char*)query32s.c_str();
 		}
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = admindb->prepare_v2(query1, &statement1);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		rc = rc1;
+		statement1 = statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-		rc = admindb->prepare_v2(query32, &statement32);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		rc = rc2;
+		statement32 = statement32_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 		int row_idx = 0;
 		int max_bulk_row_idx = resultset->rows_count / 32;
@@ -7341,8 +7351,6 @@ void ProxySQL_Admin::save_pgsql_servers_runtime_to_database(bool _runtime) {
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 	if (resultset) delete resultset;
 	resultset = NULL;
@@ -7403,7 +7411,9 @@ void ProxySQL_Admin::save_pgsql_servers_runtime_to_database(bool _runtime) {
 		if (_runtime)
 			StrQuery += "runtime_";
 		StrQuery += "pgsql_hostgroup_attributes (hostgroup_id, max_num_online_servers, autocommit, free_connections_pct, init_connect, multiplex, connection_warming, throttle_connections_per_sec, ignore_session_variables, hostgroup_settings, servers_defaults, comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
-		rc = admindb->prepare_v2(StrQuery.c_str(), &statement);
+		auto [rc1, statement_unique] = admindb->prepare_v2(StrQuery.c_str());
+		rc = rc1;
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 		//proxy_info("New pgsql_aws_aurora_hostgroups table\n");
 		for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
@@ -7425,7 +7435,6 @@ void ProxySQL_Admin::save_pgsql_servers_runtime_to_database(bool _runtime) {
 			rc = (*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, admindb);
 			rc = (*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
-		(*proxy_sqlite3_finalize)(statement);
 	}
 	if (resultset) delete resultset;
 	resultset = NULL;
@@ -8595,9 +8604,13 @@ void ProxySQL_Admin::save_proxysql_servers_runtime_to_database(bool _runtime) {
 			query32 = (char *)query32s.c_str();
 		}
 
-		rc = admindb->prepare_v2(query1, &statement1);
+		auto [rc1, statement1_unique] = admindb->prepare_v2(query1);
+		rc = rc1;
+		statement1 = statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
-		rc = admindb->prepare_v2(query32, &statement32);
+		auto [rc2, statement32_unique] = admindb->prepare_v2(query32);
+		rc = rc2;
+		statement32 = statement32_unique.get();
 		ASSERT_SQLITE_OK(rc, admindb);
 
 		int row_idx=0;
@@ -8627,8 +8640,6 @@ void ProxySQL_Admin::save_proxysql_servers_runtime_to_database(bool _runtime) {
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 	}
 	if(resultset) delete resultset;
 	resultset=NULL;
@@ -8675,7 +8686,9 @@ void ProxySQL_Admin::dump_coredump_filter_values_table() {
 	int rc;
 	const char *query = "REPLACE INTO runtime_coredump_filters VALUES (?1,?2)";
 	sqlite3_stmt *stmt = NULL;
-	rc = admindb->prepare_v2(query,&stmt);
+	auto [rc1, stmt_unique] = admindb->prepare_v2(query);
+	rc = rc1;
+	stmt = stmt_unique.get();
 	ASSERT_SQLITE_OK(rc, admindb);
 	admindb->execute((char *)"BEGIN");
 	admindb->execute((char *)"DELETE FROM runtime_coredump_filters");
@@ -8692,7 +8705,6 @@ void ProxySQL_Admin::dump_coredump_filter_values_table() {
 		free(lineno);
 	}
 	admindb->execute((char *)"COMMIT");
-	(*proxy_sqlite3_finalize)(stmt);
 }
 
 #ifdef TEST_GALERA
@@ -8706,7 +8718,9 @@ void ProxySQL_Admin::enable_galera_testing() {
 	admindb->execute("DELETE FROM mysql_servers WHERE hostgroup_id BETWEEN 2271 AND 2300");
 	char *query=(char *)"INSERT INTO mysql_servers (hostgroup_id,hostname,use_ssl,comment) VALUES (?1, ?2, ?3, ?4)";
 
-	rc = admindb->prepare_v2(query, &statement);
+	auto [rc1, statement_unique] = admindb->prepare_v2(query);
+	rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, admindb);
 	for (unsigned int j=1; j<4; j++) {
 		proxy_info("Admin is enabling Galera Testing using SQLite3 Server and writer_HG %d\n" , 2260+j*10+1);
@@ -8724,7 +8738,6 @@ void ProxySQL_Admin::enable_galera_testing() {
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement);
 	admindb->execute("INSERT INTO mysql_galera_hostgroups (writer_hostgroup, backup_writer_hostgroup, reader_hostgroup, offline_hostgroup, active, max_writers, writer_is_also_reader, max_transactions_behind, comment) VALUES (2271, 2272, 2273, 2274, 0, 1, 1, 0, 'Automated Galera Testing Cluster 1')");
 	admindb->execute("INSERT INTO mysql_galera_hostgroups (writer_hostgroup, backup_writer_hostgroup, reader_hostgroup, offline_hostgroup, active, max_writers, writer_is_also_reader, max_transactions_behind, comment) VALUES (2281, 2282, 2283, 2284, 0, 1, 1, 0, 'Automated Galera Testing Cluster 2')");
 	admindb->execute("INSERT INTO mysql_galera_hostgroups (writer_hostgroup, backup_writer_hostgroup, reader_hostgroup, offline_hostgroup, active, max_writers, writer_is_also_reader, max_transactions_behind, comment) VALUES (2291, 2292, 2293, 2294, 0, 1, 1, 0, 'Automated Galera Testing Cluster 3')");
@@ -8749,7 +8762,9 @@ void ProxySQL_Admin::enable_aurora_testing_populate_mysql_servers() {
 	unsigned int num_aurora_servers = GloSQLite3Server->num_aurora_servers[0];
 	admindb->execute("DELETE FROM mysql_servers WHERE hostgroup_id BETWEEN 1271 AND 1276");
 	char *query=(char *)"INSERT INTO mysql_servers (hostgroup_id,hostname,use_ssl,comment) VALUES (?1, ?2, ?3, ?4)";
-	int rc = admindb->prepare_v2(query, &statement);
+	auto [rc1, statement_unique] = admindb->prepare_v2(query);
+	int rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, admindb);
 	for (unsigned int j=1; j<4; j++) {
 		proxy_info("Admin is enabling AWS Aurora Testing using SQLite3 Server and HGs 127%d and 127%d\n" , j*2-1 , j*2);
@@ -8777,7 +8792,6 @@ void ProxySQL_Admin::enable_aurora_testing_populate_mysql_servers() {
 			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, admindb);
 		}
 	}
-	(*proxy_sqlite3_finalize)(statement);
 }
 
 void ProxySQL_Admin::enable_aurora_testing_populate_mysql_aurora_hostgroups() {

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2320,7 +2320,7 @@ void* child_telnet(void* arg)
 	}
 	shutdown(client,SHUT_RDWR);
 	close(client);
-	return arg;
+	return NULL;
 }
 
 /*

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -306,6 +306,7 @@ char *s_strdup(char *s) {
 
 int admin_load_main_=0;
 bool admin_nostart_=false;
+static volatile int admin_client_threads_active = 0;
 
 int __admin_refresh_interval=0;
 
@@ -2078,6 +2079,7 @@ void *child_mysql(void *arg) {
 			__sync_fetch_and_add(&GloVars.statuses.stack_memory_admin_threads,tmp_stack_size);
 		}
 	}
+	__sync_fetch_and_add(&admin_client_threads_active, 1);
 
 	arg_proxysql_adm*myarg = (arg_proxysql_adm*)arg;
 	int client = myarg->client_t;
@@ -2138,6 +2140,9 @@ void *child_mysql(void *arg) {
 	//free(arg->addr); // do not free
 	free(arg);
 
+	if (__sync_fetch_and_add(&glovars.shutdown,0) != 0) {
+		goto __exit_child_mysql;
+	}
 	sess->client_myds->myprot.generate_pkt_initial_handshake(true,NULL,NULL, &sess->thread_session_id, false);
 
 	while (__sync_fetch_and_add(&glovars.shutdown,0)==0) {
@@ -2183,6 +2188,7 @@ void *child_mysql(void *arg) {
 __exit_child_mysql:
 	delete mysql_thr;
 
+	__sync_fetch_and_sub(&admin_client_threads_active, 1);
 	__sync_fetch_and_sub(&GloVars.statuses.stack_memory_admin_threads,tmp_stack_size);
 
 	return NULL;
@@ -2198,6 +2204,7 @@ void* child_postgres(void* arg) {
 			__sync_fetch_and_add(&GloVars.statuses.stack_memory_admin_threads, tmp_stack_size);
 		}
 	}
+	__sync_fetch_and_add(&admin_client_threads_active, 1);
 
 	arg_proxysql_adm* myarg = (arg_proxysql_adm*)arg;
 	int client = myarg->client_t;
@@ -2250,6 +2257,9 @@ void* child_postgres(void* arg) {
 	//free(arg->addr); // do not free
 	free(arg);
 
+	if (__sync_fetch_and_add(&glovars.shutdown, 0) != 0) {
+		goto __exit_child_postgres;
+	}
 	myds->DSS = STATE_SERVER_HANDSHAKE;
 	sess->status = CONNECTING_CLIENT;
 
@@ -2300,6 +2310,7 @@ void* child_postgres(void* arg) {
 __exit_child_postgres:
 	delete pgsql_thr;
 
+	__sync_fetch_and_sub(&admin_client_threads_active, 1);
 	__sync_fetch_and_sub(&GloVars.statuses.stack_memory_admin_threads, tmp_stack_size);
 
 	return NULL;
@@ -2398,8 +2409,11 @@ void * admin_main_loop(void *arg) {
 			admin_nostart_=false;
 			pthread_mutex_unlock(&GloVars.global.start_mutex);
 		}
+		if (__sync_fetch_and_add(&glovars.shutdown,0) != 0 || *shutdown != 0) {
+			break;
+		}
 		if ((rc == -1 && errno == EINTR) || rc==0) {
-        // poll() timeout, try again
+			// poll() timeout, try again
 			goto __end_while_pool;
 		}
 		for (i=1;i<nfds;i++) {
@@ -2413,6 +2427,18 @@ void * admin_main_loop(void *arg) {
 				passarg->addr_size = sizeof(custom_sockaddr);
 				memset(passarg->addr, 0, sizeof(custom_sockaddr));
 				passarg->client_t = accept(fds[i].fd, (struct sockaddr*)passarg->addr, &passarg->addr_size);
+				if (passarg->client_t < 0) {
+					free(passarg->addr);
+					free(passarg);
+					continue;
+				}
+				if (__sync_fetch_and_add(&glovars.shutdown,0) != 0 || *shutdown != 0) {
+					::shutdown(passarg->client_t, SHUT_RDWR);
+					close(passarg->client_t);
+					free(passarg->addr);
+					free(passarg);
+					continue;
+				}
 //		printf("Connected: %s:%d  sock=%d\n", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port), client_t);
 				pthread_attr_getstacksize (&attr, &stacks);
 //		printf("Default stack size = %d\n", stacks);
@@ -2976,6 +3002,9 @@ void ProxySQL_Admin::admin_shutdown() {
 	}
 	AdminHTTPServer = NULL;
 	pthread_join(admin_thr, NULL);
+	while (__sync_fetch_and_add(&admin_client_threads_active, 0) != 0) {
+		usleep(1000);
+	}
 	delete admindb;
 	delete statsdb;
 	delete configdb;
@@ -8858,4 +8887,3 @@ void ProxySQL_Admin::enable_replicationlag_testing() {
 	mysql_servers_wrunlock();
 }
 #endif // TEST_REPLICATIONLAG
-

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -990,7 +990,7 @@ int ProxySQL_Admin::FlushDigestTableToDisk(SQLite3DB *_db) {
 			rc=(*proxy_sqlite3_bind_text)(statement32, (idx*15)+3, qds->schemaname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
 			rc=(*proxy_sqlite3_bind_text)(statement32, (idx*15)+4, qds->username, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
 			rc=(*proxy_sqlite3_bind_text)(statement32, (idx*15)+5, qds->client_address, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
-			sprintf(qdsp.digest,"0x%016llX", (long long unsigned int)qds->digest);
+			snprintf(qdsp.digest, sizeof(qdsp.digest),"0x%016llX", (long long unsigned int)qds->digest);
 			rc=(*proxy_sqlite3_bind_text)(statement32, (idx*15)+6, qdsp.digest, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
 			if (qds->digest_text) {
 				rc=(*proxy_sqlite3_bind_text)(statement32, (idx*15)+7, qds->digest_text, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
@@ -1035,7 +1035,7 @@ int ProxySQL_Admin::FlushDigestTableToDisk(SQLite3DB *_db) {
 			rc=(*proxy_sqlite3_bind_text)(statement1, 3, qds->schemaname, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
 			rc=(*proxy_sqlite3_bind_text)(statement1, 4, qds->username, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
 			rc=(*proxy_sqlite3_bind_text)(statement1, 5, qds->client_address, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
-			sprintf(qdsp.digest,"0x%016llX", (long long unsigned int)qds->digest);
+			snprintf(qdsp.digest, sizeof(qdsp.digest),"0x%016llX", (long long unsigned int)qds->digest);
 			rc=(*proxy_sqlite3_bind_text)(statement1, 6, qdsp.digest, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
 			if (qds->digest_text) {
 				rc=(*proxy_sqlite3_bind_text)(statement1, 7, qds->digest_text, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sdb);
@@ -1826,8 +1826,8 @@ SQLite3_result * ProxySQL_Admin::generate_show_fields_from(const char *tablename
 	tn[j]=0;
 	SQLite3_result *resultset=NULL;
 	char *q1=(char *)"PRAGMA table_info(%s)";
-	char *q2=(char *)malloc(strlen(q1)+strlen(tn));
-	sprintf(q2,q1,tn);
+	char *q2=(char *)malloc(strlen(q1)+strlen(tn)+1);
+	snprintf(q2, strlen(q1) + strlen(tn) + 1, q1, tn);
 	int affected_rows;
 	int cols;
 	char *error=NULL;
@@ -1909,7 +1909,7 @@ SQLite3_result * ProxySQL_Admin::generate_show_table_status(const char *tablenam
 	SQLite3_result *resultset=NULL;
 	char *q1=(char *)"PRAGMA table_info(%s)";
 	char *q2=(char *)malloc(strlen(q1)+strlen(tn)+32);
-	sprintf(q2,q1,tn);
+	snprintf(q2, strlen(q1) + strlen(tn) + 32, q1, tn);
 	int affected_rows;
 	int cols;
 	char *error=NULL;
@@ -1961,10 +1961,10 @@ SQLite3_result * ProxySQL_Admin::generate_show_table_status(const char *tablenam
 	pta[2]=(char *)"10";
 	pta[3]=(char *)"Dynamic";
 	delete resultset;
-	sprintf(q2,"SELECT COUNT(*) FROM %s",tn);
+	snprintf(q2, strlen(q1) + strlen(tn) + 32, "SELECT COUNT(*) FROM %s", tn);
 	admindb->execute_statement(q2, &error , &cols , &affected_rows , &resultset);
 	char buf[20];
-	sprintf(buf,"%d",resultset->rows_count);
+	snprintf(buf, sizeof(buf),"%d",resultset->rows_count);
 	pta[4]=buf;
 	delete resultset;
 	free(q2);
@@ -3088,7 +3088,7 @@ void ProxySQL_Admin::dump_mysql_collations() {
 	char *query=(char *)"INSERT INTO mysql_collations VALUES (%d, \"%s\", \"%s\", \"\")";
 	admindb->execute("DELETE FROM mysql_collations");
 	do {
-		sprintf(buf,query,c->nr, c->name, c->csname);
+		snprintf(buf, sizeof(buf),query,c->nr, c->name, c->csname);
 		admindb->execute(buf);
 		++c;
 	} while (c[0].nr != 0);
@@ -3590,31 +3590,31 @@ char * ProxySQL_Admin::get_variable(char *name) {
 		if (!strcasecmp(name,"stats_credentials"))
 			return s_strdup(variables.stats_credentials);
 		if (!strcasecmp(name,"stats_mysql_connection_pool")) {
-			sprintf(intbuf,"%d",variables.stats_mysql_connection_pool);
+			snprintf(intbuf, sizeof(intbuf),"%d",variables.stats_mysql_connection_pool);
 			return strdup(intbuf);
 		}
 		if (!strcasecmp(name,"stats_mysql_connections")) {
-			sprintf(intbuf,"%d",variables.stats_mysql_connections);
+			snprintf(intbuf, sizeof(intbuf),"%d",variables.stats_mysql_connections);
 			return strdup(intbuf);
 		}
 		if (!strcasecmp(name,"stats_mysql_query_cache")) {
-			sprintf(intbuf,"%d",variables.stats_mysql_query_cache);
+			snprintf(intbuf, sizeof(intbuf),"%d",variables.stats_mysql_query_cache);
 			return strdup(intbuf);
 		}
 		if (!strcasecmp(name,"stats_mysql_query_digest_to_disk")) {
-			sprintf(intbuf,"%d",variables.stats_mysql_query_digest_to_disk);
+			snprintf(intbuf, sizeof(intbuf),"%d",variables.stats_mysql_query_digest_to_disk);
 			return strdup(intbuf);
 		}
 		if (!strcasecmp(name,"stats_mysql_eventslog_sync_buffer_to_disk")) {
-			sprintf(intbuf,"%d",variables.stats_mysql_eventslog_sync_buffer_to_disk);
+			snprintf(intbuf, sizeof(intbuf),"%d",variables.stats_mysql_eventslog_sync_buffer_to_disk);
 			return strdup(intbuf);
 		}
 		if (!strcasecmp(name,"stats_system_cpu")) {
-			sprintf(intbuf,"%d",variables.stats_system_cpu);
+			snprintf(intbuf, sizeof(intbuf),"%d",variables.stats_system_cpu);
 			return strdup(intbuf);
 		}
 		if (!strcasecmp(name,"stats_system_memory")) {
-			sprintf(intbuf,"%d",variables.stats_system_memory);
+			snprintf(intbuf, sizeof(intbuf),"%d",variables.stats_system_memory);
 			return strdup(intbuf);
 		}
 	}
@@ -3624,43 +3624,43 @@ char * ProxySQL_Admin::get_variable(char *name) {
 	if (!strcasecmp(name,"telnet_admin_ifaces")) return s_strdup(variables.telnet_admin_ifaces);
 	if (!strcasecmp(name,"telnet_stats_ifaces")) return s_strdup(variables.telnet_stats_ifaces);
 	if (!strcasecmp(name,"cluster_check_interval_ms")) {
-		sprintf(intbuf,"%d",variables.cluster_check_interval_ms);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_check_interval_ms);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_check_status_frequency")) {
-		sprintf(intbuf,"%d",variables.cluster_check_status_frequency);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_check_status_frequency);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_mysql_query_rules_diffs_before_sync")) {
-		sprintf(intbuf,"%d",variables.cluster_mysql_query_rules_diffs_before_sync);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_mysql_query_rules_diffs_before_sync);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_mysql_servers_diffs_before_sync")) {
-		sprintf(intbuf,"%d",variables.cluster_mysql_servers_diffs_before_sync);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_mysql_servers_diffs_before_sync);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_mysql_users_diffs_before_sync")) {
-		sprintf(intbuf,"%d",variables.cluster_mysql_users_diffs_before_sync);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_mysql_users_diffs_before_sync);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_proxysql_servers_diffs_before_sync")) {
-		sprintf(intbuf,"%d",variables.cluster_proxysql_servers_diffs_before_sync);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_proxysql_servers_diffs_before_sync);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_mysql_variables_diffs_before_sync")) {
-		sprintf(intbuf,"%d",variables.cluster_mysql_variables_diffs_before_sync);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_mysql_variables_diffs_before_sync);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_admin_variables_diffs_before_sync")) {
-		sprintf(intbuf,"%d",variables.cluster_admin_variables_diffs_before_sync);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_admin_variables_diffs_before_sync);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_ldap_variables_diffs_before_sync")) {
-		sprintf(intbuf,"%d",variables.cluster_ldap_variables_diffs_before_sync);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.cluster_ldap_variables_diffs_before_sync);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_mysql_servers_sync_algorithm")) {
-		sprintf(intbuf, "%d", variables.cluster_mysql_servers_sync_algorithm);
+		snprintf(intbuf, sizeof(intbuf), "%d", variables.cluster_mysql_servers_sync_algorithm);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"cluster_mysql_query_rules_save_to_disk")) {
@@ -3685,7 +3685,7 @@ char * ProxySQL_Admin::get_variable(char *name) {
 		return strdup((variables.cluster_ldap_variables_save_to_disk ? "true" : "false"));
 	}
 	if (!strcasecmp(name,"refresh_interval")) {
-		sprintf(intbuf,"%d",variables.refresh_interval);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.refresh_interval);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"read_only")) {
@@ -3721,22 +3721,22 @@ char * ProxySQL_Admin::get_variable(char *name) {
 		return strdup((variables.restapi_enabled ? "true" : "false"));
 	}
 	if (!strcasecmp(name,"restapi_port")) {
-		sprintf(intbuf,"%d",variables.restapi_port);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.restapi_port);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"web_enabled")) {
 		return strdup((variables.web_enabled ? "true" : "false"));
 	}
 	if (!strcasecmp(name,"web_verbosity")) {
-		sprintf(intbuf, "%d", variables.web_verbosity);
+		snprintf(intbuf, sizeof(intbuf), "%d", variables.web_verbosity);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"web_port")) {
-		sprintf(intbuf,"%d",variables.web_port);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.web_port);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"prometheus_memory_metrics_interval")) {
-		sprintf(intbuf, "%d", variables.p_memory_metrics_interval);
+		snprintf(intbuf, sizeof(intbuf), "%d", variables.p_memory_metrics_interval);
 		return strdup(intbuf);
 	}
 #ifdef DEBUG
@@ -3744,24 +3744,25 @@ char * ProxySQL_Admin::get_variable(char *name) {
 		return strdup((variables.debug ? "true" : "false"));
 	}
 	if (!strcasecmp(name,"debug_output")) {
-		sprintf(intbuf, "%d", debug_output);
+		snprintf(intbuf, sizeof(intbuf), "%d", debug_output);
 		return strdup(intbuf);
 	}
 #endif /* DEBUG */
 	if (!strcasecmp(name,"coredump_generation_interval_ms")) {
-		sprintf(intbuf,"%d",variables.coredump_generation_interval_ms);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.coredump_generation_interval_ms);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name,"coredump_generation_threshold")) {
-		sprintf(intbuf,"%d",variables.coredump_generation_threshold);
+		snprintf(intbuf, sizeof(intbuf),"%d",variables.coredump_generation_threshold);
 		return strdup(intbuf);
 	}
 	if (!strcasecmp(name, "ssl_keylog_file")) {
 		char* ssl_keylog_file = s_strdup(variables.ssl_keylog_file);
 		if (ssl_keylog_file != NULL && strlen(ssl_keylog_file) > 0) {
 			if ((ssl_keylog_file[0] != '/')) { // relative path 
-				char* tmp_ssl_keylog_file = (char*)malloc(strlen(GloVars.datadir) + strlen(ssl_keylog_file) + 2);
-				sprintf(tmp_ssl_keylog_file, "%s/%s", GloVars.datadir, ssl_keylog_file);
+				size_t tmp_ssl_keylog_file_len = strlen(GloVars.datadir) + strlen(ssl_keylog_file) + 2;
+				char* tmp_ssl_keylog_file = (char*)malloc(tmp_ssl_keylog_file_len);
+				snprintf(tmp_ssl_keylog_file, tmp_ssl_keylog_file_len, "%s/%s", GloVars.datadir, ssl_keylog_file);
 				free(ssl_keylog_file);
 				ssl_keylog_file = tmp_ssl_keylog_file;
 			}
@@ -4555,8 +4556,9 @@ bool ProxySQL_Admin::set_variable(char *name, char *value, bool lock) {  // this
 				if (is_absolute_path) { // absolute path
 					sslkeylogfile = strdup(value);
 				} else { // relative path
-					sslkeylogfile = (char*)malloc(strlen(GloVars.datadir) + strlen(value) + 2);
-					sprintf(sslkeylogfile, "%s/%s", GloVars.datadir, value);
+					size_t sslkeylogfile_len = strlen(GloVars.datadir) + strlen(value) + 2;
+					sslkeylogfile = (char*)malloc(sslkeylogfile_len);
+					snprintf(sslkeylogfile, sslkeylogfile_len, "%s/%s", GloVars.datadir, value);
 				}
 				if (proxysql_keylog_open(sslkeylogfile) == false) {
 					free(sslkeylogfile);
@@ -4731,7 +4733,7 @@ void ProxySQL_Admin::save_mysql_query_rules_from_runtime(bool _runtime) {
 				int l=strlen(o)+4;
 				arg_len+=l;
 				buffs[i]=(char *)malloc(l);
-				sprintf(buffs[i],"'%s'",o);
+				snprintf(buffs[i], l, "'%s'", o);
 				if (o!=r->fields[i]) { // there was a copy
 					free(o);
 				}
@@ -4739,12 +4741,12 @@ void ProxySQL_Admin::save_mysql_query_rules_from_runtime(bool _runtime) {
 				int l=9;
 				arg_len+=l;
 				buffs[i]=(char *)malloc(l);
-				sprintf(buffs[i],"NULL");
+				snprintf(buffs[i], l, "NULL");
 			}
 		}
 		char *query=(char *)malloc(strlen(a)+arg_len+32);
 
-		sprintf(query,a,
+		snprintf(query, strlen(a) + arg_len + 32, a,
 			buffs[0],
 			buffs[1],
 			buffs[2],
@@ -4817,7 +4819,7 @@ void ProxySQL_Admin::save_pgsql_query_rules_from_runtime(bool _runtime) {
 				int l = strlen(o) + 4;
 				arg_len += l;
 				buffs[i] = (char*)malloc(l);
-				sprintf(buffs[i], "'%s'", o);
+				snprintf(buffs[i], l, "'%s'", o);
 				if (o != r->fields[i]) { // there was a copy
 					free(o);
 				}
@@ -4826,12 +4828,12 @@ void ProxySQL_Admin::save_pgsql_query_rules_from_runtime(bool _runtime) {
 				int l = 9;
 				arg_len += l;
 				buffs[i] = (char*)malloc(l);
-				sprintf(buffs[i], "NULL");
+				snprintf(buffs[i], l, "NULL");
 			}
 		}
 		char* query = (char*)malloc(strlen(a) + arg_len + 32);
 
-		sprintf(query, a,
+		snprintf(query, strlen(a) + arg_len + 32, a,
 			buffs[0],
 			buffs[1],
 			buffs[2],
@@ -5292,7 +5294,7 @@ void ProxySQL_Admin::flush_debug_levels_runtime_to_database(SQLite3DB *db, bool 
   int l=strlen(a)+100;
   for (i=0;i<PROXY_DEBUG_UNKNOWN;i++) {
     char *query=(char *)malloc(l);
-    sprintf(query, a, GloVars.global.gdbg_lvl[i].name, GloVars.global.gdbg_lvl[i].verbosity);
+    snprintf(query, l, a, GloVars.global.gdbg_lvl[i].name, GloVars.global.gdbg_lvl[i].verbosity);
     db->execute(query);
     free(query);
   }
@@ -5397,7 +5399,7 @@ int ProxySQL_Admin::flush_debug_levels_database_to_runtime(SQLite3DB *db) {
   for (i=0;i<PROXY_DEBUG_UNKNOWN;i++) {
     sqlite3_stmt *statement;
     char *buff=(char *)malloc(l);
-    sprintf(buff,query,GloVars.global.gdbg_lvl[i].name);
+    snprintf(buff, l, query, GloVars.global.gdbg_lvl[i].name);
     if((*proxy_sqlite3_prepare_v2)(_db, buff, -1, &statement, 0) != SQLITE_OK) {
       proxy_debug(PROXY_DEBUG_SQLITE, 1, "SQLITE: Error on (*proxy_sqlite3_prepare_v2)() running query \"%s\" : %s\n", buff, (*proxy_sqlite3_errmsg)(_db));
       (*proxy_sqlite3_finalize)(statement);
@@ -5648,7 +5650,7 @@ void ProxySQL_Admin::__attach_db(SQLite3DB *db1, SQLite3DB *db2, char *alias) {
 	const char *a="ATTACH DATABASE '%s' AS %s";
 	int l=strlen(a)+strlen(db2->get_url())+strlen(alias)+5;
 	char *cmd=(char *)malloc(l);
-	sprintf(cmd,a,db2->get_url(), alias);
+	snprintf(cmd, l, a, db2->get_url(), alias);
 	db1->execute(cmd);
 	free(cmd);
 }
@@ -5758,7 +5760,7 @@ void ProxySQL_Admin::__refresh_users(
 			}
 			uint32_t d32[2];
 			memcpy(&d32, &hash1, sizeof(hash1));
-			sprintf(buf,"0x%0X%0X", d32[0], d32[1]);
+			snprintf(buf, sizeof(buf),"0x%0X%0X", d32[0], d32[1]);
 
 			buff = buf;
 		} else {
@@ -5845,7 +5847,7 @@ void ProxySQL_Admin::__refresh_pgsql_users(
 			//}
 			uint32_t d32[2];
 			memcpy(&d32, &hash1, sizeof(hash1));
-			sprintf(buf, "0x%0X%0X", d32[0], d32[1]);
+			snprintf(buf, sizeof(buf), "0x%0X%0X", d32[0], d32[1]);
 
 			buff = buf;
 		}
@@ -5936,8 +5938,9 @@ void ProxySQL_Admin::send_error_msg_to_client(S* sess, const char *msg, uint16_t
 		 // Code for MySQL clients
 		MySQL_Data_Stream* myds = sess->client_myds;
 		myds->DSS = STATE_QUERY_SENT_DS;
-		char* new_msg = (char*)malloc(strlen(msg) + sizeof(prefix_msg));
-		sprintf(new_msg, "%s%s", prefix_msg, msg);
+		size_t new_msg_len = strlen(msg) + sizeof(prefix_msg);
+		char* new_msg = (char*)malloc(new_msg_len);
+		snprintf(new_msg, new_msg_len, "%s%s", prefix_msg, msg);
 		myds->myprot.generate_pkt_ERR(true, NULL, NULL, 1, mysql_err_code, (char*)"28000", new_msg);
 		free(new_msg);
 		myds->DSS = STATE_SLEEP;
@@ -5945,8 +5948,9 @@ void ProxySQL_Admin::send_error_msg_to_client(S* sess, const char *msg, uint16_t
 		// Code for PostgreSQL clients
 		PgSQL_Data_Stream* myds = sess->client_myds;
 		myds->DSS = STATE_QUERY_SENT_DS;
-		char* new_msg = (char*)malloc(strlen(msg) + sizeof(prefix_msg));
-		sprintf(new_msg, "%s%s", prefix_msg, msg);
+		size_t new_msg_len = strlen(msg) + sizeof(prefix_msg);
+		char* new_msg = (char*)malloc(new_msg_len);
+		snprintf(new_msg, new_msg_len, "%s%s", prefix_msg, msg);
 		myds->myprot.generate_error_packet(true, true, new_msg, PGSQL_ERROR_CODES::ERRCODE_RAISE_EXCEPTION, false);
 		free(new_msg);
 		myds->DSS = STATE_SLEEP;
@@ -5974,7 +5978,7 @@ void ProxySQL_Admin::__delete_inactive_users(enum cred_username_type usertype) {
 	else if constexpr (pt == SERVER_TYPE_PGSQL) 
 		str = (char*)"SELECT username FROM main.pgsql_users WHERE %s=1 AND active=0";
 	char *query=(char *)malloc(strlen(str)+15);
-	sprintf(query,str,(usertype==USERNAME_BACKEND ? "backend" : "frontend"));
+	snprintf(query, strlen(str) + 15, str, (usertype==USERNAME_BACKEND ? "backend" : "frontend"));
 	admindb->execute_statement(query, &error , &cols , &affected_rows , &resultset);
 	if (error) {
 		proxy_error("Error on %s : %s\n", query, error);
@@ -6065,7 +6069,7 @@ SQLite3_result* ProxySQL_Admin::__add_active_users(
 			str = (char*)"SELECT username,password,use_ssl,default_hostgroup,transaction_persistent,fast_forward,max_connections,attributes,comment FROM main.pgsql_users WHERE %s=1 AND active=1 AND default_hostgroup>=0 AND username='%s'";
 		}
 		query=(char *)malloc(strlen(str)+strlen(__user)+15);
-		sprintf(query,str,(usertype==USERNAME_BACKEND ? "backend" : "frontend"),__user);
+		snprintf(query, strlen(str) + strlen(__user) + 15, str, (usertype==USERNAME_BACKEND ? "backend" : "frontend"), __user);
 		admindb->execute_statement(query, &error , &cols , &affected_rows , &resultset);
 	}
 
@@ -6228,7 +6232,7 @@ void ProxySQL_Admin::__add_active_clickhouse_users(char *__user) {
 		str=(char *)"SELECT username,password,max_connections FROM main.clickhouse_users WHERE active=1 AND username='%s'";
 		query=(char *)malloc(strlen(str)+strlen(__user)+15);
 		//sprintf(query,str,(usertype==USERNAME_BACKEND ? "backend" : "frontend"),__user);
-		sprintf(query,str,__user);
+		snprintf(query, strlen(str) + strlen(__user) + 15, str, __user);
 	}
 #ifdef ADDUSER_STMT_RAW
 	admindb->execute_statement_raw(query, &error , &cols , &affected_rows , &statement);
@@ -6815,7 +6819,14 @@ void ProxySQL_Admin::save_clickhouse_users_runtime_to_database(bool _runtime) {
 			}
 			if (_runtime==false) {
 				query=(char *)malloc(strlen(q)+strlen(ad->username)*2+strlen(ad->password)+strlen(ad->default_schema)+256);
-				sprintf(query, q, ad->username, ad->password, ad->max_connections);
+				snprintf(
+					query,
+					strlen(q)+strlen(ad->username)*2+strlen(ad->password)+strlen(ad->default_schema)+256,
+					q,
+					ad->username,
+					ad->password,
+					ad->max_connections
+				);
 				proxy_debug(PROXY_DEBUG_ADMIN, 4, "%s\n", query);
 				admindb->execute(query);
 				free(query);
@@ -6874,7 +6885,7 @@ void ProxySQL_Admin::save_scheduler_runtime_to_database(bool _runtime) {
 		for (i=0; i<5; i++) {
 			if (sr->args[i]) {
 				args[i]=(char *)malloc(strlen(sr->args[i])+4);
-				sprintf(args[i],"\"%s\"",sr->args[i]);
+				snprintf(args[i], strlen(sr->args[i]) + 4, "\"%s\"", sr->args[i]);
 			} else {
 				args[i]=(char *)"NULL";
 			}
@@ -6889,7 +6900,7 @@ void ProxySQL_Admin::save_scheduler_runtime_to_database(bool _runtime) {
 		}
 		char *query=(char *)malloc(l);
 
-		sprintf(query, q,
+		snprintf(query, l, q,
 			sr->id, is_active, sr->interval_ms,
 			sr->filename, args[0],
 			args[1], args[2],
@@ -7026,7 +7037,7 @@ void ProxySQL_Admin::save_mysql_servers_runtime_to_database(bool _runtime) {
 			char *query=(char *)malloc(strlen(q)+strlen(r->fields[0])+strlen(r->fields[1])+strlen(r->fields[2])+16+l);
 			if (r->fields[3]) {
 				char *o=escape_string_single_quotes(r->fields[3],false);
-				sprintf(query, q, r->fields[0], r->fields[1], r->fields[2], o);
+				snprintf(query, strlen(q)+strlen(r->fields[0])+strlen(r->fields[1])+strlen(r->fields[2])+16+l, q, r->fields[0], r->fields[1], r->fields[2], o);
 				if (o!=r->fields[3]) { // there was a copy
 					free(o);
 				}
@@ -7380,7 +7391,7 @@ void ProxySQL_Admin::save_pgsql_servers_runtime_to_database(bool _runtime) {
 			char* query = (char*)malloc(strlen(q) + strlen(r->fields[0]) + strlen(r->fields[1]) + strlen(r->fields[2]) + 16 + l);
 			if (r->fields[3]) {
 				char* o = escape_string_single_quotes(r->fields[3], false);
-				sprintf(query, q, r->fields[0], r->fields[1], r->fields[2], o);
+				snprintf(query, strlen(q) + strlen(r->fields[0]) + strlen(r->fields[1]) + strlen(r->fields[2]) + 16 + l, q, r->fields[0], r->fields[1], r->fields[2], o);
 				if (o != r->fields[3]) { // there was a copy
 					free(o);
 				}
@@ -8037,7 +8048,7 @@ void ProxySQL_Admin::save_mcp_query_rules_from_runtime(bool _runtime) {
 					int l = strlen(o) + 4;
 					arg_len += l;
 					buffs[i] = (char*)malloc(l);
-					sprintf(buffs[i], "'%s'", o);
+					snprintf(buffs[i], l, "'%s'", o);
 					if (o != r->fields[i]) { // there was a copy
 						free(o);
 					}
@@ -8045,13 +8056,13 @@ void ProxySQL_Admin::save_mcp_query_rules_from_runtime(bool _runtime) {
 					int l = 5;
 					arg_len += l;
 					buffs[i] = (char*)malloc(l);
-					sprintf(buffs[i], "NULL");
+					snprintf(buffs[i], l, "NULL");
 				}
 			}
 
 			char* query = (char*)malloc(strlen(a) + arg_len + 32);
 
-			sprintf(query, a,
+			snprintf(query, strlen(a) + arg_len + 32, a,
 				buffs[0],  // rule_id
 				buffs[1],  // active
 				buffs[2],  // username
@@ -8148,7 +8159,7 @@ char* ProxySQL_Admin::load_mysql_query_rules_to_runtime(SQLite3_result* SQLite3_
 				hash1 += hash2;
 				uint32_t d32[2];
 				memcpy(&d32, &hash1, sizeof(hash1));
-				sprintf(buf,"0x%0X%0X", d32[0], d32[1]);
+				snprintf(buf, sizeof(buf),"0x%0X%0X", d32[0], d32[1]);
 
 				buff = buf;
 			} else {
@@ -8350,7 +8361,7 @@ char* ProxySQL_Admin::load_pgsql_query_rules_to_runtime(SQLite3_result* SQLite3_
 					hash1 += hash2;
 					uint32_t d32[2];
 					memcpy(&d32, &hash1, sizeof(hash1));
-					sprintf(buf, "0x%0X%0X", d32[0], d32[1]);
+					snprintf(buf, sizeof(buf), "0x%0X%0X", d32[0], d32[1]);
 
 					buff = buf;
 				}
@@ -8546,7 +8557,7 @@ void ProxySQL_Admin::load_proxysql_servers_to_runtime(bool _lock, const std::str
 			uint32_t d32[2];
 			char buf[20];
 			memcpy(&d32, &hash1, sizeof(hash1));
-			sprintf(buf,"0x%0X%0X", d32[0], d32[1]);
+			snprintf(buf, sizeof(buf),"0x%0X%0X", d32[0], d32[1]);
 			GloVars.checksums_values.proxysql_servers.set_checksum(buf);
 			GloVars.checksums_values.proxysql_servers.version++;
 			time_t t = time(NULL);

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -6293,9 +6293,10 @@ void ProxySQL_Admin::dump_checksums_values_table() {
 		GloVars.checksums_values.dumped_at = GloVars.checksums_values.updates_cnt;
 	}
 	char *q = (char *)"REPLACE INTO runtime_checksums_values VALUES (?1 , ?2 , ?3 , ?4)";
-	sqlite3_stmt *statement1 = NULL;
-	rc = admindb->prepare_v2(q,&statement1);
-	ASSERT_SQLITE_OK(rc, admindb);
+	auto [rc1, statement1_unique] = admindb->prepare_v2(q);
+	ASSERT_SQLITE_OK(rc1, admindb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	int rc;
 	admindb->execute((char *)"BEGIN");
 	admindb->execute((char *)"DELETE FROM runtime_checksums_values");
 
@@ -6402,7 +6403,6 @@ void ProxySQL_Admin::dump_checksums_values_table() {
 
 	admindb->execute((char *)"COMMIT");
 	pthread_mutex_unlock(&GloVars.checksum_mutex);
-	(*proxy_sqlite3_finalize)(statement1);
 }
 
 void ProxySQL_Admin::save_mysql_users_runtime_to_database(bool _runtime) {
@@ -6431,9 +6431,6 @@ void ProxySQL_Admin::save_mysql_users_runtime_to_database(bool _runtime) {
 	char *q_stmt1_f=NULL;
 	char *q_stmt1_b=NULL;
 
-	sqlite3_stmt *f_statement1=NULL;
-	sqlite3_stmt *b_statement1=NULL;
-
 	if (_runtime) {
 		q_stmt1_f=qfr_stmt1;
 		q_stmt1_b=qbr_stmt1;
@@ -6442,10 +6439,13 @@ void ProxySQL_Admin::save_mysql_users_runtime_to_database(bool _runtime) {
 		q_stmt1_b=qb_stmt1;
 	}
 
-	rc = admindb->prepare_v2(q_stmt1_f, &f_statement1);
-	ASSERT_SQLITE_OK(rc, admindb);
-	rc = admindb->prepare_v2(q_stmt1_b, &b_statement1);
-	ASSERT_SQLITE_OK(rc, admindb);
+	auto [rc1, f_statement1_unique] = admindb->prepare_v2(q_stmt1_f);
+	ASSERT_SQLITE_OK(rc1, admindb);
+	auto [rc2, b_statement1_unique] = admindb->prepare_v2(q_stmt1_b);
+	ASSERT_SQLITE_OK(rc2, admindb);
+	sqlite3_stmt *f_statement1 = f_statement1_unique.get();
+	sqlite3_stmt *b_statement1 = b_statement1_unique.get();
+	int rc;
 
 	for (i=0; i<num_users; i++) {
 		account_details_t *ad=ads[i];
@@ -6479,9 +6479,6 @@ void ProxySQL_Admin::save_mysql_users_runtime_to_database(bool _runtime) {
 		free(ad->attributes);
 		free(ad);
 	}
-
-	(*proxy_sqlite3_finalize)(f_statement1);
-	(*proxy_sqlite3_finalize)(b_statement1);
 
 	free(ads);
 }

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -6296,7 +6296,6 @@ void ProxySQL_Admin::dump_checksums_values_table() {
 	auto [rc1, statement1_unique] = admindb->prepare_v2(q);
 	ASSERT_SQLITE_OK(rc1, admindb);
 	sqlite3_stmt *statement1 = statement1_unique.get();
-	int rc;
 	admindb->execute((char *)"BEGIN");
 	admindb->execute((char *)"DELETE FROM runtime_checksums_values");
 
@@ -6445,7 +6444,6 @@ void ProxySQL_Admin::save_mysql_users_runtime_to_database(bool _runtime) {
 	ASSERT_SQLITE_OK(rc2, admindb);
 	sqlite3_stmt *f_statement1 = f_statement1_unique.get();
 	sqlite3_stmt *b_statement1 = b_statement1_unique.get();
-	int rc;
 
 	for (i=0; i<num_users; i++) {
 		account_details_t *ad=ads[i];
@@ -6526,7 +6524,7 @@ void ProxySQL_Admin::save_pgsql_users_runtime_to_database(bool _runtime) {
 	ASSERT_SQLITE_OK(rc2, admindb);
 	sqlite3_stmt* f_statement1 = f_statement1_unique.get();
 	sqlite3_stmt* b_statement1 = b_statement1_unique.get();
-	int rc;
+
 	for (i = 0; i < num_users; i++) {
 		//fprintf(stderr,"%s %d\n", ads[i]->username, ads[i]->default_hostgroup);
 		pgsql_account_details_t* ad = ads[i];

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -1871,8 +1871,7 @@ int ProxySQL_Admin::stats___mysql_query_digests(bool reset, bool copy) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 /*
 		char *query=(char *)malloc(strlen(a)+arg_len+32);
 		sprintf(query,a,r->fields[10],r->fields[0],r->fields[1],r->fields[2],r->fields[3],r->fields[4],r->fields[5],r->fields[6],r->fields[7],r->fields[8],r->fields[9]);

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -933,6 +933,7 @@ CREATE TABLE stats_mysql_processlist (
 	}
 	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
+	delete resultset;
 }
 
 void ProxySQL_Admin::stats___pgsql_processlist() {
@@ -1074,6 +1075,7 @@ void ProxySQL_Admin::stats___pgsql_processlist() {
 	}
 	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
+	delete resultset;
 }
 
 void ProxySQL_Admin::stats___mysql_connection_pool(bool _reset) {

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -227,9 +227,9 @@ void ProxySQL_Admin::stats___memory_metrics() {
 	}
 	(*proxy_sqlite3_status64)(SQLITE_STATUS_MEMORY_USED, &current, &highwater, 0);
 	vn=(char *)"SQLite3_memory_bytes";
-	sprintf(bu,"%lld",current);
+	snprintf(bu, sizeof(bu),"%lld",current);
 	query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-	sprintf(query,a,vn,bu);
+	snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 	statsdb->execute(query);
 	free(query);
 #ifndef NOJEM
@@ -249,39 +249,39 @@ void ProxySQL_Admin::stats___memory_metrics() {
 //		size_t rss_bytes = resident - allocated;
 //		float metadata_pct = ((float)metadata / resident)*100;
 		vn=(char *)"jemalloc_resident";
-		sprintf(bu,"%lu",resident);
+		snprintf(bu, sizeof(bu),"%lu",resident);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn=(char *)"jemalloc_active";
-		sprintf(bu,"%lu",active);
+		snprintf(bu, sizeof(bu),"%lu",active);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn=(char *)"jemalloc_allocated";
-		sprintf(bu,"%lu",allocated);
+		snprintf(bu, sizeof(bu),"%lu",allocated);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn=(char *)"jemalloc_mapped";
-		sprintf(bu,"%lu",mapped);
+		snprintf(bu, sizeof(bu),"%lu",mapped);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn=(char *)"jemalloc_metadata";
-		sprintf(bu,"%lu",metadata);
+		snprintf(bu, sizeof(bu),"%lu",metadata);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn=(char *)"jemalloc_retained";
-		sprintf(bu,"%lu",retained);
+		snprintf(bu, sizeof(bu),"%lu",retained);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -290,9 +290,9 @@ void ProxySQL_Admin::stats___memory_metrics() {
 		if (GloMyAuth) {
 			unsigned long mu = GloMyAuth->memory_usage();
 			vn=(char *)"Auth_memory";
-			sprintf(bu,"%lu",mu);
+			snprintf(bu, sizeof(bu),"%lu",mu);
 			query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query,a,vn,bu);
+			snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 		}
@@ -301,36 +301,36 @@ void ProxySQL_Admin::stats___memory_metrics() {
 		if (GloMyQPro) {
 			unsigned long long mu = GloMyQPro->get_query_digests_total_size();
 			vn=(char *)"mysql_query_digest_memory";
-			sprintf(bu,"%llu",mu);
+			snprintf(bu, sizeof(bu),"%llu",mu);
 			query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query,a,vn,bu);
+			snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 		}
 		if (GloMyQPro) {
 			unsigned long long mu = GloMyQPro->get_rules_mem_used();
 			vn=(char *)"mysql_query_rules_memory";
-			sprintf(bu,"%llu",mu);
+			snprintf(bu, sizeof(bu),"%llu",mu);
 			query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query,a,vn,bu);
+			snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 		}
 		if (GloPgQPro) {
 			unsigned long long mu = GloPgQPro->get_query_digests_total_size();
 			vn = (char*)"pgsql_query_digest_memory";
-			sprintf(bu, "%llu", mu);
+			snprintf(bu, sizeof(bu), "%llu", mu);
 			query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-			sprintf(query, a, vn, bu);
+			snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 		}
 		if (GloPgQPro) {
 			unsigned long long mu = GloPgQPro->get_rules_mem_used();
 			vn = (char*)"pgsql_query_rules_memory";
-			sprintf(bu, "%llu", mu);
+			snprintf(bu, sizeof(bu), "%llu", mu);
 			query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-			sprintf(query, a, vn, bu);
+			snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 		}
@@ -339,15 +339,15 @@ void ProxySQL_Admin::stats___memory_metrics() {
 			uint64_t prep_stmt_backend_mem_usage;
 			GloMyStmt->get_memory_usage(prep_stmt_metadata_mem_usage, prep_stmt_backend_mem_usage);
 			vn = (char*)"prepare_statement_metadata_memory";
-			sprintf(bu, "%lu", prep_stmt_metadata_mem_usage);
+			snprintf(bu, sizeof(bu), "%lu", prep_stmt_metadata_mem_usage);
 			query=(char*)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query, a, vn, bu);
+			snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 			vn = (char*)"prepare_statement_backend_memory";
-			sprintf(bu, "%lu", prep_stmt_backend_mem_usage);
+			snprintf(bu, sizeof(bu), "%lu", prep_stmt_backend_mem_usage);
 			query=(char*)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query, a, vn, bu);
+			snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 		}
@@ -355,30 +355,30 @@ void ProxySQL_Admin::stats___memory_metrics() {
 			unsigned long long mu = 0;
 			mu = GloMyQPro->get_firewall_memory_users_table();
 			vn=(char *)"mysql_firewall_users_table";
-			sprintf(bu,"%llu",mu);
+			snprintf(bu, sizeof(bu),"%llu",mu);
 			query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query,a,vn,bu);
+			snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 			mu = GloMyQPro->get_firewall_memory_users_config();
 			vn=(char *)"mysql_firewall_users_config";
-			sprintf(bu,"%llu",mu);
+			snprintf(bu, sizeof(bu),"%llu",mu);
 			query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query,a,vn,bu);
+			snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 			mu = GloMyQPro->get_firewall_memory_rules_table();
 			vn=(char *)"mysql_firewall_rules_table";
-			sprintf(bu,"%llu",mu);
+			snprintf(bu, sizeof(bu),"%llu",mu);
 			query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query,a,vn,bu);
+			snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 			mu = GloMyQPro->get_firewall_memory_rules_config();
 			vn=(char *)"mysql_firewall_rules_config";
-			sprintf(bu,"%llu",mu);
+			snprintf(bu, sizeof(bu),"%llu",mu);
 			query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-			sprintf(query,a,vn,bu);
+			snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 			statsdb->execute(query);
 			free(query);
 		}
@@ -387,23 +387,23 @@ void ProxySQL_Admin::stats___memory_metrics() {
 		unsigned long mu;
 		mu =  __sync_fetch_and_add(&GloVars.statuses.stack_memory_mysql_threads,0);
 		vn=(char *)"stack_memory_mysql_threads";
-		sprintf(bu,"%lu",mu);
+		snprintf(bu, sizeof(bu),"%lu",mu);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		mu =  __sync_fetch_and_add(&GloVars.statuses.stack_memory_admin_threads,0);
 		vn=(char *)"stack_memory_admin_threads";
-		sprintf(bu,"%lu",mu);
+		snprintf(bu, sizeof(bu),"%lu",mu);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		mu =  __sync_fetch_and_add(&GloVars.statuses.stack_memory_cluster_threads,0);
 		vn=(char *)"stack_memory_cluster_threads";
-		sprintf(bu,"%lu",mu);
+		snprintf(bu, sizeof(bu),"%lu",mu);
 		query=(char *)malloc(strlen(a)+strlen(vn)+strlen(bu)+16);
-		sprintf(query,a,vn,bu);
+		snprintf(query, strlen(a)+strlen(vn)+strlen(bu)+16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -494,17 +494,17 @@ const void sqlite3_global_stats_row_step(
 	char buf[32] = { 0 };
 
 	if constexpr (std::is_same_v<T, int32_t>)  {
-		sprintf(buf, "%d", val);
+		snprintf(buf, sizeof(buf), "%d", val);
 	} else if constexpr (std::is_same_v<T, uint64_t>) {
-		sprintf(buf, "%lu", (unsigned long)val);
+		snprintf(buf, sizeof(buf), "%lu", (unsigned long)val);
 	} else if constexpr (std::is_same_v<T, unsigned long>) {
-		sprintf(buf, "%lu", val);
+		snprintf(buf, sizeof(buf), "%lu", val);
 	} else if constexpr (std::is_same_v<T, unsigned long long>) {
-		sprintf(buf, "%llu", val);
+		snprintf(buf, sizeof(buf), "%llu", val);
 	} else if constexpr (std::is_same_v<T, long long>) {
-		sprintf(buf, "%lld", val);
+		snprintf(buf, sizeof(buf), "%lld", val);
 	} else if constexpr (std::is_same_v<T, bool>) {
-		sprintf(buf, "%s", val ? "true" : "false");
+		snprintf(buf, sizeof(buf), "%s", val ? "true" : "false");
 	} else {
 		static_assert(always_false<T>, "Non-exhaustive switch");
 	}
@@ -639,7 +639,7 @@ void ProxySQL_Admin::stats___pgsql_global() {
 			arg_len += strlen(r->fields[i]);
 		}
 		char* query = (char*)malloc(strlen(a) + arg_len + 32);
-		sprintf(query, a, r->fields[0], r->fields[1]);
+		snprintf(query, strlen(a) + arg_len + 32, a, r->fields[0], r->fields[1]);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -655,7 +655,7 @@ void ProxySQL_Admin::stats___pgsql_global() {
 				arg_len += strlen(r->fields[i]);
 			}
 			char* query = (char*)malloc(strlen(a) + arg_len + 32);
-			sprintf(query, a, r->fields[0], r->fields[1]);
+			snprintf(query, strlen(a) + arg_len + 32, a, r->fields[0], r->fields[1]);
 			statsdb->execute(query);
 			free(query);
 		}
@@ -670,17 +670,17 @@ void ProxySQL_Admin::stats___pgsql_global() {
 	char* vn = NULL;
 	char* query = NULL;
 	vn = (char*)"SQLite3_memory_bytes";
-	sprintf(bu, "%lld", current);
+	snprintf(bu, sizeof(bu), "%lld", current);
 	query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-	sprintf(query, a, vn, bu);
+	snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 	statsdb->execute(query);
 	free(query);
 
 	unsigned long long connpool_mem = PgHGM->Get_Memory_Stats();
 	vn = (char*)"ConnPool_memory_bytes";
-	sprintf(bu, "%llu", connpool_mem);
+	snprintf(bu, sizeof(bu), "%llu", connpool_mem);
 	query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-	sprintf(query, a, vn, bu);
+	snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 	statsdb->execute(query);
 	free(query);
 
@@ -693,39 +693,39 @@ void ProxySQL_Admin::stats___pgsql_global() {
 		uint64_t stmt_server_active_total = 0;
 		GloPgStmt->get_metrics(&stmt_client_active_unique, &stmt_client_active_total, &stmt_max_stmt_id, &stmt_cached, &stmt_server_active_unique, &stmt_server_active_total);
 		vn = (char*)"Stmt_Client_Active_Total";
-		sprintf(bu, "%lu", stmt_client_active_total);
+		snprintf(bu, sizeof(bu), "%lu", stmt_client_active_total);
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn = (char*)"Stmt_Client_Active_Unique";
-		sprintf(bu, "%lu", stmt_client_active_unique);
+		snprintf(bu, sizeof(bu), "%lu", stmt_client_active_unique);
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn = (char*)"Stmt_Server_Active_Total";
-		sprintf(bu, "%lu", stmt_server_active_total);
+		snprintf(bu, sizeof(bu), "%lu", stmt_server_active_total);
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn = (char*)"Stmt_Server_Active_Unique";
-		sprintf(bu, "%lu", stmt_server_active_unique);
+		snprintf(bu, sizeof(bu), "%lu", stmt_server_active_unique);
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn = (char*)"Stmt_Max_Stmt_id";
-		sprintf(bu, "%lu", stmt_max_stmt_id);
+		snprintf(bu, sizeof(bu), "%lu", stmt_max_stmt_id);
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 		vn = (char*)"Stmt_Cached";
-		sprintf(bu, "%lu", stmt_cached);
+		snprintf(bu, sizeof(bu), "%lu", stmt_cached);
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -738,7 +738,7 @@ void ProxySQL_Admin::stats___pgsql_global() {
 				arg_len += strlen(r->fields[i]);
 			}
 			char* query = (char*)malloc(strlen(a) + arg_len + 32);
-			sprintf(query, a, r->fields[0], r->fields[1]);
+			snprintf(query, strlen(a) + arg_len + 32, a, r->fields[0], r->fields[1]);
 			statsdb->execute(query);
 			free(query);
 		}
@@ -756,7 +756,7 @@ void ProxySQL_Admin::stats___pgsql_global() {
 					arg_len += strlen(r->fields[i]);
 				}
 				char* query = (char*)malloc(strlen(a) + arg_len + 32);
-				sprintf(query, a, r->fields[0], r->fields[1]);
+				snprintf(query, strlen(a) + arg_len + 32, a, r->fields[0], r->fields[1]);
 				statsdb->execute(query);
 				free(query);
 			}
@@ -768,17 +768,17 @@ void ProxySQL_Admin::stats___pgsql_global() {
 	if (GloPgQPro) {
 		unsigned long long mu = GloPgQPro->get_new_req_conns_count();
 		vn = (char*)"new_req_conns_count";
-		sprintf(bu, "%llu", mu);
+		snprintf(bu, sizeof(bu), "%llu", mu);
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 	}
 	{
 		vn = (char*)"pgsql_listener_paused";
-		sprintf(bu, "%s", (admin_proxysql_pgsql_paused == true ? "true" : "false"));
+		snprintf(bu, sizeof(bu), "%s", (admin_proxysql_pgsql_paused == true ? "true" : "false"));
 		query = (char*)malloc(strlen(a) + strlen(vn) + strlen(bu) + 16);
-		sprintf(query, a, vn, bu);
+		snprintf(query, strlen(a) + strlen(vn) + strlen(bu) + 16, a, vn, bu);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -1091,7 +1091,7 @@ void ProxySQL_Admin::stats___mysql_connection_pool(bool _reset) {
 			arg_len+=strlen(r->fields[i]);
 		}
 		char *query=(char *)malloc(strlen(a)+arg_len+32);
-		sprintf(query,a,r->fields[0],r->fields[1],r->fields[2],r->fields[3],r->fields[4],r->fields[5],r->fields[6],r->fields[7],r->fields[8],r->fields[9],r->fields[10],r->fields[11],r->fields[12],r->fields[13]);
+		snprintf(query, strlen(a)+arg_len+32, a,r->fields[0],r->fields[1],r->fields[2],r->fields[3],r->fields[4],r->fields[5],r->fields[6],r->fields[7],r->fields[8],r->fields[9],r->fields[10],r->fields[11],r->fields[12],r->fields[13]);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -1117,7 +1117,7 @@ void ProxySQL_Admin::stats___pgsql_connection_pool(bool _reset) {
 			arg_len += strlen(r->fields[i]);
 		}
 		char* query = (char*)malloc(strlen(a) + arg_len + 32);
-		sprintf(query, a, r->fields[0], r->fields[1], r->fields[2], r->fields[3], r->fields[4], r->fields[5], r->fields[6], r->fields[7], r->fields[8], r->fields[9], r->fields[10], r->fields[11], r->fields[12]);
+		snprintf(query, strlen(a) + arg_len + 32, a, r->fields[0], r->fields[1], r->fields[2], r->fields[3], r->fields[4], r->fields[5], r->fields[6], r->fields[7], r->fields[8], r->fields[9], r->fields[10], r->fields[11], r->fields[12]);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -1340,7 +1340,7 @@ void ProxySQL_Admin::stats___mysql_commands_counters() {
 			arg_len+=strlen(r->fields[i]);
 		}
 		char *query=(char *)malloc(strlen(a)+arg_len+32);
-		sprintf(query,a,r->fields[0],r->fields[1],r->fields[2],r->fields[3],r->fields[4],r->fields[5],r->fields[6],r->fields[7],r->fields[8],r->fields[9],r->fields[10],r->fields[11],r->fields[12],r->fields[13],r->fields[14]);
+		snprintf(query, strlen(a)+arg_len+32, a,r->fields[0],r->fields[1],r->fields[2],r->fields[3],r->fields[4],r->fields[5],r->fields[6],r->fields[7],r->fields[8],r->fields[9],r->fields[10],r->fields[11],r->fields[12],r->fields[13],r->fields[14]);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -1362,7 +1362,7 @@ void ProxySQL_Admin::stats___pgsql_commands_counters() {
 			arg_len += strlen(r->fields[i]);
 		}
 		char* query = (char*)malloc(strlen(a) + arg_len + 32);
-		sprintf(query, a, r->fields[0], r->fields[1], r->fields[2], r->fields[3], r->fields[4], r->fields[5], r->fields[6], r->fields[7], r->fields[8], r->fields[9], r->fields[10], r->fields[11], r->fields[12], r->fields[13], r->fields[14]);
+		snprintf(query, strlen(a) + arg_len + 32, a, r->fields[0], r->fields[1], r->fields[2], r->fields[3], r->fields[4], r->fields[5], r->fields[6], r->fields[7], r->fields[8], r->fields[9], r->fields[10], r->fields[11], r->fields[12], r->fields[13], r->fields[14]);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -1384,7 +1384,7 @@ void ProxySQL_Admin::stats___mysql_query_rules() {
 			arg_len+=strlen(r->fields[i]);
 		}
 		char *query=(char *)malloc(strlen(a)+arg_len+32);
-		sprintf(query,a,r->fields[0],r->fields[1]);
+		snprintf(query, strlen(a)+arg_len+32, a,r->fields[0],r->fields[1]);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -1406,7 +1406,7 @@ void ProxySQL_Admin::stats___pgsql_query_rules() {
 			arg_len += strlen(r->fields[i]);
 		}
 		char* query = (char*)malloc(strlen(a) + arg_len + 32);
-		sprintf(query, a, r->fields[0], r->fields[1]);
+		snprintf(query, strlen(a) + arg_len + 32, a, r->fields[0], r->fields[1]);
 		statsdb->execute(query);
 		free(query);
 	}
@@ -1712,7 +1712,7 @@ int ProxySQL_Admin::stats___save_mysql_query_digest_to_sqlite(
 		SQLite3_row *row  = resultset ? resultset->rows[i] : NULL;
 		char digest_hex_str[20]; // 2+sizeof(unsigned long long)*2+2
 		if (!resultset) {
-			sprintf(digest_hex_str, "0x%016llX", (long long unsigned int)qds->digest);
+			snprintf(digest_hex_str, sizeof(digest_hex_str), "0x%016llX", (long long unsigned int)qds->digest);
 		}
 		int idx=row_idx%32;
 		if (row_idx<max_bulk_row_idx) { // bulk
@@ -1876,7 +1876,7 @@ int ProxySQL_Admin::stats___mysql_query_digests(bool reset, bool copy) {
 	// RAII auto-finalizes statement1 and statement32
 /*
 		char *query=(char *)malloc(strlen(a)+arg_len+32);
-		sprintf(query,a,r->fields[10],r->fields[0],r->fields[1],r->fields[2],r->fields[3],r->fields[4],r->fields[5],r->fields[6],r->fields[7],r->fields[8],r->fields[9]);
+		snprintf(query, strlen(a)+arg_len+32, a,r->fields[10],r->fields[0],r->fields[1],r->fields[2],r->fields[3],r->fields[4],r->fields[5],r->fields[6],r->fields[7],r->fields[8],r->fields[9]);
 		statsdb->execute(query);
 		free(query);
 	}

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -793,8 +793,6 @@ void ProxySQL_Admin::stats___mysql_processlist() {
 	SQLite3_result * resultset=GloMTH->SQL3_Processlist(variables.mysql_processlist);
 	if (resultset==NULL) return;
 
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 	//sqlite3 *mydb3=statsdb->get_db();
 	char *query1=NULL;
 	char *query32=NULL;
@@ -804,12 +802,12 @@ void ProxySQL_Admin::stats___mysql_processlist() {
 	query32s = "INSERT OR IGNORE INTO stats_mysql_processlist VALUES " + generate_multi_rows_query(32,16);
 	query32 = (char *)query32s.c_str();
 
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 
 /* for reference
 CREATE TABLE stats_mysql_processlist (
@@ -933,8 +931,7 @@ CREATE TABLE stats_mysql_processlist (
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
 	delete resultset;
 }
@@ -958,11 +955,13 @@ void ProxySQL_Admin::stats___pgsql_processlist() {
 	query32 = (char*)query32s.c_str();
 
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	statsdb->execute("BEGIN");
 	statsdb->execute("DELETE FROM stats_pgsql_processlist");
@@ -1078,8 +1077,7 @@ void ProxySQL_Admin::stats___pgsql_processlist() {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
 	delete resultset;
 }
@@ -1143,8 +1141,6 @@ void ProxySQL_Admin::stats___mysql_free_connections() {
 	SQLite3_result * resultset=MyHGM->SQL3_Free_Connections();
 	if (resultset==NULL) return;
 
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 	//sqlite3 *mydb3=statsdb->get_db();
 	char *query1=NULL;
 	char *query32=NULL;
@@ -1155,11 +1151,13 @@ void ProxySQL_Admin::stats___mysql_free_connections() {
 	query32 = (char *)query32s.c_str();
 
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	statsdb->execute("BEGIN");
 	statsdb->execute("DELETE FROM stats_mysql_free_connections");
@@ -1257,11 +1255,13 @@ void ProxySQL_Admin::stats___pgsql_free_connections() {
 	query32 = (char*)query32s.c_str();
 
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	statsdb->execute("BEGIN");
 	statsdb->execute("DELETE FROM stats_pgsql_free_connections");
@@ -1804,8 +1804,6 @@ int ProxySQL_Admin::stats___mysql_query_digests(bool reset, bool copy) {
 	if (resultset==NULL) return 0;
 	statsdb->execute("BEGIN");
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 	//sqlite3 *mydb3=statsdb->get_db();
 	char *query1=NULL;
 	char *query32=NULL;
@@ -1828,11 +1826,13 @@ int ProxySQL_Admin::stats___mysql_query_digests(bool reset, bool copy) {
 	}
 
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx=0;
 	int max_bulk_row_idx=resultset->rows_count/32;
 	max_bulk_row_idx=max_bulk_row_idx*32;
@@ -2039,8 +2039,6 @@ void ProxySQL_Admin::stats___mysql_errors(bool reset) {
 	if (resultset==NULL) return;
 	statsdb->execute("BEGIN");
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 	//sqlite3 *mydb3=statsdb->get_db();
 	char *query1=NULL;
 	char *query32=NULL;
@@ -2061,11 +2059,13 @@ void ProxySQL_Admin::stats___mysql_errors(bool reset) {
 	}
 
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx=0;
 	int max_bulk_row_idx=resultset->rows_count/32;
 	max_bulk_row_idx=max_bulk_row_idx*32;
@@ -2107,8 +2107,7 @@ void ProxySQL_Admin::stats___mysql_errors(bool reset) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
 	delete resultset;
 }
@@ -2350,8 +2349,6 @@ void ProxySQL_Admin::stats___mysql_prepared_statements_info() {
 	if (resultset==NULL) return;
 	statsdb->execute("BEGIN");
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement32=NULL;
 	//sqlite3 *mydb3=statsdb->get_db();
 	char *query1=NULL;
 	char *query32=NULL;
@@ -2362,11 +2359,13 @@ void ProxySQL_Admin::stats___mysql_prepared_statements_info() {
 	query32 = (char *)query32s.c_str();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx=0;
 	int max_bulk_row_idx=resultset->rows_count/32;
 	max_bulk_row_idx=max_bulk_row_idx*32;
@@ -2404,8 +2403,7 @@ void ProxySQL_Admin::stats___mysql_prepared_statements_info() {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
 	delete resultset;
 }
@@ -2429,11 +2427,13 @@ void ProxySQL_Admin::stats___pgsql_prepared_statements_info() {
 	query32 = (char*)query32s.c_str();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx = 0;
 	int max_bulk_row_idx = resultset->rows_count / 32;
 	max_bulk_row_idx = max_bulk_row_idx * 32;
@@ -2469,8 +2469,7 @@ void ProxySQL_Admin::stats___pgsql_prepared_statements_info() {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
 	delete resultset;
 }

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -933,7 +933,6 @@ CREATE TABLE stats_mysql_processlist (
 	}
 	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
-	delete resultset;
 }
 
 void ProxySQL_Admin::stats___pgsql_processlist() {
@@ -1075,7 +1074,6 @@ void ProxySQL_Admin::stats___pgsql_processlist() {
 	}
 	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
-	delete resultset;
 }
 
 void ProxySQL_Admin::stats___mysql_connection_pool(bool _reset) {
@@ -1441,8 +1439,9 @@ void ProxySQL_Admin::stats___proxysql_servers_checksums() {
 		//sqlite3 *mydb3=statsdb->get_db();
 		char *query1=NULL;
 		query1=(char *)"INSERT INTO stats_proxysql_servers_checksums VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = statsdb->prepare_v2(query1, &statement1);
+		auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+		rc = rc1;
+		statement1 = statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, statsdb);
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 			SQLite3_row *r1=*it;
@@ -1459,7 +1458,6 @@ void ProxySQL_Admin::stats___proxysql_servers_checksums() {
 			rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, statsdb);
 			rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, statsdb);
 		}
-		(*proxy_sqlite3_finalize)(statement1);
 	}
 	statsdb->execute("COMMIT");
 	delete resultset;
@@ -1478,8 +1476,9 @@ void ProxySQL_Admin::stats___proxysql_servers_metrics() {
 		//sqlite3 *mydb3=statsdb->get_db();
 		char *query1=NULL;
 		query1=(char *)"INSERT INTO stats_proxysql_servers_metrics VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = statsdb->prepare_v2(query1, &statement1);
+		auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+		rc = rc1;
+		statement1 = statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, statsdb);
 		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 			SQLite3_row *r1=*it;
@@ -1497,7 +1496,6 @@ void ProxySQL_Admin::stats___proxysql_servers_metrics() {
 			rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, statsdb);
 			rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, statsdb);
 		}
-		(*proxy_sqlite3_finalize)(statement1);
 	}
 	statsdb->execute("COMMIT");
 	delete resultset;
@@ -1532,9 +1530,13 @@ void ProxySQL_Admin::stats___proxysql_message_metrics(bool reset) {
 	sqlite3_stmt* statement32 = nullptr;
 	int rc = 0;
 
-	rc = statsdb->prepare_v2(query1, &statement1);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	rc = rc1;
+	statement1 = statement1_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
-	rc = statsdb->prepare_v2(query32, &statement32);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	rc = rc2;
+	statement32 = statement32_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
 
 	int row_idx = 0;
@@ -1573,9 +1575,6 @@ void ProxySQL_Admin::stats___proxysql_message_metrics(bool reset) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
-
 	statsdb->execute("COMMIT");
 	delete resultset;
 }
@@ -1593,7 +1592,9 @@ void ProxySQL_Admin::stats___mcp_query_tools_counters(bool reset) {
 		: "INSERT INTO stats_mcp_query_tools_counters VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)";
 
 	sqlite3_stmt* statement = NULL;
-	int rc = statsdb->prepare_v2(query_str, &statement);
+	auto [rc1, statement_unique] = statsdb->prepare_v2(query_str);
+	int rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
 
 	if (reset) {
@@ -1658,7 +1659,6 @@ void ProxySQL_Admin::stats___mcp_query_tools_counters(bool reset) {
 		}
 	}
 
-	(*proxy_sqlite3_finalize)(statement);
 	statsdb->execute("COMMIT");
 }
 #endif /* PROXYSQLGENAI */
@@ -1686,9 +1686,13 @@ int ProxySQL_Admin::stats___save_mysql_query_digest_to_sqlite(
 		query32 = (char *)query32s.c_str();
 	}
 
-	rc = statsdb->prepare_v2(query1, &statement1);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	rc = rc1;
+	statement1 = statement1_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
-	rc = statsdb->prepare_v2(query32, &statement32);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	rc = rc2;
+	statement32 = statement32_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
 	int row_idx=0;
 	int num_rows = resultset ? resultset->rows_count : digest_umap->size();
@@ -1772,8 +1776,6 @@ int ProxySQL_Admin::stats___save_mysql_query_digest_to_sqlite(
 		else
 			it++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
 	if (reset) {
 		if (copy) {
 			statsdb->execute("INSERT INTO stats_mysql_query_digest SELECT * FROM stats_mysql_query_digest_reset");
@@ -1947,7 +1949,9 @@ void ProxySQL_Admin::stats___mysql_client_host_cache(bool reset) {
 	statsdb->execute("DELETE FROM stats_mysql_client_host_cache_reset");
 	statsdb->execute("DELETE FROM stats_mysql_client_host_cache");
 
-	rc = statsdb->prepare_v2(query, &statement);
+	auto [rc1, statement_unique] = statsdb->prepare_v2(query);
+	rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
 
 	for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
@@ -1961,8 +1965,6 @@ void ProxySQL_Admin::stats___mysql_client_host_cache(bool reset) {
 		rc=(*proxy_sqlite3_clear_bindings)(statement);
 		rc=(*proxy_sqlite3_reset)(statement);
 	}
-
-	(*proxy_sqlite3_finalize)(statement);
 
 	if (reset) {
 		statsdb->execute("INSERT INTO stats_mysql_client_host_cache SELECT * FROM stats_mysql_client_host_cache_reset");
@@ -1993,7 +1995,9 @@ void ProxySQL_Admin::stats___pgsql_client_host_cache(bool reset) {
 	statsdb->execute("DELETE FROM stats_pgsql_client_host_cache_reset");
 	statsdb->execute("DELETE FROM stats_pgsql_client_host_cache");
 
-	rc = statsdb->prepare_v2(query, &statement);
+	auto [rc1, statement_unique] = statsdb->prepare_v2(query);
+	rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
 
 	for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
@@ -2007,8 +2011,6 @@ void ProxySQL_Admin::stats___pgsql_client_host_cache(bool reset) {
 		rc = (*proxy_sqlite3_clear_bindings)(statement);
 		rc = (*proxy_sqlite3_reset)(statement);
 	}
-
-	(*proxy_sqlite3_finalize)(statement);
 
 	if (reset) {
 		statsdb->execute("INSERT INTO stats_pgsql_client_host_cache SELECT * FROM stats_pgsql_client_host_cache_reset");
@@ -2291,11 +2293,13 @@ void ProxySQL_Admin::stats___mysql_gtid_executed() {
 		query32s = "INSERT INTO stats_mysql_gtid_executed VALUES " + generate_multi_rows_query(32,4);
 		query32 = (char *)query32s.c_str();
 
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
-		rc = statsdb->prepare_v2(query1, &statement1);
+		auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+		rc = rc1;
+		statement1 = statement1_unique.get();
 		ASSERT_SQLITE_OK(rc, statsdb);
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
-		rc = statsdb->prepare_v2(query32, &statement32);
+		auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+		rc = rc2;
+		statement32 = statement32_unique.get();
 		ASSERT_SQLITE_OK(rc, statsdb);
 		int row_idx=0;
 		int max_bulk_row_idx=resultset->rows_count/32;
@@ -2324,8 +2328,6 @@ void ProxySQL_Admin::stats___mysql_gtid_executed() {
 			}
 			row_idx++;
 		}
-		(*proxy_sqlite3_finalize)(statement1);
-		(*proxy_sqlite3_finalize)(statement32);
 		delete resultset;
 		resultset = NULL;
 	}
@@ -2772,7 +2774,9 @@ void ProxySQL_Admin::stats___mcp_query_rules() {
 	// Use prepared statement to prevent SQL injection
 	const char* query_str = "INSERT INTO stats_mcp_query_rules VALUES (?1, ?2)";
 	sqlite3_stmt* statement = nullptr;
-	int rc = statsdb->prepare_v2(query_str, &statement);
+	auto [rc1, statement_unique] = statsdb->prepare_v2(query_str);
+	int rc = rc1;
+	statement = statement_unique.get();
 	ASSERT_SQLITE_OK(rc, statsdb);
 
 	for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
@@ -2787,7 +2791,6 @@ void ProxySQL_Admin::stats___mcp_query_rules() {
 		rc = (*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, statsdb);
 	}
 
-	(*proxy_sqlite3_finalize)(statement);
 	statsdb->execute("COMMIT");
 	delete resultset;
 }

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -2174,8 +2174,7 @@ void ProxySQL_Admin::stats___pgsql_errors(bool reset) {
 		}
 		row_idx++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
 }
 
@@ -2575,8 +2574,7 @@ int ProxySQL_Admin::stats___save_pgsql_query_digest_to_sqlite(
 		else
 			it++;
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	if (reset) {
 		if (copy) {
 			statsdb->execute("INSERT INTO stats_pgsql_query_digest SELECT * FROM stats_pgsql_query_digest_reset");

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -943,9 +943,6 @@ void ProxySQL_Admin::stats___pgsql_processlist() {
 	SQLite3_result* resultset = GloPTH->SQL3_Processlist(variables.pgsql_processlist);
 	if (resultset == NULL) return;
 
-	sqlite3_stmt* statement1 = NULL;
-	sqlite3_stmt* statement32 = NULL;
-
 	char* query1 = NULL;
 	char* query32 = NULL;
 	std::string query32s = "";
@@ -957,10 +954,9 @@ void ProxySQL_Admin::stats___pgsql_processlist() {
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
 	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
 	ASSERT_SQLITE_OK(rc1, statsdb);
-	sqlite3_stmt *statement1 = statement1_unique.get();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
 	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
 	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	statsdb->execute("BEGIN");
@@ -1232,8 +1228,7 @@ void ProxySQL_Admin::stats___mysql_free_connections() {
 		row_idx++;
 	}
 	statsdb->execute("COMMIT");
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	delete resultset;
 }
 
@@ -1243,8 +1238,6 @@ void ProxySQL_Admin::stats___pgsql_free_connections() {
 	SQLite3_result* resultset = PgHGM->SQL3_Free_Connections();
 	if (resultset == NULL) return;
 
-	sqlite3_stmt* statement1 = NULL;
-	sqlite3_stmt* statement32 = NULL;
 	//sqlite3 *mydb3=statsdb->get_db();
 	char* query1 = NULL;
 	char* query32 = NULL;
@@ -1257,10 +1250,9 @@ void ProxySQL_Admin::stats___pgsql_free_connections() {
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
 	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
 	ASSERT_SQLITE_OK(rc1, statsdb);
-	sqlite3_stmt *statement1 = statement1_unique.get();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
 	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
 	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	sqlite3_stmt *statement32 = statement32_unique.get();
 
 	statsdb->execute("BEGIN");
@@ -1331,8 +1323,7 @@ void ProxySQL_Admin::stats___pgsql_free_connections() {
 		row_idx++;
 	}
 	statsdb->execute("COMMIT");
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement32);
+	// RAII auto-finalizes statement1 and statement32
 	delete resultset;
 }
 
@@ -2118,8 +2109,6 @@ void ProxySQL_Admin::stats___pgsql_errors(bool reset) {
 	if (!resultset) return;
 	statsdb->execute("BEGIN");
 	int rc;
-	sqlite3_stmt* statement1 = NULL;
-	sqlite3_stmt* statement32 = NULL;
 	char* query1 = NULL;
 	char* query32 = NULL;
 	std::string query32s = "";
@@ -2139,10 +2128,12 @@ void ProxySQL_Admin::stats___pgsql_errors(bool reset) {
 		query32 = (char*)query32s.c_str();
 	}
 
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx = 0;
 	int max_bulk_row_idx = resultset->rows_count / 32;
 	max_bulk_row_idx = max_bulk_row_idx * 32;
@@ -2415,8 +2406,6 @@ void ProxySQL_Admin::stats___pgsql_prepared_statements_info() {
 	if (resultset == NULL) return;
 	statsdb->execute("BEGIN");
 	int rc;
-	sqlite3_stmt* statement1 = NULL;
-	sqlite3_stmt* statement32 = NULL;
 	//sqlite3 *mydb3=statsdb->get_db();
 	char* query1 = NULL;
 	char* query32 = NULL;
@@ -2429,10 +2418,9 @@ void ProxySQL_Admin::stats___pgsql_prepared_statements_info() {
 	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query1, -1, &statement1, 0);
 	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
 	ASSERT_SQLITE_OK(rc1, statsdb);
-	sqlite3_stmt *statement1 = statement1_unique.get();
-	//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query32, -1, &statement32, 0);
 	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
 	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx = 0;
 	int max_bulk_row_idx = resultset->rows_count / 32;
@@ -2481,8 +2469,6 @@ int ProxySQL_Admin::stats___save_pgsql_query_digest_to_sqlite(
 ) {
 	statsdb->execute("BEGIN");
 	int rc;
-	sqlite3_stmt* statement1 = NULL;
-	sqlite3_stmt* statement32 = NULL;
 	char* query1 = NULL;
 	char* query32 = NULL;
 	std::string query32s = "";
@@ -2499,10 +2485,12 @@ int ProxySQL_Admin::stats___save_pgsql_query_digest_to_sqlite(
 		query32 = (char*)query32s.c_str();
 	}
 
-	rc = statsdb->prepare_v2(query1, &statement1);
-	ASSERT_SQLITE_OK(rc, statsdb);
-	rc = statsdb->prepare_v2(query32, &statement32);
-	ASSERT_SQLITE_OK(rc, statsdb);
+	auto [rc1, statement1_unique] = statsdb->prepare_v2(query1);
+	ASSERT_SQLITE_OK(rc1, statsdb);
+	auto [rc2, statement32_unique] = statsdb->prepare_v2(query32);
+	ASSERT_SQLITE_OK(rc2, statsdb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement32 = statement32_unique.get();
 	int row_idx = 0;
 	int num_rows = resultset ? resultset->rows_count : digest_umap->size();
 	int max_bulk_row_idx = num_rows / 32;

--- a/lib/ProxySQL_Admin_Tests2.cpp
+++ b/lib/ProxySQL_Admin_Tests2.cpp
@@ -320,9 +320,9 @@ bool ProxySQL_Admin::ProxySQL_Test___Verify_mysql_query_rules_fast_routing(
 unsigned int ProxySQL_Admin::ProxySQL_Test___GenerateRandom_mysql_query_rules_fast_routing(unsigned int cnt, bool empty) {
 	char *a = (char *)"INSERT OR IGNORE INTO mysql_query_rules_fast_routing VALUES (?1, ?2, ?3, ?4, '')";
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	rc=admindb->prepare_v2(a, &statement1);
-	ASSERT_SQLITE_OK(rc, admindb);
+	auto [rc1, statement1_unique] = admindb->prepare_v2(a);
+	ASSERT_SQLITE_OK(rc1, admindb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
 	admindb->execute("DELETE FROM mysql_query_rules_fast_routing");
 	char * username_buf = (char *)malloc(128);
 	char * schemaname_buf = (char *)malloc(256);
@@ -363,7 +363,6 @@ unsigned int ProxySQL_Admin::ProxySQL_Test___GenerateRandom_mysql_query_rules_fa
 		rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, admindb);
 		rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, admindb);
 	}
-	(*proxy_sqlite3_finalize)(statement1);
 	free(username_buf);
 	free(schemaname_buf);
 	return cnt;
@@ -376,12 +375,12 @@ void ProxySQL_Admin::ProxySQL_Test___MySQL_HostGroups_Manager_generate_many_clus
 	char *q1 = (char *)"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (?1, ?2, ?3), (?4, ?5, ?6), (?7, ?8, ?9)";
 	char *q2 = (char *)"INSERT INTO mysql_replication_hostgroups (writer_hostgroup, reader_hostgroup) VALUES (?1, ?2)";
 	int rc;
-	sqlite3_stmt *statement1=NULL;
-	sqlite3_stmt *statement2=NULL;
-	rc=admindb->prepare_v2(q1, &statement1);
-	ASSERT_SQLITE_OK(rc, admindb);
-	rc=admindb->prepare_v2(q2, &statement2);
-	ASSERT_SQLITE_OK(rc, admindb);
+	auto [rc1, statement1_unique] = admindb->prepare_v2(q1);
+	ASSERT_SQLITE_OK(rc1, admindb);
+	auto [rc2, statement2_unique] = admindb->prepare_v2(q2);
+	ASSERT_SQLITE_OK(rc2, admindb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	sqlite3_stmt *statement2 = statement2_unique.get();
 	char hostnamebuf1[32];
 	char hostnamebuf2[32];
 	char hostnamebuf3[32];
@@ -407,8 +406,6 @@ void ProxySQL_Admin::ProxySQL_Test___MySQL_HostGroups_Manager_generate_many_clus
 		rc=(*proxy_sqlite3_clear_bindings)(statement2); ASSERT_SQLITE_OK(rc, admindb);
 		rc=(*proxy_sqlite3_reset)(statement2); ASSERT_SQLITE_OK(rc, admindb);
 	}
-	(*proxy_sqlite3_finalize)(statement1);
-	(*proxy_sqlite3_finalize)(statement2);
 	load_mysql_servers_to_runtime();
 	mysql_servers_wrunlock();
 }

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -1187,11 +1187,10 @@ void ProxySQL_Cluster::pull_mysql_query_rules_from_peer(const string& expected_c
 						GloAdmin->admindb->execute("DELETE FROM mysql_query_rules_fast_routing");
 						MYSQL_ROW row;
 						char *q = (char *)"INSERT INTO mysql_query_rules (rule_id, active, username, schemaname, flagIN, client_addr, proxy_addr, proxy_port, digest, match_digest, match_pattern, negate_match_pattern, re_modifiers, flagOUT, replace_pattern, destination_hostgroup, cache_ttl, cache_empty_result, cache_timeout, reconnect, timeout, retries, delay, next_query_flagIN, mirror_flagOUT, mirror_hostgroup, error_msg, ok_msg, sticky_conn, multiplex, gtid_from_hostgroup, log, apply, attributes, comment) VALUES (?1 , ?2 , ?3 , ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35)";
-						sqlite3_stmt *statement1 = NULL;
-						//sqlite3 *mydb3 = GloAdmin->admindb->get_db();
-						//rc=(*proxy_sqlite3_prepare_v2)(mydb3, q, -1, &statement1, 0);
-						int rc = GloAdmin->admindb->prepare_v2(q, &statement1);
-						ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+						auto [rc1, statement1_unique] = GloAdmin->admindb->prepare_v2(q);
+						ASSERT_SQLITE_OK(rc1, GloAdmin->admindb);
+						sqlite3_stmt *statement1 = statement1_unique.get();
+						int rc;
 						GloAdmin->admindb->execute("BEGIN TRANSACTION");
 						while ((row = mysql_fetch_row(result1))) {
 							rc=(*proxy_sqlite3_bind_int64)(statement1, 1, atoll(row[0])); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // rule_id
@@ -1233,21 +1232,19 @@ void ProxySQL_Cluster::pull_mysql_query_rules_from_peer(const string& expected_c
 							rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 							rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 						}
-						(*proxy_sqlite3_finalize)(statement1);
+						// RAII auto-finalizes statement1
 						GloAdmin->admindb->execute("COMMIT");
 
 
 						std::string query32frs = "INSERT INTO mysql_query_rules_fast_routing(username, schemaname, flagIN, destination_hostgroup, comment) VALUES " + generate_multi_rows_query(32,5);
 						char *q1fr = (char *)"INSERT INTO mysql_query_rules_fast_routing(username, schemaname, flagIN, destination_hostgroup, comment) VALUES (?1, ?2, ?3, ?4, ?5)";
 						char *q32fr = (char *)query32frs.c_str();
-						sqlite3_stmt *statement1fr = NULL;
-						sqlite3_stmt *statement32fr = NULL;
-						//rc=(*proxy_sqlite3_prepare_v2)(mydb3, q1fr, -1, &statement1fr, 0);
-						rc = GloAdmin->admindb->prepare_v2(q1fr, &statement1fr);
-						ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
-						//rc=(*proxy_sqlite3_prepare_v2)(mydb3, q32fr, -1, &statement32fr, 0);
-						rc = GloAdmin->admindb->prepare_v2(q32fr, &statement32fr);
-						ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+						auto [rc2, statement1fr_unique] = GloAdmin->admindb->prepare_v2(q1fr);
+						ASSERT_SQLITE_OK(rc2, GloAdmin->admindb);
+						auto [rc3, statement32fr_unique] = GloAdmin->admindb->prepare_v2(q32fr);
+						ASSERT_SQLITE_OK(rc3, GloAdmin->admindb);
+						sqlite3_stmt *statement1fr = statement1fr_unique.get();
+						sqlite3_stmt *statement32fr = statement32fr_unique.get();
 						int row_idx=0;
 						int max_bulk_row_idx=mysql_num_rows(result2)/32;
 						max_bulk_row_idx=max_bulk_row_idx*32;
@@ -1277,8 +1274,7 @@ void ProxySQL_Cluster::pull_mysql_query_rules_from_peer(const string& expected_c
 							}
 							row_idx++;
 						}
-						(*proxy_sqlite3_finalize)(statement1fr);
-						(*proxy_sqlite3_finalize)(statement32fr);
+						// RAII auto-finalizes statement1fr and statement32fr
 						//GloAdmin->admindb->execute("PRAGMA integrity_check");
 						GloAdmin->admindb->execute("COMMIT");
 
@@ -1369,9 +1365,10 @@ void update_mysql_users(MYSQL_RES* result) {
 		" schema_locked, transaction_persistent, fast_forward, backend, frontend, max_connections, attributes, comment)"
 		" VALUES (?1 , ?2 , ?3 , ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)";
 
-	sqlite3_stmt *statement1 = NULL;
-	int rc = GloAdmin->admindb->prepare_v2(q, &statement1);
-	ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+	auto [rc1, statement1_unique] = GloAdmin->admindb->prepare_v2(q);
+	ASSERT_SQLITE_OK(rc1, GloAdmin->admindb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	int rc;
 
 	while (MYSQL_ROW row = mysql_fetch_row(result)) {
 		rc=(*proxy_sqlite3_bind_text)(statement1, 1, row[0], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // username
@@ -1393,6 +1390,7 @@ void update_mysql_users(MYSQL_RES* result) {
 		rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 		rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 	}
+	// RAII auto-finalizes statement1 (fixes memory leak)
 }
 
 void update_ldap_mappings(MYSQL_RES* result) {
@@ -1402,9 +1400,10 @@ void update_ldap_mappings(MYSQL_RES* result) {
 		" VALUES (?1 , ?2 , ?3 , ?4)"
 	);
 
-	sqlite3_stmt *statement1 = NULL;
-	int rc = GloAdmin->admindb->prepare_v2(q, &statement1);
-	ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+	auto [rc1, statement1_unique] = GloAdmin->admindb->prepare_v2(q);
+	ASSERT_SQLITE_OK(rc1, GloAdmin->admindb);
+	sqlite3_stmt *statement1 = statement1_unique.get();
+	int rc;
 
 	while (MYSQL_ROW row = mysql_fetch_row(result)) {
 		rc=(*proxy_sqlite3_bind_int64)(statement1, 1, atoll(row[0])); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // priority
@@ -1416,6 +1415,7 @@ void update_ldap_mappings(MYSQL_RES* result) {
 		rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 		rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 	}
+	// RAII auto-finalizes statement1 (fixes memory leak)
 }
 
 void ProxySQL_Cluster::pull_mysql_users_from_peer(const string& expected_checksum, const time_t epoch) {

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -2221,18 +2221,18 @@ void ProxySQL_Cluster::pull_mysql_servers_v2_from_peer(const mysql_servers_v2_ch
 						proxy_debug(PROXY_DEBUG_CLUSTER, 5, "Writing mysql_hostgroup_attributes table\n");
 						proxy_info("Cluster: Writing mysql_hostgroup_attributes table\n");
 						GloAdmin->admindb->execute("DELETE FROM mysql_hostgroup_attributes");
-						{
-							const char* q = (const char*)"INSERT INTO mysql_hostgroup_attributes ( "
-								"hostgroup_id, max_num_online_servers, autocommit, free_connections_pct, "
-								"init_connect, multiplex, connection_warming, throttle_connections_per_sec, "
-								"ignore_session_variables, hostgroup_settings, servers_defaults, comment) VALUES "
-								"(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
-							sqlite3_stmt *statement1 = NULL;
-							int rc = GloAdmin->admindb->prepare_v2(q, &statement1);
-							ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+							{
+								const char* q = (const char*)"INSERT INTO mysql_hostgroup_attributes ( "
+									"hostgroup_id, max_num_online_servers, autocommit, free_connections_pct, "
+									"init_connect, multiplex, connection_warming, throttle_connections_per_sec, "
+									"ignore_session_variables, hostgroup_settings, servers_defaults, comment) VALUES "
+									"(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
+								auto [rc, statement1_unique] = GloAdmin->admindb->prepare_v2(q);
+								ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+								sqlite3_stmt *statement1 = statement1_unique.get();
 
-							while ((row = mysql_fetch_row(results[5]))) {
-								rc=(*proxy_sqlite3_bind_int64)(statement1, 1, atol(row[0])); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // hostgroup_id
+								while ((row = mysql_fetch_row(results[5]))) {
+									rc=(*proxy_sqlite3_bind_int64)(statement1, 1, atol(row[0])); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // hostgroup_id
 								rc=(*proxy_sqlite3_bind_int64)(statement1, 2, atol(row[1])); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // max_num_online_servers
 								rc=(*proxy_sqlite3_bind_int64)(statement1, 3, atol(row[2])); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // autocommit
 								rc=(*proxy_sqlite3_bind_int64)(statement1, 4, atol(row[3])); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // free_connections_pct
@@ -2244,12 +2244,11 @@ void ProxySQL_Cluster::pull_mysql_servers_v2_from_peer(const mysql_servers_v2_ch
 								rc=(*proxy_sqlite3_bind_text)(statement1, 10,row[9], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // hostgroup_settings
 								rc=(*proxy_sqlite3_bind_text)(statement1, 11, row[10], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // servers_defaults
 								rc=(*proxy_sqlite3_bind_text)(statement1, 12, row[11], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // comment
-								SAFE_SQLITE3_STEP2(statement1);
-								rc = (*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
-								rc = (*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+									SAFE_SQLITE3_STEP2(statement1);
+									rc = (*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+									rc = (*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+								}
 							}
-							(*proxy_sqlite3_finalize)(statement1);
-						}
 
 						proxy_debug(PROXY_DEBUG_CLUSTER, 5, "Dumping fetched 'mysql_hostgroup_attributes'\n");
 						proxy_info("Dumping fetched 'mysql_hostgroup_attributes'\n");
@@ -2261,14 +2260,14 @@ void ProxySQL_Cluster::pull_mysql_servers_v2_from_peer(const mysql_servers_v2_ch
 						proxy_debug(PROXY_DEBUG_CLUSTER, 5, "Writing mysql_servers_ssl_params table\n");
 						proxy_info("Cluster: Writing mysql_servers_ssl_params table\n");
 						GloAdmin->admindb->execute("DELETE FROM mysql_servers_ssl_params");
-						{
-							const char* q = (const char*)"INSERT INTO mysql_servers_ssl_params (hostname, port, username, ssl_ca, ssl_cert, ssl_key, ssl_capath, ssl_crl, ssl_crlpath, ssl_cipher, tls_version, comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
-							sqlite3_stmt *statement1 = NULL;
-							int rc = GloAdmin->admindb->prepare_v2(q, &statement1);
-							ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+							{
+								const char* q = (const char*)"INSERT INTO mysql_servers_ssl_params (hostname, port, username, ssl_ca, ssl_cert, ssl_key, ssl_capath, ssl_crl, ssl_crlpath, ssl_cipher, tls_version, comment) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
+								auto [rc, statement1_unique] = GloAdmin->admindb->prepare_v2(q);
+								ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+								sqlite3_stmt *statement1 = statement1_unique.get();
 
-							while ((row = mysql_fetch_row(results[6]))) {
-								rc=(*proxy_sqlite3_bind_text)(statement1,  1,  row[0],  -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // hostname
+								while ((row = mysql_fetch_row(results[6]))) {
+									rc=(*proxy_sqlite3_bind_text)(statement1,  1,  row[0],  -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // hostname
 								rc=(*proxy_sqlite3_bind_int64)(statement1, 2,  atol(row[1]));                  ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // port
 								rc=(*proxy_sqlite3_bind_text)(statement1,  3,  row[2],  -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // username
 								rc=(*proxy_sqlite3_bind_text)(statement1,  4,  row[3],  -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // ssl_ca
@@ -2280,12 +2279,11 @@ void ProxySQL_Cluster::pull_mysql_servers_v2_from_peer(const mysql_servers_v2_ch
 								rc=(*proxy_sqlite3_bind_text)(statement1,  10, row[9],  -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // ssl_cipher
 								rc=(*proxy_sqlite3_bind_text)(statement1,  11, row[10], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // tls_version
 								rc=(*proxy_sqlite3_bind_text)(statement1,  12, row[11], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // comment
-								SAFE_SQLITE3_STEP2(statement1);
-								rc = (*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
-								rc = (*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+									SAFE_SQLITE3_STEP2(statement1);
+									rc = (*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+									rc = (*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+								}
 							}
-							(*proxy_sqlite3_finalize)(statement1);
-						}
 
 						proxy_debug(PROXY_DEBUG_CLUSTER, 5, "Dumping fetched 'mysql_servers_ssl_params'\n");
 						proxy_info("Dumping fetched 'mysql_servers_ssl_params'\n");

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -2470,7 +2470,7 @@ void ProxySQL_Cluster::pull_global_variables_from_peer(const string& var_type, c
 					sqlite3_stmt *statement1 = statement1_unique.get();
 
 					while ((row = mysql_fetch_row(result))) {
-						rc=(*proxy_sqlite3_bind_text)(statement1, 1, row[0], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // variable_name
+						int rc=(*proxy_sqlite3_bind_text)(statement1, 1, row[0], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // variable_name
 						rc=(*proxy_sqlite3_bind_text)(statement1, 2, row[1], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // variable_value
 
 						SAFE_SQLITE3_STEP2(statement1);

--- a/lib/ProxySQL_Cluster.cpp
+++ b/lib/ProxySQL_Cluster.cpp
@@ -2465,9 +2465,9 @@ void ProxySQL_Cluster::pull_global_variables_from_peer(const string& var_type, c
 
 					MYSQL_ROW row;
 					char *q = (char *)"INSERT OR REPLACE INTO global_variables (variable_name, variable_value) VALUES (?1 , ?2)";
-					sqlite3_stmt *statement1 = NULL;
-					int rc = GloAdmin->admindb->prepare_v2(q, &statement1);
-					ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
+					auto [rc1, statement1_unique] = GloAdmin->admindb->prepare_v2(q);
+					ASSERT_SQLITE_OK(rc1, GloAdmin->admindb);
+					sqlite3_stmt *statement1 = statement1_unique.get();
 
 					while ((row = mysql_fetch_row(result))) {
 						rc=(*proxy_sqlite3_bind_text)(statement1, 1, row[0], -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, GloAdmin->admindb); // variable_name
@@ -2477,7 +2477,7 @@ void ProxySQL_Cluster::pull_global_variables_from_peer(const string& var_type, c
 						rc=(*proxy_sqlite3_clear_bindings)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 						rc=(*proxy_sqlite3_reset)(statement1); ASSERT_SQLITE_OK(rc, GloAdmin->admindb);
 					}
-
+					// RAII auto-finalizes statement1
 					mysql_free_result(result);
 					proxy_debug(PROXY_DEBUG_CLUSTER, 5, "Loading to runtime %s Variables from peer %s:%d\n", vars_type_str, hostname, port);
 					proxy_info("Cluster: Loading to runtime %s Variables from peer %s:%d\n", vars_type_str, hostname, port);

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -44,7 +44,13 @@ struct DebugLogEntry {
 };
 
 static const size_t limitSize = 100;
-static std::vector<DebugLogEntry> log_buffer = {};
+/*
+ * NOTE: Intentionally leaked.
+ * During fast shutdown paths we can call exit() while worker threads are still
+ * emitting debug logs. A static std::vector would be destroyed by exit handlers
+ * and could race with concurrent push_back(), causing use-after-free.
+ */
+static std::vector<DebugLogEntry>* log_buffer = new std::vector<DebugLogEntry>();
 
 
 /**
@@ -60,7 +66,7 @@ static std::vector<DebugLogEntry> log_buffer = {};
 void sync_log_buffer_to_disk(SQLite3DB *db) {
 	int rc;
 	db->execute("BEGIN TRANSACTION");
-	for (const auto& entry : log_buffer) {
+	for (const auto& entry : *log_buffer) {
 		rc=(*proxy_sqlite3_bind_int64)(statement1, 1, entry.time); ASSERT_SQLITE_OK(rc, db);
 		rc=(*proxy_sqlite3_bind_int64)(statement1, 2, entry.lapse);ASSERT_SQLITE_OK(rc, db);
 		rc=(*proxy_sqlite3_bind_int64)(statement1, 3, entry.thr); ASSERT_SQLITE_OK(rc, db);
@@ -78,7 +84,7 @@ void sync_log_buffer_to_disk(SQLite3DB *db) {
 		rc=(*proxy_sqlite3_reset)(statement1); // ASSERT_SQLITE_OK(rc, db);
 	}
 	db->execute("COMMIT");
-	log_buffer.clear();
+	log_buffer->clear();
 }
 
 /**
@@ -279,14 +285,14 @@ void proxy_debug_func(
 			entry.verbosity = verbosity;
 			entry.message = origdebugbuff;
 			entry.backtrace = longdebugbuff2;
-			log_buffer.push_back(entry);
+			log_buffer->push_back(entry);
 			// we now batch writes
 			// note1: in case of crash, the database will have some missing entries,
 			// but the entries can be read in `log_buffer` in the core dump
 			// note2: also in case of shutdown , `log_buffer` will have entries that won't be saved.
 			// if we really want *all* entries, we could just call sync_log_buffer_to_disk() on shutdown
 			if (
-				(log_buffer.size() >= limitSize)
+				(log_buffer->size() >= limitSize)
 				||
 				(entry.file == "ProxySQL_Admin.cpp" && entry.funct == "flush_logs")
 			) {

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -21,6 +21,7 @@ static pthread_mutex_t debug_mutex;
 static pthread_rwlock_t filters_rwlock;
 static SQLite3DB * debugdb_disk = NULL;
 sqlite3_stmt *statement1=NULL;
+static stmt_unique_ptr statement1_unique {};
 static unsigned int debug_output = 1;
 
 
@@ -256,12 +257,15 @@ void proxy_debug_func(
 		}
 	} else {
 		SQLite3DB *db = debugdb_disk;
-		int rc = 0;
-		if (statement1==NULL) {
-			const char *a = "INSERT INTO debug_log (id, time, lapse, thread, file, line, funct, modnum, modname, verbosity, message, note, backtrace) VALUES (NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, ?11)";
-			rc=db->prepare_v2(a, &statement1);
-			ASSERT_SQLITE_OK(rc, db);
-		}
+			int rc = 0;
+			if (statement1==NULL) {
+				const char *a = "INSERT INTO debug_log (id, time, lapse, thread, file, line, funct, modnum, modname, verbosity, message, note, backtrace) VALUES (NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, ?11)";
+				auto [stmt_rc, prepared_statement_unique] = db->prepare_v2(a);
+				rc = stmt_rc;
+				ASSERT_SQLITE_OK(rc, db);
+				statement1_unique = std::move(prepared_statement_unique);
+				statement1 = statement1_unique.get();
+			}
 		if (debug_output == 1 || debug_output == 3) {
 			// to stderr
 			if (longdebugbuff[0] != 0) {

--- a/src/SQLite3_Server.cpp
+++ b/src/SQLite3_Server.cpp
@@ -1434,17 +1434,19 @@ void SQLite3_Server::populate_galera_table(MySQL_Session *sess) {
 	char buf[1024];
 	sprintf(buf, (char *)"SELECT * FROM HOST_STATUS_GALERA WHERE hostgroup_id = %d LIMIT 1", hg_id);
 	sessdb->execute_statement(buf, &error , &cols , &affected_rows , &resultset);
-	if (resultset->rows_count==0) {
-		//sessdb->execute("DELETE FROM HOST_STATUS_GALERA");
-		sqlite3_stmt *statement=NULL;
-		int rc;
-		char *query=(char *)"INSERT INTO HOST_STATUS_GALERA VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)";
-		//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
-		rc = sessdb->prepare_v2(query, &statement);
-		ASSERT_SQLITE_OK(rc, sessdb);
-		for (unsigned int i=0; i<num_galera_servers[cluster_id]; i++) {
-			string serverid = "";
-			serverid = "127.1." + std::to_string(cluster_id+1) + "." + std::to_string(i+11);
+		if (resultset->rows_count==0) {
+			//sessdb->execute("DELETE FROM HOST_STATUS_GALERA");
+			sqlite3_stmt *statement=NULL;
+			int rc;
+			char *query=(char *)"INSERT INTO HOST_STATUS_GALERA VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)";
+			//rc=(*proxy_sqlite3_prepare_v2)(mydb3, query, -1, &statement, 0);
+			auto [stmt_rc, statement_unique] = sessdb->prepare_v2(query);
+			rc = stmt_rc;
+			statement = statement_unique.get();
+			ASSERT_SQLITE_OK(rc, sessdb);
+			for (unsigned int i=0; i<num_galera_servers[cluster_id]; i++) {
+				string serverid = "";
+				serverid = "127.1." + std::to_string(cluster_id+1) + "." + std::to_string(i+11);
 //			fprintf(stderr,"%d , %s:3306 \n", hg_id , serverid.c_str());
 
 			rc=(*proxy_sqlite3_bind_int64)(statement, 1, hg_id); ASSERT_SQLITE_OK(rc, sessdb);
@@ -1460,14 +1462,13 @@ void SQLite3_Server::populate_galera_table(MySQL_Session *sess) {
 
 			rc=(*proxy_sqlite3_bind_text)(statement, 11, (char *)"DISABLED", -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, sessdb);
 
-			SAFE_SQLITE3_STEP2(statement);
-			rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, sessdb);
-			rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, sessdb);
+				SAFE_SQLITE3_STEP2(statement);
+				rc=(*proxy_sqlite3_clear_bindings)(statement); ASSERT_SQLITE_OK(rc, sessdb);
+				rc=(*proxy_sqlite3_reset)(statement); ASSERT_SQLITE_OK(rc, sessdb);
+			}
 		}
-		(*proxy_sqlite3_finalize)(statement);
+		sessdb->execute("COMMIT");
 	}
-	sessdb->execute("COMMIT");
-}
 #endif // TEST_GALERA
 
 #ifdef TEST_AURORA
@@ -1534,7 +1535,9 @@ void SQLite3_Server::populate_aws_aurora_table(MySQL_Session *sess, uint32_t whg
 	sqlite3_stmt* stmt = NULL;
     const char query[] { "INSERT INTO REPLICA_HOST_STATUS VALUES (?1, ?2, ?3, ?4, ?5, ?6)" };
 
-	rc = sessdb->prepare_v2(query, &stmt);
+	auto [stmt_rc, stmt_unique] = sessdb->prepare_v2(query);
+	rc = stmt_rc;
+	stmt = stmt_unique.get();
 	ASSERT_SQLITE_OK(rc, sessdb);
 
 #ifndef TEST_AURORA_RANDOM
@@ -1616,9 +1619,8 @@ void SQLite3_Server::populate_aws_aurora_table(MySQL_Session *sess, uint32_t whg
 			}
 		}
 
-		(*proxy_sqlite3_finalize)(stmt);
-		delete resultset;
-	} else {
+			delete resultset;
+		} else {
 		// We just re-generate deterministic 'SESSION_IDS', preserving 'MASTER_SESSION_ID' values:
 		// 'SESSION_IDS' are preserved, 'MASTER_SESSION_ID' or others.
 		for (SQLite3_row* row : host_status->rows) {
@@ -1692,8 +1694,7 @@ void SQLite3_Server::populate_aws_aurora_table(MySQL_Session *sess, uint32_t whg
 		float cpu = get_rand_cpu();
 		bind_query_params(sessdb, stmt, serverid, aurora_domain, sessionid, cpu, lut, lag_ms);
 	}
-	(*proxy_sqlite3_finalize)(stmt);
-#endif // TEST_AURORA_RANDOM
+	#endif // TEST_AURORA_RANDOM
 }
 #endif // TEST_AURORA
 

--- a/src/proxy_tls.cpp
+++ b/src/proxy_tls.cpp
@@ -144,17 +144,17 @@ void write_x509(const char *filen, X509 *x) {
 	BIO_free_all( x509file );
 }
 
-void write_rsa_key(const char *filen, RSA *rsa) {
+void write_rsa_key(const char *filen, EVP_PKEY *pkey) {
 	BIO* pOut = BIO_new_file(filen, "w");
 	if (!pOut) {
 		proxy_error("Error on BIO_new_file\n");
 		exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
 	}
-	if (!PEM_write_bio_RSAPrivateKey( pOut, rsa, NULL, NULL, 0, NULL, NULL)) {
-		proxy_error("Error on PEM_write_bio_RSAPrivateKey for %s\n", filen);
+	if (!PEM_write_bio_PrivateKey(pOut, pkey, NULL, NULL, 0, NULL, NULL)) {
+		proxy_error("Error on PEM_write_bio_PrivateKey for %s\n", filen);
 		exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
 	}
-	BIO_free_all( pOut );
+	BIO_free_all(pOut);
 }
 
 
@@ -219,7 +219,6 @@ int ssl_mkit(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int days, boo
 	X509 *x1;
 	X509 *x2;
 	EVP_PKEY *pk;
-	RSA *rsa;
 
 	// relative path to datadir of ssl files
 	const char * ssl_key_rp = (const char *)"proxysql-key.pem";
@@ -286,46 +285,38 @@ int ssl_mkit(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int days, boo
 	if (bootstrap == true && nfiles == 0) {
 		proxy_info("No SSL keys/certificates found in datadir (%s). Generating new keys/certificates.\n", GloVars.datadir);
 		if ((pkeyp == NULL) || (*pkeyp == NULL)) {
-			if ((pk = EVP_PKEY_new()) == NULL) {
-				proxy_error("Unable to run EVP_PKEY_new()\n");
+			// Generate RSA key using OpenSSL 3.0 EVP_PKEY API
+			EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+			if (!ctx) {
+				proxy_error("Unable to create EVP_PKEY_CTX for RSA\n");
 				exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
 			}
+			if (EVP_PKEY_keygen_init(ctx) <= 0) {
+				proxy_error("Unable to initialize EVP_PKEY keygen\n");
+				EVP_PKEY_CTX_free(ctx);
+				exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
+			}
+			if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, bits) <= 0) {
+				proxy_error("Unable to set RSA key size\n");
+				EVP_PKEY_CTX_free(ctx);
+				exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
+			}
+			if (EVP_PKEY_generate(ctx, &pk) <= 0) {
+				proxy_error("Unable to generate RSA key\n");
+				EVP_PKEY_CTX_free(ctx);
+				exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
+			}
+			EVP_PKEY_CTX_free(ctx);
 		} else
 			pk = *pkeyp;
 
-		rsa = RSA_new();
+		write_rsa_key(ssl_key_fp, pk);
 
-		if (!rsa) {
-			proxy_error("Unable to run RSA_new()\n");
-			exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
-		}
-		BIGNUM *e= BN_new();
-		if (!e) {
-			proxy_error("Unable to run BN_new()\n");
-			exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
-		}
-		if (!BN_set_word(e, RSA_F4) || !RSA_generate_key_ex(rsa, bits, e, NULL)) {
-			RSA_free(rsa);
-			BN_free(e);
-			proxy_error("Unable to run BN_new()\n");
-			exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
-		}
-		BN_free(e);
-
-
-		write_rsa_key(ssl_key_fp, rsa);
-
-		if (!EVP_PKEY_assign_RSA(pk, rsa)) {
-			proxy_error("Unable to run EVP_PKEY_assign_RSA()\n");
-			exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
-		}
 		time_t t = time(NULL);
 		x1 = generate_x509(pk, (const unsigned char *)"ProxySQL_Auto_Generated_CA_Certificate", t, 3650, NULL, NULL);
 		write_x509(ssl_ca_fp, x1);
 		x2 = generate_x509(pk, (const unsigned char *)"ProxySQL_Auto_Generated_Server_Certificate", t, 3650, x1, pk);
 		write_x509(ssl_cert_fp, x2);
-
-		rsa = NULL;
 	} else {
 		proxy_info("SSL keys/certificates found in datadir (%s): loading them.\n", GloVars.datadir);
 		if (bootstrap == true) {

--- a/src/proxy_tls.cpp
+++ b/src/proxy_tls.cpp
@@ -216,9 +216,9 @@ X509 * proxy_read_x509(const char *filen, bool bootstrap, std::string& msg) {
 
 // return 0 un success
 int ssl_mkit(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int days, bool bootstrap, std::string& msg) {
-	X509 *x1;
-	X509 *x2;
-	EVP_PKEY *pk;
+	X509 *x1 = NULL;
+	X509 *x2 = NULL;
+	EVP_PKEY *pk = NULL;
 
 	// relative path to datadir of ssl files
 	const char * ssl_key_rp = (const char *)"proxysql-key.pem";
@@ -302,7 +302,7 @@ int ssl_mkit(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int days, boo
 				exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
 			}
 			if (EVP_PKEY_generate(ctx, &pk) <= 0) {
-				proxy_error("Unable to generate RSA key\n");
+				proxy_error("Unable to generate RSA key: %s\n", ERR_error_string(ERR_get_error(), NULL));
 				EVP_PKEY_CTX_free(ctx);
 				exit(EXIT_SUCCESS); // we exit gracefully to avoid being restarted
 			}
@@ -469,4 +469,3 @@ int ProxySQL_create_or_load_TLS(bool bootstrap, std::string& msg) {
 	BIO_free(bio_err);
 	return ret;
 }
-

--- a/test/sqlite_history_convert.cpp
+++ b/test/sqlite_history_convert.cpp
@@ -49,7 +49,10 @@ void insert_row(SQLite3DB& statsdb, unordered_map<string,int>& varmap, SQLite3_r
 	query.pop_back();
 	query += ")";
     sqlite3_stmt *statement=NULL;
-	int rc = statsdb.prepare_v2(query.c_str(), &statement);
+	auto prepared_statement = statsdb.prepare_v2(query.c_str());
+	int rc = prepared_statement.first;
+	stmt_unique_ptr statement_unique = std::move(prepared_statement.second);
+	statement = statement_unique.get();
 	assert(rc==SQLITE_OK);
 	for (auto it = res->rows.begin() ; it != res->rows.end(); ++it) {
 		SQLite3_row *r=*it;

--- a/test/tap/tests/aurora.cpp
+++ b/test/tap/tests/aurora.cpp
@@ -69,7 +69,10 @@ void SQLite3_Server::populate_aws_aurora_table(MySQL_Session *sess) {
 	int rc;
     char *query=(char *)"INSERT INTO REPLICA_HOST_STATUS VALUES (?1, ?2, ?3, ?4, ?5)";
     //rc=sqlite3_prepare_v2(mydb3, query, -1, &statement, 0);
-    rc = sessdb->prepare_v2(query, &statement);
+    auto prepared_statement = sessdb->prepare_v2(query);
+    rc = prepared_statement.first;
+    stmt_unique_ptr statement_unique = std::move(prepared_statement.second);
+    statement = statement_unique.get();
     ASSERT_SQLITE_OK(rc, sessdb);
 	time_t __timer;
 	char lut[30];
@@ -132,7 +135,6 @@ void SQLite3_Server::populate_aws_aurora_table(MySQL_Session *sess) {
 		rc=sqlite3_clear_bindings(statement); ASSERT_SQLITE_OK(rc, sessdb);
 		rc=sqlite3_reset(statement); ASSERT_SQLITE_OK(rc, sessdb);
 	}
-	sqlite3_finalize(statement);
 }
 
 void SQLite3_Server_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *pkt) {
@@ -471,5 +473,3 @@ __run_query:
 	l_free(pkt->size-sizeof(mysql_hdr),query_no_space); // it is always freed here
 	l_free(query_length,query);
 }
-
-

--- a/test/tap/tests/galera_1_timeout_count.cpp
+++ b/test/tap/tests/galera_1_timeout_count.cpp
@@ -92,7 +92,10 @@ void SQLite3_Server::populate_galera_table(MySQL_Session *sess) {
 		int rc;
 		char *query=(char *)"INSERT INTO HOST_STATUS_GALERA VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
 		//rc=sqlite3_prepare_v2(mydb3, query, -1, &statement, 0);
-		rc = sessdb->prepare_v2(query, &statement);
+		auto prepared_statement = sessdb->prepare_v2(query);
+		rc = prepared_statement.first;
+		stmt_unique_ptr statement_unique = std::move(prepared_statement.second);
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, sessdb);
 		for (unsigned int i=0; i<num_galera_servers[cluster_id]; i++) {
 			string serverid = "";
@@ -113,7 +116,6 @@ void SQLite3_Server::populate_galera_table(MySQL_Session *sess) {
 			rc=sqlite3_clear_bindings(statement); ASSERT_SQLITE_OK(rc, sessdb);
 			rc=sqlite3_reset(statement); ASSERT_SQLITE_OK(rc, sessdb);
 		}
-		sqlite3_finalize(statement);
 	}
 	sessdb->execute("COMMIT");
 }
@@ -258,4 +260,3 @@ void SQLite3_Server_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *p
 	l_free(pkt->size-sizeof(mysql_hdr),query_no_space); // it is always freed here
 	l_free(query_length,query);
 }
-

--- a/test/tap/tests/galera_2_timeout_no_count.cpp
+++ b/test/tap/tests/galera_2_timeout_no_count.cpp
@@ -93,7 +93,10 @@ void SQLite3_Server::populate_galera_table(MySQL_Session *sess) {
 		int rc;
 		char *query=(char *)"INSERT INTO HOST_STATUS_GALERA VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
 		//rc=sqlite3_prepare_v2(mydb3, query, -1, &statement, 0);
-		rc = sessdb->prepare_v2(query, &statement);
+		auto prepared_statement = sessdb->prepare_v2(query);
+		rc = prepared_statement.first;
+		stmt_unique_ptr statement_unique = std::move(prepared_statement.second);
+		statement = statement_unique.get();
 		ASSERT_SQLITE_OK(rc, sessdb);
 		for (unsigned int i=0; i<num_galera_servers[cluster_id]; i++) {
 			string serverid = "";
@@ -114,7 +117,6 @@ void SQLite3_Server::populate_galera_table(MySQL_Session *sess) {
 			rc=sqlite3_clear_bindings(statement); ASSERT_SQLITE_OK(rc, sessdb);
 			rc=sqlite3_reset(statement); ASSERT_SQLITE_OK(rc, sessdb);
 		}
-		sqlite3_finalize(statement);
 	}
 	sessdb->execute("COMMIT");
 }
@@ -272,4 +274,3 @@ void SQLite3_Server_session_handler(MySQL_Session *sess, void *_pa, PtrSize_t *p
 	l_free(pkt->size-sizeof(mysql_hdr),query_no_space); // it is always freed here
 	l_free(query_length,query);
 }
-


### PR DESCRIPTION
## Summary
- Replace deprecated OpenSSL RSA APIs with OpenSSL 3.0 EVP_PKEY keygen API
- Rebased on top of v3.0-misc260209 which contains prepare_v2 RAII migration fixes

## Changes
- Replace `RSA_new()` + `RSA_generate_key_ex()` with `EVP_PKEY_keygen()`
- Replace `PEM_write_bio_RSAPrivateKey()` with `PEM_write_bio_PrivateKey()`
- Remove `EVP_PKEY_assign_RSA()` - use `EVP_PKEY` directly
- Update `write_rsa_key()` function signature to accept `EVP_PKEY*` instead of `RSA*`

## Deprecation warnings eliminated
- `RSA_new()`
- `RSA_generate_key_ex()`
- `RSA_free()`
- `EVP_PKEY_assign_RSA()`
- `PEM_write_bio_RSAPrivateKey()`

## Note
MD5_* deprecation warnings in PgSQL_Protocol.cpp remain as a separate issue (scram-md5 authentication uses legacy MD5 API).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved DB statement handling to automatic RAII management for safer, more reliable save/load, monitoring, and admin operations.
  * PostgreSQL copy-command matcher is now always available in threads/sessions.
  * Modernized TLS key generation to use current OpenSSL key APIs.

* **Bug Fixes**
  * Fixed an integer type-mismatch in a buffer-size comparison.

* **Chores**
  * Minor thread-constructor parameter adjusted for safer string handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->