### PR TITLE
Handle late COPY protocol messages after session exits fast_forward mode - P0

### DIFF
--- a/include/PgSQL_Connection.h
+++ b/include/PgSQL_Connection.h
@@ -364,7 +364,7 @@ public:
 	bool is_connected() const;
 	void compute_unknown_transaction_status();
 	void async_free_result();
-	void flush();
+	void flush(bool is_resync = false);
 	bool IsActiveTransaction();
 	bool IsKnownActiveTransaction();
 	bool IsServerOffline();

--- a/include/PgSQL_Session.h
+++ b/include/PgSQL_Session.h
@@ -419,7 +419,7 @@ private:
 	 *
 	 * @return void.
 	 */
-	void switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::string_view command, SESSION_FORWARD_TYPE session_type);
+	bool switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::string_view command, SESSION_FORWARD_TYPE session_type);
 
 	/**
 	 * @brief Switches session from fast forward mode to normal mode.

--- a/include/PgSQL_Session.h
+++ b/include/PgSQL_Session.h
@@ -417,7 +417,7 @@ private:
 	 * @param command Command that causes the session to switch to fast forward mode.
 	 * @param session_type SESSION_FORWARD_TYPE indicating the type of session.
 	 *
-	 * @return void.
+	 * @return bool.
 	 */
 	bool switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::string_view command, SESSION_FORWARD_TYPE session_type);
 

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -2875,6 +2875,15 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 		}
 
 		query_length = hdr.data.size;
+
+		// Validate minimum query size (need at least 1 byte + null terminator)
+		if (query_length < 2 || hdr.data.ptr == NULL) {
+			proxy_warning("Query too short: %u bytes\n", query_length);
+			SPA->send_error_msg_to_client(sess, "Malformed query packet");
+			run_query = false;
+			goto __run_query;
+		}
+
 		query = (char*)l_alloc(query_length);
 		memcpy(query, (char*)hdr.data.ptr, query_length - 1);
 	} else {
@@ -4712,7 +4721,7 @@ __run_query:
 		pthread_mutex_unlock(&pa->sql_query_global_mutex);
 	} else {
 		// The admin module may have already been freed in case of "PROXYSQL STOP"
-		if (strcasecmp(query_no_space, "PROXYSQL STOP") == 0) {
+		if (query_no_space && strcasecmp(query_no_space, "PROXYSQL STOP") == 0) {
 			// Command is "PROXYSQL STOP"
 			if (admin_nostart_ && __sync_fetch_and_add((uint8_t*)&GloVars.global.nostart, 0)) {
 				pthread_mutex_unlock(&pa->sql_query_global_mutex);
@@ -4721,8 +4730,13 @@ __run_query:
 			pthread_mutex_unlock(&pa->sql_query_global_mutex);
 		}
 	}
-	l_free(pkt->size-sizeof(mysql_hdr),query_no_space); // it is always freed here
-	l_free(query_length,query);
+
+	if (query_no_space) {
+		l_free(query_length, query_no_space);
+	}
+	if (query) {
+		l_free(query_length, query);
+	}
 }
 
 // Explicitly instantiate the required template class and member functions

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -2877,8 +2877,9 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 		query_length = hdr.data.size;
 
 		// Validate minimum query size (need at least 1 byte + null terminator)
-		if (query_length < 2 || hdr.data.ptr == NULL) {
-			proxy_warning("Query too short: %u bytes\n", query_length);
+		if (query_length < 2 || hdr.data.ptr == NULL ||
+			((const char*)hdr.data.ptr)[query_length - 1] != '\0') {
+			proxy_warning("Malformed query packet: %u bytes\n", query_length);
 			SPA->send_error_msg_to_client(sess, "Malformed query packet");
 			run_query = false;
 			goto __run_query;

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -1212,7 +1212,7 @@ void PgSQL_Connection::fetch_result_cont(short event) {
 	}
 }
 
-void PgSQL_Connection::flush() {
+void PgSQL_Connection::flush(bool is_resync) {
 	int res = PQflush(pgsql_conn);
 
 	if (res > 0) {
@@ -1222,7 +1222,11 @@ void PgSQL_Connection::flush() {
 		async_exit_status = PG_EVENT_READ;
 	}
 	else {
-		set_error_from_PQerrorMessage();
+		if (!is_resync) {
+			set_error_from_PQerrorMessage();
+		} else {
+			resync_failed = true;
+		}
 		proxy_error("Failed to flush data to backend. %s\n", get_error_code_with_message().c_str());
 		async_exit_status = PG_EVENT_NONE;
 	}
@@ -1773,7 +1777,7 @@ void PgSQL_Connection::resync_start() {
 		resync_failed = true;
 		return;
 	}
-	async_exit_status = PG_EVENT_WRITE;
+	flush(true);
 }
 
 void PgSQL_Connection::resync_cont(short event) {
@@ -1781,17 +1785,7 @@ void PgSQL_Connection::resync_cont(short event) {
 	proxy_debug(PROXY_DEBUG_MYSQL_PROTOCOL, 6, "event=%d\n", event);
 	async_exit_status = PG_EVENT_NONE;
 	if (event & POLLOUT) {
-		int res = PQflush(pgsql_conn);
-
-		if (res > 0) {
-			async_exit_status = PG_EVENT_WRITE;
-		} else if (res == 0) {
-			async_exit_status = PG_EVENT_READ;
-		} else {
-			proxy_error("Failed to flush data to backend.\n");
-			async_exit_status = PG_EVENT_NONE;
-			resync_failed = true;
-		}
+		flush(true);
 	}
 }
 

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -2191,6 +2191,15 @@ bool PgSQL_Connection::handle_copy_out(const PGresult* result, uint64_t* process
 void PgSQL_Connection::notice_handler_cb(void* arg, const PGresult* result) {
 	assert(arg);
 	PgSQL_Connection* conn = (PgSQL_Connection*)arg;
+	if (conn->query_result == nullptr) {
+		// Notice received without active query_result. This can happen when:
+		// - RESET SESSION is in progress (DISCARD ALL or ROLLBACK)
+		proxy_debug(PROXY_DEBUG_MYSQL_COM, 5, "Notice received without active query_result [State: %d, FD: %d]: %s\n",
+			(int)conn->async_state_machine,
+			conn->get_pg_socket_fd(),
+			(result ? PQresultErrorMessage(result) : "unknown notice"));
+		return;
+	}
 	const unsigned int bytes_recv = conn->query_result->add_notice(result);
 	conn->update_bytes_recv(bytes_recv);
 }

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -919,6 +919,7 @@ handler_again:
 	}
 	break;
 	case ASYNC_RESET_SESSION_END:
+		PQsetNoticeReceiver(pgsql_conn, &PgSQL_Connection::unhandled_notice_cb, this);
 		if (is_error_present()) {
 			NEXT_IMMEDIATE(ASYNC_RESET_SESSION_FAILED);
 		}
@@ -1934,6 +1935,7 @@ void PgSQL_Connection::reset_session_start() {
 	assert(pgsql_conn);
 	reset_error();
 	async_exit_status = PG_EVENT_NONE;
+	PQsetNoticeReceiver(pgsql_conn, &PgSQL_Connection::notice_handler_cb, this);
 
 	reset_session_in_pipeline = is_pipeline_active();
 	if (reset_session_in_pipeline) {

--- a/lib/PgSQL_Data_Stream.cpp
+++ b/lib/PgSQL_Data_Stream.cpp
@@ -1311,8 +1311,11 @@ int PgSQL_Data_Stream::buffer2array() {
 		d = header[read_pos++];
 		pkgsize += (a << 24) | (b << 16) | (c << 8) | d;
 
-		queueIN.pkt.size = pkgsize;
-		queueIN.pkt.ptr = l_alloc(queueIN.pkt.size);
+		// PostgreSQL packets should always be >= 5 bytes.
+		const size_t alloc_size = (pkgsize < sizeof(header)) ? sizeof(header) : pkgsize;
+		queueIN.pkt.size = alloc_size;
+		queueIN.pkt.ptr = l_alloc(alloc_size);
+
 		memcpy(queueIN.pkt.ptr, header, sizeof(header)); // immediately copy the header into the packet
 		queueIN.partial = sizeof(header);
 		ret += sizeof(header);

--- a/lib/PgSQL_Extended_Query_Message.cpp
+++ b/lib/PgSQL_Extended_Query_Message.cpp
@@ -175,9 +175,9 @@ bool PgSQL_Describe_Message::parse(PtrSize_t& pkt) {
 		return false;
 	}
 
-	// Validate remaining length for statement name (at least 1 byte for null-terminated string)
+	// Validate remaining length for statement type (at least 1 byte for null-terminated string)
 	if (offset >= pkt_len) {
-		return false;  // Not enough data for statement name
+		return false;  // Not enough data for statement type
 	}
 
 	// Read the statement type (1 byte)
@@ -250,6 +250,12 @@ bool PgSQL_Close_Message::parse(PtrSize_t& pkt) {
 		proxy_debug(PROXY_DEBUG_MYSQL_CONNECTION, 1, "Packet size too small: %u bytes\n", pkt.size);
 		return false;
 	}
+
+	// Validate remaining length for statement type (1 byte)
+	if (offset >= pkt_len) {
+		return false;  // Not enough data for statement type
+	}
+
 	// Read the statement type (1 byte)
 	data.stmt_type = *(packet + offset);
 	offset += sizeof(uint8_t);

--- a/lib/PgSQL_Extended_Query_Message.cpp
+++ b/lib/PgSQL_Extended_Query_Message.cpp
@@ -175,7 +175,7 @@ bool PgSQL_Describe_Message::parse(PtrSize_t& pkt) {
 		return false;
 	}
 
-	// Validate remaining length for statement type (at least 1 byte for null-terminated string)
+	// Validate remaining length for statement type (exactly 1 byte)
 	if (offset >= pkt_len) {
 		return false;  // Not enough data for statement type
 	}

--- a/lib/PgSQL_Protocol.cpp
+++ b/lib/PgSQL_Protocol.cpp
@@ -579,7 +579,7 @@ unsigned int get_string(const char* data, unsigned int len, const char** dst_p)
 
 bool PgSQL_Protocol::load_conn_parameters(pgsql_hdr* pkt)
 {
-	uint32_t offset = 0; 
+	uint32_t offset = 0;
 
 	while (offset < pkt->data.size) {
 		char* nameptr = (char*)pkt->data.ptr + offset;
@@ -587,15 +587,28 @@ bool PgSQL_Protocol::load_conn_parameters(pgsql_hdr* pkt)
 		char* valptr;
 
 		if (*nameptr == '\0')
-			break;			/* found packet terminator */
-		valoffset = offset + strlen(nameptr) + 1;
+			break;			// found terminator
+
+		// Find null terminator for name within bounds
+		const char* name_nul = (const char*)memchr(nameptr, 0, pkt->data.size - offset);
+		if (!name_nul)
+			break; // malformed: name not null-terminated
+
+		valoffset = offset + (name_nul - nameptr) + 1;
+		
 		if (valoffset >= pkt->data.size)
-			break;			/* missing value, will complain below */
+			break;			// missing value, will complain below
+
 		valptr = (char*)pkt->data.ptr + valoffset;
+
+		// Find null terminator for value within bounds
+		const char* val_nul = (const char*)memchr(valptr, 0, pkt->data.size - valoffset);
+		if (!val_nul)
+			break; // malformed: name not null-terminated
 
 		(*myds)->myconn->conn_params.set_value(nameptr, valptr);
 
-		offset = valoffset + strlen(valptr) + 1;
+		offset = valoffset + (val_nul - valptr) + 1;
 	}
 
 	if (offset != pkt->data.size - 1) {

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -2277,6 +2277,7 @@ __implicit_sync:
 							pkt = { 0, nullptr };
 							break;
 						default:
+							reset_extended_query_frame();
 							proxy_error("Not implemented yet. Message type:'%c'\n", c);
 							client_myds->setDSS_STATE_QUERY_SENT_NET();
 							client_myds->myprot.generate_error_packet(true, true, "Feature not supported", PGSQL_ERROR_CODES::ERRCODE_FEATURE_NOT_SUPPORTED,

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5680,7 +5680,7 @@ bool PgSQL_Session::switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::stri
 
 	// Check if there are pending packets in client_myds->PSarrayIN
 	// This is an error condition, we cannot switch to fast forward mode
-	if (client_myds->PSarrayIN->len) {
+	if (client_myds && client_myds->PSarrayIN && client_myds->PSarrayIN->len) {
 		proxy_error("Cannot switch to fast forward mode: unexpected pending packets in client_myds->PSarrayIN (len=%u). Command: %.*s\n",
 			client_myds->PSarrayIN->len, (int)command.size(), command.data());
 		return false;
@@ -5692,8 +5692,8 @@ bool PgSQL_Session::switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::stri
 	if (client_myds && client_myds->addr.addr) {
 		client_info += " from client " + std::string(client_myds->addr.addr) + ":" + std::to_string(client_myds->addr.port);
 	}
-	proxy_info("Received command '%s'%s. Switching to Fast Forward mode (Session Type:0x%02X)\n",
-		command.data(), client_info.c_str(), session_type);
+	proxy_info("Received command '%.*s'%s. Switching to Fast Forward mode (Session Type:0x%02X)\n",
+		(int)command.size(), command.data(), client_info.c_str(), session_type);
 	session_fast_forward = session_type;
 
 	mybe->server_myds->reinit_queues(); // reinitialize the queues in the myds . By default, they are not active

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5973,6 +5973,16 @@ int PgSQL_Session::handle_post_sync_parse_message(PgSQL_Parse_Message* parse_msg
 
 	// Fallback: forward to backend
 	mybe = find_or_create_backend(current_hostgroup);
+
+	// set query retries
+	mybe->server_myds->query_retries_on_failure = pgsql_thread___query_retries_on_failure;
+	// if a number of retries is set in mysql_query_rules, that takes priority
+	if (qpo) {
+		if (qpo->retries >= 0) {
+			mybe->server_myds->query_retries_on_failure = qpo->retries;
+		}
+	}
+
 	status = PROCESSING_STMT_PREPARE;
 	mybe->server_myds->connect_retries_on_failure = pgsql_thread___connect_retries_on_failure;
 	pause_until = 0;
@@ -6117,6 +6127,16 @@ int PgSQL_Session::handle_post_sync_describe_message(PgSQL_Describe_Message* des
 	}
 
 	mybe = find_or_create_backend(current_hostgroup);
+
+	// set query retries
+	mybe->server_myds->query_retries_on_failure = pgsql_thread___query_retries_on_failure;
+	// if a number of retries is set in mysql_query_rules, that takes priority
+	if (qpo) {
+		if (qpo->retries >= 0) {
+			mybe->server_myds->query_retries_on_failure = qpo->retries;
+		}
+	}
+
 	status = PROCESSING_STMT_DESCRIBE;
 	mybe->server_myds->connect_retries_on_failure = pgsql_thread___connect_retries_on_failure;
 	pause_until = 0;
@@ -6394,6 +6414,16 @@ int PgSQL_Session::handle_post_sync_execute_message(PgSQL_Execute_Message* execu
 	}
 
 	mybe = find_or_create_backend(current_hostgroup);
+
+	// set query retries
+	mybe->server_myds->query_retries_on_failure = pgsql_thread___query_retries_on_failure;
+	// if a number of retries is set in mysql_query_rules, that takes priority
+	if (qpo) {
+		if (qpo->retries >= 0) {
+			mybe->server_myds->query_retries_on_failure = qpo->retries;
+		}
+	}
+
 	status = PROCESSING_STMT_EXECUTE;
 	mybe->server_myds->connect_retries_on_failure = pgsql_thread___connect_retries_on_failure;
 	pause_until = 0;

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -2048,6 +2048,24 @@ __implicit_sync:
 							if (session_type == PROXYSQL_SESSION_PGSQL) {
 								bool rc_break = false;
 								bool lock_hostgroup = false;
+
+								if (pkt.size < 6) {
+									proxy_error("Malformed query packet received: size %u < 6\n", pkt.size);
+									l_free(pkt.size, pkt.ptr);
+									handler_ret = -1;
+									return handler_ret;
+								}
+
+								unsigned int query_len = pkt.size - 5; // excluding header
+								char* query_ptr = (char*)pkt.ptr + 5;
+
+								if (query_ptr[query_len - 1] != '\0') {
+									proxy_error("Malformed query packet received: missing null terminator\n");
+									l_free(pkt.size, pkt.ptr);
+									handler_ret = -1;
+									return handler_ret;
+								}
+
 								if (session_fast_forward == SESSION_FORWARD_TYPE_NONE) {
 									// Note: CurrentQuery sees the query as sent by the client.
 									// shortly after, the packets it used to contain the query will be deallocated
@@ -2071,23 +2089,6 @@ __implicit_sync:
 								timespec endt;
 								if (thread->variables.stats_time_query_processor) {
 									clock_gettime(CLOCK_THREAD_CPUTIME_ID, &begint);
-								}
-
-								if (pkt.size < 6) {
-									proxy_error("Malformed query packet received: size %u < 6\n", pkt.size);
-									l_free(pkt.size, pkt.ptr);
-									handler_ret = -1;
-									return handler_ret;
-								}
-
-								unsigned int query_len = pkt.size - 5; // excluding header
-								char* query_ptr = (char*)pkt.ptr + 5;
-
-								if (query_ptr[query_len - 1] != '\0') {
-									proxy_error("Malformed query packet received: missing null terminator\n");
-									l_free(pkt.size, pkt.ptr);
-									handler_ret = -1;
-									return handler_ret;
 								}
 
 								qpo = GloPgQPro->process_query(this, query_ptr, query_len, &CurrentQuery);

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -2072,8 +2072,23 @@ __implicit_sync:
 								if (thread->variables.stats_time_query_processor) {
 									clock_gettime(CLOCK_THREAD_CPUTIME_ID, &begint);
 								}
+
+								if (pkt.size < 6) {
+									proxy_error("Malformed query packet received: size %u < 6\n", pkt.size);
+									l_free(pkt.size, pkt.ptr);
+									handler_ret = -1;
+									return handler_ret;
+								}
+
 								unsigned int query_len = pkt.size - 5; // excluding header
 								char* query_ptr = (char*)pkt.ptr + 5;
+
+								if (query_ptr[query_len - 1] != '\0') {
+									proxy_error("Malformed query packet received: missing null terminator\n");
+									l_free(pkt.size, pkt.ptr);
+									handler_ret = -1;
+									return handler_ret;
+								}
 
 								qpo = GloPgQPro->process_query(this, query_ptr, query_len, &CurrentQuery);
 								if (thread->variables.stats_time_query_processor) {

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -2951,7 +2951,7 @@ handler_again:
 						goto __exit_DSS__STATE_NOT_INITIALIZED;
 					}
 
-					if (!switch_normal_to_fast_forward_mode(pkt, std::string(matched.data(), matched.size()), SESSION_FORWARD_TYPE_COPY_FROM_STDIN_STDOUT)) {
+					if (!switch_normal_to_fast_forward_mode(pkt, std::string_view(matched.data(), matched.size()), SESSION_FORWARD_TYPE_COPY_FROM_STDIN_STDOUT)) {
 						// Failed to switch to fast forward mode due to pending packets
 						client_myds->setDSS_STATE_QUERY_SENT_NET();
 						client_myds->myprot.generate_error_packet(true, true, "Unexpected packet sequence during COPY command",
@@ -5664,8 +5664,8 @@ bool PgSQL_Session::switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::stri
 	// Check if there are pending packets in client_myds->PSarrayIN
 	// This is an error condition, we cannot switch to fast forward mode
 	if (client_myds->PSarrayIN->len) {
-		proxy_error("Cannot switch to fast forward mode: unexpected pending packets in client_myds->PSarrayIN (len=%d). Command: %s\n",
-			client_myds->PSarrayIN->len, command.data());
+		proxy_error("Cannot switch to fast forward mode: unexpected pending packets in client_myds->PSarrayIN (len=%u). Command: %.*s\n",
+			client_myds->PSarrayIN->len, (int)command.size(), command.data());
 		return false;
 	}
 

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -2259,6 +2259,23 @@ __implicit_sync:
 							}
 						}
 							break;
+						// Handle PostgreSQL COPY protocol frontend messages that may arrive
+						// after an error during COPY FROM STDIN caused a switch back to normal mode.
+						//
+						// Race condition scenario:
+						// 1. COPY FROM STDIN starts -> session switches to fast_forward mode
+						// 2. Backend returns error during COPY -> session switches back to normal mode
+						// 3. Client has already pipelined CopyData('d')/CopyDone('c')/CopyFail('f') messages
+						// 4. These messages are now in the queue but session is no longer in fast_forward
+						//
+						// These messages are meant for fast_forward mode. Simply ignore them.
+						case 'd':
+						case 'c':
+						case 'f':
+							proxy_debug(PROXY_DEBUG_NET, 5, "Ignoring late COPY protocol message '%c' from client - COPY operation already terminated, session no longer in fast_forward mode\n", c);
+							l_free(pkt.size, pkt.ptr);
+							pkt = { 0, nullptr };
+							break;
 						default:
 							proxy_error("Not implemented yet. Message type:'%c'\n", c);
 							client_myds->setDSS_STATE_QUERY_SENT_NET();
@@ -2934,7 +2951,15 @@ handler_again:
 						goto __exit_DSS__STATE_NOT_INITIALIZED;
 					}
 
-					switch_normal_to_fast_forward_mode(pkt, std::string(matched.data(), matched.size()), SESSION_FORWARD_TYPE_COPY_FROM_STDIN_STDOUT);
+					if (!switch_normal_to_fast_forward_mode(pkt, std::string(matched.data(), matched.size()), SESSION_FORWARD_TYPE_COPY_FROM_STDIN_STDOUT)) {
+						// Failed to switch to fast forward mode due to pending packets
+						client_myds->setDSS_STATE_QUERY_SENT_NET();
+						client_myds->myprot.generate_error_packet(true, true, "Unexpected packet sequence during COPY command",
+							PGSQL_ERROR_CODES::ERRCODE_PROTOCOL_VIOLATION, false, true);
+						RequestEnd(myds, true);
+						finishQuery(myds, myconn, false);
+						goto __exit_DSS__STATE_NOT_INITIALIZED;
+					}
 					break;
 				}
 			}
@@ -5632,9 +5657,17 @@ void PgSQL_Session::set_previous_status_mode3(bool allow_execute) {
 	}
 }
 
-void PgSQL_Session::switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::string_view command, SESSION_FORWARD_TYPE session_type) {
+bool PgSQL_Session::switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::string_view command, SESSION_FORWARD_TYPE session_type) {
 
-	if (session_fast_forward || session_type == SESSION_FORWARD_TYPE_PERMANENT) return;
+	if (session_fast_forward || session_type == SESSION_FORWARD_TYPE_PERMANENT) return true;
+
+	// Check if there are pending packets in client_myds->PSarrayIN
+	// This is an error condition, we cannot switch to fast forward mode
+	if (client_myds->PSarrayIN->len) {
+		proxy_error("Cannot switch to fast forward mode: unexpected pending packets in client_myds->PSarrayIN (len=%d). Command: %s\n",
+			client_myds->PSarrayIN->len, command.data());
+		return false;
+	}
 
 	// we use a switch to write the command in the info message
 	std::string client_info;
@@ -5645,11 +5678,6 @@ void PgSQL_Session::switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::stri
 	proxy_info("Received command '%s'%s. Switching to Fast Forward mode (Session Type:0x%02X)\n",
 		command.data(), client_info.c_str(), session_type);
 	session_fast_forward = session_type;
-
-	if (client_myds->PSarrayIN->len) {
-		proxy_error("UNEXPECTED PACKET FROM CLIENT -- PLEASE REPORT A BUG\n");
-		assert(0);
-	}
 
 	mybe->server_myds->reinit_queues(); // reinitialize the queues in the myds . By default, they are not active
 	// We reinitialize the 'wait_until' since this session shouldn't wait for processing as
@@ -5690,6 +5718,8 @@ void PgSQL_Session::switch_normal_to_fast_forward_mode(PtrSize_t& pkt, std::stri
 	// need to reset mysql_real_query
 	mybe->server_myds->pgsql_real_query.reset();
 	CurrentQuery.end();
+
+	return true;
 }
 
 void PgSQL_Session::switch_fast_forward_to_normal_mode() {

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -251,6 +251,7 @@
   "pgsql-reg_test_5284_frontend_ssl_enforcement-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5273_bind_parameter_format-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5352_prepared_statement_refcount_race-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5415_copy_error_recovery-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "ai_error_handling_edge_cases-t": [ "ai-g1" ],
   "ai_llm_retry_scenarios-t": [ "ai-g1" ],
   "ai_validation-t": [ "ai-g1" ],

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -249,6 +249,7 @@
   "pgsql-monitor_ssl_connections_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-parameterized_kill_queries_test-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5284_frontend_ssl_enforcement-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-test_malformed_packet-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5273_bind_parameter_format-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5352_prepared_statement_refcount_race-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-reg_test_5415_copy_error_recovery-t": [ "default-g4", "mysql-auto_increment_delay_multiplex=0-g4", "mysql-multiplexing=false-g4", "mysql-query_digests=0-g4", "mysql-query_digests_keep_comment=1-g4" ],

--- a/test/tap/tests/pgsql-copy_freeze_error_recovery-t.cpp
+++ b/test/tap/tests/pgsql-copy_freeze_error_recovery-t.cpp
@@ -1,0 +1,410 @@
+/**
+ * @file pgsql-copy_freeze_error_recovery-t.cpp
+ * @brief Tests COPY FROM ... FREEZE error recovery in ProxySQL
+ *
+ * This test reproduces the scenario where:
+ * 1. COPY command enters fast_forward mode
+ * 2. Backend returns ERROR + ReadyForQuery immediately (before client sends data)
+ *    because FREEZE requires table to be created or truncated in the current subtransaction
+ * 3. Session should correctly return to normal mode
+ * 4. Subsequent queries should work normally
+ *
+ * This is a regression test for proper session state recovery after a failed COPY
+ * command that entered fast_forward mode.
+ */
+
+#include <string>
+#include <sstream>
+#include <memory>
+#include <vector>
+#include "libpq-fe.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+CommandLine cl;
+
+using PGConnPtr = std::unique_ptr<PGconn, decltype(&PQfinish)>;
+
+/**
+ * @brief Creates a new PostgreSQL connection
+ * @param with_ssl Whether to use SSL for the connection
+ * @return A unique pointer to the PGconn structure
+ */
+PGConnPtr createNewConnection(bool with_ssl) {
+    std::stringstream ss;
+    ss << "host=" << cl.pgsql_host << " port=" << cl.pgsql_port;
+    ss << " user=" << cl.pgsql_username << " password=" << cl.pgsql_password;
+    ss << " dbname=postgres";
+    ss << (with_ssl ? " sslmode=require" : " sslmode=disable");
+
+    PGconn* conn = PQconnectdb(ss.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        fprintf(stderr, "Connection failed: %s", PQerrorMessage(conn));
+        PQfinish(conn);
+        return PGConnPtr(nullptr, &PQfinish);
+    }
+    return PGConnPtr(conn, &PQfinish);
+}
+
+/**
+ * @brief Executes a single query and checks the result status
+ * @param conn The PostgreSQL connection
+ * @param query The query to execute
+ * @param expected_status The expected result status
+ * @return true if the query succeeded with expected status, false otherwise
+ */
+bool executeQuery(PGconn* conn, const char* query, ExecStatusType expected_status = PGRES_COMMAND_OK) {
+    PGresult* res = PQexec(conn, query);
+    bool success = PQresultStatus(res) == expected_status;
+    if (!success) {
+        diag("Query '%s' failed: %s", query, PQerrorMessage(conn));
+    }
+    PQclear(res);
+    return success;
+}
+
+/**
+ * @brief Setup test table
+ * @param conn The PostgreSQL connection
+ * @return true if setup succeeded, false otherwise
+ */
+bool setupTestTable(PGconn* conn) {
+    PGresult* res = PQexec(conn, "DROP TABLE IF EXISTS copy_freeze_test");
+    PQclear(res);
+
+    res = PQexec(conn, "CREATE TABLE copy_freeze_test (id int, name text)");
+    bool success = PQresultStatus(res) == PGRES_COMMAND_OK;
+    if (!success) {
+        diag("Failed to create table: %s", PQerrorMessage(conn));
+    }
+    PQclear(res);
+    return success;
+}
+
+/**
+ * @brief Cleanup test table
+ * @param conn The PostgreSQL connection
+ */
+void cleanupTestTable(PGconn* conn) {
+    PGresult* res = PQexec(conn, "DROP TABLE IF EXISTS copy_freeze_test");
+    PQclear(res);
+}
+
+/**
+ * @brief Test 1: COPY FREEZE fails immediately and session recovers
+ *
+ * This test verifies that when a COPY ... FREEZE command fails because the table
+ * was not created or truncated in the current subtransaction, the session properly
+ * returns to normal mode and subsequent queries work correctly.
+ *
+ * @param conn The PostgreSQL connection
+ */
+void testCopyFreezeFailsImmediately(PGconn* conn) {
+    diag("Test: COPY FREEZE fails immediately (table not truncated in current transaction)");
+
+    // Execute COPY FREEZE - this should fail because table was not truncated
+    // in the current subtransaction
+    PGresult* res = PQexec(conn, "COPY copy_freeze_test FROM stdin CSV FREEZE");
+
+    // The COPY may return PGRES_COPY_IN (if server sends CopyIn before error)
+    // or PGRES_FATAL_ERROR (if server sends error immediately)
+    ExecStatusType status = PQresultStatus(res);
+
+    if (status == PGRES_COPY_IN) {
+        diag("COPY entered COPY_IN mode, sending data...");
+
+        // Send data - but backend will reject it
+        if (PQputCopyData(conn, "1,test1\n", 8) != 1) {
+            diag("PQputCopyData failed: %s", PQerrorMessage(conn));
+        }
+        if (PQputCopyEnd(conn, NULL) != 1) {
+            diag("PQputCopyEnd failed: %s", PQerrorMessage(conn));
+        }
+
+        // Get the final result
+        PQclear(res);
+        res = PQgetResult(conn);
+        status = PQresultStatus(res);
+    }
+
+    // The COPY should fail
+    ok(status == PGRES_FATAL_ERROR,
+       "COPY FREEZE should fail when table not truncated in current transaction: %s",
+       PQresultErrorMessage(res));
+    PQclear(res);
+
+    // Consume any remaining results
+    while ((res = PQgetResult(conn)) != NULL) {
+        PQclear(res);
+    }
+
+    diag("Testing subsequent queries after COPY error...");
+
+    // Test: BEGIN should work
+    res = PQexec(conn, "BEGIN");
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "BEGIN should work after COPY error: %s", PQerrorMessage(conn));
+    PQclear(res);
+
+    // Test: TRUNCATE should work
+    res = PQexec(conn, "TRUNCATE copy_freeze_test");
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "TRUNCATE should work: %s", PQerrorMessage(conn));
+    PQclear(res);
+
+    // Test: SAVEPOINT should work
+    res = PQexec(conn, "SAVEPOINT s1");
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "SAVEPOINT should work: %s", PQerrorMessage(conn));
+    PQclear(res);
+
+    // Test: COMMIT should work
+    res = PQexec(conn, "COMMIT");
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "COMMIT should work: %s", PQerrorMessage(conn));
+    PQclear(res);
+}
+
+/**
+ * @brief Test 2: COPY FREEZE succeeds when properly set up
+ *
+ * This test verifies that COPY ... FREEZE works correctly when the table
+ * is properly truncated within the same transaction before the COPY command.
+ *
+ * IMPORTANT: COPY FREEZE requires that the table was created or truncated
+ * in the CURRENT subtransaction. Using SAVEPOINT between TRUNCATE and COPY
+ * FREEZE will cause failure because TRUNCATE is then in the parent subtransaction.
+ *
+ * @param conn The PostgreSQL connection
+ */
+void testCopyFreezeSucceedsWithProperSetup(PGconn* conn) {
+    diag("Test: COPY FREEZE succeeds with proper transaction setup (no savepoint between TRUNCATE and COPY)");
+
+    // Begin transaction
+    PGresult* res = PQexec(conn, "BEGIN");
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "BEGIN should succeed: %s", PQerrorMessage(conn));
+    PQclear(res);
+
+    // Truncate table in same transaction
+    // NOTE: No SAVEPOINT here - COPY FREEZE requires TRUNCATE in current subtransaction
+    res = PQexec(conn, "TRUNCATE copy_freeze_test");
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "TRUNCATE should succeed: %s", PQerrorMessage(conn));
+    PQclear(res);
+
+    // Now COPY FREEZE should work (TRUNCATE is in same subtransaction)
+    res = PQexec(conn, "COPY copy_freeze_test FROM stdin CSV FREEZE");
+    ok(PQresultStatus(res) == PGRES_COPY_IN,
+       "COPY FREEZE should enter COPY_IN mode: %s", PQerrorMessage(conn));
+
+    // Send data
+    ok(PQputCopyData(conn, "1,test1\n", 8) == 1,
+       "PQputCopyData should succeed");
+    ok(PQputCopyData(conn, "2,test2\n", 8) == 1,
+       "PQputCopyData should succeed");
+    ok(PQputCopyEnd(conn, NULL) == 1,
+       "PQputCopyEnd should succeed");
+
+    PQclear(res);
+    res = PQgetResult(conn);
+
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "COPY FREEZE should succeed after proper setup: %s",
+       PQresultErrorMessage(res));
+    PQclear(res);
+
+    // Consume any remaining results
+    while ((res = PQgetResult(conn)) != NULL) {
+        PQclear(res);
+    }
+
+    // Commit transaction
+    res = PQexec(conn, "COMMIT");
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "COMMIT should succeed: %s", PQerrorMessage(conn));
+    PQclear(res);
+}
+
+/**
+ * @brief Test 3: Verify data was inserted correctly
+ *
+ * @param conn The PostgreSQL connection
+ */
+void testDataVerification(PGconn* conn) {
+    diag("Test: Verify data was inserted correctly");
+
+    PGresult* res = PQexec(conn, "SELECT * FROM copy_freeze_test ORDER BY id");
+    ok(PQresultStatus(res) == PGRES_TUPLES_OK,
+       "SELECT should succeed: %s", PQerrorMessage(conn));
+
+    int rows = PQntuples(res);
+    ok(rows == 2, "Should have 2 rows, got %d", rows);
+
+    bool row1_ok = (rows >= 1) && (strcmp(PQgetvalue(res, 0, 0), "1") == 0) &&
+                   (strcmp(PQgetvalue(res, 0, 1), "test1") == 0);
+    ok(row1_ok, "Row 1 should be (1, test1)");
+
+    bool row2_ok = (rows >= 2) && (strcmp(PQgetvalue(res, 1, 0), "2") == 0) &&
+                   (strcmp(PQgetvalue(res, 1, 1), "test2") == 0);
+    ok(row2_ok, "Row 2 should be (2, test2)");
+    PQclear(res);
+}
+
+/**
+ * @brief Test 4: Multiple COPY errors in sequence
+ *
+ * This test verifies that the session can recover from multiple consecutive
+ * COPY errors.
+ *
+ * @param conn The PostgreSQL connection
+ */
+void testMultipleCopyErrors(PGconn* conn) {
+    diag("Test: Multiple consecutive COPY errors");
+
+    // First COPY error
+    PGresult* res = PQexec(conn, "COPY copy_freeze_test FROM stdin CSV FREEZE");
+    ExecStatusType status = PQresultStatus(res);
+
+    if (status == PGRES_COPY_IN) {
+        PQputCopyEnd(conn, NULL);
+        PQclear(res);
+        res = PQgetResult(conn);
+    }
+    ok(PQresultStatus(res) == PGRES_FATAL_ERROR,
+       "First COPY FREEZE should fail: %s", PQresultErrorMessage(res));
+    PQclear(res);
+    while ((res = PQgetResult(conn)) != NULL) PQclear(res);
+
+    // Second COPY error
+    res = PQexec(conn, "COPY copy_freeze_test FROM stdin CSV FREEZE");
+    status = PQresultStatus(res);
+
+    if (status == PGRES_COPY_IN) {
+        PQputCopyEnd(conn, NULL);
+        PQclear(res);
+        res = PQgetResult(conn);
+    }
+    ok(PQresultStatus(res) == PGRES_FATAL_ERROR,
+       "Second COPY FREEZE should fail: %s", PQresultErrorMessage(res));
+    PQclear(res);
+    while ((res = PQgetResult(conn)) != NULL) PQclear(res);
+
+    // Verify subsequent normal query works
+    res = PQexec(conn, "SELECT 1");
+    ok(PQresultStatus(res) == PGRES_TUPLES_OK,
+       "SELECT should work after multiple COPY errors: %s", PQerrorMessage(conn));
+    PQclear(res);
+}
+
+/**
+ * @brief Test 5: COPY error followed by successful COPY
+ *
+ * This test verifies that after a COPY error, a properly executed COPY
+ * command can succeed.
+ *
+ * @param conn The PostgreSQL connection
+ */
+void testCopyErrorThenSuccess(PGconn* conn) {
+    diag("Test: COPY error followed by successful COPY");
+
+    // Truncate table first
+    PGresult* res = PQexec(conn, "TRUNCATE copy_freeze_test");
+    PQclear(res);
+
+    // First COPY - will fail (no transaction/truncate in same transaction)
+    res = PQexec(conn, "COPY copy_freeze_test FROM stdin CSV FREEZE");
+    ExecStatusType status = PQresultStatus(res);
+
+    if (status == PGRES_COPY_IN) {
+        PQputCopyEnd(conn, NULL);
+        PQclear(res);
+        res = PQgetResult(conn);
+    }
+    ok(PQresultStatus(res) == PGRES_FATAL_ERROR,
+       "First COPY FREEZE should fail: %s", PQresultErrorMessage(res));
+    PQclear(res);
+    while ((res = PQgetResult(conn)) != NULL) PQclear(res);
+
+    // Now do it properly
+    res = PQexec(conn, "BEGIN");
+    PQclear(res);
+    res = PQexec(conn, "TRUNCATE copy_freeze_test");
+    PQclear(res);
+
+    res = PQexec(conn, "COPY copy_freeze_test FROM stdin CSV");
+    if (PQresultStatus(res) == PGRES_COPY_IN) {
+        PQputCopyData(conn, "3,test3\n", 7);
+        PQputCopyEnd(conn, NULL);
+        PQclear(res);
+        res = PQgetResult(conn);
+    }
+    ok(PQresultStatus(res) == PGRES_COMMAND_OK,
+       "Regular COPY should succeed after COPY FREEZE error: %s",
+       PQresultErrorMessage(res));
+    PQclear(res);
+    while ((res = PQgetResult(conn)) != NULL) PQclear(res);
+
+    res = PQexec(conn, "COMMIT");
+    PQclear(res);
+
+    // Verify data
+    res = PQexec(conn, "SELECT COUNT(*) FROM copy_freeze_test");
+    ok(PQresultStatus(res) == PGRES_TUPLES_OK &&
+       PQntuples(res) > 0 &&
+       atoi(PQgetvalue(res, 0, 0)) == 1,
+       "Should have 1 row after successful COPY, got %s",
+       PQgetvalue(res, 0, 0));
+    PQclear(res);
+}
+
+/**
+ * @brief Run all tests
+ */
+void runTests(PGconn* conn) {
+    // Setup
+    if (!setupTestTable(conn)) {
+        BAIL_OUT("Failed to setup test table");
+        return;
+    }
+
+    // Run test functions
+    testCopyFreezeFailsImmediately(conn);
+    testCopyFreezeSucceedsWithProperSetup(conn);
+    testDataVerification(conn);
+    testMultipleCopyErrors(conn);
+    testCopyErrorThenSuccess(conn);
+
+    // Cleanup
+    cleanupTestTable(conn);
+}
+
+int main(int argc, char** argv) {
+    // Total tests:
+    // testCopyFreezeFailsImmediately: 5 tests (COPY fail, BEGIN, TRUNCATE, SAVEPOINT, COMMIT)
+    // testCopyFreezeSucceedsWithProperSetup: 8 tests (BEGIN, TRUNCATE, COPY_IN, 3x data, result, COMMIT)
+    // testDataVerification: 4 tests (SELECT, row count, 2x row data)
+    // testMultipleCopyErrors: 3 tests (2x error, SELECT)
+    // testCopyErrorThenSuccess: 3 tests (error, success, count)
+    // Total: 23 tests
+    plan(23);
+
+    if (cl.getEnv()) {
+        return exit_status();
+    }
+
+    // Create connection
+    PGConnPtr conn = createNewConnection(false);
+    if (!conn) {
+        BAIL_OUT("Failed to connect to ProxySQL");
+        return exit_status();
+    }
+
+    diag("Connected to ProxySQL via port %d", cl.pgsql_port);
+
+    // Run tests
+    runTests(conn.get());
+
+    return exit_status();
+}

--- a/test/tap/tests/pgsql-reg_test_5415_copy_error_recovery-t.cpp
+++ b/test/tap/tests/pgsql-reg_test_5415_copy_error_recovery-t.cpp
@@ -1,13 +1,11 @@
 /**
- * @file pgsql-copy_freeze_error_recovery-t.cpp
- * @brief Tests COPY FROM ... FREEZE error recovery in ProxySQL
+ * @file pgsql-reg_test_5415_copy_error_recovery-t.cpp
+ * @brief Tests COPY FROM ... STDIN error recovery in ProxySQL
  *
- * This test reproduces the scenario where:
- * 1. COPY command enters fast_forward mode
- * 2. Backend returns ERROR + ReadyForQuery immediately (before client sends data)
- *    because FREEZE requires table to be created or truncated in the current subtransaction
- * 3. Session should correctly return to normal mode
- * 4. Subsequent queries should work normally
+ * When a COPY FROM STDIN operation encounters an error, the session switches back to normal mode. 
+ * However, the client may have already pipelined CopyData('d'), CopyDone('c'), or CopyFail('f') messages 
+ * that are still in the input queue. These messages fell through to the default case of message handler, 
+ * generating a spurious "Feature not supported" error.
  *
  * This is a regression test for proper session state recovery after a failed COPY
  * command that entered fast_forward mode.

--- a/test/tap/tests/pgsql-test_malformed_packet-t.cpp
+++ b/test/tap/tests/pgsql-test_malformed_packet-t.cpp
@@ -53,6 +53,10 @@ constexpr uint32_t PG_SSL_REQUEST_CODE = 80877103;  // (1234 << 16) | 5679
 constexpr uint32_t PG_CANCEL_REQUEST_CODE = 80877102;  // (1234 << 16) | 5678
 constexpr uint32_t PG_GSS_ENCRYPT_CODE = 80877104;  // (1234 << 16) | 5680
 
+// Forward declarations for helper functions
+bool send_exact(int sock, const void* buf, size_t len);
+bool recv_exact(int sock, void* buf, size_t len);
+
 #define REPORT_ERROR_AND_EXIT(fmt, ...) \
     do { \
         fprintf(stderr, "File %s, line %d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
@@ -128,8 +132,7 @@ void test_malformed_packet(const std::string& test_name,
     }
 
     // Send the malformed data
-    ssize_t bytes_sent = send(sock, data.data(), data.size(), 0);
-    if (bytes_sent < 0) {
+    if (!send_exact(sock, data.data(), data.size())) {
         close(sock);
         ok(0, "%s: Failed to send data", test_name.c_str());
         return;
@@ -139,14 +142,17 @@ void test_malformed_packet(const std::string& test_name,
     std::vector<char> buffer(BUFFER_SIZE);
     ssize_t bytes_received = recv(sock, buffer.data(), buffer.size(), 0);
 
-    // Valid outcomes: connection closed OR any response
-    // The key is that ProxySQL handles the packet without crashing
-    bool connection_closed = (bytes_received <= 0);
-    bool got_response = (bytes_received > 0);
-    bool handled_gracefully = connection_closed || got_response;
+    // Valid outcomes:
+    // - Connection closed (bytes_received == 0): ProxySQL rejected/closed connection
+    // - Timeout (bytes_received < 0 with EAGAIN/EWOULDBLOCK): No response within timeout
+    // - Error response (bytes_received > 0 && buffer[0] == 'E'): ProxySQL sent error
+    bool connection_closed = (bytes_received == 0);
+    bool timeout = (bytes_received < 0 && (errno == EAGAIN || errno == EWOULDBLOCK));
+    bool got_error_response = (bytes_received > 0 && buffer[0] == 'E');
+    bool handled_gracefully = connection_closed || timeout || got_error_response;
 
-    ok(handled_gracefully, "%s: Malformed packet handled (received: %ld bytes)",
-       test_name.c_str(), (long)bytes_received);
+    ok(handled_gracefully, "%s: Malformed packet handled (closed=%d, timeout=%d, error=%d)",
+       test_name.c_str(), (int)connection_closed, (int)timeout, (int)got_error_response);
 
     close(sock);
 }
@@ -489,6 +495,21 @@ bool recv_exact(int sock, void* buf, size_t len) {
 }
 
 /**
+ * @brief Send an exact number of bytes to socket
+ * @return true if all bytes sent, false on error/short write
+ */
+bool send_exact(int sock, const void* buf, size_t len) {
+    const char* ptr = (const char*)buf;
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = send(sock, ptr + sent, len - sent, 0);
+        if (n <= 0) return false;
+        sent += n;
+    }
+    return true;
+}
+
+/**
  * @brief Read a PostgreSQL message from socket
  */
 bool read_message(int sock, char& type, std::vector<uint8_t>& buffer) {
@@ -537,7 +558,7 @@ void test_malformed_packet_phase2(const std::string& test_name,
 
     // Step 1: Send valid startup packet
     auto startup = build_startup_packet({{"user", username}});
-    if (send(sock, startup.data(), startup.size(), 0) < 0) {
+    if (!send_exact(sock, startup.data(), startup.size())) {
         close(sock);
         ok(0, "%s: Failed to send startup", test_name.c_str());
         return;
@@ -554,7 +575,7 @@ void test_malformed_packet_phase2(const std::string& test_name,
 
     // Step 3: Send password response (cleartext for simplicity)
     auto password_pkt = build_password_packet(password);
-    if (send(sock, password_pkt.data(), password_pkt.size(), 0) < 0) {
+    if (!send_exact(sock, password_pkt.data(), password_pkt.size())) {
         close(sock);
         ok(0, "%s: Failed to send password", test_name.c_str());
         return;
@@ -599,36 +620,79 @@ void test_malformed_packet_phase2(const std::string& test_name,
 
     // Authentication successful - now we have an authenticated connection
 
-    // Step 5: Send the malformed packet on the authenticated connection
-    ssize_t sent = send(sock, malformed_data.data(), malformed_data.size(), 0);
-    if (sent < 0) {
+    // Step 5: Drain post-authentication messages until ReadyForQuery ('Z')
+    // PostgreSQL sends ParameterStatus ('S'), BackendKeyData ('K'), etc. after auth
+    // We need to consume these before sending the malformed packet to ensure
+    // the response we read is actually for the malformed packet, not startup noise
+    bool ready_for_query = false;
+    for (int i = 0; i < 16; ++i) {
+        char msg_type = 0;
+        std::vector<uint8_t> msg_data;
+        if (!read_message(sock, msg_type, msg_data)) break;
+        if (msg_type == 'Z') {
+            ready_for_query = true;
+            break;
+        }
+        if (msg_type == 'E') break; // Error during startup
+    }
+    if (!ready_for_query) {
+        close(sock);
+        ok(0, "%s: Did not reach ReadyForQuery before malformed packet", test_name.c_str());
+        return;
+    }
+
+    // Step 6: Send the malformed packet on the authenticated connection
+    if (!send_exact(sock, malformed_data.data(), malformed_data.size())) {
         close(sock);
         ok(0, "%s: Failed to send malformed data", test_name.c_str());
         return;
     }
 
-    // Step 6: Try to receive response
-    // ProxySQL may send multiple responses (auth completion, parameter status, etc.)
-    // followed by an error response 'E' for the malformed packet, or close connection
-    std::vector<char> buffer(BUFFER_SIZE);
-    ssize_t bytes_received = recv(sock, buffer.data(), buffer.size(), 0);
+    // Step 7: Wait for response to the malformed packet
+    // Keep reading messages until we get an error response, connection close, or timeout
+    bool got_error_response = false;
+    bool connection_closed = false;
+    bool timeout = false;
+    char first_byte = 0;
 
-    // Check if we got an error response 'E' or connection closed
-    // Note: There may be pending post-auth messages, so any of these outcomes is valid:
-    // 1. Connection closed (ProxySQL rejected the malformed packet)
-    // 2. 'E' error response (ProxySQL sent an error for the malformed packet)
-    // 3. Other messages (post-auth protocol messages)
-    bool connection_closed = (bytes_received <= 0);
-    bool got_error_response = (bytes_received > 0 && buffer[0] == 'E');
-    bool got_other_response = (bytes_received > 0 && buffer[0] != 'E');
+    for (int i = 0; i < 16; ++i) {
+        char msg_type = 0;
+        std::vector<uint8_t> msg_data;
 
-    // Any outcome is acceptable as long as ProxySQL doesn't crash
-    // The key test is the final operational check
-    bool handled_gracefully = connection_closed || got_error_response || got_other_response;
+        // Try to read a message with timeout
+        ssize_t bytes_received = recv(sock, &msg_type, 1, MSG_PEEK | MSG_DONTWAIT);
+        if (bytes_received == 0) {
+            connection_closed = true;
+            break;
+        }
+        if (bytes_received < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                timeout = true;
+            }
+            break;
+        }
 
-    ok(handled_gracefully, "%s: Phase 2 malformed packet sent (received: %ld bytes, first=0x%02X)",
-       test_name.c_str(), (long)bytes_received,
-       bytes_received > 0 ? (unsigned char)buffer[0] : 0);
+        // Message available, read it fully
+        if (!read_message(sock, msg_type, msg_data)) {
+            connection_closed = true;
+            break;
+        }
+
+        first_byte = msg_type;
+
+        // Check if this is an error response to our malformed packet
+        if (msg_type == 'E') {
+            got_error_response = true;
+            break;
+        }
+        // Continue reading if it's other protocol traffic
+    }
+
+    bool handled_gracefully = connection_closed || timeout || got_error_response;
+
+    ok(handled_gracefully, "%s: Phase 2 malformed packet handled (closed=%d, timeout=%d, error=%d, first=0x%02X)",
+       test_name.c_str(), (int)connection_closed, (int)timeout, (int)got_error_response,
+       first_byte);
 
     close(sock);
 }

--- a/test/tap/tests/pgsql-test_malformed_packet-t.cpp
+++ b/test/tap/tests/pgsql-test_malformed_packet-t.cpp
@@ -1,0 +1,1026 @@
+/**
+ * @file pgsql-test_malformed_packet-t.cpp
+ * @brief Validates ProxySQL's PostgreSQL protocol handling stability and ensures it does not crash
+ *        when subjected to multiple malformed packets on its admin and backend connections.
+ *
+ * This test has two phases:
+ *
+ * Phase 1: Malformed packets BEFORE authentication
+ * - Sends various malformed PostgreSQL protocol packets prior to completing authentication
+ * - Verifies that ProxySQL properly rejects malformed packets without crashing
+ *
+ * Phase 2: Malformed packets AFTER authentication
+ * - Establishes authenticated connections to BACKEND and ADMIN interfaces
+ * - Sends malformed packets (Query, Parse, Bind, Execute, etc.) after successful authentication
+ * - Verifies that ProxySQL handles malformed data gracefully and remains operational
+ *
+ * Verification criteria for both phases:
+ * 1. ProxySQL does not crash when receiving malformed packets
+ * 2. ProxySQL properly closes the connection or sends error responses
+ * 3. ProxySQL remains operational for legitimate connections after test completion
+ *
+ * Test cases cover:
+ * - Truncated startup packets
+ * - Invalid length fields (zero, too large, mismatched, integer overflow)
+ * - Malformed SSL requests and cancel requests
+ * - Invalid packet types before startup
+ * - Malformed SASL authentication data
+ * - Query packets with missing null terminators (Phase 2)
+ * - Extended query protocol malformed packets (Parse, Bind, Execute, Close, Describe) (Phase 2)
+ * - Copy protocol malformed packets (Phase 2)
+ */
+
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/tcp.h>
+#include <cstring>
+#include <vector>
+#include <string>
+#include <sstream>
+
+#include "libpq-fe.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+constexpr size_t BUFFER_SIZE = 4096;
+constexpr int TIMEOUT_SEC = 5;
+
+// PostgreSQL protocol constants
+constexpr uint32_t PG_PROTOCOL_VERSION = 196608;  // 3.0 (0x00030000)
+constexpr uint32_t PG_SSL_REQUEST_CODE = 80877103;  // (1234 << 16) | 5679
+constexpr uint32_t PG_CANCEL_REQUEST_CODE = 80877102;  // (1234 << 16) | 5678
+constexpr uint32_t PG_GSS_ENCRYPT_CODE = 80877104;  // (1234 << 16) | 5680
+
+#define REPORT_ERROR_AND_EXIT(fmt, ...) \
+    do { \
+        fprintf(stderr, "File %s, line %d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+        close(sock); \
+        return; \
+    } while (0)
+
+typedef enum {
+    BACKEND = 0,
+    ADMIN
+} Connection_type_t;
+
+/**
+ * @brief Create a raw TCP socket connection to the specified host and port
+ */
+int create_raw_connection(const std::string& host, int port) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+        fprintf(stderr, "Socket creation failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    // Set socket timeout
+    struct timeval timeout;
+    timeout.tv_sec = TIMEOUT_SEC;
+    timeout.tv_usec = 0;
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        fprintf(stderr, "Failed to set socket timeout: %s\n", strerror(errno));
+        close(sock);
+        return -1;
+    }
+
+    // Set TCP_NODELAY for immediate packet sending
+    int flag = 1;
+    setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+
+    sockaddr_in server_addr{};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(port);
+
+    if (inet_pton(AF_INET, host.c_str(), &server_addr.sin_addr) <= 0) {
+        fprintf(stderr, "Invalid address: %s\n", host.c_str());
+        close(sock);
+        return -1;
+    }
+
+    if (connect(sock, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+        fprintf(stderr, "Connection failed: %s\n", strerror(errno));
+        close(sock);
+        return -1;
+    }
+
+    return sock;
+}
+
+/**
+ * @brief Send a malformed packet and verify ProxySQL handles it gracefully
+ *
+ * Valid outcomes:
+ * - Connection closed (bytes_received <= 0): ProxySQL rejected the packet immediately
+ * - Error response received (bytes_received > 0): ProxySQL sent an error packet (also valid)
+ * - Both are acceptable - what matters is ProxySQL doesn't crash
+ */
+void test_malformed_packet(const std::string& test_name,
+                          const std::string& host,
+                          int port,
+                          const std::vector<uint8_t>& data) {
+
+    int sock = create_raw_connection(host, port);
+    if (sock < 0) {
+        ok(0, "%s: Failed to create connection", test_name.c_str());
+        return;
+    }
+
+    // Send the malformed data
+    ssize_t bytes_sent = send(sock, data.data(), data.size(), 0);
+    if (bytes_sent < 0) {
+        close(sock);
+        ok(0, "%s: Failed to send data", test_name.c_str());
+        return;
+    }
+
+    // Try to receive response
+    std::vector<char> buffer(BUFFER_SIZE);
+    ssize_t bytes_received = recv(sock, buffer.data(), buffer.size(), 0);
+
+    // Either connection close OR error response are valid outcomes
+    // The key is that ProxySQL handles the malformed packet gracefully
+    bool handled_gracefully = (bytes_received <= 0) ||  // Connection closed
+                               (bytes_received > 0);     // Got error response
+
+    ok(handled_gracefully, "%s: Malformed packet handled (received: %ld bytes)",
+       test_name.c_str(), (long)bytes_received);
+
+    close(sock);
+}
+
+/**
+ * @brief Verify ProxySQL is still operational after malformed packet test
+ */
+bool verify_proxysql_alive(const CommandLine& cl, Connection_type_t conn_type) {
+    std::stringstream ss;
+    if (conn_type == BACKEND) {
+        ss << "host=" << cl.pgsql_host << " port=" << cl.pgsql_port;
+        ss << " user=" << cl.pgsql_username << " password=" << cl.pgsql_password;
+    } else {
+        // Admin interface - use MySQL admin credentials on PostgreSQL admin port
+        ss << "host=" << cl.admin_host << " port=" << cl.pgsql_admin_port;
+        ss << " user=" << cl.admin_username << " password=" << cl.admin_password;
+    }
+    ss << " sslmode=disable";
+
+    PGconn* conn = PQconnectdb(ss.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        PQfinish(conn);
+        return false;
+    }
+
+    // Try a simple query
+    PGresult* res = PQexec(conn, "SELECT 1");
+    bool success = (PQresultStatus(res) == PGRES_TUPLES_OK);
+    PQclear(res);
+    PQfinish(conn);
+
+    return success;
+}
+
+/**
+ * @brief Build a valid startup packet
+ */
+std::vector<uint8_t> build_startup_packet(const std::vector<std::pair<std::string, std::string>>& params) {
+    std::vector<uint8_t> packet;
+
+    // Reserve space for length (4 bytes)
+    packet.resize(4);
+
+    // Protocol version (4 bytes, big-endian)
+    packet.push_back((PG_PROTOCOL_VERSION >> 24) & 0xFF);
+    packet.push_back((PG_PROTOCOL_VERSION >> 16) & 0xFF);
+    packet.push_back((PG_PROTOCOL_VERSION >> 8) & 0xFF);
+    packet.push_back(PG_PROTOCOL_VERSION & 0xFF);
+
+    // Parameters (name\0value\0)
+    for (const auto& [name, value] : params) {
+        for (char c : name) packet.push_back(c);
+        packet.push_back(0);
+        for (char c : value) packet.push_back(c);
+        packet.push_back(0);
+    }
+
+    // Null terminator
+    packet.push_back(0);
+
+    // Update length
+    uint32_t len = packet.size();
+    packet[0] = (len >> 24) & 0xFF;
+    packet[1] = (len >> 16) & 0xFF;
+    packet[2] = (len >> 8) & 0xFF;
+    packet[3] = len & 0xFF;
+
+    return packet;
+}
+
+/**
+ * @brief Build SSL request packet
+ */
+std::vector<uint8_t> build_ssl_request_packet() {
+    std::vector<uint8_t> packet(8);
+
+    // Length
+    packet[0] = 0;
+    packet[1] = 0;
+    packet[2] = 0;
+    packet[3] = 8;
+
+    // SSL request code
+    packet[4] = (PG_SSL_REQUEST_CODE >> 24) & 0xFF;
+    packet[5] = (PG_SSL_REQUEST_CODE >> 16) & 0xFF;
+    packet[6] = (PG_SSL_REQUEST_CODE >> 8) & 0xFF;
+    packet[7] = PG_SSL_REQUEST_CODE & 0xFF;
+
+    return packet;
+}
+
+/**
+ * @brief Build cancel request packet
+ */
+std::vector<uint8_t> build_cancel_request_packet(uint32_t pid, uint32_t key) {
+    std::vector<uint8_t> packet(16);
+
+    // Length
+    packet[0] = 0;
+    packet[1] = 0;
+    packet[2] = 0;
+    packet[3] = 16;
+
+    // Cancel request code
+    packet[4] = (PG_CANCEL_REQUEST_CODE >> 24) & 0xFF;
+    packet[5] = (PG_CANCEL_REQUEST_CODE >> 16) & 0xFF;
+    packet[6] = (PG_CANCEL_REQUEST_CODE >> 8) & 0xFF;
+    packet[7] = PG_CANCEL_REQUEST_CODE & 0xFF;
+
+    // Process ID
+    packet[8] = (pid >> 24) & 0xFF;
+    packet[9] = (pid >> 16) & 0xFF;
+    packet[10] = (pid >> 8) & 0xFF;
+    packet[11] = pid & 0xFF;
+
+    // Secret key
+    packet[12] = (key >> 24) & 0xFF;
+    packet[13] = (key >> 16) & 0xFF;
+    packet[14] = (key >> 8) & 0xFF;
+    packet[15] = key & 0xFF;
+
+    return packet;
+}
+
+/**
+ * @brief Build password message packet (type 'p')
+ */
+std::vector<uint8_t> build_password_packet(const std::string& password) {
+    std::vector<uint8_t> packet;
+
+    // Type byte
+    packet.push_back('p');
+
+    // Reserve space for length
+    packet.resize(5);
+
+    // Password (null-terminated)
+    for (char c : password) packet.push_back(c);
+    packet.push_back(0);
+
+    // Update length (includes length field itself)
+    uint32_t len = packet.size() - 1;  // Exclude type byte from length
+    packet[1] = (len >> 24) & 0xFF;
+    packet[2] = (len >> 16) & 0xFF;
+    packet[3] = (len >> 8) & 0xFF;
+    packet[4] = len & 0xFF;
+
+    return packet;
+}
+
+void run_malformed_packet_tests(const std::string& host, int port, const char* target_name) {
+    diag(">>> Testing malformed packets on %s (%s:%d) <<<", target_name, host.c_str(), port);
+
+    // ==================== STARTUP PACKET TESTS ====================
+
+    // Test 1: Empty packet
+    test_malformed_packet("Empty packet", host, port, {});
+
+    // Test 2: Truncated startup - only length, no version
+    test_malformed_packet("Truncated startup (length only)", host, port,
+        {0x00, 0x00, 0x00, 0x08});
+
+    // Test 3: Startup with length = 0
+    test_malformed_packet("Startup with zero length", host, port,
+        {0x00, 0x00, 0x00, 0x00});
+
+    // Test 4: Startup with length = 4 (too small, only version, no params)
+    test_malformed_packet("Startup with minimal length", host, port,
+        {0x00, 0x00, 0x00, 0x04, 0x00, 0x03, 0x00, 0x00});
+
+    // Test 5: Startup with invalid protocol version (0)
+    test_malformed_packet("Startup with version 0", host, port,
+        {0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00});
+
+    // Test 6: Startup with invalid protocol version (1)
+    test_malformed_packet("Startup with version 1", host, port,
+        {0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01});
+
+    // Test 7: Startup with huge length (potential DoS)
+    test_malformed_packet("Startup with huge length", host, port,
+        {0x7F, 0xFF, 0xFF, 0xFF, 0x00, 0x03, 0x00, 0x00});
+
+    // Test 8: Startup with length > packet size (mismatch)
+    test_malformed_packet("Startup length > data", host, port,
+        {0x00, 0x00, 0x00, 0x20, 0x00, 0x03, 0x00, 0x00});
+
+    // Test 9: Startup packet without null terminator
+    test_malformed_packet("Startup without terminator", host, port,
+        {0x00, 0x00, 0x00, 0x0C, 0x00, 0x03, 0x00, 0x00,
+         'u', 's', 'e', 'r'});
+
+    // Test 10: Startup with user param but no value
+    test_malformed_packet("Startup with user, no value", host, port,
+        {0x00, 0x00, 0x00, 0x0D, 0x00, 0x03, 0x00, 0x00,
+         'u', 's', 'e', 'r', 0x00});
+
+    // Test 11: Startup with only version and null terminator
+    test_malformed_packet("Startup with only version", host, port,
+        {0x00, 0x00, 0x00, 0x09, 0x00, 0x03, 0x00, 0x00, 0x00});
+
+    // ==================== SSL REQUEST TESTS ====================
+
+    // Test 12: SSL request with wrong length (too short)
+    test_malformed_packet("SSL request with short length", host, port,
+        {0x00, 0x00, 0x00, 0x04,
+         (PG_SSL_REQUEST_CODE >> 24) & 0xFF,
+         (PG_SSL_REQUEST_CODE >> 16) & 0xFF,
+         (PG_SSL_REQUEST_CODE >> 8) & 0xFF,
+         PG_SSL_REQUEST_CODE & 0xFF});
+
+    // Test 13: SSL request with wrong length (too long)
+    test_malformed_packet("SSL request with long length", host, port,
+        {0x00, 0x00, 0x00, 0x10,
+         (PG_SSL_REQUEST_CODE >> 24) & 0xFF,
+         (PG_SSL_REQUEST_CODE >> 16) & 0xFF,
+         (PG_SSL_REQUEST_CODE >> 8) & 0xFF,
+         PG_SSL_REQUEST_CODE & 0xFF});
+
+    // Test 14: SSL request with invalid code
+    test_malformed_packet("SSL request with invalid code", host, port,
+        {0x00, 0x00, 0x00, 0x08,
+         0xDE, 0xAD, 0xBE, 0xEF});
+
+    // Test 15: GSS encrypt request (not supported)
+    test_malformed_packet("GSS encrypt request", host, port,
+        {0x00, 0x00, 0x00, 0x08,
+         (PG_GSS_ENCRYPT_CODE >> 24) & 0xFF,
+         (PG_GSS_ENCRYPT_CODE >> 16) & 0xFF,
+         (PG_GSS_ENCRYPT_CODE >> 8) & 0xFF,
+         PG_GSS_ENCRYPT_CODE & 0xFF});
+
+    // ==================== CANCEL REQUEST TESTS ====================
+
+    // Test 16: Cancel request with length too short (< 16)
+    test_malformed_packet("Cancel request too short", host, port,
+        {0x00, 0x00, 0x00, 0x0C,
+         (PG_CANCEL_REQUEST_CODE >> 24) & 0xFF,
+         (PG_CANCEL_REQUEST_CODE >> 16) & 0xFF,
+         (PG_CANCEL_REQUEST_CODE >> 8) & 0xFF,
+         PG_CANCEL_REQUEST_CODE & 0xFF,
+         0x00, 0x00, 0x00, 0x01});
+
+    // Test 17: Cancel request with length too long (> 268)
+    test_malformed_packet("Cancel request too long", host, port,
+        {0x00, 0x00, 0x01, 0x0D,  // 269 bytes
+         (PG_CANCEL_REQUEST_CODE >> 24) & 0xFF,
+         (PG_CANCEL_REQUEST_CODE >> 16) & 0xFF,
+         (PG_CANCEL_REQUEST_CODE >> 8) & 0xFF,
+         PG_CANCEL_REQUEST_CODE & 0xFF});
+
+    // Test 18: Cancel request with invalid code
+    test_malformed_packet("Cancel request invalid code", host, port,
+        {0x00, 0x00, 0x00, 0x10,
+         0xDE, 0xAD, 0xBE, 0xEF,
+         0x00, 0x00, 0x00, 0x01,
+         0x00, 0x00, 0x00, 0x02});
+
+    // ==================== PACKET TYPE CONFUSION TESTS ====================
+
+    // Test 19: Regular packet type before startup
+    test_malformed_packet("Password packet before startup", host, port,
+        build_password_packet("test"));
+
+    // Test 20: Query packet before startup
+    test_malformed_packet("Query packet before startup", host, port,
+        {'Q', 0x00, 0x00, 0x00, 0x0D, 'S', 'E', 'L', 'E', 'C', 'T', ' ', '1', 0x00});
+
+    // Test 21: Unknown packet type
+    test_malformed_packet("Unknown packet type (0xFF)", host, port,
+        {0xFF, 0x00, 0x00, 0x00, 0x04});
+
+    // Test 22: Packet with length overflow (negative when cast to signed)
+    test_malformed_packet("Packet with length 0x80000000", host, port,
+        {'Q', 0x80, 0x00, 0x00, 0x00});
+
+    // Test 23: Special packet with non-zero second byte
+    test_malformed_packet("Special packet with non-zero second byte", host, port,
+        {0x00, 0x01, 0x00, 0x00, 0x00, 0x08});
+
+    // ==================== MALFORMED DATA TESTS ====================
+
+    // Test 24: Random binary data
+    test_malformed_packet("Random binary data", host, port,
+        {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0});
+
+    // Test 25: All zeros
+    test_malformed_packet("All zeros packet", host, port,
+        std::vector<uint8_t>(100, 0x00));
+
+    // Test 26: All 0xFF
+    test_malformed_packet("All 0xFF packet", host, port,
+        std::vector<uint8_t>(100, 0xFF));
+
+    // Test 27: Maximum length field with minimal data
+    test_malformed_packet("Max length, min data", host, port,
+        {'Q', 0xFF, 0xFF, 0xFF, 0xFF});
+
+    // Test 28: Startup v2 protocol (deprecated)
+    test_malformed_packet("Startup v2 protocol", host, port,
+        {0x00, 0x00, 0x00, 0x08, 0x00, 0x02, 0x00, 0x00});
+}
+
+/**
+ * @brief Build a PostgreSQL message packet with type byte
+ */
+std::vector<uint8_t> build_message_packet(char type, const std::vector<uint8_t>& data) {
+    std::vector<uint8_t> packet;
+    packet.reserve(1 + 4 + data.size());
+
+    // Message type
+    packet.push_back(type);
+
+    // Message length (includes self)
+    uint32_t len = data.size() + 4;
+    packet.push_back((len >> 24) & 0xFF);
+    packet.push_back((len >> 16) & 0xFF);
+    packet.push_back((len >> 8) & 0xFF);
+    packet.push_back(len & 0xFF);
+
+    // Message data
+    packet.insert(packet.end(), data.begin(), data.end());
+
+    return packet;
+}
+
+/**
+ * @brief Read a PostgreSQL message from socket
+ */
+bool read_message(int sock, char& type, std::vector<uint8_t>& buffer) {
+    // Read message type (1 byte)
+    char type_buf[1];
+    ssize_t n = recv(sock, type_buf, 1, 0);
+    if (n <= 0) return false;
+    type = type_buf[0];
+
+    // Read length (4 bytes, big-endian, includes self)
+    char len_buf[4];
+    n = recv(sock, len_buf, 4, 0);
+    if (n != 4) return false;
+
+    int32_t len = ((unsigned char)len_buf[0] << 24) |
+                  ((unsigned char)len_buf[1] << 16) |
+                  ((unsigned char)len_buf[2] << 8) |
+                  (unsigned char)len_buf[3];
+
+    if (len < 4) return false;
+
+    // Read message body
+    int32_t body_len = len - 4;
+    buffer.resize(body_len);
+    int32_t received = 0;
+    while (received < body_len) {
+        n = recv(sock, buffer.data() + received, body_len - received, 0);
+        if (n <= 0) return false;
+        received += n;
+    }
+
+    return true;
+}
+
+/**
+ * @brief Send a malformed packet on an authenticated connection (Phase 2)
+ *
+ * Phase 2 tests send malformed packets AFTER successful authentication.
+ * This tests post-authentication crash vulnerabilities.
+ */
+void test_malformed_packet_phase2(const std::string& test_name,
+                                   const std::string& host,
+                                   int port,
+                                   const std::string& username,
+                                   const std::string& password,
+                                   const std::vector<uint8_t>& malformed_data) {
+
+    int sock = create_raw_connection(host, port);
+    if (sock < 0) {
+        ok(0, "%s: Failed to create connection", test_name.c_str());
+        return;
+    }
+
+    // Step 1: Send valid startup packet
+    auto startup = build_startup_packet({{"user", username}});
+    if (send(sock, startup.data(), startup.size(), 0) < 0) {
+        close(sock);
+        ok(0, "%s: Failed to send startup", test_name.c_str());
+        return;
+    }
+
+    // Step 2: Wait for authentication request (usually MD5 or SASL)
+    char auth_type;
+    std::vector<uint8_t> auth_data;
+    if (!read_message(sock, auth_type, auth_data)) {
+        close(sock);
+        ok(0, "%s: Failed to read auth request", test_name.c_str());
+        return;
+    }
+
+    // Step 3: Send password response (cleartext for simplicity)
+    auto password_pkt = build_password_packet(password);
+    if (send(sock, password_pkt.data(), password_pkt.size(), 0) < 0) {
+        close(sock);
+        ok(0, "%s: Failed to send password", test_name.c_str());
+        return;
+    }
+
+    // Step 4: Wait for authentication result
+    if (!read_message(sock, auth_type, auth_data)) {
+        close(sock);
+        ok(0, "%s: Failed to read auth result", test_name.c_str());
+        return;
+    }
+
+    // Check if authentication succeeded
+    if (auth_type == 'E') {
+        // Authentication failed - this is OK for our purposes,
+        // we still want to test if malformed packets crash ProxySQL
+        // but we can't send them on an authenticated connection
+        // Send the malformed data anyway to see if it crashes
+        ssize_t sent = send(sock, malformed_data.data(), malformed_data.size(), 0);
+        close(sock);
+        ok(sent > 0, "%s: Sent malformed data after auth failure (sent: %ld)",
+           test_name.c_str(), (long)sent);
+        return;
+    }
+
+    if (auth_type != 'R' || auth_data.size() < 4) {
+        // Unexpected response
+        send(sock, malformed_data.data(), malformed_data.size(), 0);
+        close(sock);
+        ok(1, "%s: Malformed packet sent after auth", test_name.c_str());
+        return;
+    }
+
+    // Check auth result code
+    int32_t auth_code = (auth_data[0] << 24) | (auth_data[1] << 16) |
+                        (auth_data[2] << 8) | auth_data[3];
+
+    if (auth_code != 0) {
+        // Authentication didn't complete successfully
+        send(sock, malformed_data.data(), malformed_data.size(), 0);
+        close(sock);
+        ok(1, "%s: Malformed packet sent after incomplete auth", test_name.c_str());
+        return;
+    }
+
+    // Authentication successful - now we have an authenticated connection
+
+    // Step 5: Send the malformed packet
+    ssize_t sent = send(sock, malformed_data.data(), malformed_data.size(), 0);
+    if (sent < 0) {
+        close(sock);
+        ok(0, "%s: Failed to send malformed data", test_name.c_str());
+        return;
+    }
+
+    // Step 6: Try to receive response (may get error or connection close)
+    std::vector<char> buffer(BUFFER_SIZE);
+    ssize_t bytes_received = recv(sock, buffer.data(), buffer.size(), 0);
+
+    bool handled_gracefully = (bytes_received <= 0) || (bytes_received > 0);
+
+    ok(handled_gracefully, "%s: Phase 2 malformed packet handled (received: %ld bytes)",
+       test_name.c_str(), (long)bytes_received);
+
+    close(sock);
+}
+
+/**
+ * @brief Run Phase 2 tests - malformed packets AFTER authentication
+ *
+ * Phase 2 tests establish a valid connection first, then send malformed
+ * packets on the authenticated connection to test post-auth crash vectors.
+ */
+void run_phase2_malformed_packet_tests(const std::string& host, int port,
+                                        const std::string& username,
+                                        const std::string& password,
+                                        const char* target_name) {
+    diag(">>> Phase 2: Testing malformed packets AFTER AUTH on %s (%s:%d) <<<",
+         target_name, host.c_str(), port);
+
+    // ==================== QUERY PACKET TESTS ('Q') ====================
+
+    // Test 1: Query packet with length < 5 (integer underflow)
+    // This targets PgSQL_Session.cpp:2079-2082 where query_len = pkt.size - 5
+    test_malformed_packet_phase2("Query packet length=4 (underflow)",
+        host, port, username, password,
+        {'Q', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 2: Query packet with length=0
+    test_malformed_packet_phase2("Query packet length=0",
+        host, port, username, password,
+        {'Q', 0x00, 0x00, 0x00, 0x00});
+
+    // Test 3: Query packet with length=1 (just type byte)
+    test_malformed_packet_phase2("Query packet length=1",
+        host, port, username, password,
+        {'Q', 0x00, 0x00, 0x00, 0x01});
+
+    // Test 4: Query with null terminator but truncated
+    test_malformed_packet_phase2("Query truncated without null",
+        host, port, username, password,
+        {'Q', 0x00, 0x00, 0x00, 0x08, 'S', 'E', 'L', 'E'});
+
+    // Test 5: Query with huge length
+    test_malformed_packet_phase2("Query with huge length",
+        host, port, username, password,
+        {'Q', 0x7F, 0xFF, 0xFF, 0xFF});
+
+    // Test 6: Query with negative length (0x80000000)
+    test_malformed_packet_phase2("Query with negative length",
+        host, port, username, password,
+        {'Q', 0x80, 0x00, 0x00, 0x00});
+
+    // ==================== EXTENDED QUERY PROTOCOL TESTS ====================
+
+    // Test 7: Parse 'P' packet with length < 5
+    test_malformed_packet_phase2("Parse packet length=4",
+        host, port, username, password,
+        {'P', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 8: Parse packet with statement name no null terminator
+    test_malformed_packet_phase2("Parse stmt name no null",
+        host, port, username, password,
+        {'P', 0x00, 0x00, 0x00, 0x0A, 's', 't', 'm', 't', '1', 0x00});
+
+    // Test 9: Parse packet with query no null terminator
+    test_malformed_packet_phase2("Parse query no null",
+        host, port, username, password,
+        {'P', 0x00, 0x00, 0x00, 0x10,
+         's', 0x00,
+         'S', 'E', 'L', 'E', 'C', 'T', ' ', '1', 0x00});
+
+    // Test 10: Bind 'B' packet with length < 5
+    test_malformed_packet_phase2("Bind packet length=4",
+        host, port, username, password,
+        {'B', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 11: Bind with malformed parameter format codes
+    test_malformed_packet_phase2("Bind malformed param formats",
+        host, port, username, password,
+        {'B', 0x00, 0x00, 0x00, 0x0C,
+         'p', 0x00,
+         's', 0x00,
+         0x00, 0x01,
+         0x00, 0x01});
+
+    // Test 12: Execute 'E' packet with length < 5
+    test_malformed_packet_phase2("Execute packet length=4",
+        host, port, username, password,
+        {'E', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 13: Execute with portal name no null
+    test_malformed_packet_phase2("Execute portal no null",
+        host, port, username, password,
+        {'E', 0x00, 0x00, 0x00, 0x08,
+         'p', 'o', 'r', 't', 'a', 'l', '1'});
+
+    // Test 14: Close 'C' packet with length < 5
+    test_malformed_packet_phase2("Close packet length=4",
+        host, port, username, password,
+        {'C', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 15: Describe 'D' packet with length < 5
+    test_malformed_packet_phase2("Describe packet length=4",
+        host, port, username, password,
+        {'D', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 16: Sync 'S' packet with invalid length
+    test_malformed_packet_phase2("Sync packet invalid length",
+        host, port, username, password,
+        {'S', 0x00, 0x00, 0x00, 0x08});
+
+    // Test 17: Flush 'H' packet with invalid length
+    test_malformed_packet_phase2("Flush packet invalid length",
+        host, port, username, password,
+        {'H', 0x00, 0x00, 0x00, 0x08});
+
+    // ==================== COPY PROTOCOL TESTS ====================
+
+    // Test 18: CopyData 'd' packet with zero length
+    test_malformed_packet_phase2("CopyData length=4",
+        host, port, username, password,
+        {'d', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 19: CopyData with huge length
+    test_malformed_packet_phase2("CopyData huge length",
+        host, port, username, password,
+        {'d', 0x7F, 0xFF, 0xFF, 0xFF});
+
+    // Test 20: CopyDone 'c' packet with invalid length
+    test_malformed_packet_phase2("CopyDone invalid length",
+        host, port, username, password,
+        {'c', 0x00, 0x00, 0x00, 0x08});
+
+    // Test 21: CopyFail 'f' packet with no error message
+    test_malformed_packet_phase2("CopyFail no message",
+        host, port, username, password,
+        {'f', 0x00, 0x00, 0x00, 0x04});
+
+    // ==================== TERMINATE MESSAGE TESTS ====================
+
+    // Test 22: Terminate 'X' packet with invalid length
+    test_malformed_packet_phase2("Terminate invalid length",
+        host, port, username, password,
+        {'X', 0xFF, 0xFF, 0xFF, 0xFF});
+
+    // Test 23: Terminate with length=0
+    test_malformed_packet_phase2("Terminate length=0",
+        host, port, username, password,
+        {'X', 0x00, 0x00, 0x00, 0x00});
+
+    // ==================== MULTI-PACKET / ARITHMETIC TESTS ====================
+
+    // Test 24: Multiple small packets in sequence
+    std::vector<uint8_t> multi_pkt;
+    for (int i = 0; i < 10; i++) {
+        multi_pkt.push_back('Q');
+        multi_pkt.push_back(0x00);
+        multi_pkt.push_back(0x00);
+        multi_pkt.push_back(0x00);
+        multi_pkt.push_back(0x05);
+        multi_pkt.push_back('x');
+    }
+    test_malformed_packet_phase2("Multiple small queries",
+        host, port, username, password, multi_pkt);
+
+    // Test 25: Rapid fire empty packets
+    std::vector<uint8_t> rapid;
+    for (int i = 0; i < 100; i++) {
+        rapid.insert(rapid.end(), {'S', 0x00, 0x00, 0x00, 0x04});
+    }
+    test_malformed_packet_phase2("Rapid fire sync packets",
+        host, port, username, password, rapid);
+
+    // ==================== DATA TYPE OVERFLOW TESTS ====================
+
+    // Test 26: Integer overflow in length field
+    test_malformed_packet_phase2("Integer overflow length",
+        host, port, username, password,
+        {'Q', 0xFF, 0xFF, 0xFF, 0xFF});
+
+    // Test 27: Parameter count overflow in Bind
+    test_malformed_packet_phase2("Bind param count overflow",
+        host, port, username, password,
+        {'B', 0x00, 0x00, 0x00, 0x20,
+         'p', 0x00,
+         's', 0x00,
+         0xFF, 0xFF,
+         0x00, 0x00});
+
+    // Test 28: Column count overflow in Parse
+    test_malformed_packet_phase2("Parse column count overflow",
+        host, port, username, password,
+        {'P', 0x00, 0x00, 0x00, 0x10,
+         's', 0x00,
+         'Q', 0x00,
+         0xFF, 0xFF,
+         0x00, 0x00});
+
+    // ==================== PASSWORD MESSAGE TESTS ====================
+    // Tests for extract_password() vulnerability
+
+    // Test 29: Password message with length=4 (too small)
+    test_malformed_packet_phase2("Password message length=4",
+        host, port, username, password,
+        {'p', 0x00, 0x00, 0x00, 0x04});
+
+    // Test 30: Password message with huge length field
+    test_malformed_packet_phase2("Password message huge length",
+        host, port, username, password,
+        {'p', 0x7F, 0xFF, 0xFF, 0xFF});
+
+    // Test 31: Password message with length=0
+    test_malformed_packet_phase2("Password message length=0",
+        host, port, username, password,
+        {'p', 0x00, 0x00, 0x00, 0x00});
+
+    // ==================== SASL AUTHENTICATION TESTS ====================
+    // Tests for scram_handle_client_first/client_final vulnerabilities
+
+    // Test 32: SASL client-first with invalid length
+    test_malformed_packet_phase2("SASL client-first invalid length",
+        host, port, username, password,
+        {'p', 0x00, 0x00, 0x00, 0x08,
+         'S', 'C', 'R', 'A', 'M', '-', 'S', 'H'});
+
+    // Test 33: SASL client-first with truncated data
+    test_malformed_packet_phase2("SASL client-first truncated",
+        host, port, username, password,
+        {'p', 0x00, 0x00, 0x01, 0x00,
+         'S', 'C', 'R', 'A', 'M', '-', 'S', 'H', 'A', '-', '2', '5', '6', 0x00});
+
+    // Test 34: SASL response with invalid length
+    test_malformed_packet_phase2("SASL response invalid length",
+        host, port, username, password,
+        {'p', 0xFF, 0xFF, 0xFF, 0xFF});
+
+    // ==================== MULTI-PACKET TESTS ====================
+    // Tests for multi_pkt underflow vulnerability
+
+    // Test 35: Multi-packet scenario with small size
+    test_malformed_packet_phase2("Multi-packet small size",
+        host, port, username, password,
+        {'Q', 0x00, 0x00, 0x00, 0x05, 'x'});
+
+    // ==================== EXTENDED QUERY LENGTH TESTS ====================
+    // Additional tests for extended query protocol
+
+    // Test 36: Parse with zero-length statement name and query
+    test_malformed_packet_phase2("Parse zero length fields",
+        host, port, username, password,
+        {'P', 0x00, 0x00, 0x00, 0x06, 0x00, 0x00});
+
+    // Test 37: Bind with zero-length portal and statement
+    test_malformed_packet_phase2("Bind zero length fields",
+        host, port, username, password,
+        {'B', 0x00, 0x00, 0x00, 0x06, 0x00, 0x00});
+
+    // Test 38: Execute with zero-length portal
+    test_malformed_packet_phase2("Execute zero length portal",
+        host, port, username, password,
+        {'E', 0x00, 0x00, 0x00, 0x05, 0x00});
+
+    // Test 39: Close with zero-length name
+    test_malformed_packet_phase2("Close zero length name",
+        host, port, username, password,
+        {'C', 0x00, 0x00, 0x00, 0x05, 0x00});
+
+    // Test 40: Describe with zero-length name
+    test_malformed_packet_phase2("Describe zero length name",
+        host, port, username, password,
+        {'D', 0x00, 0x00, 0x00, 0x05, 0x00});
+
+    // ==================== PACKET TYPE CONFUSION AFTER AUTH ====================
+
+    // Test 41: Startup packet sent after authentication
+    test_malformed_packet_phase2("Startup after auth",
+        host, port, username, password,
+        {0x00, 0x00, 0x00, 0x08, 0x00, 0x03, 0x00, 0x00});
+
+    // Test 42: SSL request after authentication
+    test_malformed_packet_phase2("SSL request after auth",
+        host, port, username, password,
+        {0x00, 0x00, 0x00, 0x08,
+         0x04, 0xD2, 0x16, 0x2F});
+
+    // Test 43: Cancel request after authentication
+    test_malformed_packet_phase2("Cancel request after auth",
+        host, port, username, password,
+        {0x00, 0x00, 0x00, 0x10,
+         0x04, 0xD2, 0x16, 0x2E,
+         0x00, 0x00, 0x00, 0x01,
+         0x00, 0x00, 0x00, 0x02});
+}
+
+/**
+ * @brief Final comprehensive check to verify ProxySQL did not crash
+ * This runs after ALL tests and reports whether ProxySQL is still alive
+ */
+bool final_crash_check(const CommandLine& cl) {
+    diag(">>> Final crash verification - checking if ProxySQL survived all malformed packets <<<");
+
+    // Try to connect to BACKEND
+    std::stringstream ss_backend;
+    ss_backend << "host=" << cl.pgsql_host << " port=" << cl.pgsql_port;
+    ss_backend << " user=" << cl.pgsql_username << " password=" << cl.pgsql_password;
+    ss_backend << " sslmode=disable";
+
+    PGconn* conn = PQconnectdb(ss_backend.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        diag("CRASH DETECTED: Cannot connect to BACKEND: %s", PQerrorMessage(conn));
+        PQfinish(conn);
+        return false;
+    }
+
+    PGresult* res = PQexec(conn, "SELECT 1");
+    bool backend_ok = (PQresultStatus(res) == PGRES_TUPLES_OK);
+    PQclear(res);
+    PQfinish(conn);
+
+    if (!backend_ok) {
+        diag("CRASH DETECTED: BACKEND query failed");
+        return false;
+    }
+
+    // Try to connect to ADMIN
+    std::stringstream ss_admin;
+    ss_admin << "host=" << cl.admin_host << " port=" << cl.pgsql_admin_port;
+    ss_admin << " user=" << cl.admin_username << " password=" << cl.admin_password;
+    ss_admin << " sslmode=disable";
+
+    conn = PQconnectdb(ss_admin.str().c_str());
+    if (PQstatus(conn) != CONNECTION_OK) {
+        diag("CRASH DETECTED: Cannot connect to ADMIN: %s", PQerrorMessage(conn));
+        PQfinish(conn);
+        return false;
+    }
+
+    res = PQexec(conn, "SELECT 1");
+    bool admin_ok = (PQresultStatus(res) == PGRES_TUPLES_OK);
+    PQclear(res);
+    PQfinish(conn);
+
+    if (!admin_ok) {
+        diag("CRASH DETECTED: ADMIN query failed");
+        return false;
+    }
+
+    return true;
+}
+
+int main(int argc, char** argv) {
+    CommandLine cl;
+
+    if (cl.getEnv()) {
+        diag("Failed to get the required environmental variables.");
+        return EXIT_FAILURE;
+    }
+
+    // Count the number of tests
+    // Phase 1: 28 tests per target (BACKEND and ADMIN) = 56 tests
+    // Phase 2: 43 tests per target (BACKEND and ADMIN) = 86 tests
+    // Plus 4 operational checks (after each target/phase) + 1 final crash check
+    const int phase1_tests = 56;  // 28 per target
+    const int phase2_tests = 86;  // 43 per target
+    const int total_malformed_tests = phase1_tests + phase2_tests;
+    const int operational_checks = 4;  // After each target in Phase 1 and Phase 2
+    const int final_check = 1;   // Final comprehensive crash check
+
+    plan(total_malformed_tests + operational_checks + final_check);
+
+    // =====================================================
+    // PHASE 1: PRE-AUTHENTICATION MALFORMED PACKETS
+    // =====================================================
+
+    // Test BACKEND connection
+    run_malformed_packet_tests(cl.pgsql_host, cl.pgsql_port, "BACKEND");
+
+    // Verify ProxySQL is still alive after BACKEND Phase 1 tests
+    bool backend_alive = verify_proxysql_alive(cl, BACKEND);
+    ok(backend_alive, "ProxySQL BACKEND operational after Phase 1");
+
+    // Test ADMIN connection
+    run_malformed_packet_tests(cl.pgsql_host, cl.pgsql_admin_port, "ADMIN");
+
+    // Verify ProxySQL is still alive after ADMIN Phase 1 tests
+    bool admin_alive = verify_proxysql_alive(cl, ADMIN);
+    ok(admin_alive, "ProxySQL ADMIN operational after Phase 1");
+
+    // =====================================================
+    // PHASE 2: POST-AUTHENTICATION MALFORMED PACKETS
+    // =====================================================
+
+    // Phase 2: Test malformed packets AFTER authentication on BACKEND
+    run_phase2_malformed_packet_tests(cl.pgsql_host, cl.pgsql_port,
+                                       cl.pgsql_username, cl.pgsql_password,
+                                       "BACKEND");
+
+    // Verify ProxySQL is still alive after BACKEND Phase 2 tests
+    backend_alive = verify_proxysql_alive(cl, BACKEND);
+    ok(backend_alive, "ProxySQL BACKEND operational after Phase 2");
+
+    // Phase 2: Test malformed packets AFTER authentication on ADMIN
+    run_phase2_malformed_packet_tests(cl.pgsql_host, cl.pgsql_admin_port,
+                                       cl.admin_username, cl.admin_password,
+                                       "ADMIN");
+
+    // Verify ProxySQL is still alive after ADMIN Phase 2 tests
+    admin_alive = verify_proxysql_alive(cl, ADMIN);
+    ok(admin_alive, "ProxySQL ADMIN operational after Phase 2");
+
+    // FINAL COMPREHENSIVE CRASH CHECK
+    // This is the most important test - it proves ProxySQL didn't crash
+    bool no_crash = final_crash_check(cl);
+    ok(no_crash, "FINAL: ProxySQL did NOT crash - ALL MALFORMED PACKET TESTS PASSED");
+
+    return exit_status();
+}

--- a/test/tap/tests/pgsql-test_malformed_packet-t.cpp
+++ b/test/tap/tests/pgsql-test_malformed_packet-t.cpp
@@ -139,10 +139,11 @@ void test_malformed_packet(const std::string& test_name,
     std::vector<char> buffer(BUFFER_SIZE);
     ssize_t bytes_received = recv(sock, buffer.data(), buffer.size(), 0);
 
-    // Either connection close OR error response are valid outcomes
-    // The key is that ProxySQL handles the malformed packet gracefully
-    bool handled_gracefully = (bytes_received <= 0) ||  // Connection closed
-                               (bytes_received > 0);     // Got error response
+    // Valid outcomes: connection closed OR any response
+    // The key is that ProxySQL handles the packet without crashing
+    bool connection_closed = (bytes_received <= 0);
+    bool got_response = (bytes_received > 0);
+    bool handled_gracefully = connection_closed || got_response;
 
     ok(handled_gracefully, "%s: Malformed packet handled (received: %ld bytes)",
        test_name.c_str(), (long)bytes_received);
@@ -473,19 +474,32 @@ std::vector<uint8_t> build_message_packet(char type, const std::vector<uint8_t>&
 }
 
 /**
+ * @brief Read an exact number of bytes from socket
+ * @return true if all bytes received, false on error/short read
+ */
+bool recv_exact(int sock, void* buf, size_t len) {
+    char* ptr = (char*)buf;
+    size_t received = 0;
+    while (received < len) {
+        ssize_t n = recv(sock, ptr + received, len - received, 0);
+        if (n <= 0) return false;
+        received += n;
+    }
+    return true;
+}
+
+/**
  * @brief Read a PostgreSQL message from socket
  */
 bool read_message(int sock, char& type, std::vector<uint8_t>& buffer) {
     // Read message type (1 byte)
     char type_buf[1];
-    ssize_t n = recv(sock, type_buf, 1, 0);
-    if (n <= 0) return false;
+    if (!recv_exact(sock, type_buf, 1)) return false;
     type = type_buf[0];
 
     // Read length (4 bytes, big-endian, includes self)
     char len_buf[4];
-    n = recv(sock, len_buf, 4, 0);
-    if (n != 4) return false;
+    if (!recv_exact(sock, len_buf, 4)) return false;
 
     int32_t len = ((unsigned char)len_buf[0] << 24) |
                   ((unsigned char)len_buf[1] << 16) |
@@ -497,12 +511,7 @@ bool read_message(int sock, char& type, std::vector<uint8_t>& buffer) {
     // Read message body
     int32_t body_len = len - 4;
     buffer.resize(body_len);
-    int32_t received = 0;
-    while (received < body_len) {
-        n = recv(sock, buffer.data() + received, body_len - received, 0);
-        if (n <= 0) return false;
-        received += n;
-    }
+    if (!recv_exact(sock, buffer.data(), body_len)) return false;
 
     return true;
 }
@@ -560,22 +569,19 @@ void test_malformed_packet_phase2(const std::string& test_name,
 
     // Check if authentication succeeded
     if (auth_type == 'E') {
-        // Authentication failed - this is OK for our purposes,
-        // we still want to test if malformed packets crash ProxySQL
-        // but we can't send them on an authenticated connection
-        // Send the malformed data anyway to see if it crashes
-        ssize_t sent = send(sock, malformed_data.data(), malformed_data.size(), 0);
+        // Authentication failed - fail the test
+        // Post-authentication tests require successful auth
         close(sock);
-        ok(sent > 0, "%s: Sent malformed data after auth failure (sent: %ld)",
-           test_name.c_str(), (long)sent);
+        ok(0, "%s: Authentication failed, cannot run post-auth test",
+           test_name.c_str());
         return;
     }
 
     if (auth_type != 'R' || auth_data.size() < 4) {
-        // Unexpected response
-        send(sock, malformed_data.data(), malformed_data.size(), 0);
+        // Unexpected response - fail the test
         close(sock);
-        ok(1, "%s: Malformed packet sent after auth", test_name.c_str());
+        ok(0, "%s: Unexpected auth response, cannot run post-auth test",
+           test_name.c_str());
         return;
     }
 
@@ -584,16 +590,16 @@ void test_malformed_packet_phase2(const std::string& test_name,
                         (auth_data[2] << 8) | auth_data[3];
 
     if (auth_code != 0) {
-        // Authentication didn't complete successfully
-        send(sock, malformed_data.data(), malformed_data.size(), 0);
+        // Authentication didn't complete successfully - fail the test
         close(sock);
-        ok(1, "%s: Malformed packet sent after incomplete auth", test_name.c_str());
+        ok(0, "%s: Authentication incomplete (code: %d), cannot run post-auth test",
+           test_name.c_str(), auth_code);
         return;
     }
 
     // Authentication successful - now we have an authenticated connection
 
-    // Step 5: Send the malformed packet
+    // Step 5: Send the malformed packet on the authenticated connection
     ssize_t sent = send(sock, malformed_data.data(), malformed_data.size(), 0);
     if (sent < 0) {
         close(sock);
@@ -601,14 +607,28 @@ void test_malformed_packet_phase2(const std::string& test_name,
         return;
     }
 
-    // Step 6: Try to receive response (may get error or connection close)
+    // Step 6: Try to receive response
+    // ProxySQL may send multiple responses (auth completion, parameter status, etc.)
+    // followed by an error response 'E' for the malformed packet, or close connection
     std::vector<char> buffer(BUFFER_SIZE);
     ssize_t bytes_received = recv(sock, buffer.data(), buffer.size(), 0);
 
-    bool handled_gracefully = (bytes_received <= 0) || (bytes_received > 0);
+    // Check if we got an error response 'E' or connection closed
+    // Note: There may be pending post-auth messages, so any of these outcomes is valid:
+    // 1. Connection closed (ProxySQL rejected the malformed packet)
+    // 2. 'E' error response (ProxySQL sent an error for the malformed packet)
+    // 3. Other messages (post-auth protocol messages)
+    bool connection_closed = (bytes_received <= 0);
+    bool got_error_response = (bytes_received > 0 && buffer[0] == 'E');
+    bool got_other_response = (bytes_received > 0 && buffer[0] != 'E');
 
-    ok(handled_gracefully, "%s: Phase 2 malformed packet handled (received: %ld bytes)",
-       test_name.c_str(), (long)bytes_received);
+    // Any outcome is acceptable as long as ProxySQL doesn't crash
+    // The key test is the final operational check
+    bool handled_gracefully = connection_closed || got_error_response || got_other_response;
+
+    ok(handled_gracefully, "%s: Phase 2 malformed packet sent (received: %ld bytes, first=0x%02X)",
+       test_name.c_str(), (long)bytes_received,
+       bytes_received > 0 ? (unsigned char)buffer[0] : 0);
 
     close(sock);
 }
@@ -989,7 +1009,7 @@ int main(int argc, char** argv) {
     ok(backend_alive, "ProxySQL BACKEND operational after Phase 1");
 
     // Test ADMIN connection
-    run_malformed_packet_tests(cl.pgsql_host, cl.pgsql_admin_port, "ADMIN");
+    run_malformed_packet_tests(cl.admin_host, cl.pgsql_admin_port, "ADMIN");
 
     // Verify ProxySQL is still alive after ADMIN Phase 1 tests
     bool admin_alive = verify_proxysql_alive(cl, ADMIN);
@@ -1009,7 +1029,7 @@ int main(int argc, char** argv) {
     ok(backend_alive, "ProxySQL BACKEND operational after Phase 2");
 
     // Phase 2: Test malformed packets AFTER authentication on ADMIN
-    run_phase2_malformed_packet_tests(cl.pgsql_host, cl.pgsql_admin_port,
+    run_phase2_malformed_packet_tests(cl.admin_host, cl.pgsql_admin_port,
                                        cl.admin_username, cl.admin_password,
                                        "ADMIN");
 


### PR DESCRIPTION
### Summary
When a `COPY FROM STDIN` operation encounters an error, the session switches back to normal mode. However, the client may have already pipelined `CopyData('d')`, `CopyDone('c')`, or `CopyFail('f')` messages that are still in the input queue.

Previously, these messages fell through to the default case, generating a spurious `"Feature not supported"` error.

This change adds explicit handling to discard these messages when session `fast_forward == SESSION_FORWARD_TYPE_NONE`, preventing the race condition from causing errors. The client does not expect a response for these messages in this scenario.

Closes [#5415](https://github.com/sysown/proxysql/issues/5415)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL protocol robustness: sessions now detect malformed or out-of-order packets (including stray COPY messages), validate startup/query packets, and abort problematic queries to avoid crashes or silent corruption.
  * Hardened resync and notice handling to avoid spurious errors during connection resets.

* **Tests**
  * Added comprehensive regression suites for malformed-packet handling and COPY FROM STDIN error recovery, covering many failure and recovery scenarios.

* **Chores**
  * Minor public API adjustments to better support resync and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->