### PR TITLE
Harden PostgreSQL connection handling against unstable backends and error scenarios - P1

### DIFF
--- a/include/PgSQL_Connection.h
+++ b/include/PgSQL_Connection.h
@@ -364,7 +364,7 @@ public:
 	bool is_connected() const;
 	void compute_unknown_transaction_status();
 	void async_free_result();
-	void flush();
+	void flush(bool is_resync = false);
 	bool IsActiveTransaction();
 	bool IsKnownActiveTransaction();
 	bool IsServerOffline();

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -1212,7 +1212,7 @@ void PgSQL_Connection::fetch_result_cont(short event) {
 	}
 }
 
-void PgSQL_Connection::flush() {
+void PgSQL_Connection::flush(bool is_resync) {
 	int res = PQflush(pgsql_conn);
 
 	if (res > 0) {
@@ -1222,7 +1222,11 @@ void PgSQL_Connection::flush() {
 		async_exit_status = PG_EVENT_READ;
 	}
 	else {
-		set_error_from_PQerrorMessage();
+		if (!is_resync) {
+			set_error_from_PQerrorMessage();
+		} else {
+			resync_failed = true;
+		}
 		proxy_error("Failed to flush data to backend. %s\n", get_error_code_with_message().c_str());
 		async_exit_status = PG_EVENT_NONE;
 	}
@@ -1773,7 +1777,7 @@ void PgSQL_Connection::resync_start() {
 		resync_failed = true;
 		return;
 	}
-	async_exit_status = PG_EVENT_WRITE;
+	flush(true);
 }
 
 void PgSQL_Connection::resync_cont(short event) {
@@ -1781,17 +1785,7 @@ void PgSQL_Connection::resync_cont(short event) {
 	proxy_debug(PROXY_DEBUG_MYSQL_PROTOCOL, 6, "event=%d\n", event);
 	async_exit_status = PG_EVENT_NONE;
 	if (event & POLLOUT) {
-		int res = PQflush(pgsql_conn);
-
-		if (res > 0) {
-			async_exit_status = PG_EVENT_WRITE;
-		} else if (res == 0) {
-			async_exit_status = PG_EVENT_READ;
-		} else {
-			proxy_error("Failed to flush data to backend.\n");
-			async_exit_status = PG_EVENT_NONE;
-			resync_failed = true;
-		}
+		flush(true);
 	}
 }
 

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -919,6 +919,7 @@ handler_again:
 	}
 	break;
 	case ASYNC_RESET_SESSION_END:
+		PQsetNoticeReceiver(pgsql_conn, &PgSQL_Connection::unhandled_notice_cb, this);
 		if (is_error_present()) {
 			NEXT_IMMEDIATE(ASYNC_RESET_SESSION_FAILED);
 		}
@@ -1934,6 +1935,7 @@ void PgSQL_Connection::reset_session_start() {
 	assert(pgsql_conn);
 	reset_error();
 	async_exit_status = PG_EVENT_NONE;
+	PQsetNoticeReceiver(pgsql_conn, &PgSQL_Connection::notice_handler_cb, this);
 
 	reset_session_in_pipeline = is_pipeline_active();
 	if (reset_session_in_pipeline) {

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -2277,6 +2277,7 @@ __implicit_sync:
 							pkt = { 0, nullptr };
 							break;
 						default:
+							reset_extended_query_frame();
 							proxy_error("Not implemented yet. Message type:'%c'\n", c);
 							client_myds->setDSS_STATE_QUERY_SENT_NET();
 							client_myds->myprot.generate_error_packet(true, true, "Feature not supported", PGSQL_ERROR_CODES::ERRCODE_FEATURE_NOT_SUPPORTED,

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5973,6 +5973,16 @@ int PgSQL_Session::handle_post_sync_parse_message(PgSQL_Parse_Message* parse_msg
 
 	// Fallback: forward to backend
 	mybe = find_or_create_backend(current_hostgroup);
+
+	// set query retries
+	mybe->server_myds->query_retries_on_failure = pgsql_thread___query_retries_on_failure;
+	// if a number of retries is set in mysql_query_rules, that takes priority
+	if (qpo) {
+		if (qpo->retries >= 0) {
+			mybe->server_myds->query_retries_on_failure = qpo->retries;
+		}
+	}
+
 	status = PROCESSING_STMT_PREPARE;
 	mybe->server_myds->connect_retries_on_failure = pgsql_thread___connect_retries_on_failure;
 	pause_until = 0;
@@ -6117,6 +6127,16 @@ int PgSQL_Session::handle_post_sync_describe_message(PgSQL_Describe_Message* des
 	}
 
 	mybe = find_or_create_backend(current_hostgroup);
+
+	// set query retries
+	mybe->server_myds->query_retries_on_failure = pgsql_thread___query_retries_on_failure;
+	// if a number of retries is set in mysql_query_rules, that takes priority
+	if (qpo) {
+		if (qpo->retries >= 0) {
+			mybe->server_myds->query_retries_on_failure = qpo->retries;
+		}
+	}
+
 	status = PROCESSING_STMT_DESCRIBE;
 	mybe->server_myds->connect_retries_on_failure = pgsql_thread___connect_retries_on_failure;
 	pause_until = 0;
@@ -6394,6 +6414,16 @@ int PgSQL_Session::handle_post_sync_execute_message(PgSQL_Execute_Message* execu
 	}
 
 	mybe = find_or_create_backend(current_hostgroup);
+
+	// set query retries
+	mybe->server_myds->query_retries_on_failure = pgsql_thread___query_retries_on_failure;
+	// if a number of retries is set in mysql_query_rules, that takes priority
+	if (qpo) {
+		if (qpo->retries >= 0) {
+			mybe->server_myds->query_retries_on_failure = qpo->retries;
+		}
+	}
+
 	status = PROCESSING_STMT_EXECUTE;
 	mybe->server_myds->connect_retries_on_failure = pgsql_thread___connect_retries_on_failure;
 	pause_until = 0;


### PR DESCRIPTION
### Summary

Harden ProxySQL's PostgreSQL connection handling by ensuring proper notice capture, correct retry behavior for extended query messages and immediate error detection during error recovery paths. Previously, certain error recovery scenarios could leave the connection in an inconsistent state or delay error detection.

### Root cause:
  - `resync_start()` deferred socket flushing to the event loop (async_exit_status = PG_EVENT_WRITE), meaning dead connections wouldn't be detected until POLLOUT was polled
  - Notice receiver was not set in `reset_session_*()`, so notices from the backend during error recovery were lost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed COPY FROM STDIN error recovery and session state management.
  * Improved error handling when switching session modes.
  * Added query retry configuration for backend query failures.

* **Tests**
  * Added new regression test suite for COPY error recovery scenarios including error handling and session state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->