### PR TITLE
Fix test_prometheus_metrics-t to handle Prometheus labels

### DIFF
--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -1855,7 +1855,13 @@ map<string, double> parse_prometheus_metrics(const string& s) {
 	for (const string ln : lines) {
 		if (ln.empty() == false && ln[0] != '#') {
 			pair<string, string> p_line_val { split_line_by_last(ln, ' ') };
-			metrics_map.insert({p_line_val.first, stod(p_line_val.second)});
+			// Strip labels from metric name (e.g., "metric{label=\"value\"}" -> "metric")
+			string metric_name = p_line_val.first;
+			size_t brace_pos = metric_name.find('{');
+			if (brace_pos != string::npos) {
+				metric_name = metric_name.substr(0, brace_pos);
+			}
+			metrics_map.insert({metric_name, stod(p_line_val.second)});
 		}
 	}
 


### PR DESCRIPTION
Update parse_prometheus_metrics() to strip labels from metric names
(e.g., 'metric{protocol="mysql"}' -> 'metric') so tests can use
simple metric names without labels.

Fixes #5378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Prometheus metrics parsing to properly normalize metric names by removing inline label sets, ensuring consistent metric storage and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->