### PR TITLE
TAP: Add MCP client helper and `run_sql_readonly` validation

### DIFF
--- a/test/tap/groups/ai/env.sh
+++ b/test/tap/groups/ai/env.sh
@@ -1,1 +1,0 @@
-export TEST_PY_TAP_INCL="ai_.*-t anomaly_.*-t genai.*-t mcp.*-t nl2sql_.*-t test_mcp.*-t vector.*-t"

--- a/test/tap/groups/ai/pre-proxysql.sql
+++ b/test/tap/groups/ai/pre-proxysql.sql
@@ -1,0 +1,14 @@
+# Enable MCP module for AI test group
+SET mcp-enabled=true;
+SET mcp-port=6071;
+
+# Configure MCP to use MySQL backend from infra-default
+# Backend hostname: mysql1.infra-default (Docker network hostname)
+SET mcp-mysql_hosts='mysql1.infra-default';
+SET mcp-mysql_ports='3306';
+SET mcp-mysql_user='root';
+SET mcp-mysql_password='root';
+
+# Apply configuration
+LOAD MCP VARIABLES TO RUNTIME;
+SAVE MCP VARIABLES TO DISK;

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -259,6 +259,7 @@
   "genai_embedding_rerank-t": [ "ai-g1" ],
   "genai_module-t": [ "ai-g1" ],
   "mcp_module-t": [ "ai-g1" ],
+  "mcp_query_run_sql_readonly-t": [ "ai-g1" ],
   "nl2sql_integration-t": [ "ai-g1" ],
   "nl2sql_internal-t": [ "ai-g1" ],
   "nl2sql_model_selection-t": [ "ai-g1" ],

--- a/test/tap/tap/Makefile
+++ b/test/tap/tap/Makefile
@@ -59,14 +59,17 @@ utils_mysql8.o: utils.cpp cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a libcurl.s
 tap.o: tap.cpp cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a libcurl.so -lssl -lcrypto libcpp_dotenv.so
 	$(CXX) -fPIC -c tap.cpp $(IDIRS) $(OPT)
 
-libtap_mariadb.a: tap.o command_line.o utils_mariadb.o cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a
-	ar rcs libtap_mariadb.a tap.o command_line.o utils_mariadb.o $(SQLITE3_LDIR)/sqlite3.o $(PROXYSQL_LDIR)/obj/sha256crypt.oo
+mcp_client.o: mcp_client.cpp mcp_client.h libcurl.so
+	$(CXX) -fPIC -c mcp_client.cpp $(IDIRS) $(OPT)
 
-libtap_mysql57.a: tap.o command_line.o utils_mysql57.o cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a
-	ar rcs libtap_mysql57.a tap.o command_line.o utils_mysql57.o $(SQLITE3_LDIR)/sqlite3.o $(PROXYSQL_LDIR)/obj/sha256crypt.oo
+libtap_mariadb.a: tap.o command_line.o utils_mariadb.o mcp_client.o cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a
+	ar rcs libtap_mariadb.a tap.o command_line.o utils_mariadb.o mcp_client.o $(SQLITE3_LDIR)/sqlite3.o $(PROXYSQL_LDIR)/obj/sha256crypt.oo
 
-libtap_mysql8.a: tap.o command_line.o utils_mysql8.o cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a
-	ar rcs libtap_mysql8.a tap.o command_line.o utils_mysql8.o $(SQLITE3_LDIR)/sqlite3.o $(PROXYSQL_LDIR)/obj/sha256crypt.oo
+libtap_mysql57.a: tap.o command_line.o utils_mysql57.o mcp_client.o cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a
+	ar rcs libtap_mysql57.a tap.o command_line.o utils_mysql57.o mcp_client.o $(SQLITE3_LDIR)/sqlite3.o $(PROXYSQL_LDIR)/obj/sha256crypt.oo
+
+libtap_mysql8.a: tap.o command_line.o utils_mysql8.o mcp_client.o cpp-dotenv/static/cpp-dotenv/libcpp_dotenv.a
+	ar rcs libtap_mysql8.a tap.o command_line.o utils_mysql8.o mcp_client.o $(SQLITE3_LDIR)/sqlite3.o $(PROXYSQL_LDIR)/obj/sha256crypt.oo
 
 libtap.so: libtap_mariadb.a cpp-dotenv/dynamic/cpp-dotenv/libcpp_dotenv.so libre2.so
 	$(CXX) -shared -o libtap.so -Wl,--whole-archive libtap_mariadb.a -Wl,--no-whole-archive $(LWGCOV)

--- a/test/tap/tap/command_line.cpp
+++ b/test/tap/tap/command_line.cpp
@@ -40,6 +40,9 @@ CommandLine::~CommandLine() {
 	if (admin_password)
 		free(admin_password);
 
+	if (mcp_auth_token)
+		free(mcp_auth_token);
+
 	if (mysql_host)
 		free(mysql_host);
 	if (mysql_username)
@@ -234,6 +237,20 @@ int CommandLine::getEnv() {
 		value = getenv("TAP_ADMINPASSWORD");
 		if (value)
 			replace_str_field(&this->admin_password, value);
+	}
+
+	{
+		// proxysql mcp connection
+		value = getenv("TAP_MCP_PORT");
+		if (value) {
+			env_port = strtol(value, NULL, 10);
+			if (env_port > 0 && env_port < 65536)
+				mcp_port = env_port;
+		}
+
+		value = getenv("TAP_MCP_AUTH_TOKEN");
+		if (value)
+			replace_str_field(&this->mcp_auth_token, value);
 	}
 
 	{

--- a/test/tap/tap/command_line.h
+++ b/test/tap/tap/command_line.h
@@ -32,6 +32,10 @@ class CommandLine {
 	char* admin_username = strdup("admin");
 	char* admin_password = strdup("admin");
 
+	// proxysql mcp connection
+	int mcp_port = 6071;
+	char* mcp_auth_token = strdup("");
+
 	// mysql admin connection
 	char* mysql_host = strdup("127.0.0.1");
 	int mysql_port = 3306;

--- a/test/tap/tap/mcp_client.cpp
+++ b/test/tap/tap/mcp_client.cpp
@@ -18,15 +18,13 @@ MCPClient::MCPClient(
     , timeout_ms_(timeout_ms)
     , request_id_(1)
 {
-    // Get defaults from environment if not provided
+    // Apply defaults if not provided
     if (host_.empty()) {
-        const char* env_host = getenv("TAP_ADMINHOST");
-        host_ = env_host ? env_host : "127.0.0.1";
+        host_ = "127.0.0.1";
     }
 
     if (port_ == 0) {
-        const char* env_port = getenv("TAP_MCPPORT");
-        port_ = env_port ? atoi(env_port) : 6071;
+        port_ = 6071;
     }
 
     // Initialize curl
@@ -65,16 +63,7 @@ void MCPClient::set_timeout(long timeout_ms) {
 }
 
 void MCPClient::set_auth_token(const std::string& token) {
-    if (token.empty()) {
-        // Clear all tokens
-        auth_tokens_.clear();
-    } else {
-        // Apply token to all known endpoints
-        const char* endpoints[] = {"config", "query", "admin", "stats", "rag", "ai", "cache"};
-        for (const char* ep : endpoints) {
-            auth_tokens_[ep] = token;
-        }
-    }
+    auth_token_ = token;
 }
 
 std::string MCPClient::get_connection_info() const {
@@ -144,10 +133,8 @@ MCPResponse MCPClient::parse_response(const std::string& raw_response, long http
 
     // 2. Try to parse response body as JSON
     json j;
-    bool is_valid_json = false;
     try {
         j = json::parse(raw_response);
-        is_valid_json = true;
     } catch (const json::parse_error& e) {
         // Not valid JSON
         if (http_code != 200) {
@@ -311,9 +298,8 @@ MCPResponse MCPClient::call_tool(
     headers = curl_slist_append(headers, "Content-Type: application/json");
 
     // Add authentication token if configured
-    auto auth_it = auth_tokens_.find(endpoint);
-    if (auth_it != auth_tokens_.end()) {
-        std::string auth_header = "Authorization: Bearer " + auth_it->second;
+    if (!auth_token_.empty()) {
+        std::string auth_header = "Authorization: Bearer " + auth_token_;
         headers = curl_slist_append(headers, auth_header.c_str());
     }
 

--- a/test/tap/tap/mcp_client.cpp
+++ b/test/tap/tap/mcp_client.cpp
@@ -1,0 +1,400 @@
+#include "mcp_client.h"
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+
+// ============================================================================
+// Constructor / Destructor
+// ============================================================================
+
+MCPClient::MCPClient(
+    const std::string& host,
+    int port,
+    long timeout_ms
+)
+    : curl_(nullptr)
+    , host_(host)
+    , port_(port)
+    , timeout_ms_(timeout_ms)
+    , request_id_(1)
+{
+    // Get defaults from environment if not provided
+    if (host_.empty()) {
+        const char* env_host = getenv("TAP_ADMINHOST");
+        host_ = env_host ? env_host : "127.0.0.1";
+    }
+
+    if (port_ == 0) {
+        const char* env_port = getenv("TAP_MCPPORT");
+        port_ = env_port ? atoi(env_port) : 6071;
+    }
+
+    // Initialize curl
+    init_curl();
+
+    // Build base URL
+    base_url_ = "http://" + host_ + ":" + std::to_string(port_);
+}
+
+MCPClient::~MCPClient() {
+    if (curl_) {
+        curl_easy_cleanup(curl_);
+        curl_ = nullptr;
+    }
+}
+
+// ============================================================================
+// Configuration Methods
+// ============================================================================
+
+void MCPClient::set_host(const std::string& host) {
+    host_ = host;
+    base_url_ = "http://" + host_ + ":" + std::to_string(port_);
+}
+
+void MCPClient::set_port(int port) {
+    port_ = port;
+    base_url_ = "http://" + host_ + ":" + std::to_string(port_);
+}
+
+void MCPClient::set_timeout(long timeout_ms) {
+    timeout_ms_ = timeout_ms;
+    if (curl_) {
+        curl_easy_setopt(curl_, CURLOPT_TIMEOUT_MS, timeout_ms_);
+    }
+}
+
+void MCPClient::set_auth_token(const std::string& token) {
+    if (token.empty()) {
+        // Clear all tokens
+        auth_tokens_.clear();
+    } else {
+        // Apply token to all known endpoints
+        const char* endpoints[] = {"config", "query", "admin", "stats", "rag", "ai", "cache"};
+        for (const char* ep : endpoints) {
+            auth_tokens_[ep] = token;
+        }
+    }
+}
+
+std::string MCPClient::get_connection_info() const {
+    return host_ + ":" + std::to_string(port_);
+}
+
+// ============================================================================
+// Private Methods - Initialization
+// ============================================================================
+
+void MCPClient::init_curl() {
+    curl_ = curl_easy_init();
+    if (!curl_) {
+        last_error_ = "Failed to initialize libcurl";
+        throw std::runtime_error(last_error_);
+    }
+
+    // Common options
+    curl_easy_setopt(curl_, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl_, CURLOPT_MAXREDIRS, 5L);
+    curl_easy_setopt(curl_, CURLOPT_TCP_KEEPALIVE, 1L);
+    curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT, 10L);
+    curl_easy_setopt(curl_, CURLOPT_TIMEOUT_MS, timeout_ms_);
+
+    // Write callback
+    curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION, write_callback);
+}
+
+// ============================================================================
+// Private Methods - URL Building
+// ============================================================================
+
+std::string MCPClient::build_url(const std::string& endpoint) const {
+    return base_url_ + "/mcp/" + endpoint;
+}
+
+// ============================================================================
+// Private Methods - Request/Response Handling
+// ============================================================================
+
+json MCPClient::build_request(const std::string& tool_name, const json& arguments) {
+    return json{
+        {"jsonrpc", "2.0"},
+        {"method", "tools/call"},
+        {"params", {
+            {"name", tool_name},
+            {"arguments", arguments}
+        }},
+        {"id", request_id_++}
+    };
+}
+
+MCPResponse MCPClient::parse_response(const std::string& raw_response, long http_code, CURLcode curl_result) {
+    MCPResponse resp;
+
+    // Always preserve HTTP context for debugging
+    resp.set_http_code(http_code);
+    resp.set_http_response(raw_response);
+
+    // 1. TRANSPORT layer errors (CURL failures)
+    if (curl_result != CURLE_OK) {
+        resp.set_error_type(MCPErrorType::TRANSPORT);
+        resp.set_error_code(curl_result);
+        resp.set_error_message("CURL error: " + std::string(curl_easy_strerror(curl_result)));
+        return resp;
+    }
+
+    // 2. Try to parse response body as JSON
+    json j;
+    bool is_valid_json = false;
+    try {
+        j = json::parse(raw_response);
+        is_valid_json = true;
+    } catch (const json::parse_error& e) {
+        // Not valid JSON
+        if (http_code != 200) {
+            // HTTP error with non-JSON body
+            resp.set_error_type(MCPErrorType::HTTP);
+            resp.set_error_code(http_code);
+            resp.set_error_message("HTTP error: " + std::to_string(http_code));
+        } else {
+            // HTTP 200 but can't parse JSON
+            resp.set_error_type(MCPErrorType::JSON_RPC);
+            resp.set_error_message("JSON parse error: " + std::string(e.what()));
+        }
+        return resp;
+    }
+
+    // 3. We have valid JSON - check for JSON-RPC error
+    bool has_jsonrpc_error = j.contains("error");
+
+    if (has_jsonrpc_error) {
+        // JSON-RPC error (regardless of HTTP status code)
+        // Per MCP spec: HTTP error responses MAY contain JSON-RPC error in body
+        resp.set_error_type(MCPErrorType::JSON_RPC);
+        json error_obj = j["error"];
+        resp.set_error_code(error_obj.value("code", 0));
+        resp.set_error_message(error_obj.value("message", "Unknown error"));
+        return resp;
+    }
+
+    // 4. No JSON-RPC error, check HTTP status
+    if (http_code != 200) {
+        // HTTP error without JSON-RPC error in body
+        resp.set_error_type(MCPErrorType::HTTP);
+        resp.set_error_code(http_code);
+        resp.set_error_message("HTTP error: " + std::to_string(http_code));
+        return resp;
+    }
+
+    // 5. HTTP 200 with valid JSON - validate JSON-RPC format
+    if (!j.contains("jsonrpc") || j["jsonrpc"] != "2.0") {
+        resp.set_error_type(MCPErrorType::JSON_RPC);
+        resp.set_error_message("Invalid JSON-RPC response format");
+        return resp;
+    }
+
+    // 6. Check for result
+    if (!j.contains("result")) {
+        // Malformed JSON-RPC (no result, no error)
+        resp.set_error_type(MCPErrorType::JSON_RPC);
+        resp.set_error_message("Malformed JSON-RPC response: missing result and error");
+        return resp;
+    }
+
+    json mcp_result = j["result"];
+
+    // 7. Parse MCP tool response format
+    // Per MCP spec: https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+    resp.set_error_type(MCPErrorType::MCP);
+
+    // Validate MCP response structure
+    if (!mcp_result.is_object()) {
+        resp.set_error_message("MCP error: result is not an object");
+        return resp;
+    }
+
+    if (!mcp_result.contains("content")) {
+        resp.set_error_message("MCP error: missing 'content' field");
+        return resp;
+    }
+
+    if (!mcp_result["content"].is_array()) {
+        resp.set_error_message("MCP error: 'content' is not an array");
+        return resp;
+    }
+
+    if (mcp_result["content"].empty()) {
+        resp.set_error_message("MCP error: 'content' array is empty");
+        return resp;
+    }
+
+    // 7a. Check for tool execution error (isError: true)
+    if (mcp_result.contains("isError") && mcp_result["isError"] == true) {
+        // Extract error message from content[0].text
+        json first_content = mcp_result["content"][0];
+        if (first_content.contains("text")) {
+            resp.set_error_message(first_content["text"].get<std::string>());
+        } else {
+            resp.set_error_message("Tool execution failed");
+        }
+        return resp;
+    }
+
+    // 7b. Extract tool result from content array
+    json first_content = mcp_result["content"][0];
+
+    // Validate content item structure
+    if (!first_content.is_object()) {
+        resp.set_error_message("MCP error: content item is not an object");
+        return resp;
+    }
+
+    if (!first_content.contains("type")) {
+        resp.set_error_message("MCP error: content item missing 'type' field");
+        return resp;
+    }
+
+    std::string content_type = first_content["type"].get<std::string>();
+
+    // Handle text content (ProxySQL returns JSON as text)
+    if (content_type == "text") {
+        if (!first_content.contains("text")) {
+            resp.set_error_message("MCP error: text content missing 'text' field");
+            return resp;
+        }
+
+        std::string text_content = first_content["text"].get<std::string>();
+
+        // Try to parse as JSON (ProxySQL serializes tool results as JSON strings)
+        try {
+            json tool_result = json::parse(text_content);
+            resp.set_error_type(MCPErrorType::NONE);
+            resp.set_result(std::make_unique<json>(tool_result));
+            return resp;
+        } catch (const json::parse_error& e) {
+            // JSON parsing failed - treat as MCP error
+            resp.set_error_message("MCP error: failed to parse text content as JSON: " +
+                                  std::string(e.what()));
+            return resp;
+        }
+    }
+
+    // Handle other content types (image, audio, resource_link, resource)
+    // For now, we don't support these in ProxySQL, so treat as error
+    resp.set_error_message("MCP error: unsupported content type '" + content_type + "'");
+    return resp;
+}
+
+size_t MCPClient::write_callback(void* contents, size_t size, size_t nmemb, void* userp) {
+    size_t total_size = size * nmemb;
+    std::string* response = static_cast<std::string*>(userp);
+    response->append(static_cast<char*>(contents), total_size);
+    return total_size;
+}
+
+// ============================================================================
+// Tool Invocation
+// ============================================================================
+
+MCPResponse MCPClient::call_tool(
+    const std::string& endpoint,
+    const std::string& tool_name,
+    const json& arguments
+) {
+    std::string response_body;
+
+    // Build JSON-RPC request
+    json rpc_request = build_request(tool_name, arguments);
+    std::string request_body = rpc_request.dump();
+
+    // Prepare HTTP headers
+    struct curl_slist* headers = nullptr;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    // Add authentication token if configured
+    auto auth_it = auth_tokens_.find(endpoint);
+    if (auth_it != auth_tokens_.end()) {
+        std::string auth_header = "Authorization: Bearer " + auth_it->second;
+        headers = curl_slist_append(headers, auth_header.c_str());
+    }
+
+    // Configure curl for this request
+    std::string url = build_url(endpoint);
+    curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl_, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, request_body.c_str());
+    curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &response_body);
+
+    // Execute request
+    CURLcode res = curl_easy_perform(curl_);
+    long http_code = 0;
+    curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &http_code);
+
+    // Cleanup headers
+    curl_slist_free_all(headers);
+
+    // Parse response with full error classification
+    MCPResponse resp = parse_response(response_body, http_code, res);
+
+    // Update last_error_ for backwards compatibility
+    if (resp.has_error()) {
+        last_error_ = resp.get_error_message();
+    }
+
+    return resp;
+}
+
+MCPResponse MCPClient::call_tool(
+    const std::string& endpoint,
+    const std::string& tool_name,
+    const std::string& arguments_json
+) {
+    try {
+        json args = json::parse(arguments_json);
+        return call_tool(endpoint, tool_name, args);
+    }
+    catch (const json::parse_error& e) {
+        MCPResponse resp;
+        resp.set_error_type(MCPErrorType::JSON_RPC);
+
+        resp.set_error_message("Invalid JSON arguments: " + std::string(e.what()));
+        return resp;
+    }
+}
+
+// ============================================================================
+// Server Connectivity
+// ============================================================================
+
+bool MCPClient::check_server() {
+    json ping_request = {
+        {"jsonrpc", "2.0"},
+        {"method", "ping"},
+        {"id", request_id_++}
+    };
+
+    std::string url = build_url("config");
+    std::string request_body = ping_request.dump();
+    std::string response_body;
+
+    struct curl_slist* headers = nullptr;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl_, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, request_body.c_str());
+    curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &response_body);
+
+    CURLcode res = curl_easy_perform(curl_);
+
+    curl_slist_free_all(headers);
+
+    if (res != CURLE_OK) {
+        last_error_ = curl_easy_strerror(res);
+        return false;
+    }
+
+    // Check for valid response (contains "result")
+    return response_body.find("\"result\"") != std::string::npos;
+}

--- a/test/tap/tap/mcp_client.h
+++ b/test/tap/tap/mcp_client.h
@@ -1,0 +1,451 @@
+#ifndef MCP_CLIENT_H
+#define MCP_CLIENT_H
+
+#include <string>
+#include <memory>
+#include <map>
+#include <curl/curl.h>
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+/**
+ * @brief Error classification for MCP responses
+ *
+ * Categorizes errors by the layer at which they occurred:
+ * - NONE: No error (success)
+ * - TRANSPORT: Network/CURL layer errors (connection failed, timeout, DNS)
+ * - HTTP: HTTP protocol errors (4xx, 5xx) WITHOUT valid JSON-RPC error in body
+ * - JSON_RPC: JSON-RPC protocol or tool errors (parse errors, invalid format, tool failures)
+ */
+enum class MCPErrorType {
+    NONE,        ///< No error - successful response
+    TRANSPORT,   ///< CURL/network layer errors
+    HTTP,        ///< HTTP protocol errors without JSON-RPC error in body
+    JSON_RPC,    ///< JSON-RPC protocol errors (parse, format, invalid structure)
+    MCP          ///< MCP tool/content errors (validation failures, tool execution errors)
+};
+
+/**
+ * @brief Response class for MCP tool calls
+ *
+ * Encapsulates parsed JSON-RPC response with multi-layer error classification.
+ * Provides clean API for test assertions and error handling.
+ *
+ * Error Handling Philosophy:
+ * - error_type: Identifies which layer the error occurred at
+ * - error_code: Numeric error code (CURL code, HTTP status, or JSON-RPC code)
+ * - error_message: Human-readable error description
+ * - http_code/http_response: Always preserved for debugging
+ *
+ * Usage:
+ *   MCPResponse resp = client.call_tool("stats", "show_status", args);
+ *   if (resp.is_success()) {
+ *       json& data = resp.get_result();
+ *   } else if (resp.is_jsonrpc_error()) {
+ *       diag("Tool error: %s (code %d)", resp.get_error_message(), resp.get_error_code());
+ *   }
+ */
+class MCPResponse {
+public:
+    /**
+     * @brief Default constructor - creates successful empty response
+     */
+    MCPResponse()
+        : result_(nullptr)
+        , error_type_(MCPErrorType::NONE)
+        , error_code_(0)
+        , http_code_(0) {}
+
+    // ========================================================================
+    // Result Access
+    // ========================================================================
+
+    /**
+     * @brief Get the result data (for success responses)
+     * @return Reference to JSON result object
+     * @throws std::runtime_error if result is null (error occurred)
+     */
+    json& get_result() {
+        if (!result_) {
+            throw std::runtime_error("Cannot get result from error response");
+        }
+        return *result_;
+    }
+
+    /**
+     * @brief Get the result data (const version)
+     * @return Const reference to JSON result object
+     * @throws std::runtime_error if result is null (error occurred)
+     */
+    const json& get_result() const {
+        if (!result_) {
+            throw std::runtime_error("Cannot get result from error response");
+        }
+        return *result_;
+    }
+
+    /**
+     * @brief Check if result is available
+     * @return true if result exists
+     */
+    bool has_result() const { return result_ != nullptr; }
+
+    // ========================================================================
+    // Error Classification
+    // ========================================================================
+
+    /**
+     * @brief Get the error type (layer where error occurred)
+     * @return Error type enum
+     */
+    MCPErrorType get_error_type() const { return error_type_; }
+
+    /**
+     * @brief Get numeric error code
+     * @return Error code (context depends on error_type)
+     */
+    int get_error_code() const { return error_code_; }
+
+    /**
+     * @brief Get human-readable error message
+     * @return Error message string
+     */
+    const std::string& get_error_message() const { return error_message_; }
+
+    // ========================================================================
+    // HTTP Context (always available for debugging)
+    // ========================================================================
+
+    /**
+     * @brief Get HTTP status code
+     * @return HTTP status code (0 if request didn't complete)
+     */
+    long get_http_code() const { return http_code_; }
+
+    /**
+     * @brief Get raw HTTP response body
+     * @return HTTP response body string
+     */
+    const std::string& get_http_response() const { return http_response_; }
+
+    // ========================================================================
+    // Convenience Helpers
+    // ========================================================================
+
+    /**
+     * @brief Check if response is successful
+     * @return true if no error occurred
+     */
+    bool is_success() const { return error_type_ == MCPErrorType::NONE; }
+
+    /**
+     * @brief Check if any error occurred
+     * @return true if error occurred at any layer
+     */
+    bool has_error() const { return error_type_ != MCPErrorType::NONE; }
+
+    /**
+     * @brief Check if error is at transport layer
+     * @return true if CURL/network error
+     */
+    bool is_transport_error() const { return error_type_ == MCPErrorType::TRANSPORT; }
+
+    /**
+     * @brief Check if error is at HTTP layer
+     * @return true if HTTP protocol error without JSON-RPC error in body
+     */
+    bool is_http_error() const { return error_type_ == MCPErrorType::HTTP; }
+
+    /**
+     * @brief Check if error is at JSON-RPC layer
+     * @return true if JSON-RPC protocol or tool error
+     */
+    bool is_jsonrpc_error() const { return error_type_ == MCPErrorType::JSON_RPC; }
+
+    /**
+     * @brief Check if error is at MCP layer
+     * @return true if MCP tool or content error
+     */
+    bool is_mcp_error() const { return error_type_ == MCPErrorType::MCP; }
+
+    // ========================================================================
+    // Internal Setters (for MCPClient use)
+    // ========================================================================
+
+    void set_result(std::unique_ptr<json> result) { result_ = std::move(result); }
+    void set_error_type(MCPErrorType type) { error_type_ = type; }
+    void set_error_code(int code) { error_code_ = code; }
+    void set_error_message(const std::string& msg) { error_message_ = msg; }
+    void set_http_code(long code) { http_code_ = code; }
+    void set_http_response(const std::string& response) { http_response_ = response; }
+
+private:
+    // Result data (present only on success)
+    std::unique_ptr<json> result_;
+
+    // Error classification
+    MCPErrorType error_type_;     ///< Which layer the error occurred at
+
+    // Error details (universal placeholders)
+    int error_code_;              ///< Numeric error code (context depends on error_type)
+    std::string error_message_;   ///< Human-readable error message
+
+    // HTTP context (always present for debugging)
+    long http_code_;              ///< HTTP status code (0 if request didn't complete)
+    std::string http_response_;   ///< Raw HTTP response body
+};
+
+/**
+ * @brief Generic MCP Client for ProxySQL MCP Server
+ *
+ * Provides a C++ interface to ProxySQL's JSON-RPC 2.0 MCP server over HTTP.
+ * Supports all MCP endpoints: config, query, admin, stats, rag, ai, cache.
+ *
+ * MCP Endpoints:
+ *   /mcp/config   - Configuration and server discovery
+ *   /mcp/query    - Query tools (run_sql_readonly, run_sql, etc.)
+ *   /mcp/admin    - Administration tools
+ *   /mcp/stats    - Statistics tools
+ *   /mcp/rag      - RAG tools (search_fts, search_vector, get_chunks, etc.)
+ *   /mcp/ai       - AI tools
+ *   /mcp/cache    - Cache tools
+ *
+ * Configuration sources (in order of precedence):
+ *   1. Constructor parameters
+ *   2. Setter methods
+ *   3. Environment variables (TAP_ADMINHOST, TAP_MCPPORT)
+ *   4. Defaults (127.0.0.1, 6071)
+ *
+ * Usage:
+ *   MCPClient mcp;  // Uses environment variables or defaults
+ *
+ *   json args = {{"query", "mysql"}, {"k", 10}};
+ *   MCPResponse resp = mcp.call_tool("rag", "rag.search_fts", args);
+ *
+ *   if (resp.is_success()) {
+ *       std::cout << (*resp.result)["results"] << std::endl;
+ *   }
+ */
+class MCPClient {
+public:
+    // ========================================================================
+    // Construction / Destruction
+    // ========================================================================
+
+    /**
+     * @brief Construct MCP Client with optional configuration
+     *
+     * All parameters are optional. If not provided, values are read from:
+     *   - host: TAP_ADMINHOST environment variable (default: 127.0.0.1)
+     *   - port: TAP_MCPPORT environment variable (default: 6071)
+     *   - timeout_ms: defaults to 30000 (30 seconds)
+     *
+     * @param host MCP server hostname (empty = use environment/default)
+     * @param port MCP server port (0 = use environment/default)
+     * @param timeout_ms Request timeout in milliseconds (default: 30000)
+     *
+     * @throws std::runtime_error if libcurl initialization fails
+     */
+    MCPClient(
+        const std::string& host = "",
+        int port = 0,
+        long timeout_ms = 30000
+    );
+
+    /**
+     * @brief Destructor - cleans up curl resources
+     */
+    ~MCPClient();
+
+    // Disable copy (curl handle is not copyable)
+    MCPClient(const MCPClient&) = delete;
+    MCPClient& operator=(const MCPClient&) = delete;
+
+    // ========================================================================
+    // Configuration Methods
+    // ========================================================================
+
+    /**
+     * @brief Set MCP server hostname
+     * @param host Hostname or IP address
+     */
+    void set_host(const std::string& host);
+
+    /**
+     * @brief Set MCP server port
+     * @param port Port number
+     */
+    void set_port(int port);
+
+    /**
+     * @brief Set request timeout
+     * @param timeout_ms Timeout in milliseconds
+     */
+    void set_timeout(long timeout_ms);
+
+    /**
+     * @brief Set authentication token for all MCP endpoints
+     *
+     * Token is added as HTTP header: "Authorization: Bearer <token>"
+     * Applies to all endpoints (config, query, admin, stats, rag, ai, cache).
+     * To clear tokens, pass an empty string.
+     *
+     * @param token Authentication token (empty string to clear)
+     */
+    void set_auth_token(const std::string& token);
+
+    // ========================================================================
+    // Server Connectivity
+    // ========================================================================
+
+    /**
+     * @brief Check if MCP server is accessible
+     *
+     * Sends a ping request to /mcp/config endpoint.
+     *
+     * @return true if server responds successfully
+     */
+    bool check_server();
+
+    // ========================================================================
+    // Tool Invocation
+    // ========================================================================
+
+    /**
+     * @brief Call an MCP tool on a specific endpoint
+     *
+     * Constructs JSON-RPC 2.0 request and sends it to the specified endpoint.
+     *
+     * JSON-RPC Request Format:
+     *   {
+     *     "jsonrpc": "2.0",
+     *     "method": "tools/call",
+     *     "params": {
+     *       "name": "<tool_name>",
+     *       "arguments": <arguments>
+     *     },
+     *     "id": <request_id>
+     *   }
+     *
+     * Example - RAG FTS Search:
+     *   json args = {{"query", "mysql"}, {"k", 10}};
+     *   MCPResponse resp = mcp.call_tool("rag", "rag.search_fts", args);
+     *
+     * Example - Query SQL:
+     *   json args = {{"sql", "SELECT * FROM users LIMIT 10"}};
+     *   MCPResponse resp = mcp.call_tool("query", "run_sql_readonly", args);
+     *
+     * Example - Admin Stats:
+     *   json args = {};
+     *   MCPResponse resp = mcp.call_tool("admin", "admin.get_stats", args);
+     *
+     * @param endpoint MCP endpoint (e.g., "rag", "query", "admin", "config")
+     * @param tool_name Tool name (e.g., "rag.search_fts", "run_sql_readonly")
+     * @param arguments JSON object with tool arguments
+     *
+     * @return MCPResponse with result or error
+     */
+    MCPResponse call_tool(
+        const std::string& endpoint,
+        const std::string& tool_name,
+        const json& arguments
+    );
+
+    /**
+     * @brief Call tool with JSON string arguments (convenience overload)
+     *
+     * @param endpoint MCP endpoint
+     * @param tool_name Tool name
+     * @param arguments_json JSON string with arguments
+     *
+     * @return MCPResponse with result or error
+     */
+    MCPResponse call_tool(
+        const std::string& endpoint,
+        const std::string& tool_name,
+        const std::string& arguments_json
+    );
+
+    // ========================================================================
+    // Utility Methods
+    // ========================================================================
+
+    /**
+     * @brief Get current timeout setting
+     * @return Timeout in milliseconds
+     */
+    long get_timeout() const { return timeout_ms_; }
+
+    /**
+     * @brief Get last error message
+     * @return Error message from last failed operation
+     */
+    std::string get_last_error() const { return last_error_; }
+
+    /**
+     * @brief Get base URL
+     * @return Full base URL (e.g., "http://127.0.0.1:6071")
+     */
+    std::string get_base_url() const { return base_url_; }
+
+    /**
+     * @brief Get connection info string
+     * @return String like "127.0.0.1:6071"
+     */
+    std::string get_connection_info() const;
+
+private:
+    // ========================================================================
+    // Private Members
+    // ========================================================================
+
+    CURL* curl_;                       ///< libcurl handle
+    std::string host_;                 ///< Server hostname
+    int port_;                         ///< Server port
+    long timeout_ms_;                  ///< Request timeout
+    std::string last_error_;           ///< Last error message
+    std::string base_url_;             ///< Full base URL
+    unsigned int request_id_;          ///< JSON-RPC request ID counter
+    std::map<std::string, std::string> auth_tokens_; ///< Per-endpoint auth tokens
+
+    // ========================================================================
+    // Private Methods
+    // ========================================================================
+
+    /**
+     * @brief Initialize libcurl
+     */
+    void init_curl();
+
+    /**
+     * @brief Build endpoint URL
+     * @param endpoint Endpoint path
+     * @return Full URL
+     */
+    std::string build_url(const std::string& endpoint) const;
+
+    /**
+     * @brief Build JSON-RPC request
+     * @param tool_name Tool name
+     * @param arguments Arguments
+     * @return JSON request object
+     */
+    json build_request(const std::string& tool_name, const json& arguments);
+
+    /**
+     * @brief Parse JSON-RPC response with error classification
+     * @param raw_response Raw JSON string
+     * @param http_code HTTP status code
+     * @param curl_result CURL result code
+     * @return MCPResponse with proper error classification
+     */
+    MCPResponse parse_response(const std::string& raw_response, long http_code, CURLcode curl_result);
+
+    /**
+     * @brief libcurl write callback
+     */
+    static size_t write_callback(void* contents, size_t size, size_t nmemb, void* userp);
+};
+
+#endif // MCP_CLIENT_H

--- a/test/tap/tap/mcp_client.h
+++ b/test/tap/tap/mcp_client.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include <memory>
-#include <map>
 #include <curl/curl.h>
 #include "json.hpp"
 
@@ -43,7 +42,7 @@ enum class MCPErrorType {
  *   if (resp.is_success()) {
  *       json& data = resp.get_result();
  *   } else if (resp.is_jsonrpc_error()) {
- *       diag("Tool error: %s (code %d)", resp.get_error_message(), resp.get_error_code());
+ *       diag("Tool error: %s (code %d)", resp.get_error_message().c_str(), resp.get_error_code());
  *   }
  */
 class MCPResponse {
@@ -214,17 +213,18 @@ private:
  * Configuration sources (in order of precedence):
  *   1. Constructor parameters
  *   2. Setter methods
- *   3. Environment variables (TAP_ADMINHOST, TAP_MCPPORT)
- *   4. Defaults (127.0.0.1, 6071)
+ *   3. Defaults (127.0.0.1:6071)
  *
  * Usage:
- *   MCPClient mcp;  // Uses environment variables or defaults
+ *   CommandLine cl;
+ *   cl.getEnv();  // Reads TAP_ADMINHOST, TAP_MCP_PORT from environment
+ *   MCPClient mcp(cl.host, cl.mcp_port);  // Pass values from CommandLine
  *
  *   json args = {{"query", "mysql"}, {"k", 10}};
  *   MCPResponse resp = mcp.call_tool("rag", "rag.search_fts", args);
  *
  *   if (resp.is_success()) {
- *       std::cout << (*resp.result)["results"] << std::endl;
+ *       std::cout << resp.get_result()["results"] << std::endl;
  *   }
  */
 class MCPClient {
@@ -236,13 +236,13 @@ public:
     /**
      * @brief Construct MCP Client with optional configuration
      *
-     * All parameters are optional. If not provided, values are read from:
-     *   - host: TAP_ADMINHOST environment variable (default: 127.0.0.1)
-     *   - port: TAP_MCPPORT environment variable (default: 6071)
+     * All parameters are optional. If not provided, defaults are used:
+     *   - host: defaults to "127.0.0.1"
+     *   - port: defaults to 6071
      *   - timeout_ms: defaults to 30000 (30 seconds)
      *
-     * @param host MCP server hostname (empty = use environment/default)
-     * @param port MCP server port (0 = use environment/default)
+     * @param host MCP server hostname (empty = use default "127.0.0.1")
+     * @param port MCP server port (0 = use default 6071)
      * @param timeout_ms Request timeout in milliseconds (default: 30000)
      *
      * @throws std::runtime_error if libcurl initialization fails
@@ -288,8 +288,7 @@ public:
      * @brief Set authentication token for all MCP endpoints
      *
      * Token is added as HTTP header: "Authorization: Bearer <token>"
-     * Applies to all endpoints (config, query, admin, stats, rag, ai, cache).
-     * To clear tokens, pass an empty string.
+     * Applies to all endpoints. To clear token, pass an empty string.
      *
      * @param token Authentication token (empty string to clear)
      */
@@ -407,7 +406,7 @@ private:
     std::string last_error_;           ///< Last error message
     std::string base_url_;             ///< Full base URL
     unsigned int request_id_;          ///< JSON-RPC request ID counter
-    std::map<std::string, std::string> auth_tokens_; ///< Per-endpoint auth tokens
+    std::string auth_token_;           ///< Authentication token for all endpoints
 
     // ========================================================================
     // Private Methods

--- a/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
@@ -119,8 +119,8 @@ int main(int argc, char** argv) {
 	}
 
 	// Setup 3: Configure MCP MySQL connection parameters
-	MYSQL_QUERY_T(admin, "SET mcp-mysql_host='" + std::string(cl.mysql_host) + "'");
-	MYSQL_QUERY_T(admin, "SET mcp-mysql_port=" + std::to_string(cl.mysql_port));
+	MYSQL_QUERY_T(admin, "SET mcp-mysql_hosts='" + std::string(cl.mysql_host) + "'");
+	MYSQL_QUERY_T(admin, "SET mcp-mysql_ports=" + std::to_string(cl.mysql_port));
 	MYSQL_QUERY_T(admin, "SET mcp-mysql_username='" + std::string(cl.mysql_username) + "'");
 	MYSQL_QUERY_T(admin, "SET mcp-mysql_password='" + std::string(cl.mysql_password) + "'");
 	MYSQL_QUERY_T(admin, "LOAD MCP VARIABLES TO RUNTIME");
@@ -141,13 +141,10 @@ int main(int argc, char** argv) {
 	// Allowed Query Tests (9 tests) - should be ALLOWED
 	// ====================================================================
 
-	// Note: The following tests are currently failing. Commenting out 
-	//       these tests until the root cause is identified and fixed.
-	//
-	// diag("--- Testing allowed queries (should be ALLOWED) ---");
-	// for (const auto& test : allowed_queries) {
-	// 	test_query_allowed(*mcp, test.name, test.sql);
-	// }
+	diag("--- Testing allowed queries (should be ALLOWED) ---");
+	for (const auto& test : allowed_queries) {
+		test_query_allowed(*mcp, test.name, test.sql);
+	}
 
 	// ====================================================================
 	// Cleanup Phase
@@ -214,7 +211,7 @@ void test_query_rejected(MCPClient& mcp, const std::string& test_name,
 
 void test_query_allowed(MCPClient& mcp, const std::string& test_name,
                        const std::string& sql) {
-	json args = {{"sql", sql}};
+	json args = {{"sql", sql}, {"schema", "test"}};
 	MCPResponse resp = mcp.call_tool("query", "run_sql_readonly", args);
 
 	// Prepare values before ok() - avoid operators in ok()

--- a/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
@@ -1,0 +1,227 @@
+/**
+ * @file mcp_query_run_sql_readonly-t.cpp
+ * @brief TAP test for MCP query endpoint - run_sql_readonly tool validation
+ *
+ * This test validates that the run_sql_readonly MCP tool properly rejects
+ * non-SELECT queries and allows valid read-only queries.
+ *
+ * Replaces: test/tap/tests/mcp_rules_testing/test_run_sql_readonly_validation.sh
+ *
+ * Test coverage (20 TAP tests):
+ * - Blocked queries: INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE,
+ *                    REPLACE, LOAD DATA, CALL, EXECUTE (11 tests)
+ * - Allowed queries: SELECT variants, SHOW, DESCRIBE, WITH/CTE, EXPLAIN,
+ *                    queries with comments (9 tests)
+ *
+ * Setup operations (not counted as tests):
+ * - MCP server connectivity check
+ * - MySQL connection
+ * - Test database creation
+ * - Test table creation with sample data
+ *
+ * Cleanup operations (not counted as tests):
+ * - Drop test tables
+ * - Close connections
+ */
+
+#include <string>
+#include <algorithm>
+
+#include "mysql.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+#include "mcp_client.h"
+
+using json = nlohmann::json;
+
+// Test case structure
+struct query_test {
+	const char* name;
+	const char* sql;
+};
+
+// Blocked query test cases (11 tests) - all expect "not read-only" error
+const query_test blocked_queries[] = {
+	{"INSERT rejected", "INSERT INTO users (id, name) VALUES (1, 'test');"},
+	{"UPDATE rejected", "UPDATE users SET name = 'test' WHERE id = 1;"},
+	{"DELETE rejected", "DELETE FROM users WHERE id = 1;"},
+	{"DROP TABLE rejected", "DROP TABLE IF EXISTS test_table;"},
+	{"CREATE TABLE rejected", "CREATE TABLE test_table (id INT);"},
+	{"ALTER TABLE rejected", "ALTER TABLE users ADD COLUMN email VARCHAR(255);"},
+	{"TRUNCATE rejected", "TRUNCATE TABLE users;"},
+	{"REPLACE rejected", "REPLACE INTO users (id, name) VALUES (1, 'test');"},
+	{"LOAD DATA rejected", "LOAD DATA INFILE '/tmp/data.csv' INTO TABLE users;"},
+	{"CALL rejected", "CALL test_procedure();"},
+	{"EXECUTE rejected", "EXECUTE immediate 'SELECT 1';"}
+};
+
+// Allowed query test cases (9 tests)
+const query_test allowed_queries[] = {
+	{"SELECT with FROM allowed", "SELECT * FROM users;"},
+	{"SELECT without FROM allowed", "SELECT (SELECT COUNT(*) FROM users);"},
+	{"WITH clause (CTE) allowed", "WITH cte AS (SELECT * FROM users) SELECT * FROM cte;"},
+	{"EXPLAIN SELECT allowed", "EXPLAIN SELECT * FROM users;"},
+	{"SHOW TABLES allowed", "SHOW TABLES;"},
+	{"SHOW DATABASES allowed", "SHOW DATABASES;"},
+	{"DESCRIBE table allowed", "DESCRIBE users;"},
+	{"SELECT with leading comment allowed", "-- This is a comment\nSELECT * FROM users;"},
+	{"SELECT with multiple comments allowed", "-- First comment\n-- Second comment\nSELECT * FROM users;"}
+};
+
+// Helper function prototypes
+void create_test_data(MYSQL* mysql);
+void test_query_rejected(MCPClient& mcp, const std::string& test_name,
+                        const std::string& sql, const std::string& expected_error);
+void test_query_allowed(MCPClient& mcp, const std::string& test_name,
+                       const std::string& sql);
+
+int main(int argc, char** argv) {
+	plan(20);
+
+	// ====================================================================
+	// Setup Phase
+	// ====================================================================
+
+	CommandLine cl;
+	if (cl.getEnv()) {
+		diag("Failed to get required environmental variables.");
+		return exit_status();
+	}
+
+	MYSQL* admin = nullptr;
+	MYSQL* mysql = nullptr;
+	MCPClient* mcp = nullptr;
+
+	diag("Testing MCP run_sql_readonly tool validation");
+
+	// Setup 1: Initialize MCP client and check server connectivity
+	mcp = new MCPClient(cl.host, cl.mcp_port);
+	if (strlen(cl.mcp_auth_token) > 0) {
+		mcp->set_auth_token(cl.mcp_auth_token);
+	}
+	if (!mcp->check_server()) {
+		diag("MCP server not accessible at %s", mcp->get_connection_info().c_str());
+		goto cleanup;
+	}
+
+	// Setup 2: Connect to Admin interface and MySQL backend 
+	admin = init_mysql_conn(cl.admin_host, cl.admin_port, cl.admin_username, cl.admin_password);
+	if (!admin) {
+		diag("ProxySQL admin connection failed");
+		goto cleanup;
+	}
+
+	mysql = init_mysql_conn(cl.mysql_host, cl.mysql_port, cl.mysql_username, cl.mysql_password);
+	if (!mysql) {
+		diag("MySQL backend connection failed");
+		goto cleanup;
+	}
+
+	// Setup 3: Configure MCP MySQL connection parameters
+	MYSQL_QUERY_T(admin, "SET mcp-mysql_host='" + std::string(cl.mysql_host) + "'");
+	MYSQL_QUERY_T(admin, "SET mcp-mysql_port=" + std::to_string(cl.mysql_port));
+	MYSQL_QUERY_T(admin, "SET mcp-mysql_username='" + std::string(cl.mysql_username) + "'");
+	MYSQL_QUERY_T(admin, "SET mcp-mysql_password='" + std::string(cl.mysql_password) + "'");
+	MYSQL_QUERY_T(admin, "LOAD MCP VARIABLES TO RUNTIME");
+
+	// Setup 4: Create test database and tables
+	create_test_data(mysql);
+
+	// ====================================================================
+	// Blocked Query Tests (11 tests) - should be REJECTED
+	// ====================================================================
+
+	diag("--- Testing blocked queries (should be REJECTED) ---");
+	for (const auto& test : blocked_queries) {
+		test_query_rejected(*mcp, test.name, test.sql, "not read-only");
+	}
+
+	// ====================================================================
+	// Allowed Query Tests (9 tests) - should be ALLOWED
+	// ====================================================================
+
+	// Note: The following tests are currently failing. Commenting out 
+	//       these tests until the root cause is identified and fixed.
+	//
+	// diag("--- Testing allowed queries (should be ALLOWED) ---");
+	// for (const auto& test : allowed_queries) {
+	// 	test_query_allowed(*mcp, test.name, test.sql);
+	// }
+
+	// ====================================================================
+	// Cleanup Phase
+	// ====================================================================
+
+cleanup:
+	if (mysql) {
+		MYSQL_QUERY_T(mysql, "DROP TABLE IF EXISTS test.users");
+		MYSQL_QUERY_T(mysql, "DROP TABLE IF EXISTS test.products");
+		mysql_close(mysql);
+	}
+
+	if (mcp) {
+		delete mcp;
+	}
+
+	return exit_status();
+}
+
+// Helper function implementations
+
+void create_test_data(MYSQL* mysql) {
+	run_q(mysql, "CREATE DATABASE IF NOT EXISTS test");
+	run_q(mysql, "USE test");
+
+	run_q(mysql, "DROP TABLE IF EXISTS products");
+	run_q(mysql, "DROP TABLE IF EXISTS users");
+
+	run_q(mysql, "CREATE TABLE users ("
+		"id INT PRIMARY KEY, "
+		"name VARCHAR(100), "
+		"email VARCHAR(255))");
+	run_q(mysql, "CREATE TABLE products ("
+		"id INT PRIMARY KEY, "
+		"name VARCHAR(100), "
+		"price DECIMAL(10,2))");
+	run_q(mysql, "INSERT INTO users VALUES "
+		"(1, 'Alice', 'alice@example.com'), "
+		"(2, 'Bob', 'bob@example.com')");
+	run_q(mysql, "INSERT INTO products VALUES "
+		"(1, 'Widget', 19.99), "
+		"(2, 'Gadget', 29.99)");
+}
+
+void test_query_rejected(MCPClient& mcp, const std::string& test_name,
+                        const std::string& sql, const std::string& expected_error) {
+	json args = {{"sql", sql}, {"schema", "test"}};
+	MCPResponse resp = mcp.call_tool("query", "run_sql_readonly", args);
+
+	// Prepare values before ok() - keep ok() expression clean
+	std::string error_msg = resp.get_error_message();
+	std::string error_lower = error_msg;
+	std::string expected_lower = expected_error;
+	std::transform(error_lower.begin(), error_lower.end(), error_lower.begin(), ::tolower);
+	std::transform(expected_lower.begin(), expected_lower.end(), expected_lower.begin(), ::tolower);
+
+	bool is_rejected = resp.is_mcp_error();
+	bool error_matches = error_lower.find(expected_lower) != std::string::npos;
+
+	ok(is_rejected && error_matches,
+	   "%s - Expected error containing '%s', got: '%s'",
+	   test_name.c_str(), expected_error.c_str(), error_msg.c_str());
+}
+
+void test_query_allowed(MCPClient& mcp, const std::string& test_name,
+                       const std::string& sql) {
+	json args = {{"sql", sql}};
+	MCPResponse resp = mcp.call_tool("query", "run_sql_readonly", args);
+
+	// Prepare values before ok() - avoid operators in ok()
+	bool is_success = resp.is_success();
+	std::string error_msg = is_success ? "none" : resp.get_error_message();
+
+	ok(is_success,
+	   "%s - Expected error: none, got: %s",
+	   test_name.c_str(), error_msg.c_str());
+}

--- a/test/tap/tests/mcp_rules_testing/test_run_sql_readonly_validation.sh
+++ b/test/tap/tests/mcp_rules_testing/test_run_sql_readonly_validation.sh
@@ -2,6 +2,9 @@
 #
 # test_run_sql_readonly_validation.sh - Test run_sql_readonly Query Validation
 #
+# DEPRECATED: This shell script is deprecated in favor of the C++ TAP test.
+# Please use: test/tap/tests/mcp_query_run_sql_readonly-t
+#
 # This script tests that the run_sql_readonly tool properly validates
 # queries and rejects non-SELECT queries.
 #


### PR DESCRIPTION
- Add `MCPClient` class for testing ProxySQL's MCP endpoints via HTTP/JSON-RPC
- Add TAP test for `run_sql_readonly` query tool validation
- Update AI test group configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled MCP integration for test runs and added test-time configuration to connect to MCP.

* **Tests**
  * Added a C++ TAP test validating MCP read-only SQL behavior and a new MCP test group.
  * Marked the older shell-based validation script as deprecated.

* **Chores**
  * Added an MCP client to the test build and introduced new MCP connection options; removed a legacy test environment export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->