### PR TITLE
[skip-ci] fix: TSDB metric collection & config load from disk

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -752,8 +752,9 @@ class ProxySQL_Admin {
 	// TSDB
 	void init_tsdb_variables();
 	void flush_tsdb_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime=false);
-	void load_tsdb_variables_to_runtime();
-	void save_tsdb_variables_from_runtime();
+	void flush_tsdb_variables___database_to_runtime(SQLite3DB *db, bool replace);
+	void load_tsdb_variables_to_runtime() { flush_tsdb_variables___database_to_runtime(admindb, true); }
+	void save_tsdb_variables_from_runtime() { flush_tsdb_variables___runtime_to_database(admindb, true, true, false); }
 
 	void load_or_update_global_settings(SQLite3DB *);
 

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -301,6 +301,14 @@ struct processlist_config_t {
 	processlist_query_options_t query_options {};
 };
 
+/**
+ * @brief Refresh all module metrics in the global Prometheus registry.
+ *
+ * Calls p_update_metrics() on every ProxySQL module so that gauges and
+ * counters reflect the current state before the registry is collected.
+ */
+void update_modules_metrics();
+
 class ProxySQL_Admin {
 	private:
 	volatile int main_shutdown;

--- a/lib/Admin_Bootstrap.cpp
+++ b/lib/Admin_Bootstrap.cpp
@@ -1269,6 +1269,7 @@ bool ProxySQL_Admin::init(const bootstrap_info_t& bootstrap_info) {
 	flush_mcp_variables___database_to_runtime(admindb, true);
 	flush_genai_variables___database_to_runtime(admindb, true);
 #endif /* PROXYSQLGENAI */
+	flush_tsdb_variables___database_to_runtime(admindb, true);
 
 	if (GloVars.__cmd_proxysql_admin_socket) {
 		set_variable((char *)"mysql_ifaces",GloVars.__cmd_proxysql_admin_socket);

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -199,6 +199,8 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 #endif // PROXYSQLCLICKHOUSE
 		} else if (modname == "ldap") {
 			rc = GloMyLdapAuth->set_variable(r->fields[0],r->fields[1]);
+		} else if (modname == "tsdb") {
+			rc = GloProxyStats->set_variable(r->fields[0],r->fields[1]);
 		}
 		const string v = string(r->fields[0]);
 		if (rc==false) {
@@ -217,6 +219,8 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 #endif // PROXYSQLCLICKHOUSE
 				} else if (modname == "ldap") {
 					val = GloMyLdapAuth->get_variable(r->fields[0]);
+				} else if (modname == "tsdb") {
+					val = GloProxyStats->get_variable(r->fields[0]);
 				}
 				char q[1000];
 					if (val) {
@@ -612,6 +616,25 @@ void ProxySQL_Admin::flush_sqliteserver_variables___database_to_runtime(SQLite3D
 		//GloClickHouse->commit();
 		GloSQLite3Server->wrunlock();
 	}
+	if (resultset) delete resultset;
+}
+
+void ProxySQL_Admin::flush_tsdb_variables___database_to_runtime(SQLite3DB *db, bool replace) {
+	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing TSDB variables. Replace:%d\n", replace);
+	if (GloProxyStats == NULL) {
+		return;
+	}
+
+	char *error=NULL;
+	int cols=0;
+	int affected_rows=0;
+	SQLite3_result *resultset=NULL;
+
+	if (flush_GENERIC_variables__retrieve__database_to_runtime("tsdb", error, cols, affected_rows, resultset) == true) {
+		flush_GENERIC_variables__process__database_to_runtime("tsdb", db, resultset, false, replace, {}, {}, {}, {});
+		flush_tsdb_variables___runtime_to_database(admindb, false, false, false, true);
+	}
+
 	if (resultset) delete resultset;
 }
 

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -9085,60 +9085,6 @@ void ProxySQL_Admin::enable_aurora_testing() {
 }
 #endif // TEST_AURORA
 
-void ProxySQL_Admin::load_tsdb_variables_to_runtime() {
-	if (GloProxyStats == NULL) {
-		return;
-	}
-	char *error=NULL;
-	int cols=0;
-	int affected_rows=0;
-	SQLite3_result *resultset=NULL;
-	// TSDB variables are in global_variables named 'tsdb-%'
-	if (flush_GENERIC_variables__retrieve__database_to_runtime("tsdb", error, cols, affected_rows, resultset) == true) {
-		for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
-			SQLite3_row *r=*it;
-			const char *name = r->fields[0];
-			const char *value = r->fields[1];
-			GloProxyStats->set_variable(name, value);
-		}
-		flush_tsdb_variables___runtime_to_database(admindb, false, false, false, true);
-	}
-	if (resultset) delete resultset;
-}
-
-void ProxySQL_Admin::save_tsdb_variables_from_runtime() {
-	if (GloProxyStats == NULL) {
-		return;
-	}
-	char **tsdb_vars = GloProxyStats->get_variables_list();
-	const char *query = "REPLACE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)";
-
-	stmt_unique_ptr u_stmt { nullptr };
-	int rc;
-
-	std::tie(rc, u_stmt) = admindb->prepare_v2(query);
-	ASSERT_SQLITE_OK(rc, admindb);
-
-	for (int i=0; tsdb_vars[i]; i++) {
-		char *val = GloProxyStats->get_variable(tsdb_vars[i]);
-		if (val) {
-			char qualified_name[128];
-			snprintf(qualified_name, sizeof(qualified_name), "tsdb-%s", tsdb_vars[i]);
-
-			rc = (*proxy_sqlite3_bind_text)(u_stmt.get(), 1, qualified_name, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb);
-			rc = (*proxy_sqlite3_bind_text)(u_stmt.get(), 2, val, -1, SQLITE_TRANSIENT); ASSERT_SQLITE_OK(rc, admindb);
-			rc = (*proxy_sqlite3_step)(u_stmt.get());
-			if (rc != SQLITE_DONE) { ASSERT_SQLITE_OK(rc, admindb); }
-			rc = (*proxy_sqlite3_reset)(u_stmt.get()); ASSERT_SQLITE_OK(rc, admindb);
-			rc = (*proxy_sqlite3_clear_bindings)(u_stmt.get()); ASSERT_SQLITE_OK(rc, admindb);
-
-			free(val);
-		}
-		free(tsdb_vars[i]);
-	}
-	free(tsdb_vars);
-}
-
 #ifdef TEST_GROUPREP
 void ProxySQL_Admin::enable_grouprep_testing() {
 	proxy_info("Admin is enabling Group Replication Testing using SQLite3 Server and HGs from 3271 to 3274\n");

--- a/lib/ProxySQL_Statistics.cpp
+++ b/lib/ProxySQL_Statistics.cpp
@@ -1803,6 +1803,10 @@ void ProxySQL_Statistics::tsdb_sampler_loop() {
 
     // Sample Prometheus metrics if registry exists
     if (GloVars.prometheus_registry) {
+        // Refresh all module metrics before collecting, ensuring gauges
+        // and counters reflect the current state (mirrors what the
+        // Prometheus /metrics endpoint does via serial_exposer).
+        update_modules_metrics();
         auto metrics = GloVars.prometheus_registry->Collect();
         time_t now = time(NULL);
         statsdb_disk->execute("BEGIN");


### PR DESCRIPTION
- `tsdb_sampler_loop()` calls `registry->Collect()` without refreshing module metrics, causing stale metric values to be stored in the TSDB. Added `update_modules_metrics()` call before `Collect()` in the sampler.

- TSDB variables stored on disk were not being loaded into runtime during startup. Added the missing `flush_tsdb_variables___database_to_runtime()` and invoke it during init.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics are now automatically refreshed before collection.

* **Refactor**
  * TSDB variable initialization refactored to use unified synchronization approach.
  * TSDB variable handling consolidated for improved consistency across startup sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->