### PR TITLE
Fix: Extended query Routing and Statistics Tracking

### DIFF
--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -750,6 +750,9 @@ handler_again:
 
 	case ASYNC_STMT_EXECUTE_START:
 		stmt_execute_start();
+		__sync_fetch_and_add(&parent->queries_sent, 1);
+		update_bytes_sent(query.length + 5);
+		statuses.questions++;
 		if (async_exit_status) {
 			next_event(ASYNC_STMT_EXECUTE_CONT);
 		} else {
@@ -808,7 +811,7 @@ handler_again:
 
 	case ASYNC_RESYNC_START:
 		if (PQpipelineStatus(pgsql_conn) == PQ_PIPELINE_OFF) {
-			proxy_warning("Resync not required — connection already synchronized.\n");
+			proxy_warning("Resync not required - connection already synchronized.\n");
 			NEXT_IMMEDIATE(ASYNC_RESYNC_END);
 		}
 		resync_start();

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -726,13 +726,24 @@ handler_again:
 		break;
 
 	case ASYNC_STMT_DESCRIBE_START:
+	{
 		stmt_describe_start();
+		__sync_fetch_and_add(&parent->queries_sent, 1);
+		size_t bytes_sent = 7 + 5; // 7 for DESCRIBE header, 5 for SYNC/FLUSH
+		if (query.extended_query_info->stmt_type == 'P') {
+			bytes_sent += query.extended_query_info->stmt_client_portal_name ? (strlen(query.extended_query_info->stmt_client_portal_name) + 1) : 0;
+		} else {
+			bytes_sent += query.backend_stmt_name ? (strlen(query.backend_stmt_name) + 1) : 0;
+		}
+		update_bytes_sent(bytes_sent);
+		statuses.questions++;
 		if (async_exit_status) {
 			next_event(ASYNC_STMT_DESCRIBE_CONT);
 		} else {
 			NEXT_IMMEDIATE(ASYNC_STMT_DESCRIBE_END);
 		}
-		break;
+	}
+	break;
 	case ASYNC_STMT_DESCRIBE_CONT:
 		if (event) {
 			stmt_describe_cont(event);
@@ -751,7 +762,7 @@ handler_again:
 	case ASYNC_STMT_EXECUTE_START:
 		stmt_execute_start();
 		__sync_fetch_and_add(&parent->queries_sent, 1);
-		update_bytes_sent(query.length + 5);
+		update_bytes_sent(query.extended_query_info->bind_msg->get_raw_pkt().size + 5);
 		statuses.questions++;
 		if (async_exit_status) {
 			next_event(ASYNC_STMT_EXECUTE_CONT);
@@ -815,6 +826,7 @@ handler_again:
 			NEXT_IMMEDIATE(ASYNC_RESYNC_END);
 		}
 		resync_start();
+		update_bytes_sent(5); // SYNC message
 		if (async_exit_status) {
 			next_event(ASYNC_RESYNC_CONT);
 		} else {

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -4470,8 +4470,13 @@ __exit_set_destination_hostgroup:
 		next_query_flagIN = qpo->next_query_flagIN;
 	}
 
-	if (qpo->destination_hostgroup >= 0 && transaction_persistent_hostgroup == -1) {
-		current_hostgroup = qpo->destination_hostgroup;
+	if (transaction_persistent_hostgroup == -1) {
+		if (qpo->destination_hostgroup >= 0) {
+			current_hostgroup = qpo->destination_hostgroup;
+		} else {
+			// No query rule matched - use default hostgroup
+			current_hostgroup = default_hostgroup;
+		}
 	}
 
 	// Hostgroup locking check

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -225,6 +225,7 @@
   "mysql-watchdog_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-extended_query_protocol_query_rules_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-extended_query_protocol_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-query_rules_routing-t": [ "pgsql17-repl-g4" ],
   "pgsql-multiplex_status_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-proxysql_cmd_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-query_cancel_session_termination_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],

--- a/test/tap/groups/pgsql17-repl/env.sh
+++ b/test/tap/groups/pgsql17-repl/env.sh
@@ -1,0 +1,5 @@
+# PostgreSQL 17 Replication Test Group
+#
+# Tests for replication, query routing, read-only detection
+
+export TEST_PY_TAP_INCL="pgsql-query_rules_routing-t"

--- a/test/tap/groups/pgsql17-repl/pre-proxysql.bash
+++ b/test/tap/groups/pgsql17-repl/pre-proxysql.bash
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# change infra config for PostgreSQL 17 replication
+# inherits env from tester script
+#
+
+INFRA=infra-$(basename $(dirname "$0") | sed 's/-g[0-9]//' | sed 's/_.*//')
+
+# destroy running infras
+$JENKINS_SCRIPTS_PATH/infra-default/docker-compose-destroy.bash
+
+# cleanup ProxySQL before starting new infra
+psql -h127.0.0.1 -p6132 -Uadmin -dadmin -c " \
+DELETE FROM pgsql_users; \
+LOAD PGSQL USERS TO RUNTIME; \
+SAVE PGSQL USERS TO DISK; \
+DELETE FROM pgsql_servers; \
+DELETE FROM pgsql_hostgroup_parameters; \
+DELETE FROM pgsql_replication_hostgroups; \
+LOAD PGSQL SERVERS TO RUNTIME; \
+SAVE PGSQL SERVERS TO DISK; \
+DELETE FROM pgsql_query_rules; \
+LOAD PGSQL QUERY RULES TO RUNTIME; \
+SAVE PGSQL QUERY RULES TO DISK; \
+DELETE FROM mysql_users; \
+LOAD MYSQL USERS TO RUNTIME; \
+SAVE MYSQL USERS TO DISK; \
+DELETE FROM mysql_servers; \
+DELETE FROM mysql_replication_hostgroups; \
+DELETE FROM mysql_group_replication_hostgroups; \
+DELETE FROM mysql_galera_hostgroups; \
+LOAD MYSQL SERVERS TO RUNTIME; \
+SAVE MYSQL SERVERS TO DISK; \
+DELETE FROM mysql_query_rules; \
+LOAD MYSQL QUERY RULES TO RUNTIME; \
+SAVE MYSQL QUERY RULES TO DISK; \
+" 2>&1
+
+# load environment for infra
+source $JENKINS_SCRIPTS_PATH/${INFRA}/.env
+
+# Start infra (this will configure ProxySQL via docker-proxy-post.bash)
+$JENKINS_SCRIPTS_PATH/infra-docker-hoster/docker-compose-init.bash
+$JENKINS_SCRIPTS_PATH/${INFRA}/docker-compose-init.bash
+
+# wait for infra to stabilize
+sleep 10

--- a/test/tap/tests/pgsql-query_rules_routing-t.cpp
+++ b/test/tap/tests/pgsql-query_rules_routing-t.cpp
@@ -1,0 +1,469 @@
+/**
+ * @file pgsql-query_rules_routing-t.cpp
+ * @brief This test is for testing query routing to different hostgroups
+ *  through 'query rules' for PostgreSQL. It aims to check that
+ *  arbitrary query rules are properly matched and queries are executed in
+ *  the target hostgroups for both 'text protocol' and 'extended query protocol'.
+ *
+ *  This test is the PostgreSQL equivalent of test_query_rules_routing-t.cpp
+ */
+
+#include <unistd.h>
+#include <string>
+#include <sstream>
+#include <chrono>
+#include <thread>
+#include <vector>
+#include <utility>
+#include <memory>
+#include "libpq-fe.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+CommandLine cl;
+
+using PGConnPtr = std::unique_ptr<PGconn, decltype(&PQfinish)>;
+
+enum ConnType {
+    ADMIN,
+    BACKEND
+};
+
+/**
+ * @brief Create a new PostgreSQL connection.
+ *
+ * @param conn_type ADMIN for admin interface, BACKEND for proxy connection.
+ * @param options Optional connection options string.
+ * @param with_ssl Whether to use SSL.
+ * @return PGConnPtr A smart pointer to PGconn.
+ */
+PGConnPtr createNewConnection(ConnType conn_type, const std::string& options = "", bool with_ssl = false) {
+    const char* host = (conn_type == BACKEND) ? cl.pgsql_host : cl.pgsql_admin_host;
+    int port = (conn_type == BACKEND) ? cl.pgsql_port : cl.pgsql_admin_port;
+    const char* username = (conn_type == BACKEND) ? cl.pgsql_username : cl.admin_username;
+    const char* password = (conn_type == BACKEND) ? cl.pgsql_password : cl.admin_password;
+
+    std::stringstream ss;
+
+    ss << "host=" << host << " port=" << port;
+    ss << " user=" << username << " password=" << password;
+    ss << (with_ssl ? " sslmode=require" : " sslmode=disable");
+
+    if (options.empty() == false) {
+        ss << " options='" << options << "'";
+    }
+
+    PGconn* conn = PQconnectdb(ss.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        diag("Connection failed to '%s': %s",
+             (conn_type == BACKEND ? "Backend" : "Admin"),
+             PQerrorMessage(conn));
+        PQfinish(conn);
+        return PGConnPtr(nullptr, &PQfinish);
+    }
+    return PGConnPtr(conn, &PQfinish);
+}
+
+/**
+ * @brief For now a query rules test for destination hostgroup is going
+ *   to consist into:
+ *
+ *   - A set of rules to apply.
+ *   - A set of queries to exercise those rules.
+ *   - The destination hostgroup in which the queries are supposed to end.
+ */
+using dst_hostgroup_test =
+    std::pair<std::vector<std::string>, std::vector<std::pair<std::string, int>>>;
+
+/**
+ * @brief Test cases for query routing to different hostgroups.
+ * Each test case contains:
+ *   - Query rules to configure
+ *   - Queries with their expected destination hostgroups
+ */
+std::vector<dst_hostgroup_test> dst_hostgroup_tests {
+    {
+        // Test 1: Basic read-write split
+        // SELECT queries go to hostgroup 1 (reader)
+        // All other queries go to hostgroup 0 (writer) via default
+        {
+            "INSERT INTO pgsql_query_rules (rule_id,active,match_pattern,destination_hostgroup,apply)"
+            " VALUES (1,1,'^SELECT.*FOR UPDATE',0,1)",
+            "INSERT INTO pgsql_query_rules (rule_id,active,match_pattern,destination_hostgroup,apply)"
+            " VALUES (2,1,'^SELECT',1,1)"
+        },
+        {
+            { "SELECT 1", 1 },
+            { "SELECT * FROM pgsql_routing_test.test_table_0 WHERE id=1", 1 },
+            { "SELECT * FROM pgsql_routing_test.test_table_0 WHERE id BETWEEN 1 AND 20", 1 },
+            { "INSERT INTO pgsql_routing_test.test_table_0 (k) VALUES (2)", 0 },
+            { "UPDATE pgsql_routing_test.test_table_0 SET pad='random' WHERE id=2", 0 },
+            { "SELECT DISTINCT c FROM pgsql_routing_test.test_table_0 WHERE id BETWEEN 1 AND 10 ORDER BY c", 1 }
+        }
+    },
+    {
+        // Test 2: Table-based routing
+        // Queries to test_table_0 go to hostgroup 1
+        // Queries to test_table_1 go to hostgroup 0
+        {
+            "INSERT INTO pgsql_query_rules (rule_id,active,match_pattern,destination_hostgroup,apply)"
+            " VALUES (1,1,'^SELECT.*FROM pgsql_routing_test.test_table_0.*',1,1)",
+            "INSERT INTO pgsql_query_rules (rule_id,active,match_pattern,destination_hostgroup,apply)"
+            " VALUES (2,1,'^SELECT.*FROM pgsql_routing_test.test_table_1.*',0,1)"
+        },
+        {
+            { "UPDATE pgsql_routing_test.test_table_0 SET pad='random' WHERE id=2", 0 },
+            { "SELECT DISTINCT c FROM pgsql_routing_test.test_table_0 WHERE id BETWEEN 1 AND 10 ORDER BY c", 1 },
+            { "SELECT c FROM pgsql_routing_test.test_table_1 WHERE id BETWEEN 1 AND 10 ORDER BY c", 0 },
+            { "INSERT INTO pgsql_routing_test.test_table_0 (k) VALUES (2)", 0 }
+        }
+    },
+    {
+        // Test 3: Mix of SELECT FOR UPDATE and regular SELECT
+        {
+            "INSERT INTO pgsql_query_rules (rule_id,active,match_pattern,destination_hostgroup,apply)"
+            " VALUES (1,1,'^SELECT.*FOR UPDATE',0,1)",
+            "INSERT INTO pgsql_query_rules (rule_id,active,match_pattern,destination_hostgroup,apply)"
+            " VALUES (2,1,'^SELECT',1,1)"
+        },
+        {
+            { "UPDATE pgsql_routing_test.test_table_0 SET pad='random' WHERE id=2", 0 },
+            { "SELECT c FROM pgsql_routing_test.test_table_0 WHERE id=1", 1 },
+            { "SELECT c FROM pgsql_routing_test.test_table_0 WHERE id BETWEEN 1 AND 20", 1 },
+            { "SELECT SUM(k) c FROM pgsql_routing_test.test_table_0 WHERE id BETWEEN 1 AND 10", 1 }
+        }
+    }
+};
+
+/**
+ * @brief Get the current query count for a specific hostgroup.
+ *
+ * @param admin A already opened PGconn connection to ProxySQL admin interface.
+ * @param hostgroup_id The 'hostgroup_id' from which to get the query count.
+ *
+ * @return The number of queries that have been executed in that hostgroup id,
+ *         or -1 on error.
+ */
+int get_hostgroup_query_count(PGconn* admin, const int hostgroup_id) {
+    if (admin == NULL) {
+        return -1;
+    }
+
+    std::stringstream ss;
+    ss << "SELECT SUM(Queries) FROM stats.stats_pgsql_connection_pool WHERE hostgroup=" << hostgroup_id;
+
+    PGresult* res = PQexec(admin, ss.str().c_str());
+    if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+        diag("Failed to get query count: %s", PQerrorMessage(admin));
+        PQclear(res);
+        return -1;
+    }
+
+    int query_count = -1;
+    if (PQntuples(res) > 0 && PQgetvalue(res, 0, 0) != NULL) {
+        query_count = atoi(PQgetvalue(res, 0, 0));
+    }
+
+    PQclear(res);
+    return query_count;
+}
+
+/**
+ * @brief Simple function that performs a text protocol query and discards the result.
+ *
+ * @param conn A already opened PGconn connection to ProxySQL.
+ * @param query The query to be executed.
+ *
+ * @return true if the query succeeded, false otherwise.
+ */
+bool perform_text_protocol_query(PGconn* conn, const std::string& query) {
+    PGresult* res = PQexec(conn, query.c_str());
+    ExecStatusType status = PQresultStatus(res);
+
+    bool success = (status == PGRES_TUPLES_OK || status == PGRES_COMMAND_OK);
+
+    if (!success) {
+        diag("Query '%s' failed: %s", query.c_str(), PQerrorMessage(conn));
+    }
+
+    PQclear(res);
+    return success;
+}
+
+/**
+ * @brief Simple function that performs an extended query protocol (prepared statement)
+ * and discards the result.
+ *
+ * @param conn A already opened PGconn connection to ProxySQL.
+ * @param query The query to be executed.
+ * @param stmt_name The name for the prepared statement.
+ *
+ * @return true if the query succeeded, false otherwise.
+ */
+bool perform_extended_query_protocol(PGconn* conn, const std::string& query, const std::string& stmt_name) {
+    // Prepare
+    PGresult* res = PQprepare(conn, stmt_name.c_str(), query.c_str(), 0, nullptr);
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        diag("Prepare failed for '%s': %s", query.c_str(), PQerrorMessage(conn));
+        PQclear(res);
+        return false;
+    }
+    PQclear(res);
+
+    // Execute
+    res = PQexecPrepared(conn, stmt_name.c_str(), 0, nullptr, nullptr, nullptr, 0);
+    ExecStatusType status = PQresultStatus(res);
+    bool success = (status == PGRES_TUPLES_OK || status == PGRES_COMMAND_OK);
+
+    if (!success) {
+        diag("Execute failed for '%s': %s", query.c_str(), PQerrorMessage(conn));
+    }
+
+    PQclear(res);
+
+    // Cleanup - deallocate the prepared statement
+    std::string dealloc_query = "DEALLOCATE " + stmt_name;
+    res = PQexec(conn, dealloc_query.c_str());
+    PQclear(res);
+
+    return success;
+}
+
+/**
+ * @brief Helper function for creating testing tables.
+ *
+ * @param backend A already opened PGconn connection through ProxySQL.
+ *
+ * @return true on success, false on failure.
+ */
+bool create_testing_tables(PGconn* backend) {
+    if (backend == NULL) {
+        return false;
+    }
+
+    // Create schema
+    PGresult* res = PQexec(backend, "CREATE SCHEMA IF NOT EXISTS pgsql_routing_test");
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        diag("Failed to create schema: %s", PQerrorMessage(backend));
+        PQclear(res);
+        return false;
+    }
+    PQclear(res);
+
+    // Create tables
+    for (int i = 0; i < 2; i++) {
+        std::stringstream ss;
+
+        // Drop table if exists
+        ss << "DROP TABLE IF EXISTS pgsql_routing_test.test_table_" << i;
+        res = PQexec(backend, ss.str().c_str());
+        PQclear(res);
+
+        // Create table
+        ss.str("");
+        ss << "CREATE TABLE pgsql_routing_test.test_table_" << i << " ("
+           << "    id SERIAL PRIMARY KEY,"
+           << "    k INTEGER NOT NULL DEFAULT 0,"
+           << "    c VARCHAR(120) NOT NULL DEFAULT '',"
+           << "    pad VARCHAR(60) NOT NULL DEFAULT ''"
+           << ")";
+        res = PQexec(backend, ss.str().c_str());
+        if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+            diag("Failed to create table: %s", PQerrorMessage(backend));
+            PQclear(res);
+            return false;
+        }
+        PQclear(res);
+
+        // Insert test data
+        ss.str("");
+        ss << "INSERT INTO pgsql_routing_test.test_table_" << i
+           << " (k, c, pad) VALUES (3427, 'foo', 'bar')";
+        res = PQexec(backend, ss.str().c_str());
+        if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+            diag("Failed to insert data: %s", PQerrorMessage(backend));
+            PQclear(res);
+            return false;
+        }
+        PQclear(res);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Clear all query rules from the admin interface.
+ *
+ * @param admin A already opened PGconn connection to ProxySQL admin interface.
+ */
+void clear_query_rules(PGconn* admin) {
+    PGresult* res = PQexec(admin, "DELETE FROM pgsql_query_rules");
+    PQclear(res);
+
+    res = PQexec(admin, "LOAD PGSQL QUERY RULES TO RUNTIME");
+    PQclear(res);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+}
+
+/**
+ * @brief Insert query rules and load them to runtime.
+ *
+ * @param admin A already opened PGconn connection to ProxySQL admin interface.
+ * @param rules The query rules to insert.
+ *
+ * @return true on success, false on failure.
+ */
+bool insert_query_rules(PGconn* admin, const std::vector<std::string>& rules) {
+    for (const auto& rule : rules) {
+        PGresult* res = PQexec(admin, rule.c_str());
+        if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+            diag("Failed to insert query rule: %s", PQerrorMessage(admin));
+            PQclear(res);
+            return false;
+        }
+        PQclear(res);
+    }
+
+    PGresult* res = PQexec(admin, "LOAD PGSQL QUERY RULES TO RUNTIME");
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        diag("Failed to load query rules: %s", PQerrorMessage(admin));
+        PQclear(res);
+        return false;
+    }
+    PQclear(res);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    return true;
+}
+
+int main(int argc, char** argv) {
+    if (cl.getEnv()) {
+        diag("Failed to get the required environmental variables.");
+        return -1;
+    }
+
+    plan(dst_hostgroup_tests.size());
+
+    // Create admin connection
+    PGConnPtr admin = createNewConnection(ADMIN);
+    if (!admin || PQstatus(admin.get()) != CONNECTION_OK) {
+        BAIL_OUT("Failed to connect to admin interface");
+        return exit_status();
+    }
+
+    // Create backend connections for text and extended query protocol
+    PGConnPtr backend_text = createNewConnection(BACKEND);
+    PGConnPtr backend_extended = createNewConnection(BACKEND);
+
+    if (!backend_text || PQstatus(backend_text.get()) != CONNECTION_OK) {
+        BAIL_OUT("Failed to connect to backend (text protocol)");
+        return exit_status();
+    }
+
+    if (!backend_extended || PQstatus(backend_extended.get()) != CONNECTION_OK) {
+        BAIL_OUT("Failed to connect to backend (extended query protocol)");
+        return exit_status();
+    }
+
+    // Create testing tables
+    if (!create_testing_tables(backend_text.get())) {
+        BAIL_OUT("Failed to create testing tables");
+        return exit_status();
+    }
+
+    // Allow tables to be visible
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Run each test case
+    for (size_t test_idx = 0; test_idx < dst_hostgroup_tests.size(); test_idx++) {
+        const auto& test_case = dst_hostgroup_tests[test_idx];
+        const auto& query_rules = test_case.first;
+        const auto& queries_hids = test_case.second;
+
+        // Clear existing rules
+        clear_query_rules(admin.get());
+
+        // Insert new rules
+        if (!insert_query_rules(admin.get(), query_rules)) {
+            ok(false, "Test %zu: Failed to insert query rules", test_idx + 1);
+            continue;
+        }
+
+        // Execute queries and check hostgroup routing
+        bool queries_properly_routed = true;
+        std::vector<std::string> text_queries_failed_to_route;
+        std::vector<std::string> extended_queries_failed_to_route;
+
+        int stmt_counter = 0;
+
+        for (const auto& query_hid : queries_hids) {
+            const std::string& query = query_hid.first;
+            int expected_hg = query_hid.second;
+
+            // Test text protocol
+            int cur_hid_queries = get_hostgroup_query_count(admin.get(), expected_hg);
+
+            if (!perform_text_protocol_query(backend_text.get(), query)) {
+                diag("Text protocol query failed: %s", query.c_str());
+            }
+
+            int new_hid_queries = get_hostgroup_query_count(admin.get(), expected_hg);
+
+            if (new_hid_queries - cur_hid_queries != 1) {
+                queries_properly_routed = false;
+                text_queries_failed_to_route.push_back(query);
+                diag("Text query '%s' routed incorrectly. Expected HG %d, query count diff: %d",
+                     query.c_str(), expected_hg, new_hid_queries - cur_hid_queries);
+            }
+
+            // Test extended query protocol (prepared statements)
+            cur_hid_queries = get_hostgroup_query_count(admin.get(), expected_hg);
+
+            std::string stmt_name = "stmt_" + std::to_string(stmt_counter++);
+            if (!perform_extended_query_protocol(backend_extended.get(), query, stmt_name)) {
+                diag("Extended query protocol failed: %s", query.c_str());
+            }
+
+            new_hid_queries = get_hostgroup_query_count(admin.get(), expected_hg);
+
+            // For prepared statements, we expect 2 queries (PREPARE + EXECUTE or similar)
+            // The exact count depends on ProxySQL implementation
+            if (new_hid_queries - cur_hid_queries < 1) {
+                queries_properly_routed = false;
+                extended_queries_failed_to_route.push_back(query);
+                diag("Extended query '%s' routed incorrectly. Expected HG %d, query count diff: %d",
+                     query.c_str(), expected_hg, new_hid_queries - cur_hid_queries);
+            }
+        }
+
+        // Report failures
+        if (!queries_properly_routed) {
+            std::stringstream rules_ss;
+            for (const auto& rule : query_rules) {
+                rules_ss << rule << "\n";
+            }
+
+            diag("Test %zu with rules:\n%s\nFailed to route text queries:",
+                 test_idx + 1, rules_ss.str().c_str());
+            for (const auto& q : text_queries_failed_to_route) {
+                diag("  - %s", q.c_str());
+            }
+
+            diag("Failed to route extended queries:");
+            for (const auto& q : extended_queries_failed_to_route) {
+                diag("  - %s", q.c_str());
+            }
+        }
+
+        ok(queries_properly_routed,
+           "Test %zu: Queries were properly routed to the target hostgroups",
+           test_idx + 1);
+    }
+
+    // Cleanup
+    clear_query_rules(admin.get());
+
+    return exit_status();
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in PostgreSQL extended query protocol (prepared statements):

1. **Routing Bug**: Queries without matching query rules were retaining the previous hostgroup instead of being routed to the default hostgroup
2. **Statistics Bug**: Extended query protocol executions were not being counted in `stats.stats_pgsql_connection_pool`
 
Added Basic read/write split TAP test

Closes [#5387](https://github.com/sysown/proxysql/issues/5387)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing query statistics tracking in asynchronous statement operations (query counters and bytes sent).
  * Fixed text formatting in connection resynchronization message.
  * Ensured default hostgroup is applied when no specific routing rule matches.

* **Tests**
  * Added comprehensive end-to-end tests validating query routing across PostgreSQL protocols.
  * Added test group and environment/setup scripts to support PostgreSQL 17 replication routing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->