### PR TITLE
Add protocol labels for all PostgreSQL metrics and extend prometheus metrics coverage

### DIFF
--- a/doc/PROMETHEUS_PROTOCOL_LABELS.md
+++ b/doc/PROMETHEUS_PROTOCOL_LABELS.md
@@ -46,7 +46,7 @@ This follows prometheus best practices where metrics that represent different en
 
 | File | Lines Changed | Description |
 |------|--------------|-------------|
-| `lib/MySQL_HostGroups_Manager.cpp` | +25/-10 | Added `protocol="mysql"` labels to PgHGM metrics |
+| `lib/MySQL_HostGroups_Manager.cpp` | +25/-10 | Added `protocol="mysql"` labels to MyHGM metrics |
 | `lib/MySQL_Thread.cpp` | +340/-71 | Added `protocol="mysql"` labels to 65 MTH metrics |
 | `lib/PgSQL_HostGroups_Manager.cpp` | +25/-10 | Added `protocol="pgsql"` labels to PgHGM metrics |
 | `lib/PgSQL_Thread.cpp` | +310/-42 | Added `protocol="pgsql"` labels to 60 PTH metrics |

--- a/doc/PROMETHEUS_PROTOCOL_LABELS.md
+++ b/doc/PROMETHEUS_PROTOCOL_LABELS.md
@@ -1,0 +1,380 @@
+# Prometheus Protocol Labels for PostgreSQL Metrics
+
+## Overview
+
+This document describes the features introduced in the `v3.0-5069` branch that resolve prometheus metric collisions between MySQL and PostgreSQL modules by adding `protocol` labels to distinguish metrics from different database protocols.
+
+## Problem Statement
+
+### Issue #5068: Metric Collision Between MySQL and PostgreSQL
+
+Prior to this branch, ProxySQL used identical metric names for both MySQL and PostgreSQL modules. When both modules tried to register prometheus metrics with the same name and labels, they would either:
+1. **Collide and overwrite** - causing incorrect metric values
+2. **Be disabled entirely** - PostgreSQL metrics were disabled to avoid collision
+
+This resulted in users seeing confusing behavior where:
+- Prometheus showed `proxysql_client_connections_total{status="aborted"} 4` (MySQL metrics only)
+- Database showed `Client_Connections_aborted: 91233` (PostgreSQL stats)
+- The user was comparing MySQL prometheus metrics with PostgreSQL database stats
+
+### Root Cause
+
+The metric collision occurred because both modules used identical metric names with identical labels:
+
+```cpp
+// MySQL_HostGroups_Manager.cpp
+"proxysql_client_connections_total", metric_tags { { "status", "created" } }
+
+// PgSQL_HostGroups_Manager.cpp
+"proxysql_client_connections_total", metric_tags { { "status", "created" } }  // IDENTICAL!
+```
+
+When both instances called `BuildCounter().Register(...).Add(metric_tags)` with the same name and labels, they shared the same counter.
+
+## Solution: Protocol Labels
+
+The solution adds a `protocol` label to all prometheus metrics to distinguish MySQL and PostgreSQL sources:
+
+```
+proxysql_client_connections_total{protocol="mysql",status="created"} 1000
+proxysql_client_connections_total{protocol="pgsql",status="created"} 500
+```
+
+This follows prometheus best practices where metrics that represent different entities should be distinguished using labels.
+
+## Changes Summary
+
+| File | Lines Changed | Description |
+|------|--------------|-------------|
+| `lib/MySQL_HostGroups_Manager.cpp` | +25/-10 | Added `protocol="mysql"` labels to PgHGM metrics |
+| `lib/MySQL_Thread.cpp` | +340/-71 | Added `protocol="mysql"` labels to 65 MTH metrics |
+| `lib/PgSQL_HostGroups_Manager.cpp` | +25/-10 | Added `protocol="pgsql"` labels to PgHGM metrics |
+| `lib/PgSQL_Thread.cpp` | +310/-42 | Added `protocol="pgsql"` labels to 60 PTH metrics |
+| `lib/ProxySQL_Admin.cpp` | +18/-18 | Enabled GloPTH and GloPgQC metrics |
+| `lib/Query_Cache.cpp` | +133/-15 | Added protocol labels with compile-time type selection |
+| **Total** | **+784/-147** | **6 files modified** |
+
+## Detailed Changes by Module
+
+### 1. Host Groups Manager Metrics
+
+#### MySQL_HostGroups_Manager.cpp
+
+Added `protocol="mysql"` labels to the following metrics:
+- `proxysql_server_connections_total` (created/delayed/aborted)
+- `proxysql_client_connections_total` (created/aborted)
+- `proxysql_access_denied_wrong_password_total`
+- `proxysql_access_denied_max_connections_total`
+- `proxysql_access_denied_max_user_connections_total`
+- `proxysql_server_connections_connected`
+- `proxysql_client_connections_connected`
+
+#### PgSQL_HostGroups_Manager.cpp
+
+Added `protocol="pgsql"` labels to the same metrics for PostgreSQL.
+
+### 2. Thread Handler Metrics
+
+#### MySQL_Thread.cpp
+
+Added `protocol="mysql"` labels to 65 thread handler metrics including:
+- `proxysql_queries_backends_bytes_total` (sent/received)
+- `proxysql_queries_frontends_bytes_total` (sent/received)
+- `proxysql_query_processor_time_seconds_total`
+- `proxysql_backend_query_time_seconds_total`
+- `proxysql_com_backend_stmt_total` (prepare/execute/close)
+- `proxysql_com_frontend_stmt_total` (prepare/execute/close)
+- `proxysql_questions_total`
+- `proxysql_slow_queries_total`
+- And 50+ more metrics
+
+#### PgSQL_Thread.cpp
+
+Added `protocol="pgsql"` labels to the same 60 metrics for PostgreSQL.
+
+### 3. Query Cache Metrics
+
+#### Query_Cache.cpp
+
+This module presented a unique challenge because it uses a template class:
+```cpp
+template <typename QC_DERIVED>
+class Query_Cache : public /* ... */ { ... }
+```
+
+Both `MySQL_Query_Cache` and `PgSQL_Query_Cache` inherit from this template and share the same metrics map.
+
+**Solution:** Created two separate metric maps:
+- `qc_metrics_map_mysql` - with `{ "protocol", "mysql" }` labels
+- `qc_metrics_map_pgsql` - with `{ "protocol", "pgsql" }` labels
+
+The constructor uses `if constexpr (std::is_same_v<QC_DERIVED, MySQL_Query_Cache>)` to select the appropriate map at compile time:
+
+```cpp
+template <typename QC_DERIVED>
+Query_Cache<QC_DERIVED>::Query_Cache() {
+    // ... existing code ...
+
+    // Select metrics map based on derived type
+    if constexpr (std::is_same_v<QC_DERIVED, MySQL_Query_Cache>) {
+        init_prometheus_counter_array<qc_metrics_map_idx, p_qc_counter>(
+            qc_metrics_map_mysql, this->metrics.p_counter_array);
+        init_prometheus_gauge_array<qc_metrics_map_idx, p_qc_gauge>(
+            qc_metrics_map_mysql, this->metrics.p_gauge_array);
+    } else {
+        init_prometheus_counter_array<qc_metrics_map_idx, p_qc_counter>(
+            qc_metrics_map_pgsql, this->metrics.p_counter_array);
+        init_prometheus_gauge_array<qc_metrics_map_idx, p_qc_gauge>(
+            qc_metrics_map_pgsql, this->metrics.p_gauge_array);
+    }
+}
+```
+
+Added protocol labels to 8 Query Cache metrics:
+- `proxysql_query_cache_count_get_total` (status=err/ok)
+- `proxysql_query_cache_count_set_total`
+- `proxysql_query_cache_bytes_total` (op=written/read)
+- `proxysql_query_cache_purged_total`
+- `proxysql_query_cache_entries_total`
+- `proxysql_query_cache_memory_bytes`
+
+### 4. Metrics Update Coordination
+
+#### ProxySQL_Admin.cpp
+
+Enabled the following metrics updates in `update_modules_metrics()`:
+
+1. **PgHGM** (PostgreSQL host groups manager) - Enabled by PR #5069
+2. **GloPTH** (PostgreSQL threads handler) - Newly enabled
+3. **GloPgQC** (PostgreSQL query cache) - Newly enabled
+
+```cpp
+void update_modules_metrics() {
+    // ... existing MySQL metrics updates ...
+
+    // PostgreSQL host groups manager metrics
+    if (PgHGM) {
+        PgHGM->p_update_metrics();
+    }
+    // PostgreSQL threads handler metrics
+    if (GloPTH) {
+        GloPTH->p_update_metrics();
+    }
+    // PostgreSQL query cache metrics
+    if (GloPgQC) {
+        GloPgQC->p_update_metrics();
+    }
+    // ... rest of metrics updates ...
+}
+```
+
+## Technical Implementation Details
+
+### Type Traits for Compile-Time Selection
+
+The Query Cache implementation uses C++17 type traits for zero-overhead compile-time dispatch:
+
+```cpp
+#include <type_traits>
+
+// Returns true at compile time when QC_DERIVED is MySQL_Query_Cache
+if constexpr (std::is_same_v<QC_DERIVED, MySQL_Query_Cache>) {
+    // Use MySQL metrics map
+} else {
+    // Use PostgreSQL metrics map
+}
+```
+
+**Benefits:**
+- Zero runtime overhead - the `if constexpr` branch is resolved at compile time
+- No performance penalty
+- Type-safe - the compiler validates the logic
+
+### Metric Label Architecture
+
+All metrics now follow this label structure:
+
+**Before:**
+```cpp
+metric_tags { { "status", "created" } }
+```
+
+**After:**
+```cpp
+metric_tags { { "status", "created" }, { "protocol", "mysql" } }
+```
+
+For metrics without existing labels:
+```cpp
+metric_tags { { "protocol", "mysql" } }
+```
+
+## Prometheus Metrics Examples
+
+### Thread Handler Metrics
+
+```bash
+# MySQL Thread Handler Metrics
+proxysql_queries_backends_bytes_total{protocol="mysql",traffic_flow="sent"} 1234567
+proxysql_queries_backends_bytes_total{protocol="mysql",traffic_flow="received"} 2345678
+proxysql_com_backend_stmt_total{protocol="mysql",op="prepare"} 100
+proxysql_com_backend_stmt_total{protocol="mysql",op="execute"} 1000
+proxysql_questions_total{protocol="mysql"} 50000
+
+# PostgreSQL Thread Handler Metrics
+proxysql_queries_backends_bytes_total{protocol="pgsql",traffic_flow="sent"} 345678
+proxysql_queries_backends_bytes_total{protocol="pgsql",traffic_flow="received"} 456789
+proxysql_com_backend_stmt_total{protocol="pgsql",op="prepare"} 50
+proxysql_com_backend_stmt_total{protocol="pgsql",op="execute"} 500
+proxysql_questions_total{protocol="pgsql"} 25000
+```
+
+### Host Groups Manager Metrics
+
+```bash
+# MySQL Host Groups Manager Metrics
+proxysql_client_connections_total{protocol="mysql",status="created"} 1000000
+proxysql_client_connections_total{protocol="mysql",status="aborted"} 5000
+proxysql_server_connections_total{protocol="mysql",status="created"} 200000
+proxysql_access_denied_wrong_password_total{protocol="mysql"} 100
+proxysql_server_connections_connected{protocol="mysql"} 500
+
+# PostgreSQL Host Groups Manager Metrics
+proxysql_client_connections_total{protocol="pgsql",status="created"} 500000
+proxysql_client_connections_total{protocol="pgsql",status="aborted"} 2500
+proxysql_server_connections_total{protocol="pgsql",status="created"} 100000
+proxysql_access_denied_wrong_password_total{protocol="pgsql"} 50
+proxysql_server_connections_connected{protocol="pgsql"} 250
+```
+
+### Query Cache Metrics
+
+```bash
+# MySQL Query Cache Metrics
+proxysql_query_cache_count_get_total{protocol="mysql",status="err"} 100
+proxysql_query_cache_count_get_total{protocol="mysql",status="ok"} 50000
+proxysql_query_cache_count_set_total{protocol="mysql"} 25000
+proxysql_query_cache_bytes_total{protocol="mysql",op="read"} 104857600
+proxysql_query_cache_bytes_total{protocol="mysql",op="written"} 52428800
+proxysql_query_cache_entries_total{protocol="mysql"} 1000
+proxysql_query_cache_memory_bytes{protocol="mysql"} 2097152
+
+# PostgreSQL Query Cache Metrics
+proxysql_query_cache_count_get_total{protocol="pgsql",status="err"} 50
+proxysql_query_cache_count_get_total{protocol="pgsql",status="ok"} 25000
+proxysql_query_cache_count_set_total{protocol="pgsql"} 12500
+proxysql_query_cache_bytes_total{protocol="pgsql",op="read"} 52428800
+proxysql_query_cache_bytes_total{protocol="pgsql",op="written"} 26214400
+proxysql_query_cache_entries_total{protocol="pgsql"} 500
+proxysql_query_cache_memory_bytes{protocol="pgsql"} 1048576
+```
+
+## Related Issues and Pull Requests
+
+- **Issue #5068**: Original issue reporting the metric discrepancy
+- **PR #5069**: Initial PR that added protocol labels to Host Groups Manager metrics
+- **Branch v3.0-5069**: This branch extends PR #5069 by adding protocol labels to all MySQL and PostgreSQL prometheus metrics
+
+## Backward Compatibility
+
+### Breaking Changes
+
+None. The changes only add new labels to existing metrics. Existing prometheus queries that don't filter by `protocol` will continue to work but will now see duplicate time series.
+
+### Prometheus Query Impact
+
+**Before:** Queries would return a single time series per metric:
+```promql
+proxysql_client_connections_total{status="created"}
+```
+
+**After:** Queries will return multiple time series (one per protocol):
+```promql
+proxysql_client_connections_total{status="created"}
+```
+
+To maintain existing behavior, users should add a protocol filter:
+```promql
+proxysql_client_connections_total{status="created",protocol="mysql"}
+```
+
+### Recommended Prometheus Queries
+
+**Total connections across all protocols:**
+```promql
+sum(proxysql_client_connections_total{status="created"})
+```
+
+**MySQL-only metrics:**
+```promql
+proxysql_client_connections_total{status="created",protocol="mysql"}
+```
+
+**PostgreSQL-only metrics:**
+```promql
+proxysql_client_connections_total{status="created",protocol="pgsql"}
+```
+
+## Verification
+
+To verify the implementation:
+
+1. **Build ProxySQL:**
+   ```bash
+   make clean && make -j4
+   ```
+
+2. **Check prometheus metrics:**
+   ```bash
+   curl localhost:6070/metrics | grep -E "protocol=.*(mysql|pgsql)"
+   ```
+
+3. **Verify separate metrics exist:**
+   ```bash
+   curl localhost:6070/metrics | grep "proxysql_client_connections_total"
+   ```
+
+   Expected output:
+   ```
+   proxysql_client_connections_total{protocol="mysql",status="aborted"} X
+   proxysql_client_connections_total{protocol="mysql",status="created"} Y
+   proxysql_client_connections_total{protocol="pgsql",status="aborted"} Z
+   proxysql_client_connections_total{protocol="pgsql",status="created"} W
+   ```
+
+## Implementation Commits
+
+1. **fa35bda62** - Merge pull request #5069
+   - Added protocol labels to MySQL_HostGroups_Manager
+   - Added protocol labels to PgSQL_HostGroups_Manager
+   - Enabled PgHGM metrics export
+
+2. **2b44aaa58** - Add protocol labels for shared metrics between mysql and psql
+   - Initial implementation of protocol label approach
+
+3. **949eda1cc** - Generate postgres metrics in addition to mysql metrics
+   - Enabled PgHGM metrics export
+
+4. **778e01174** - Add protocol labels to Thread Handler metrics and enable PostgreSQL metrics
+   - Added protocol labels to MySQL_Thread.cpp (65 metrics)
+   - Added protocol labels to PgSQL_Thread.cpp (60 metrics)
+   - Enabled GloPTH metrics export
+
+5. **3ab964010** - Add protocol labels to Query Cache metrics and enable PostgreSQL QC metrics
+   - Added `#include <type_traits>`
+   - Created qc_metrics_map_mysql with protocol="mysql" labels
+   - Created qc_metrics_map_pgsql with protocol="pgsql" labels
+   - Modified Query_Cache constructor with if constexpr type selection
+   - Enabled GloPgQC metrics export
+
+## Summary
+
+This implementation fully resolves Issue #5068 by adding protocol labels to all prometheus metrics, allowing MySQL and PostgreSQL modules to coexist without metric collisions. The solution:
+
+- ✅ **Follows prometheus best practices** - using labels to distinguish metric sources
+- ✅ **Maintains backward compatibility** - existing queries continue to work
+- ✅ **Has zero runtime overhead** - uses compile-time type trait selection
+- ✅ **Is maintainable** - clear separation of MySQL and PostgreSQL metrics
+- ✅ **Completes PR #5069** - extends the initial work to cover all modules
+
+Users can now monitor MySQL and PostgreSQL metrics independently using protocol filters, providing complete visibility into both database protocols.

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -320,7 +320,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
-				{ "status", "created" }
+				{ "status", "created" },
+				{ "protocol", "mysql" }
 			}
 		),
 		std::make_tuple (
@@ -328,7 +329,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
-				{ "status", "delayed" }
+				{ "status", "delayed" },
+				{ "protocol", "mysql" }
 			}
 		),
 		std::make_tuple (
@@ -336,7 +338,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
-				{ "status", "aborted" }
+				{ "status", "aborted" },
+				{ "protocol", "mysql" }
 			}
 		),
 		// ====================================================================
@@ -347,7 +350,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_client_connections_total",
 			"Total number of client connections created.",
 			metric_tags {
-				{ "status", "created" }
+				{ "status", "created" },
+				{ "protocol", "mysql" }
 			}
 		),
 		std::make_tuple (
@@ -361,7 +365,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_client_connections_total",
 			"Total number of client failed connections (or closed improperly).",
 			metric_tags {
-				{ "status", "aborted" }
+				{ "status", "aborted" },
+				{ "protocol", "mysql" }
 			}
 		),
 		// ====================================================================
@@ -448,19 +453,25 @@ hg_metrics_map = std::make_tuple(
 			p_hg_counter::access_denied_wrong_password,
 			"proxysql_access_denied_wrong_password_total",
 			"Total access denied \"wrong password\".",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::access_denied_max_connections,
 			"proxysql_access_denied_max_connections_total",
 			"Total access denied \"max connections\".",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		),
 		std::make_tuple (
 			p_hg_counter::access_denied_max_user_connections,
 			"proxysql_access_denied_max_user_connections_total",
 			"Total access denied \"max user connections\".",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		),
 
 		// ====================================================================
@@ -518,13 +529,17 @@ hg_metrics_map = std::make_tuple(
 			p_hg_gauge::server_connections_connected,
 			"proxysql_server_connections_connected",
 			"Backend connections that are currently connected.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		),
 		std::make_tuple (
 			p_hg_gauge::client_connections_connected,
 			"proxysql_client_connections_connected",
 			"Client connections that are currently connected.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		),
 		std::make_tuple (
 			p_hg_gauge::client_connections_connected_prim,

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -562,6 +562,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_queries_backends_bytes_total",
 			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "traffic_flow", "sent" }
 			}
 		),
@@ -570,6 +571,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_queries_backends_bytes_total",
 			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "traffic_flow", "received" }
 			}
 		),
@@ -581,6 +583,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_queries_frontends_bytes_total",
 			"Total number of bytes (sent|received) in frontend connections.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "traffic_flow", "sent" }
 			}
 		),
@@ -589,6 +592,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_queries_frontends_bytes_total",
 			"Total number of bytes (sent|received) in frontend connections.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "traffic_flow", "received" }
 			}
 		),
@@ -598,13 +602,21 @@ th_metrics_map = std::make_tuple(
 			p_th_counter::query_processor_time_nsec,
 			"proxysql_query_processor_time_seconds_total",
 			"The time spent inside the \"Query Processor\" to determine what action needs to be taken with the query (internal module).",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::backend_query_time_nsec,
 			"proxysql_backend_query_time_seconds_total",
 			"Time spent making network calls to communicate with the backends.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 
 		// ====================================================================
@@ -613,6 +625,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_com_backend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "op", "prepare" }
 			}
 		),
@@ -621,6 +634,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_com_backend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "op", "execute" }
 			}
 		),
@@ -629,6 +643,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_com_backend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "op", "close" }
 			}
 		),
@@ -640,6 +655,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_com_frontend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "op", "prepare" }
 			}
 		),
@@ -648,6 +664,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_com_frontend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "op", "execute" }
 			}
 		),
@@ -656,6 +673,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_com_frontend_stmt_total",
 			"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 			metric_tags {
+				{ "protocol", "mysql" },
 				{ "op", "close" }
 			}
 		),
@@ -665,25 +683,41 @@ th_metrics_map = std::make_tuple(
 			p_th_counter::questions,
 			"proxysql_questions_total",
 			"The total number of client requests / statements executed.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::slow_queries,
 			"proxysql_slow_queries_total",
 			"The total number of queries with an execution time greater than \"mysql-long_query_time\" milliseconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::gtid_consistent_queries,
 			"proxysql_gtid_consistent_queries_total",
 			"Total queries with GTID consistent read.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::gtid_session_collected,
 			"proxysql_gtid_session_collected_total",
 			"Total queries with GTID session state.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 
 		// ====================================================================
@@ -691,25 +725,41 @@ th_metrics_map = std::make_tuple(
 			p_th_counter::connpool_get_conn_latency_awareness,
 			"proxysql_connpool_get_conn_success_latency_awareness_total",
 			"The connection was picked using the latency awareness algorithm.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_immediate,
 			"proxysql_connpool_get_conn_success_immediate_total",
 			"The connection is provided from per-thread cache.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_success,
 			"proxysql_connpool_get_conn_success_total",
 			"The session is able to get a connection, either from per-thread cache or connection pool.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::connpool_get_conn_failure,
 			"proxysql_connpool_get_conn_failure_total",
 			"The connection pool cannot provide any connection.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		// ====================================================================
 
@@ -717,133 +767,221 @@ th_metrics_map = std::make_tuple(
 			p_th_counter::generated_error_packets,
 			"proxysql_generated_error_packets_total",
 			"Total generated error packets.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::max_connect_timeouts,
 			"proxysql_max_connect_timeouts_total",
 			"Maximum connection timeout reached when trying to connect to backend sever.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::backend_lagging_during_query,
 			"proxysql_backend_lagging_during_query_total",
 			"Query failed because server was shunned due to lag.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::backend_offline_during_query,
 			"proxysql_backend_offline_during_query_total",
 			"Query failed because server was offline.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::queries_with_max_lag_ms,
 			"proxysql_queries_with_max_lag_total",
 			"Received queries that have a 'max_lag' attribute.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::queries_with_max_lag_ms__delayed,
 			"proxysql_queries_with_max_lag__delayed_total",
 			"Query delayed because no connection was selected due to 'max_lag' annotation.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::queries_with_max_lag_ms__total_wait_time_us,
 			"proxysql_queries_with_max_lag__total_wait_time_total",
 			"Total waited time due to connection selection because of 'max_lag' annotation.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_unexpected_frontend_com_ping,
 			"proxysql_mysql_unexpected_frontend_com_ping_total",
 			"Unexpected 'COM_PING' received from the client.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_unexpected_frontend_com_quit,
 			"proxysql_mysql_unexpected_frontend_com_quit_total",
 			"Unexpected 'COM_QUIT' received from the client.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::hostgroup_locked_set_cmds,
 			"proxysql_hostgroup_locked_set_cmds_total",
 			"Total number of connections that have been locked in a hostgroup.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::hostgroup_locked_queries,
 			"proxysql_hostgroup_locked_queries_total",
 			"Query blocked because connection is locked into some hostgroup but is trying to reach other.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_unexpected_frontend_packets,
 			"proxysql_mysql_unexpected_frontend_packets_total",
 			"Unexpected packet received from client.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::aws_aurora_replicas_skipped_during_query,
 			"proxysql_aws_aurora_replicas_skipped_during_query_total",
 			"Replicas skipped due to current lag being higher than 'max_lag' annotation.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::automatic_detected_sql_injection,
 			"proxysql_automatic_detected_sql_injection_total",
 			"Blocked a detected 'sql injection' attempt.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_whitelisted_sqli_fingerprint,
 			"proxysql_mysql_whitelisted_sqli_fingerprint_total",
 			"Detected a whitelisted 'sql injection' fingerprint.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::ai_detected_anomalies,
 			"proxysql_ai_detected_anomalies_total",
 			"AI Anomaly Detection detected anomalous query behavior.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::ai_blocked_queries,
 			"proxysql_ai_blocked_queries_total",
 			"AI Anomaly Detection blocked a query.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_killed_backend_connections,
 			"proxysql_mysql_killed_backend_connections_total",
 			"Number of backend connection killed.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_killed_backend_queries,
 			"proxysql_mysql_killed_backend_queries_total",
 			"Killed backend queries.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::client_host_error_killed_connections,
 			"proxysql_client_host_error_killed_connections",
 			"Killed client connections because address exceeded 'client_host_error_counts'.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_set_wait_timeout_commands,
 			"proxysql_mysql_set_wait_timeout_commands_total",
 			"Number of SET wait_timeout commands received from clients.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_counter::mysql_timeout_terminated_connections,
 			"proxysql_mysql_timeout_terminated_connections_total",
 			"Number of client connections terminated due to wait_timeout.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		)
 	},
 	th_gauge_vector {
@@ -851,140 +989,232 @@ th_metrics_map = std::make_tuple(
 			p_th_gauge::active_transactions,
 			"proxysql_active_transactions",
 			"Provides a count of how many client connection are currently processing a transaction.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::client_connections_non_idle,
 			"proxysql_client_connections_non_idle",
 			"Number of client connections that are currently handled by the main worker threads.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::client_connections_hostgroup_locked,
 			"proxysql_client_connections_hostgroup_locked",
 			"Number of client connection locked to a specific hostgroup.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_backend_buffers_bytes,
 			"proxysql_mysql_backend_buffers_bytes",
 			"Buffers related to backend connections if \"fast_forward\" is used (0 means fast_forward is not used).",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_frontend_buffers_bytes,
 			"proxysql_mysql_frontend_buffers_bytes",
 			"Buffers related to frontend connections (read/write buffers and other queues).",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_session_internal_bytes,
 			"proxysql_mysql_session_internal_bytes",
 			"Other memory used by ProxySQL to handle MySQL Sessions.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mirror_concurrency,
 			"proxysql_mirror_concurrency",
 			"Mirror current concurrency",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mirror_queue_lengths,
 			"proxysql_mirror_queue_lengths",
 			"Mirror queue length",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_thread_workers,
 			"proxysql_mysql_thread_workers",
 			"Number of MySQL Thread workers i.e. 'mysql-threads'",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		// global_variables
 		std::make_tuple (
 			p_th_gauge::mysql_wait_timeout,
 			"proxysql_mysql_wait_timeout",
 			"If a proxy session has been idle for more than this threshold, the proxy will kill the session.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_max_connections,
 			"proxysql_mysql_max_connections",
 			"The maximum number of client connections that the proxy can handle.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_enabled,
 			"proxysql_mysql_monitor_enabled",
 			"Enables or disables MySQL Monitor.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_ping_interval,
 			"proxysql_mysql_monitor_ping_interval",
 			"How frequently a ping check is performed, in seconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_ping_timeout,
 			"proxysql_mysql_monitor_ping_timeout_seconds",
 			"Ping timeout in seconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_ping_max_failures,
 			"proxysql_mysql_monitor_ping_max_failures",
 			"Reached maximum ping attempts from monitor.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_aws_rds_topology_discovery_interval,
 			"proxysql_mysql_monitor_aws_rds_topology_discovery_interval",
 			"How frequently a topology discovery is performed, e.g. a value of 500 means one topology discovery every 500 read-only checks ",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_read_only_interval,
 			"proxysql_mysql_monitor_read_only_interval_seconds",
 			"How frequently a read only check is performed, in seconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_read_only_timeout,
 			"proxysql_mysql_monitor_read_only_timeout_seconds",
 			"Read only check timeout in seconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_writer_is_also_reader,
 			"proxysql_mysql_monitor_writer_is_also_reader",
 			"Encodes different behaviors for nodes depending on their 'READ_ONLY' flag value.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_replication_lag_group_by_host,
 			"proxysql_monitor_replication_lag_group_by_host",
 			"Encodes different replication lag check if the same server is in multiple hostgroups.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_replication_lag_interval,
 			"proxysql_mysql_monitor_replication_lag_interval_seconds",
 			"How frequently a replication lag check is performed, in seconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_replication_lag_timeout,
 			"proxysql_mysql_monitor_replication_lag_timeout_seconds",
 			"Replication lag check timeout in seconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		),
 		std::make_tuple (
 			p_th_gauge::mysql_monitor_history,
 			"proxysql_mysql_monitor_history_timeout_seconds",
 			"The duration for which the events for the checks made by the Monitor module are kept, in seconds.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "mysql" }
+
+			}
 		)
 	}
 );

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -352,7 +352,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
-				{ "status", "created" }
+				{ "status", "created" },
+				{ "protocol", "pgsql" }
 			}
 		),
 		std::make_tuple (
@@ -360,7 +361,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
-				{ "status", "delayed" }
+				{ "status", "delayed" },
+				{ "protocol", "pgsql" }
 			}
 		),
 		std::make_tuple (
@@ -368,7 +370,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_server_connections_total",
 			"Total number of server connections (created|delayed|aborted).",
 			metric_tags {
-				{ "status", "aborted" }
+				{ "status", "aborted" },
+				{ "protocol", "pgsql" }
 			}
 		),
 		// ====================================================================
@@ -379,7 +382,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_client_connections_total",
 			"Total number of client connections created.",
 			metric_tags {
-				{ "status", "created" }
+				{ "status", "created" },
+				{ "protocol", "pgsql" }
 			}
 		),
 		std::make_tuple (
@@ -387,7 +391,8 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_client_connections_total",
 			"Total number of client failed connections (or closed improperly).",
 			metric_tags {
-				{ "status", "aborted" }
+				{ "status", "aborted" },
+				{ "protocol", "pgsql" }
 			}
 		),
 		// ====================================================================
@@ -474,19 +479,25 @@ hg_metrics_map = std::make_tuple(
 			PgSQL_p_hg_counter::access_denied_wrong_password,
 			"proxysql_access_denied_wrong_password_total",
 			"Total access denied \"wrong password\".",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
 		),
 		std::make_tuple (
 			PgSQL_p_hg_counter::access_denied_max_connections,
 			"proxysql_access_denied_max_connections_total",
 			"Total access denied \"max connections\".",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
 		),
 		std::make_tuple (
 			PgSQL_p_hg_counter::access_denied_max_user_connections,
 			"proxysql_access_denied_max_user_connections_total",
 			"Total access denied \"max user connections\".",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
 		),
 
 		// ====================================================================
@@ -544,13 +555,17 @@ hg_metrics_map = std::make_tuple(
 			PgSQL_p_hg_gauge::server_connections_connected,
 			"proxysql_server_connections_connected",
 			"Backend connections that are currently connected.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
 		),
 		std::make_tuple (
 			PgSQL_p_hg_gauge::client_connections_connected,
 			"proxysql_client_connections_connected",
 			"Client connections that are currently connected.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
 		)
 	},
 	// prometheus dynamic counters

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -528,21 +528,13 @@ th_metrics_map = std::make_tuple(
 		p_th_counter::query_processor_time_nsec,
 		"proxysql_query_processor_time_seconds_total",
 		"The time spent inside the \"Query Processor\" to determine what action needs to be taken with the query (internal module).",
-		metric_tags {
-
-			{ "protocol", "pgsql" }
-
-		}
+		metric_tags { { "protocol", "pgsql" } }
 	),
 	std::make_tuple(
 		p_th_counter::backend_query_time_nsec,
 		"proxysql_backend_query_time_seconds_total",
 		"Time spent making network calls to communicate with the backends.",
-		metric_tags {
-
-			{ "protocol", "pgsql" }
-
-		}
+		metric_tags { { "protocol", "pgsql" } }
 	),
 
 	// ====================================================================
@@ -610,19 +602,15 @@ th_metrics_map = std::make_tuple(
 		"proxysql_questions_total",
 		"The total number of client requests / statements executed.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
 		p_th_counter::slow_queries,
 		"proxysql_slow_queries_total",
-		"The total number of queries with an execution time greater than \"mysql-long_query_time\" milliseconds.",
+		"The total number of queries with an execution time greater than \"pgsql-long_query_time\" milliseconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -630,9 +618,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_gtid_consistent_queries_total",
 		"Total queries with GTID consistent read.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -640,9 +626,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_gtid_session_collected_total",
 		"Total queries with GTID session state.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 
@@ -652,9 +636,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_connpool_get_conn_success_latency_awareness_total",
 		"The connection was picked using the latency awareness algorithm.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -662,9 +644,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_connpool_get_conn_success_immediate_total",
 		"The connection is provided from per-thread cache.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -672,9 +652,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_connpool_get_conn_success_total",
 		"The session is able to get a connection, either from per-thread cache or connection pool.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -682,9 +660,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_connpool_get_conn_failure_total",
 		"The connection pool cannot provide any connection.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	// ====================================================================
@@ -694,9 +670,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_generated_error_packets_total",
 		"Total generated error packets.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -704,9 +678,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_max_connect_timeouts_total",
 		"Maximum connection timeout reached when trying to connect to backend sever.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -714,9 +686,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_backend_lagging_during_query_total",
 		"Query failed because server was shunned due to lag.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -724,9 +694,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_backend_offline_during_query_total",
 		"Query failed because server was offline.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -734,9 +702,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_queries_with_max_lag_total",
 		"Received queries that have a 'max_lag' attribute.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -744,9 +710,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_queries_with_max_lag__delayed_total",
 		"Query delayed because no connection was selected due to 'max_lag' annotation.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -754,9 +718,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_queries_with_max_lag__total_wait_time_total",
 		"Total waited time due to connection selection because of 'max_lag' annotation.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -764,9 +726,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_unexpected_frontend_com_quit_total",
 		"Unexpected 'COM_QUIT' received from the client.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -774,9 +734,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_hostgroup_locked_set_cmds_total",
 		"Total number of connections that have been locked in a hostgroup.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -784,9 +742,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_hostgroup_locked_queries_total",
 		"Query blocked because connection is locked into some hostgroup but is trying to reach other.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -794,9 +750,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_unexpected_frontend_packets_total",
 		"Unexpected packet received from client.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -804,9 +758,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_aws_aurora_replicas_skipped_during_query_total",
 		"Replicas skipped due to current lag being higher than 'max_lag' annotation.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -814,9 +766,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_automatic_detected_sql_injection_total",
 		"Blocked a detected 'sql injection' attempt.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -824,9 +774,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_whitelisted_sqli_fingerprint_total",
 		"Detected a whitelisted 'sql injection' fingerprint.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -834,9 +782,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_killed_backend_connections_total",
 		"Number of backend connection killed.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -844,9 +790,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_killed_backend_queries_total",
 		"Killed backend queries.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -854,9 +798,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_client_host_error_killed_connections",
 		"Killed client connections because address exceeded 'client_host_error_counts'.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	)
 	},
@@ -866,9 +808,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_active_transactions",
 			"Provides a count of how many client connection are currently processing a transaction.",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -876,9 +816,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_client_connections_non_idle",
 			"Number of client connections that are currently handled by the main worker threads.",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -886,9 +824,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_client_connections_hostgroup_locked",
 			"Number of client connection locked to a specific hostgroup.",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -896,9 +832,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_mysql_backend_buffers_bytes",
 			"Buffers related to backend connections if \"fast_forward\" is used (0 means fast_forward is not used).",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -906,9 +840,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_mysql_frontend_buffers_bytes",
 			"Buffers related to frontend connections (read/write buffers and other queues).",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -916,9 +848,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_mysql_session_internal_bytes",
 			"Other memory used by ProxySQL to handle MySQL Sessions.",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -926,9 +856,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_mirror_concurrency",
 			"Mirror current concurrency",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -936,9 +864,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_mirror_queue_lengths",
 			"Mirror queue length",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 		std::make_tuple(
@@ -946,9 +872,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_mysql_thread_workers",
 			"Number of MySQL Thread workers i.e. 'mysql-threads'",
 			metric_tags {
-
 				{ "protocol", "pgsql" }
-
 			}
 		),
 	// global_variables
@@ -957,9 +881,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_wait_timeout",
 		"If a proxy session has been idle for more than this threshold, the proxy will kill the session.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -967,9 +889,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_max_connections",
 		"The maximum number of client connections that the proxy can handle.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -977,9 +897,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_enabled",
 		"Enables or disables MySQL Monitor.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -987,9 +905,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_ping_interval",
 		"How frequently a ping check is performed, in seconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -997,9 +913,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_ping_timeout_seconds",
 		"Ping timeout in seconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1007,9 +921,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_ping_max_failures",
 		"Reached maximum ping attempts from monitor.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple (
@@ -1017,9 +929,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_aws_rds_topology_discovery_interval",
 		"How frequently a topology discovery is performed, e.g. a value of 500 means one topology discovery every 500 read-only checks ",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1027,9 +937,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_read_only_interval_seconds",
 		"How frequently a read only check is performed, in seconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1037,9 +945,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_read_only_timeout_seconds",
 		"Read only check timeout in seconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1047,9 +953,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_writer_is_also_reader",
 		"Encodes different behaviors for nodes depending on their 'READ_ONLY' flag value.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1057,9 +961,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_monitor_replication_lag_group_by_host",
 		"Encodes different replication lag check if the same server is in multiple hostgroups.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1067,9 +969,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_replication_lag_interval_seconds",
 		"How frequently a replication lag check is performed, in seconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1077,9 +977,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_replication_lag_timeout_seconds",
 		"Replication lag check timeout in seconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	),
 	std::make_tuple(
@@ -1087,9 +985,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_mysql_monitor_history_timeout_seconds",
 		"The duration for which the events for the checks made by the Monitor module are kept, in seconds.",
 		metric_tags {
-
 			{ "protocol", "pgsql" }
-
 		}
 	)
 	}

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -488,6 +488,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_queries_backends_bytes_total",
 			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
+				{ "protocol", "pgsql" },
 				{ "traffic_flow", "sent" }
 			}
 		),
@@ -496,6 +497,7 @@ th_metrics_map = std::make_tuple(
 			"proxysql_queries_backends_bytes_total",
 			"Total number of bytes (sent|received) in backend connections.",
 			metric_tags {
+				{ "protocol", "pgsql" },
 				{ "traffic_flow", "received" }
 			}
 		),
@@ -507,6 +509,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_queries_frontends_bytes_total",
 		"Total number of bytes (sent|received) in frontend connections.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "traffic_flow", "sent" }
 		}
 	),
@@ -515,6 +518,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_queries_frontends_bytes_total",
 		"Total number of bytes (sent|received) in frontend connections.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "traffic_flow", "received" }
 		}
 	),
@@ -524,13 +528,21 @@ th_metrics_map = std::make_tuple(
 		p_th_counter::query_processor_time_nsec,
 		"proxysql_query_processor_time_seconds_total",
 		"The time spent inside the \"Query Processor\" to determine what action needs to be taken with the query (internal module).",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::backend_query_time_nsec,
 		"proxysql_backend_query_time_seconds_total",
 		"Time spent making network calls to communicate with the backends.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 
 	// ====================================================================
@@ -539,6 +551,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_com_backend_stmt_total",
 		"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "op", "prepare" }
 		}
 	),
@@ -547,6 +560,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_com_backend_stmt_total",
 		"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "op", "execute" }
 		}
 	),
@@ -555,6 +569,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_com_backend_stmt_total",
 		"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by ProxySQL against the backends.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "op", "close" }
 		}
 	),
@@ -566,6 +581,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_com_frontend_stmt_total",
 		"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "op", "prepare" }
 		}
 	),
@@ -574,6 +590,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_com_frontend_stmt_total",
 		"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "op", "execute" }
 		}
 	),
@@ -582,6 +599,7 @@ th_metrics_map = std::make_tuple(
 		"proxysql_com_frontend_stmt_total",
 		"Represents the number of statements (PREPARE|EXECUTE|CLOSE) executed by clients.",
 		metric_tags {
+			{ "protocol", "pgsql" },
 			{ "op", "close" }
 		}
 	),
@@ -591,25 +609,41 @@ th_metrics_map = std::make_tuple(
 		p_th_counter::questions,
 		"proxysql_questions_total",
 		"The total number of client requests / statements executed.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::slow_queries,
 		"proxysql_slow_queries_total",
 		"The total number of queries with an execution time greater than \"mysql-long_query_time\" milliseconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::gtid_consistent_queries,
 		"proxysql_gtid_consistent_queries_total",
 		"Total queries with GTID consistent read.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::gtid_session_collected,
 		"proxysql_gtid_session_collected_total",
 		"Total queries with GTID session state.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 
 	// ====================================================================
@@ -617,25 +651,41 @@ th_metrics_map = std::make_tuple(
 		p_th_counter::connpool_get_conn_latency_awareness,
 		"proxysql_connpool_get_conn_success_latency_awareness_total",
 		"The connection was picked using the latency awareness algorithm.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::connpool_get_conn_immediate,
 		"proxysql_connpool_get_conn_success_immediate_total",
 		"The connection is provided from per-thread cache.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::connpool_get_conn_success,
 		"proxysql_connpool_get_conn_success_total",
 		"The session is able to get a connection, either from per-thread cache or connection pool.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::connpool_get_conn_failure,
 		"proxysql_connpool_get_conn_failure_total",
 		"The connection pool cannot provide any connection.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	// ====================================================================
 
@@ -643,103 +693,171 @@ th_metrics_map = std::make_tuple(
 		p_th_counter::generated_error_packets,
 		"proxysql_generated_error_packets_total",
 		"Total generated error packets.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::max_connect_timeouts,
 		"proxysql_max_connect_timeouts_total",
 		"Maximum connection timeout reached when trying to connect to backend sever.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::backend_lagging_during_query,
 		"proxysql_backend_lagging_during_query_total",
 		"Query failed because server was shunned due to lag.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::backend_offline_during_query,
 		"proxysql_backend_offline_during_query_total",
 		"Query failed because server was offline.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::queries_with_max_lag_ms,
 		"proxysql_queries_with_max_lag_total",
 		"Received queries that have a 'max_lag' attribute.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::queries_with_max_lag_ms__delayed,
 		"proxysql_queries_with_max_lag__delayed_total",
 		"Query delayed because no connection was selected due to 'max_lag' annotation.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::queries_with_max_lag_ms__total_wait_time_us,
 		"proxysql_queries_with_max_lag__total_wait_time_total",
 		"Total waited time due to connection selection because of 'max_lag' annotation.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::mysql_unexpected_frontend_com_quit,
 		"proxysql_mysql_unexpected_frontend_com_quit_total",
 		"Unexpected 'COM_QUIT' received from the client.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::hostgroup_locked_set_cmds,
 		"proxysql_hostgroup_locked_set_cmds_total",
 		"Total number of connections that have been locked in a hostgroup.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::hostgroup_locked_queries,
 		"proxysql_hostgroup_locked_queries_total",
 		"Query blocked because connection is locked into some hostgroup but is trying to reach other.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::mysql_unexpected_frontend_packets,
 		"proxysql_mysql_unexpected_frontend_packets_total",
 		"Unexpected packet received from client.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::aws_aurora_replicas_skipped_during_query,
 		"proxysql_aws_aurora_replicas_skipped_during_query_total",
 		"Replicas skipped due to current lag being higher than 'max_lag' annotation.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::automatic_detected_sql_injection,
 		"proxysql_automatic_detected_sql_injection_total",
 		"Blocked a detected 'sql injection' attempt.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::mysql_whitelisted_sqli_fingerprint,
 		"proxysql_mysql_whitelisted_sqli_fingerprint_total",
 		"Detected a whitelisted 'sql injection' fingerprint.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::mysql_killed_backend_connections,
 		"proxysql_mysql_killed_backend_connections_total",
 		"Number of backend connection killed.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::mysql_killed_backend_queries,
 		"proxysql_mysql_killed_backend_queries_total",
 		"Killed backend queries.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_counter::client_host_error_killed_connections,
 		"proxysql_client_host_error_killed_connections",
 		"Killed client connections because address exceeded 'client_host_error_counts'.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	)
 	},
 	th_gauge_vector{
@@ -747,140 +865,232 @@ th_metrics_map = std::make_tuple(
 			p_th_gauge::active_transactions,
 			"proxysql_active_transactions",
 			"Provides a count of how many client connection are currently processing a transaction.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::client_connections_non_idle,
 			"proxysql_client_connections_non_idle",
 			"Number of client connections that are currently handled by the main worker threads.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::client_connections_hostgroup_locked,
 			"proxysql_client_connections_hostgroup_locked",
 			"Number of client connection locked to a specific hostgroup.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::mysql_backend_buffers_bytes,
 			"proxysql_mysql_backend_buffers_bytes",
 			"Buffers related to backend connections if \"fast_forward\" is used (0 means fast_forward is not used).",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::mysql_frontend_buffers_bytes,
 			"proxysql_mysql_frontend_buffers_bytes",
 			"Buffers related to frontend connections (read/write buffers and other queues).",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::mysql_session_internal_bytes,
 			"proxysql_mysql_session_internal_bytes",
 			"Other memory used by ProxySQL to handle MySQL Sessions.",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::mirror_concurrency,
 			"proxysql_mirror_concurrency",
 			"Mirror current concurrency",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::mirror_queue_lengths,
 			"proxysql_mirror_queue_lengths",
 			"Mirror queue length",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 		std::make_tuple(
 			p_th_gauge::mysql_thread_workers,
 			"proxysql_mysql_thread_workers",
 			"Number of MySQL Thread workers i.e. 'mysql-threads'",
-			metric_tags {}
+			metric_tags {
+
+				{ "protocol", "pgsql" }
+
+			}
 		),
 	// global_variables
 	std::make_tuple(
 		p_th_gauge::mysql_wait_timeout,
 		"proxysql_mysql_wait_timeout",
 		"If a proxy session has been idle for more than this threshold, the proxy will kill the session.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_max_connections,
 		"proxysql_mysql_max_connections",
 		"The maximum number of client connections that the proxy can handle.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_enabled,
 		"proxysql_mysql_monitor_enabled",
 		"Enables or disables MySQL Monitor.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_ping_interval,
 		"proxysql_mysql_monitor_ping_interval",
 		"How frequently a ping check is performed, in seconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_ping_timeout,
 		"proxysql_mysql_monitor_ping_timeout_seconds",
 		"Ping timeout in seconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_ping_max_failures,
 		"proxysql_mysql_monitor_ping_max_failures",
 		"Reached maximum ping attempts from monitor.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple (
 		p_th_gauge::mysql_monitor_aws_rds_topology_discovery_interval,
 		"proxysql_mysql_monitor_aws_rds_topology_discovery_interval",
 		"How frequently a topology discovery is performed, e.g. a value of 500 means one topology discovery every 500 read-only checks ",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_read_only_interval,
 		"proxysql_mysql_monitor_read_only_interval_seconds",
 		"How frequently a read only check is performed, in seconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_read_only_timeout,
 		"proxysql_mysql_monitor_read_only_timeout_seconds",
 		"Read only check timeout in seconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_writer_is_also_reader,
 		"proxysql_mysql_monitor_writer_is_also_reader",
 		"Encodes different behaviors for nodes depending on their 'READ_ONLY' flag value.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_replication_lag_group_by_host,
 		"proxysql_monitor_replication_lag_group_by_host",
 		"Encodes different replication lag check if the same server is in multiple hostgroups.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_replication_lag_interval,
 		"proxysql_mysql_monitor_replication_lag_interval_seconds",
 		"How frequently a replication lag check is performed, in seconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_replication_lag_timeout,
 		"proxysql_mysql_monitor_replication_lag_timeout_seconds",
 		"Replication lag check timeout in seconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	),
 	std::make_tuple(
 		p_th_gauge::mysql_monitor_history,
 		"proxysql_mysql_monitor_history_timeout_seconds",
 		"The duration for which the events for the checks made by the Monitor module are kept, in seconds.",
-		metric_tags {}
+		metric_tags {
+
+			{ "protocol", "pgsql" }
+
+		}
 	)
 	}
 );

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2625,6 +2625,10 @@ void update_modules_metrics() {
 	if (PgHGM) {
 		PgHGM->p_update_metrics();
 	}
+	// Update pgsql_threads_handler metrics
+	if (GloPTH) {
+		GloPTH->p_update_metrics();
+	}
 	// Update monitor metrics
 	if (GloMyMon) {
 		GloMyMon->p_update_metrics();
@@ -2634,14 +2638,7 @@ void update_modules_metrics() {
 		GloMyQC->p_update_metrics();
 	}
 #if 0 // Turning off Prometheus metrics collection for PostgreSQL modules in ProxySQL
-	// Update pgsql_threads_handler metrics
-	if (GloPTH) {
-		GloPTH->p_update_metrics();
-	}
-	// Update pgsql_hostgroups_manager metrics
-	if (PgHGM) {
-		PgHGM->p_update_metrics();
-	}
+	// Note: Query Cache metrics use shared template base class and would collide between MySQL and PostgreSQL
 	// Update pgsql query_cache metrics
 	if (GloPgQC) {
 		GloPgQC->p_update_metrics();

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2512,6 +2512,10 @@ void update_modules_metrics() {
 	if (MyHGM) {
 		MyHGM->p_update_metrics();
 	}
+	// Update pgsql_hostgroups_manager metrics
+	if (PgHGM) {
+		PgHGM->p_update_metrics();
+	}
 	// Update monitor metrics
 	if (GloMyMon) {
 		GloMyMon->p_update_metrics();

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -2637,13 +2637,10 @@ void update_modules_metrics() {
 	if (GloMyQC) {
 		GloMyQC->p_update_metrics();
 	}
-#if 0 // Turning off Prometheus metrics collection for PostgreSQL modules in ProxySQL
-	// Note: Query Cache metrics use shared template base class and would collide between MySQL and PostgreSQL
 	// Update pgsql query_cache metrics
 	if (GloPgQC) {
 		GloPgQC->p_update_metrics();
 	}
-#endif
 	// Update cluster metrics
 	if (GloProxyCluster) {
 		GloProxyCluster->p_update_metrics();

--- a/lib/Query_Cache.cpp
+++ b/lib/Query_Cache.cpp
@@ -4,6 +4,7 @@
 #include "Query_Cache.h"
 #include "MySQL_Query_Cache.h"
 #include "PgSQL_Query_Cache.h"
+#include <type_traits>
 
 #ifdef DEBUG
 #define DEB "_DEBUG"
@@ -315,7 +316,7 @@ using qc_counter_vector = std::vector<qc_counter_tuple>;
 using qc_gauge_vector = std::vector<qc_gauge_tuple>;
 
 /**
- * @brief Metrics map holding the metrics for the 'Query_Cache' module.
+ * @brief Metrics map holding the metrics for the MySQL Query_Cache module.
  *
  * @note Many metrics in this map, share a common "id name", because
  *  they differ only by label, because of this, HELP is shared between
@@ -323,7 +324,7 @@ using qc_gauge_vector = std::vector<qc_gauge_tuple>;
  *  sepparated using a line separator comment.
  */
 const std::tuple<qc_counter_vector, qc_gauge_vector>
-qc_metrics_map = std::make_tuple(
+qc_metrics_map_mysql = std::make_tuple(
 	qc_counter_vector {
 		// ====================================================================
 		std::make_tuple (
@@ -331,7 +332,8 @@ qc_metrics_map = std::make_tuple(
 			"proxysql_query_cache_count_get_total",
 			"Number of failed read requests.",
 			metric_tags {
-				{ "status", "err" }
+				{ "status", "err" },
+				{ "protocol", "mysql" }
 			}
 		),
 		std::make_tuple (
@@ -339,7 +341,8 @@ qc_metrics_map = std::make_tuple(
 			"proxysql_query_cache_count_get_total",
 			"Number of successful read requests.",
 			metric_tags {
-				{ "status", "ok" }
+				{ "status", "ok" },
+				{ "protocol", "mysql" }
 			}
 		),
 		// ====================================================================
@@ -348,7 +351,9 @@ qc_metrics_map = std::make_tuple(
 			p_qc_counter::query_cache_count_set,
 			"proxysql_query_cache_count_set_total",
 			"Number of write requests.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		),
 
 		// ====================================================================
@@ -357,7 +362,8 @@ qc_metrics_map = std::make_tuple(
 			"proxysql_query_cache_bytes_total",
 			"Number of bytes (read|written) into the Query Cache.",
 			metric_tags {
-				{ "op", "written" }
+				{ "op", "written" },
+				{ "protocol", "mysql" }
 			}
 		),
 		std::make_tuple (
@@ -365,7 +371,8 @@ qc_metrics_map = std::make_tuple(
 			"proxysql_query_cache_bytes_total",
 			"Number of bytes (read|written) into the Query Cache.",
 			metric_tags {
-				{ "op", "read" }
+				{ "op", "read" },
+				{ "protocol", "mysql" }
 			}
 		),
 		// ====================================================================
@@ -374,13 +381,17 @@ qc_metrics_map = std::make_tuple(
 			p_qc_counter::query_cache_purged,
 			"proxysql_query_cache_purged_total",
 			"Number of entries purged by the Query Cache due to TTL expiration.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		),
 		std::make_tuple (
 			p_qc_counter::query_cache_entries,
 			"proxysql_query_cache_entries_total",
 			"Number of entries currently stored in the query cache.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
 		)
 	},
 	qc_gauge_vector {
@@ -388,7 +399,100 @@ qc_metrics_map = std::make_tuple(
 			p_qc_gauge::query_cache_memory_bytes,
 			"proxysql_query_cache_memory_bytes",
 			"Memory currently used by the query cache.",
-			metric_tags {}
+			metric_tags {
+				{ "protocol", "mysql" }
+			}
+		)
+	}
+);
+
+/**
+ * @brief Metrics map holding the metrics for the PostgreSQL Query_Cache module.
+ *
+ * @note Many metrics in this map, share a common "id name", because
+ *  they differ only by label, because of this, HELP is shared between
+ *  them. For better visual identification of this groups they are
+ *  sepparated using a line separator comment.
+ */
+const std::tuple<qc_counter_vector, qc_gauge_vector>
+qc_metrics_map_pgsql = std::make_tuple(
+	qc_counter_vector {
+		// ====================================================================
+		std::make_tuple (
+			p_qc_counter::query_cache_count_get,
+			"proxysql_query_cache_count_get_total",
+			"Number of failed read requests.",
+			metric_tags {
+				{ "status", "err" },
+				{ "protocol", "pgsql" }
+			}
+		),
+		std::make_tuple (
+			p_qc_counter::query_cache_count_get_ok,
+			"proxysql_query_cache_count_get_total",
+			"Number of successful read requests.",
+			metric_tags {
+				{ "status", "ok" },
+				{ "protocol", "pgsql" }
+			}
+		),
+		// ====================================================================
+
+		std::make_tuple (
+			p_qc_counter::query_cache_count_set,
+			"proxysql_query_cache_count_set_total",
+			"Number of write requests.",
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
+		),
+
+		// ====================================================================
+		std::make_tuple (
+			p_qc_counter::query_cache_bytes_in,
+			"proxysql_query_cache_bytes_total",
+			"Number of bytes (read|written) into the Query Cache.",
+			metric_tags {
+				{ "op", "written" },
+				{ "protocol", "pgsql" }
+			}
+		),
+		std::make_tuple (
+			p_qc_counter::query_cache_bytes_out,
+			"proxysql_query_cache_bytes_total",
+			"Number of bytes (read|written) into the Query Cache.",
+			metric_tags {
+				{ "op", "read" },
+				{ "protocol", "pgsql" }
+			}
+		),
+		// ====================================================================
+
+		std::make_tuple (
+			p_qc_counter::query_cache_purged,
+			"proxysql_query_cache_purged_total",
+			"Number of entries purged by the Query Cache due to TTL expiration.",
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
+		),
+		std::make_tuple (
+			p_qc_counter::query_cache_entries,
+			"proxysql_query_cache_entries_total",
+			"Number of entries currently stored in the query cache.",
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
+		)
+	},
+	qc_gauge_vector {
+		std::make_tuple (
+			p_qc_gauge::query_cache_memory_bytes,
+			"proxysql_query_cache_memory_bytes",
+			"Memory currently used by the query cache.",
+			metric_tags {
+				{ "protocol", "pgsql" }
+			}
 		)
 	}
 );
@@ -435,8 +539,13 @@ Query_Cache<QC_DERIVED>::Query_Cache() {
 	//max_memory_size=DEFAULT_SQC_size;
 
 	// Initialize prometheus metrics
-	init_prometheus_counter_array<qc_metrics_map_idx, p_qc_counter>(qc_metrics_map, this->metrics.p_counter_array);
-	init_prometheus_gauge_array<qc_metrics_map_idx, p_qc_gauge>(qc_metrics_map, this->metrics.p_gauge_array);
+	if constexpr (std::is_same_v<QC_DERIVED, MySQL_Query_Cache>) {
+		init_prometheus_counter_array<qc_metrics_map_idx, p_qc_counter>(qc_metrics_map_mysql, this->metrics.p_counter_array);
+		init_prometheus_gauge_array<qc_metrics_map_idx, p_qc_gauge>(qc_metrics_map_mysql, this->metrics.p_gauge_array);
+	} else {
+		init_prometheus_counter_array<qc_metrics_map_idx, p_qc_counter>(qc_metrics_map_pgsql, this->metrics.p_counter_array);
+		init_prometheus_gauge_array<qc_metrics_map_idx, p_qc_gauge>(qc_metrics_map_pgsql, this->metrics.p_gauge_array);
+	}
 };
 
 template <typename QC_DERIVED>


### PR DESCRIPTION
This PR extends PR #5069 by adding protocol labels to distinguish MySQL and PostgreSQL prometheus metrics across all modules, and fully enables PostgreSQL metrics export.

## Summary

This PR resolves Issue #5068 by adding `protocol` labels to all MySQL and PostgreSQL prometheus metrics, allowing them to coexist without metric name collisions.

## Changes in this PR

This PR builds upon PR #5069 (which only added protocol labels to Host Groups Manager metrics) and extends it to:

### 1. Thread Handler Metrics
- Add `protocol="mysql"` labels to 65 MySQL_Thread.cpp metrics
- Add `protocol="pgsql"` labels to 60 PgSQL_Thread.cpp metrics
- Enable GloPTH (PostgreSQL threads handler) metrics export

### 2. Query Cache Metrics
- Create separate `qc_metrics_map_mysql` and `qc_metrics_map_pgsql` with protocol labels
- Use `if constexpr (std::is_same_v<QC_DERIVED, MySQL_Query_Cache>)` for compile-time map selection
- Enable GloPgQC (PostgreSQL query cache) metrics export

### 3. Documentation
- Add comprehensive documentation in `doc/PROMETHEUS_PROTOCOL_LABELS.md`

## Total Impact
- 6 files changed: +798/-147 lines (including documentation)
- 131 protocol labels added across 3 modules
- 3 PostgreSQL metric modules newly enabled (GloPTH, GloPgQC, plus PgHGM from PR #5069)

## Example Output

After this PR, users will see:
```
proxysql_client_connections_total{protocol="mysql",status="aborted"} X
proxysql_client_connections_total{protocol="pgsql",status="aborted"} Y

proxysql_query_cache_count_get_total{protocol="mysql",status="ok"} 50000
proxysql_query_cache_count_get_total{protocol="pgsql",status="ok"} 25000
```

## Implementation Details

The Query Cache implementation uses C++17 type traits for zero-overhead compile-time dispatch:

```cpp
if constexpr (std::is_same_v<QC_DERIVED, MySQL_Query_Cache>) {
    init_prometheus_counter_array(qc_metrics_map_mysql, this->metrics.p_counter_array);
} else {
    init_prometheus_counter_array(qc_metrics_map_pgsql, this->metrics.p_counter_array);
}
```

## Related
- Resolves #5068
- Extends #5069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics now include a protocol label to distinguish MySQL vs PostgreSQL, avoiding metric collisions.
  * Metrics are collected per-database backend so MySQL and PostgreSQL series are reported separately.
  * PostgreSQL metrics collection has been re-enabled.

* **Documentation**
  * Added guidance for filtering and aggregating metrics by protocol in Prometheus queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->