### PR TITLE
[DONOTMERGE] Fix crash in monitor_GR_thread_HG due to stale DEBUG connection tracking (issue #5256)

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -365,6 +365,30 @@ MYSQL * MySQL_Monitor_Connection_Pool::get_connection(char *hostname, int port, 
 					// close connection if not used for a while
 					unsigned long long then = *(unsigned long long*)mysql->net.buff;
 					if (now > (then + mysql_thread___monitor_ping_interval * 1000 * 10)) {
+#ifdef DEBUG
+						// CRITICAL FIX for issue #5256:
+						// When a connection becomes stale and is queued for closure, we MUST remove it
+						// from the DEBUG 'conns' array BEFORE queuing. If we don't:
+						// 1. The connection is closed (via destructor's close_mysql())
+						// 2. The connection pointer remains in 'conns' array
+						// 3. Later, malloc may reuse the same pointer for a new connection
+						// 4. conn_register() will find this pointer in 'conns' and assert
+						//
+						// The stale connection was added to 'conns' in a previous get_connection()
+						// call when it was retrieved from the pool. We need to remove it now.
+						for (unsigned int j=0; j<conns->len; j++) {
+							MYSQL *my1 = (MYSQL *)conns->index(j);
+							if (!my1) continue;
+							if (my1 == mysql) {
+								conns->remove_index_fast(j);
+								proxy_debug(PROXY_DEBUG_MONITOR, 7,
+									"Removing stale MYSQL with FD %d from DEBUG registry before closure: MYSQL %p\n",
+									mysql->net.fd, mysql);
+								break;
+							}
+						}
+#endif // DEBUG
+						// Queue the stale connection for asynchronous closure
 						MySQL_Monitor_State_Data* mmsd = new MySQL_Monitor_State_Data(MON_CLOSE_CONNECTION, (char*)"", 0, false);
 						mmsd->mysql = mysql;
 						GloMyMon->queue->add(new WorkItem<MySQL_Monitor_State_Data>(mmsd, NULL));


### PR DESCRIPTION
---

## ⚠️ DISCLAIMER: This PR was created by an AI coding agent (Claude)

**Please review all changes carefully before merging. The AI agent has performed analysis and implemented a fix based on code review, but human verification is essential.**

---

## Summary

Fixes #5256 - Crash in `monitor_GR_thread_HG` with assertion failure:
```
MySQL_Monitor.cpp:270: assert(my!=my1)
```

## Problem Description

When a stale connection was detected in `get_connection()`, it was queued for closure via a `MON_CLOSE_CONNECTION` work item. However, the connection was **never removed from the DEBUG `conns` tracking array**. This caused a race condition that could lead to a crash:

### Crash Scenario:
1. Connection X retrieved from pool → added to DEBUG `conns` array
2. Connection X returned to pool → removed from DEBUG `conns` array  
3. Connection X retrieved again → added to DEBUG `conns` array again
4. Connection X found stale → queued for `MON_CLOSE_CONNECTION`
5. Worker thread processes work item → connection X closed via destructor
6. **BUG:** Connection X pointer still remains in DEBUG `conns` array!
7. `create_new_connection()` returns MYSQL* with same address (malloc reuse)
8. `conn_register()` finds this pointer in `conns` → **assertion fails**

### Why It's Hard to Reproduce:
- DEBUG-only (the `conns` array only exists in DEBUG builds)
- Timing-dependent (requires `malloc` to reuse the exact same pointer address)
- Rare condition (requires connection to become stale while checked out)

## Root Cause

The stale connection was added to `conns` when retrieved from the pool, but was never removed from `conns` when found stale and queued for closure.

## Solution

Before queuing a stale connection for closure, **remove it from the DEBUG `conns` array**. This ensures the connection pointer is properly unregistered before being closed and potentially reused by malloc.

### Code Changes

**File:** `lib/MySQL_Monitor.cpp`  
**Function:** `MySQL_Monitor_Connection_Pool::get_connection()`

Added DEBUG-only code to remove stale connections from the tracking array before queuing for closure.

## Testing

- ✅ Compiles successfully
- Manual verification of code logic
- Awaiting testing and validation

## Additional Notes

- The fix is wrapped in `#ifdef DEBUG` since the `conns` array is DEBUG-only
- Added verbose inline documentation for maintainability
- The same issue does NOT exist in `purge_some_connections()` because those connections are from the idle pool (already removed from `conns` when returned)

---

**Reviewed by:** @sysown (please review)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stale connection handling in database connection pooling to ensure proper resource cleanup and prevent potential issues with reusing pooled connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->