### PR TITLE
feat: add friend declaration for MetricsCollector to access MyHostGroups

### DIFF
--- a/include/Base_HostGroups_Manager.h
+++ b/include/Base_HostGroups_Manager.h
@@ -9,6 +9,13 @@ class PgSQL_SrvC;
 class MySrvList;
 class PgSQL_SrvList;
 
+// Forward declaration for WebUI monitoring metrics collector
+namespace ProxySQL {
+namespace Monitoring {
+class MetricsCollector;
+}
+}
+
 #include "proxysql.h"
 #include "cpp.h"
 #include "proxysql_gtid.h"
@@ -666,6 +673,7 @@ class Base_HostGroups_Manager {
 
 	friend class MySQL_HostGroups_Manager;
 	friend class PgSQL_HostGroups_Manager;
+	friend class ProxySQL::Monitoring::MetricsCollector;
 
 };
 

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -123,6 +123,13 @@
 
 typedef std::unordered_map<std::uint64_t, void *> umap_mysql_errors;
 
+// Forward declaration for WebUI monitoring metrics collector
+namespace ProxySQL {
+namespace Monitoring {
+class MetricsCollector;
+}
+}
+
 class MySrvConnList;
 class MySrvC;
 class MySrvList;
@@ -792,6 +799,9 @@ class MySQL_HostGroups_Manager : public Base_HostGroups_Manager<MyHGC> {
 	void group_replication_lag_action_set_server_status(MyHGC* myhgc, char* address, int port, int lag_count, bool enable);
 
 	public:
+	// Friend declaration for WebUI monitoring metrics collector
+	friend class ProxySQL::Monitoring::MetricsCollector;
+
 	std::mutex galera_set_writer_mutex;
 	/**
 	 * @brief Mutex used to guard 'mysql_servers_to_monitor' resulset.

--- a/include/PgSQL_HostGroups_Manager.h
+++ b/include/PgSQL_HostGroups_Manager.h
@@ -107,6 +107,13 @@ class PgSQL_SrvC;
 class PgSQL_SrvList;
 class PgSQL_HGC;
 
+// Forward declaration for WebUI monitoring metrics collector
+namespace ProxySQL {
+namespace Monitoring {
+class MetricsCollector;
+}
+}
+
 class PgSQL_Errors_stats {
 public:
 	PgSQL_Errors_stats(int _hostgroup, const char* _hostname, int _port, const char* _username, const char* _address, const char* _dbname,
@@ -571,6 +578,9 @@ class PgSQL_HostGroups_Manager : public Base_HostGroups_Manager<PgSQL_HGC> {
 	);
 
 	public:
+	// Friend declaration for WebUI monitoring metrics collector
+	friend class ProxySQL::Monitoring::MetricsCollector;
+
 	/**
 	 * @brief Mutex used to guard 'pgsql_servers_to_monitor' resulset.
 	 */


### PR DESCRIPTION
Allow the WebUI monitoring MetricsCollector to access the private MyHostGroups member of Base_HostGroups_Manager for thread-safe iteration through configured servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal monitoring infrastructure across host group managers to enable enhanced metrics collection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->