### PR TITLE
Revert "Reset current_hostgroup to default when no query rule matches"

### DIFF
--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -4470,13 +4470,8 @@ __exit_set_destination_hostgroup:
 		next_query_flagIN = qpo->next_query_flagIN;
 	}
 
-	if (transaction_persistent_hostgroup == -1) {
-		if (qpo->destination_hostgroup >= 0) {
-			current_hostgroup = qpo->destination_hostgroup;
-		} else {
-			// No query rule matched - use default hostgroup
-			current_hostgroup = default_hostgroup;
-		}
+	if (qpo->destination_hostgroup >= 0 && transaction_persistent_hostgroup == -1) {
+		current_hostgroup = qpo->destination_hostgroup;
 	}
 
 	// Hostgroup locking check


### PR DESCRIPTION
This reverts commit 1b3d20388ef829df7df9b2f3ea70becbdd9e6291.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined host group routing logic for persistent database transactions to eliminate unnecessary fallback routing behavior, ensuring more predictable connection assignment in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->