### PR TITLE
Add PostgreSQL psql meta-command support to admin interface

### DIFF
--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -310,52 +310,30 @@ const std::vector<std::string> LOAD_COREDUMP_FROM_MEMORY = {
 
 extern unordered_map<string,std::tuple<string, vector<string>, vector<string>>> load_save_disk_commands;
 
-// Helper function: Escape single quotes in a string for SQL safety
-// Returns number of chars written to dst (excluding null terminator)
-static size_t escape_sql_string(char* dst, const char* src, size_t dst_size) {
-	if (!dst || !src || dst_size == 0) return 0;
-
-	size_t i = 0, j = 0;
-	while (src[i] && j < dst_size - 1) {
-		if (src[i] == '\'') {
-			// Escape single quote by doubling it
-			if (j < dst_size - 2) {
-				dst[j++] = '\'';
-				dst[j++] = '\'';
-			}
-		}
-		else {
-			dst[j++] = src[i];
-		}
-		i++;
-	}
-	dst[j] = '\0';
-	return j;
-}
-
 // Helper function: Extract pattern from c.relname OPERATOR or LIKE clause
 // Returns true if pattern was found, false otherwise
 // pattern_buf must be at least 128 bytes
+// Note: Returns raw unescaped pattern - escaping happens in convert_regex_to_like
 static bool extract_psql_pattern(const char* query, char* pattern_buf, size_t buf_size) {
-	if (!query || !pattern_buf || buf_size < 64) return false;
+	if (!query || !pattern_buf || buf_size < 128) return false;
 
 	pattern_buf[0] = '\0';
 
 	// Look for pattern in c.relname
-	char* relname_pos = strcasestr((char*)query, "c.relname");
+	const char* relname_pos = strcasestr(query, "c.relname");
 	if (!relname_pos) return false;
 
 	// Skip to the operator or LIKE keyword
-	char* value_pos = relname_pos + strlen("c.relname");
+	const char* value_pos = relname_pos + strlen("c.relname");
 	while (*value_pos && *value_pos == ' ') value_pos++;
 
 	// Safety check: ensure we haven't gone past end of string
 	if (!*value_pos) return false;
 
-	char* pattern = nullptr;
+	const char* pattern = nullptr;
 
 	// Check for LIKE operator first
-	char* like_pos = strcasestr(value_pos, "LIKE");
+	const char* like_pos = strcasestr(value_pos, "LIKE");
 	if (like_pos) {
 		like_pos += 4; // Skip "LIKE"
 		while (*like_pos && *like_pos == ' ') like_pos++;
@@ -363,11 +341,13 @@ static bool extract_psql_pattern(const char* query, char* pattern_buf, size_t bu
 	}
 	// Check for OPERATOR operator
 	else if (strcasestr(value_pos, "OPERATOR")) {
-		char* op_pos = strcasestr(value_pos, "OPERATOR");
-		char* value_start = strchr(op_pos, '\'');
-		if (value_start) {
-			value_start++;
-			pattern = value_start;
+		const char* op_pos = strcasestr(value_pos, "OPERATOR");
+		if (op_pos) {
+			const char* value_start = strchr(op_pos, '\'');
+			if (value_start) {
+				value_start++;
+				pattern = value_start;
+			}
 		}
 	}
 
@@ -377,25 +357,26 @@ static bool extract_psql_pattern(const char* query, char* pattern_buf, size_t bu
 	while (*pattern && *pattern == ' ') pattern++;
 
 	// Find end of pattern (first quote or newline)
-	char* end = pattern;
-	size_t max_len = buf_size / 2 - 1; // Leave room for escaping
-	while (*end && *end != '\'' && *end != '\n' && (end - pattern) < (int)max_len) end++;
+	const char* end = pattern;
+	size_t max_len = buf_size - 1; // Reserve one byte for null terminator
+	while (*end && *end != '\'' && *end != '\n' && (size_t)(end - pattern) < max_len) end++;
 
-	// Copy and escape to safe buffer
+	// Copy raw pattern to buffer (no escaping here - happens in convert_regex_to_like)
 	size_t len = end - pattern;
-	if (len > 0) {
-		escape_sql_string(pattern_buf, pattern, buf_size);
+	if (len > 0 && len < buf_size) {
+		memcpy(pattern_buf, pattern, len);
+		pattern_buf[len] = '\0';
 		return true;
 	}
 
 	return false;
 }
-
 // Helper function: Convert PostgreSQL regex pattern to SQLite LIKE pattern
 // Handles: ^, $, (), and .* to % conversion
-// dst_size should be at least 128 (twice src size for escaping)
+// Also escapes single quotes for SQL safety
+// dst_size should be at least 128 (twice src size for potential escaping)
 static void convert_regex_to_like(char* dst, const char* src, size_t dst_size) {
-	if (!dst || !src || dst_size < 64) return;
+	if (!dst || !src || dst_size < 128) return;
 
 	char* dst_end = dst + dst_size - 1;
 
@@ -416,11 +397,13 @@ static void convert_regex_to_like(char* dst, const char* src, size_t dst_size) {
 			// Skip regex grouping parentheses
 			src++;
 		}
+		else if (*src == '\'') {
+			// Escape single quotes for SQL safety (double them)
+			*dst++ = '\'';
+			*dst++ = '\'';
+			src++;
+		}
 		else {
-			// Escape single quotes for SQL safety
-			if (*src == '\'' && dst < dst_end - 1) {
-				*dst++ = '\'';
-			}
 			*dst++ = *src++;
 		}
 	}
@@ -428,15 +411,14 @@ static void convert_regex_to_like(char* dst, const char* src, size_t dst_size) {
 }
 
 // Unified handler for \dt, \di, \dv commands
-// relkind_char: 'r' for tables, 'i' for indexes, 'v' for views
 // sqlite_type: "table", "index", or "view"
 // columns: columns to SELECT (e.g., "name" or "name, tbl_name")
 static void handle_psql_list_command(const char* query_no_space, char** query, unsigned int* query_length,
-	char relkind_char, const char* sqlite_type, const char* columns) {
+	const char* sqlite_type, const char* columns) {
 	// Check for pattern in WHERE clause
 	const char* where_clause = strcasestr(query_no_space, "WHERE");
 	char pattern_buf[128] = { 0 };
-	char converted_pattern[128] = { 0 };
+	char converted_pattern[256] = { 0 };
 	char buf[512] = { 0 };
 
 	if (where_clause && extract_psql_pattern(where_clause, pattern_buf, sizeof(pattern_buf))) {
@@ -4288,7 +4270,7 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 				strcasestr(query_no_space, "FROM pg_class c") != nullptr) &&
 				strcasestr(query_no_space, "c.relkind IN ('r'") != nullptr) {
 				l_free(query_length, query);
-				handle_psql_list_command(query_no_space, &query, &query_length, 'r', "table", "name");
+				handle_psql_list_command(query_no_space, &query, &query_length, "table", "name");
 				goto __run_query;
 			}
 
@@ -4297,7 +4279,7 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 				 strcasestr(query_no_space, "FROM pg_class c") != nullptr) &&
 				strcasestr(query_no_space, "c.relkind IN ('i'") != nullptr) {
 				l_free(query_length, query);
-				handle_psql_list_command(query_no_space, &query, &query_length, 'i', "index", "name, tbl_name");
+				handle_psql_list_command(query_no_space, &query, &query_length, "index", "name, tbl_name");
 				goto __run_query;
 			}
 
@@ -4306,7 +4288,7 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 				 strcasestr(query_no_space, "FROM pg_class c") != nullptr) &&
 				strcasestr(query_no_space, "c.relkind IN ('v'") != nullptr) {
 				l_free(query_length, query);
-				handle_psql_list_command(query_no_space, &query, &query_length, 'v', "view", "name");
+				handle_psql_list_command(query_no_space, &query, &query_length, "view", "name");
 				goto __run_query;
 			}
 		}

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -310,6 +310,151 @@ const std::vector<std::string> LOAD_COREDUMP_FROM_MEMORY = {
 
 extern unordered_map<string,std::tuple<string, vector<string>, vector<string>>> load_save_disk_commands;
 
+// Helper function: Escape single quotes in a string for SQL safety
+// Returns number of chars written to dst (excluding null terminator)
+static size_t escape_sql_string(char* dst, const char* src, size_t dst_size) {
+	if (!dst || !src || dst_size == 0) return 0;
+
+	size_t i = 0, j = 0;
+	while (src[i] && j < dst_size - 1) {
+		if (src[i] == '\'') {
+			// Escape single quote by doubling it
+			if (j < dst_size - 2) {
+				dst[j++] = '\'';
+				dst[j++] = '\'';
+			}
+		}
+		else {
+			dst[j++] = src[i];
+		}
+		i++;
+	}
+	dst[j] = '\0';
+	return j;
+}
+
+// Helper function: Extract pattern from c.relname OPERATOR or LIKE clause
+// Returns true if pattern was found, false otherwise
+// pattern_buf must be at least 128 bytes
+static bool extract_psql_pattern(const char* query, char* pattern_buf, size_t buf_size) {
+	if (!query || !pattern_buf || buf_size < 64) return false;
+
+	pattern_buf[0] = '\0';
+
+	// Look for pattern in c.relname
+	char* relname_pos = strcasestr((char*)query, "c.relname");
+	if (!relname_pos) return false;
+
+	// Skip to the operator or LIKE keyword
+	char* value_pos = relname_pos + strlen("c.relname");
+	while (*value_pos && *value_pos == ' ') value_pos++;
+
+	// Safety check: ensure we haven't gone past end of string
+	if (!*value_pos) return false;
+
+	char* pattern = nullptr;
+
+	// Check for LIKE operator first
+	char* like_pos = strcasestr(value_pos, "LIKE");
+	if (like_pos) {
+		like_pos += 4; // Skip "LIKE"
+		while (*like_pos && *like_pos == ' ') like_pos++;
+		pattern = like_pos;
+	}
+	// Check for OPERATOR operator
+	else if (strcasestr(value_pos, "OPERATOR")) {
+		char* op_pos = strcasestr(value_pos, "OPERATOR");
+		char* value_start = strchr(op_pos, '\'');
+		if (value_start) {
+			value_start++;
+			pattern = value_start;
+		}
+	}
+
+	if (!pattern) return false;
+
+	// Skip leading spaces
+	while (*pattern && *pattern == ' ') pattern++;
+
+	// Find end of pattern (first quote or newline)
+	char* end = pattern;
+	size_t max_len = buf_size / 2 - 1; // Leave room for escaping
+	while (*end && *end != '\'' && *end != '\n' && (end - pattern) < (int)max_len) end++;
+
+	// Copy and escape to safe buffer
+	size_t len = end - pattern;
+	if (len > 0) {
+		escape_sql_string(pattern_buf, pattern, buf_size);
+		return true;
+	}
+
+	return false;
+}
+
+// Helper function: Convert PostgreSQL regex pattern to SQLite LIKE pattern
+// Handles: ^, $, (), and .* to % conversion
+// dst_size should be at least 128 (twice src size for escaping)
+static void convert_regex_to_like(char* dst, const char* src, size_t dst_size) {
+	if (!dst || !src || dst_size < 64) return;
+
+	char* dst_end = dst + dst_size - 1;
+
+	// Skip ^ at start
+	if (*src == '^') src++;
+
+	// Copy pattern, converting regex to LIKE
+	while (*src && dst < dst_end - 1) { // Reserve space for potential escape
+		if (*src == '.' && *(src + 1) == '*') {
+			*dst++ = '%';
+			src += 2;
+		}
+		else if (*src == '$' && (*(src + 1) == '\0' || *(src + 1) == '\'')) {
+			// Skip $ at end
+			break;
+		}
+		else if (*src == '(' || *src == ')') {
+			// Skip regex grouping parentheses
+			src++;
+		}
+		else {
+			// Escape single quotes for SQL safety
+			if (*src == '\'' && dst < dst_end - 1) {
+				*dst++ = '\'';
+			}
+			*dst++ = *src++;
+		}
+	}
+	*dst = '\0';
+}
+
+// Unified handler for \dt, \di, \dv commands
+// relkind_char: 'r' for tables, 'i' for indexes, 'v' for views
+// sqlite_type: "table", "index", or "view"
+// columns: columns to SELECT (e.g., "name" or "name, tbl_name")
+static void handle_psql_list_command(const char* query_no_space, char** query, unsigned int* query_length,
+	char relkind_char, const char* sqlite_type, const char* columns) {
+	// Check for pattern in WHERE clause
+	const char* where_clause = strcasestr(query_no_space, "WHERE");
+	char pattern_buf[128] = { 0 };
+	char converted_pattern[128] = { 0 };
+	char buf[512] = { 0 };
+
+	if (where_clause && extract_psql_pattern(where_clause, pattern_buf, sizeof(pattern_buf))) {
+		convert_regex_to_like(converted_pattern, pattern_buf, sizeof(converted_pattern));
+		// Build query with pattern - note: converted_pattern is already escaped
+		snprintf(buf, sizeof(buf), "SELECT %s FROM sqlite_master WHERE type='%s' AND name NOT LIKE 'sqlite_%%' AND name LIKE '%s' ORDER BY name",
+			columns, sqlite_type, converted_pattern);
+	}
+	else {
+		// Build query without pattern
+		snprintf(buf, sizeof(buf), "SELECT %s FROM sqlite_master WHERE type='%s' AND name NOT LIKE 'sqlite_%%' ORDER BY name",
+			columns, sqlite_type);
+	}
+
+	*query = l_strdup(buf);
+	*query_length = strlen(*query) + 1;
+}
+
 bool is_admin_command_or_alias(const std::vector<std::string>& cmds, char *query_no_space, int query_no_space_length) {
 	for (std::vector<std::string>::const_iterator it=cmds.begin(); it!=cmds.end(); ++it) {
 		if ((unsigned int)query_no_space_length==it->length() && !strncasecmp(it->c_str(), query_no_space, query_no_space_length)) {
@@ -4104,6 +4249,67 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 		}
 		run_query = false;
 		goto __run_query;
+	}
+
+
+	// Handle PostgreSQL meta commands expanded by psql client
+	// These commands are intercepted and converted to appropriate SQLite queries
+	if constexpr (std::is_same_v<S, PgSQL_Session>) {
+		if (query_no_space_length >= strlen("SELECT") && !strncasecmp("SELECT", query_no_space, strlen("SELECT"))) {
+			// \l, \l+ : List databases
+			// psql: SELECT ... FROM pg_catalog.pg_database ...
+			// sqlite: PRAGMA DATABASE_LIST
+			if (strcasestr(query_no_space, "FROM pg_catalog.pg_database") != nullptr ||
+				strcasestr(query_no_space, "FROM pg_database") != nullptr) {
+				l_free(query_length, query);
+				query = l_strdup("PRAGMA DATABASE_LIST");
+				query_length = strlen(query) + 1;
+				goto __run_query;
+			}
+
+			// \d : List all relations (without table name)
+			// psql: SELECT ... FROM pg_catalog.pg_class c ... WHERE c.relkind IN ('r','p','v','m','S','f','')
+			// sqlite: SELECT name, type FROM sqlite_master WHERE type IN ('table', 'view', 'index', 'trigger') ...
+			// Note: \d includes 'v' (views) in relkind, \dt does not
+			if ((strcasestr(query_no_space, "FROM pg_catalog.pg_class c") != nullptr ||
+				strcasestr(query_no_space, "FROM pg_class c") != nullptr) &&
+				strcasestr(query_no_space, "c.relkind IN ('r','p','v'") != nullptr) {
+
+				l_free(query_length, query);
+				// List all relations
+				query = l_strdup("SELECT name, type FROM sqlite_master WHERE type IN ('table', 'view', 'index', 'trigger') AND name NOT LIKE 'sqlite_%' ORDER BY type, name");
+				query_length = strlen(query) + 1;
+				goto __run_query;
+			}
+
+			// \dt [pattern] : List tables (with optional pattern)
+			// psql: SELECT ... FROM pg_catalog.pg_class c ... WHERE c.relkind IN ('r','p', ...)
+			if ((strcasestr(query_no_space, "FROM pg_catalog.pg_class c") != nullptr ||
+				strcasestr(query_no_space, "FROM pg_class c") != nullptr) &&
+				strcasestr(query_no_space, "c.relkind IN ('r'") != nullptr) {
+				l_free(query_length, query);
+				handle_psql_list_command(query_no_space, &query, &query_length, 'r', "table", "name");
+				goto __run_query;
+			}
+
+			// \di [pattern] : List indexes (with optional pattern)
+			if ((strcasestr(query_no_space, "FROM pg_catalog.pg_class c") != nullptr ||
+				 strcasestr(query_no_space, "FROM pg_class c") != nullptr) &&
+				strcasestr(query_no_space, "c.relkind IN ('i'") != nullptr) {
+				l_free(query_length, query);
+				handle_psql_list_command(query_no_space, &query, &query_length, 'i', "index", "name, tbl_name");
+				goto __run_query;
+			}
+
+			// \dv [pattern] : List views (with optional pattern)
+			if ((strcasestr(query_no_space, "FROM pg_catalog.pg_class c") != nullptr ||
+				 strcasestr(query_no_space, "FROM pg_class c") != nullptr) &&
+				strcasestr(query_no_space, "c.relkind IN ('v'") != nullptr) {
+				l_free(query_length, query);
+				handle_psql_list_command(query_no_space, &query, &query_length, 'v', "view", "name");
+				goto __run_query;
+			}
+		}
 	}
 
 	if (strncasecmp("SHOW ", query_no_space, 5)) {

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -337,6 +337,8 @@ static bool extract_psql_pattern(const char* query, char* pattern_buf, size_t bu
 	if (like_pos) {
 		like_pos += 4; // Skip "LIKE"
 		while (*like_pos && *like_pos == ' ') like_pos++;
+		// Skip opening quote if present
+		if (*like_pos == '\'') like_pos++;
 		pattern = like_pos;
 	}
 	// Check for OPERATOR operator

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -244,6 +244,7 @@
   "test_ssl_fast_forward-3_libmysql-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "test_ignore_min_gtid-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-query_digests_stages_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql_admin_metacmds-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-monitor_ssl_connections_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-parameterized_kill_queries_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5284_frontend_ssl_enforcement-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],

--- a/test/tap/tests/pgsql_admin_metacmds-t.cpp
+++ b/test/tap/tests/pgsql_admin_metacmds-t.cpp
@@ -1,0 +1,183 @@
+/**
+ * @file pgsql_admin_metacmds-t.cpp
+ * @brief This test validates PostgreSQL psql meta-commands in the admin interface.
+ * Uses actual psql client to test: \dt, \di, \dv, \d, \l commands
+ */
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include <cstring>
+#include <cstdlib>
+#include <array>
+#include <memory>
+
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+// Execute a command and return its output
+std::string exec(const char* cmd) {
+	std::array<char, 128> buffer;
+	std::string result;
+	std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+	if (!pipe) {
+		return "";
+	}
+	while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+		result += buffer.data();
+	}
+	return result;
+}
+
+// Check if psql is available
+bool psql_available() {
+	return system("which psql > /dev/null 2>&1") == 0;
+}
+
+// Build psql connection string
+std::string build_psql_cmd(const CommandLine& cl, const char* meta_cmd) {
+	std::stringstream ss;
+	ss << "PGPASSWORD=" << cl.admin_password << " ";
+	ss << "psql -h " << cl.pgsql_admin_host;
+	ss << " -p " << cl.pgsql_admin_port;
+	ss << " -U " << cl.admin_username;
+	ss << " -d postgres";
+	ss << " -c \"" << meta_cmd << "\"";
+	ss << " 2>&1";
+	return ss.str();
+}
+
+void test_psql_list_databases(const CommandLine& cl) {
+	std::string cmd = build_psql_cmd(cl, "\\l");
+	std::string output = exec(cmd.c_str());
+
+	// Check if output contains expected content
+	bool has_list = output.find("List of databases") != std::string::npos;
+	bool has_name = output.find("name") != std::string::npos;
+
+	ok(has_list && has_name, "\\l (list databases): returned valid output");
+}
+
+void test_psql_list_tables(const CommandLine& cl) {
+	// Test \dt
+	std::string cmd = build_psql_cmd(cl, "\\dt");
+	std::string output = exec(cmd.c_str());
+
+	// Check for "List of relations" or table names
+	bool has_output = output.find("List of relations") != std::string::npos ||
+	                  output.find("name") != std::string::npos ||
+	                  output.find("Did not find any relation") != std::string::npos;
+	ok(has_output, "\\dt (list tables): returned valid output");
+
+	// Test \dt with pattern
+	cmd = build_psql_cmd(cl, "\\dt runtime*");
+	output = exec(cmd.c_str());
+
+	has_output = output.find("List of relations") != std::string::npos ||
+	             output.find("name") != std::string::npos;
+	ok(has_output, "\\dt runtime* (tables with pattern): returned valid output");
+}
+
+void test_psql_list_indexes(const CommandLine& cl) {
+	std::string cmd = build_psql_cmd(cl, "\\di");
+	std::string output = exec(cmd.c_str());
+
+	bool has_output = output.find("Schema") != std::string::npos ||
+	                  output.find("No matching relations") != std::string::npos ||
+	                  output.find("Did not find any relations") != std::string::npos;
+	ok(has_output, "\\di (list indexes): returned valid output");
+}
+
+void test_psql_list_views(const CommandLine& cl) {
+	std::string cmd = build_psql_cmd(cl, "\\dv");
+	std::string output = exec(cmd.c_str());
+
+	bool has_output = output.find("Schema") != std::string::npos ||
+	                  output.find("No matching relations") != std::string::npos ||
+	                  output.find("Did not find any relations") != std::string::npos;
+	ok(has_output, "\\dv (list views): returned valid output");
+}
+
+void test_psql_list_all_relations(const CommandLine& cl) {
+	std::string cmd = build_psql_cmd(cl, "\\d");
+	std::string output = exec(cmd.c_str());
+
+	// Check for "List of relations" or relation names
+	bool has_output = output.find("List of relations") != std::string::npos ||
+	                  output.find("name") != std::string::npos ||
+	                  output.find("type") != std::string::npos;
+	ok(has_output, "\\d (list all relations): returned valid output");
+}
+
+void test_psql_sql_injection_protection(const CommandLine& cl) {
+	// Test that single quotes in patterns don't cause issues
+	std::string cmd = build_psql_cmd(cl, "\\dt test' OR '1'='1");
+	std::string output = exec(cmd.c_str());
+
+	diag("SQL injection test output: %s", output.c_str());
+
+	// Should either return no results or error gracefully, not crash
+	bool handled_safely = output.find("ERROR") != std::string::npos ||
+	                      output.find("No matching relations") != std::string::npos ||
+	                      output.find("Did not find any relation") != std::string::npos;
+	ok(handled_safely, "SQL injection protection: pattern with quotes handled safely");
+}
+
+void test_psql_version_and_info(const CommandLine& cl) {
+	// Test \conninfo
+	std::string cmd = build_psql_cmd(cl, "\\conninfo");
+	std::string output = exec(cmd.c_str());
+
+	bool has_connection_info = output.find("connected") != std::string::npos ||
+	                           output.find("database") != std::string::npos;
+	ok(has_connection_info, "\\conninfo: returned connection information");
+}
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	// Check if psql is available
+	if (!psql_available()) {
+		plan(1);
+		skip(1, "psql client not available");
+		return exit_status();
+	}
+
+	// Skip test if PostgreSQL admin port is not configured
+	if (cl.pgsql_admin_port == 0) {
+		plan(1);
+		skip(1, "PostgreSQL admin interface not configured");
+		return exit_status();
+	}
+
+	plan(9);
+
+	// Test connection first
+	std::string test_cmd = build_psql_cmd(cl, "\\conninfo");
+	std::string test_output = exec(test_cmd.c_str());
+	bool connected = test_output.find("connected") != std::string::npos ||
+	                 test_output.find("database") != std::string::npos;
+	ok(connected, "Connected to PostgreSQL admin interface");
+
+	if (!connected) {
+		diag("Failed to connect to PostgreSQL admin interface");
+		return exit_status();
+	}
+
+	// Run all meta-command tests
+	test_psql_list_databases(cl);
+	test_psql_list_tables(cl);
+	test_psql_list_indexes(cl);
+	test_psql_list_views(cl);
+	test_psql_list_all_relations(cl);
+	test_psql_sql_injection_protection(cl);
+	test_psql_version_and_info(cl);
+
+	return exit_status();
+}

--- a/test/tap/tests/pgsql_admin_metacmds-t.cpp
+++ b/test/tap/tests/pgsql_admin_metacmds-t.cpp
@@ -134,6 +134,21 @@ void test_psql_version_and_info(const CommandLine& cl) {
 	ok(has_connection_info, "\\conninfo: returned connection information");
 }
 
+void test_psql_buffer_overflow_protection(const CommandLine& cl) {
+	// Test for potential buffer overflow with many quotes
+	std::string long_pattern = std::string(100, '\'');
+	std::string cmd = build_psql_cmd(cl, ("\\dt " + long_pattern).c_str());
+	std::string output = exec(cmd.c_str());
+
+	diag("Buffer overflow test output: %s", output.c_str());
+
+	// Should either return no results or error gracefully, not crash
+	bool handled_safely = output.find("ERROR") != std::string::npos ||
+		output.find("No matching relations") != std::string::npos ||
+		output.find("Did not find any relation") != std::string::npos;
+	ok(handled_safely, "Buffer overflow protection: long pattern with quotes handled safely");
+}
+
 int main(int argc, char** argv) {
 	CommandLine cl;
 
@@ -156,7 +171,7 @@ int main(int argc, char** argv) {
 		return exit_status();
 	}
 
-	plan(9);
+	plan(10);
 
 	// Test connection first
 	std::string test_cmd = build_psql_cmd(cl, "\\conninfo");
@@ -178,6 +193,6 @@ int main(int argc, char** argv) {
 	test_psql_list_all_relations(cl);
 	test_psql_sql_injection_protection(cl);
 	test_psql_version_and_info(cl);
-
+	test_psql_buffer_overflow_protection(cl);
 	return exit_status();
 }


### PR DESCRIPTION
### Description
This PR adds support for common `psql` meta-commands (`\dt`, `\di`, `\dv`, `\d`, `\l`) in ProxySQL's PostgreSQL admin interface (port 6132). The expanded queries targeting PostgreSQL system catalogs (`pg_catalog.pg_class`, `pg_catalog.pg_database`) are now intercepted and translated to SQLite queries against the internal configuration database.

Closes [#5365](https://github.com/sysown/proxysql/issues/5365)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin interface recognizes PostgreSQL psql meta-commands (\l, \d, \dt, \di, \dv) to list databases, relations, tables, indexes, and views with LIKE/regex-style pattern support and improved matching behavior.
  * Converts common psql pattern forms to SQLite-friendly filters and preserves existing behavior for non-meta commands.

* **Tests**
  * Added end-to-end tests validating listings, pattern filtering, injection-like inputs, connection info, and buffer/robustness cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->