### PR TITLE
fix: crash on macOS/FreeBSD when running PostgreSQL queries

### DIFF
--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -228,9 +228,9 @@ public:
 #ifdef IDLE_THREADS
 	PtrArray* idle_mysql_sessions;
 	PtrArray* resume_mysql_sessions;
-	CopyCmdMatcher *copy_cmd_matcher;
 	pgsql_conn_exchange_t myexchange;
 #endif // IDLE_THREADS
+	CopyCmdMatcher *copy_cmd_matcher;
 
 	int pipefd[2];
 	PgSQL_Session_Interrupt_Queue_t sess_intrpt_queue;

--- a/lib/Base_Thread.cpp
+++ b/lib/Base_Thread.cpp
@@ -43,9 +43,7 @@ void Base_Thread::register_session(T thr, S _sess, bool up_start) {
 //	}
 	_sess->match_regexes=match_regexes;
 	if constexpr (std::is_same_v<T, PgSQL_Thread*>) {
-#ifdef IDLE_THREADS
 		_sess->copy_cmd_matcher = (static_cast<PgSQL_Thread*>(this))->copy_cmd_matcher;
-#endif
 	}
 
 	if (up_start)

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -2709,12 +2709,10 @@ PgSQL_Thread::~PgSQL_Thread() {
 		match_regexes = NULL;
 	}
 
-#ifdef IDLE_THREADS
 	if (copy_cmd_matcher) {
 		delete copy_cmd_matcher;
 		copy_cmd_matcher = NULL;
 	}
-#endif
 
 	if (thr_SetParser != NULL) {
 		delete thr_SetParser;
@@ -2769,9 +2767,7 @@ bool PgSQL_Thread::init() {
 	match_regexes[2] = new Session_Regex((char*)"^SET(?: +)(|SESSION +)TRANSACTION(?: +)(?:(?:(ISOLATION(?: +)LEVEL)(?: +)(REPEATABLE(?: +)READ|READ(?: +)COMMITTED|READ(?: +)UNCOMMITTED|SERIALIZABLE))|(?:(READ)(?: +)(WRITE|ONLY)))");
 	match_regexes[3] = new Session_Regex((char*)"^SET(?: +)(|SESSION +)`?(client_encoding|names)`?( *)(|=|TO)( *)");
 
-#ifdef IDLE_THREADS
 	copy_cmd_matcher = new CopyCmdMatcher();
-#endif
 
 	return true;
 }
@@ -4014,9 +4010,7 @@ PgSQL_Thread::PgSQL_Thread() {
 		status_variables.stvar[i] = 0;
 	}
 	match_regexes = NULL;
-#ifdef IDLE_THREADS
 	copy_cmd_matcher = NULL;
-#endif
 
 	variables.min_num_servers_lantency_awareness = 1000;
 	variables.aurora_max_lag_ms_only_read_from_replicas = 2;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,10 @@ using json = nlohmann::json;
 
 #include <sys/mman.h>
 
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
 #include <uuid/uuid.h>
 #include <atomic>
 
@@ -3007,7 +3011,18 @@ int main(int argc, const char * argv[]) {
 		int fd = -1;
 		char buff[PATH_MAX+1];
 		ssize_t len = -1;
-#if defined(__FreeBSD__)
+#if defined(__APPLE__)
+		uint32_t bufsize = sizeof(buff) - 1;
+		if (_NSGetExecutablePath(buff, &bufsize) == 0) {
+			len = bufsize;
+			// Resolve symlinks to get the real path
+			char resolved[PATH_MAX];
+			if (realpath(buff, resolved) != NULL) {
+				strncpy(buff, resolved, sizeof(buff) - 1);
+				len = strlen(buff);
+			}
+		}
+#elif defined(__FreeBSD__)
 		len = readlink("/proc/curproc/file", buff, sizeof(buff)-1);
 #else
 		len = readlink("/proc/self/exe", buff, sizeof(buff)-1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3012,15 +3012,15 @@ int main(int argc, const char * argv[]) {
 		char buff[PATH_MAX+1];
 		ssize_t len = -1;
 #if defined(__APPLE__)
-		uint32_t bufsize = sizeof(buff) - 1;
+		uint32_t bufsize = sizeof(buff);
 		if (_NSGetExecutablePath(buff, &bufsize) == 0) {
-			len = bufsize;
 			// Resolve symlinks to get the real path
 			char resolved[PATH_MAX];
 			if (realpath(buff, resolved) != NULL) {
 				strncpy(buff, resolved, sizeof(buff) - 1);
-				len = strlen(buff);
+				buff[sizeof(buff) - 1] = '\0';
 			}
+			len = strlen(buff);
 		}
 #elif defined(__FreeBSD__)
 		len = readlink("/proc/curproc/file", buff, sizeof(buff)-1);


### PR DESCRIPTION
## Summary

Fixes a crash that occurred immediately when running any PostgreSQL query on macOS and FreeBSD systems.

## Problem

ProxySQL crashed with a NULL pointer dereference in `CopyCmdMatcher::match()` when processing PostgreSQL queries on macOS and FreeBSD.

**Backtrace:**
```
* thread #11, stop reason = EXC_BAD_ACCESS (code=1, address=0x5c)
  frame #5: CopyCmdMatcher::match(this=0x0000000000000000, query="SELECT ?;", ...) const at PgSQL_Thread.h:149:10
  frame #6: PgSQL_Session::handler(...) at PgSQL_Session.cpp:2924:27
```

## Root Cause

`copy_cmd_matcher` was guarded by `#ifdef IDLE_THREADS`, but `IDLE_THREADS` is **explicitly disabled** on macOS (`__APPLE__`) and FreeBSD in `proxy_defines.h:5-8`:

```cpp
#if !defined(__FreeBSD__) && !defined(__APPLE__)
#define IDLE_THREADS
#endif
```

This created an inconsistent configuration where:
- `PgSQL_Thread::copy_cmd_matcher` was **not defined** on macOS/FreeBSD
- `PgSQL_Session::copy_cmd_matcher` was **always defined**
- The initialization from thread to session was **compiled out**
- Usage at `PgSQL_Session.cpp:2924` was **not guarded** → NULL pointer dereference

## Solution

Removed `#ifdef IDLE_THREADS` guards from `copy_cmd_matcher` since:

1. **COPY command detection is a fundamental PostgreSQL feature** - it detects `COPY ... FROM STDIN/STDOUT` commands for fast-forward mode
2. **It has no dependency on idle threads** - the feature works independently of the threading model
3. **This is the correct fix** - disabling COPY support on macOS/FreeBSD would be incorrect

## Changes

- `include/PgSQL_Thread.h` - Moved `CopyCmdMatcher *copy_cmd_matcher;` outside `#ifdef IDLE_THREADS`
- `lib/PgSQL_Thread.cpp` - Removed `#ifdef IDLE_THREADS` guards from initialization/cleanup
- `lib/Base_Thread.cpp` - Removed `#ifdef IDLE_THREADS` guard from copy operation

## Testing

Tested manually on macOS - PostgreSQL queries now work correctly without crashes.

## Affected Systems

- macOS (`__APPLE__`)
- FreeBSD (`__FreeBSD__`)

Fixes #5359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization for improved maintainability. Conditional compilation directives were restructured to simplify the codebase without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->