### PR TITLE
Parse GTID ranges on proxysql_mysqlbinlog update messages.

### DIFF
--- a/include/GTID_Server_Data.h
+++ b/include/GTID_Server_Data.h
@@ -31,7 +31,4 @@ class GTID_Server_Data {
 	void dump();
 };
 
-// TODO: replace me by a method once GTID sets are rewritten into a class.
-bool addGtidInterval(const std::string& uuid, const gtid_interval_t &iv, gtid_set_t& gtid_executed);
-
 #endif // CLASS_GTID_Server_Data_H

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -138,9 +138,6 @@ class MyHGC;
 struct peer_runtime_mysql_servers_t;
 struct peer_mysql_servers_v2_t;
 
-std::string gtid_executed_to_string(gtid_set_t& gtid_executed);
-void addGtid(const gtid_t& gtid, gtid_set_t& gtid_executed);
-
 #include "GTID_Server_Data.h"
 
 /*

--- a/include/proxysql_gtid.h
+++ b/include/proxysql_gtid.h
@@ -7,22 +7,36 @@
 #include <unordered_map>
 #include <utility>
 
-typedef std::pair<std::string, int64_t> gtid_t;
+typedef int64_t gtid_t;
 
+// Encapsulates a UUID:GTID pair.
+class Uuid_Gtid {
+	public:
+		std::string uuid;
+		gtid_t gtid;
+
+	public:
+		Uuid_Gtid(const std::string _uuid, const gtid_t _gtid);
+
+		Uuid_Gtid copy();
+};
+typedef Uuid_Gtid ugtid_t;
+
+// Encapsulates an interval of GTIDs.
 class Gtid_Interval {
 	public:
-		int64_t start;
-		int64_t end;
+		gtid_t start;
+		gtid_t end;
 
 	public:
-		explicit Gtid_Interval(const int64_t gtid);
 		explicit Gtid_Interval(const int64_t _start, const int64_t _end);
+		explicit Gtid_Interval(const gtid_t gtid);
 		explicit Gtid_Interval(const char* s);
 		explicit Gtid_Interval(const std::string& s);
 
-		const std::string to_string(void);
 		const bool contains(const Gtid_Interval& other);
-		const bool contains(int64_t gtid);
+		const bool contains(gtid_t gtid);
+		const std::string to_string(void);
 		const bool append(const Gtid_Interval& other);
 		const bool merge(const Gtid_Interval& other);
 
@@ -33,27 +47,26 @@ class Gtid_Interval {
 };
 typedef Gtid_Interval gtid_interval_t;
 
-// TODO: make me a proper class.
-typedef std::unordered_map<std::string, std::list<gtid_interval_t>> gtid_set_t;
-
-/*
-class Gtid_Server_Info {
+// Encapsulates a map of UUID -> GTID intervals.
+class Gtid_Set {
 	public:
-	gtid_set_t executed_gtid_set;
-	char *hostname;
-	uint16_t mysql_port;
-	uint16_t gtid_port;
-	bool active;
-	Gtid_Server_Info(char *_h, uint16_t _mp, uint16_t _gp) {
-		hostname = strdup(_h);
-		mysql_port = _mp;
-		gtid_port = _gp;
-		active = true;
-	};
-	~Gtid_Server_Info() {
-		free(hostname);
-	};
+		std::unordered_map<std::string, std::list<gtid_interval_t>> map;
+
+	public:
+		Gtid_Set();
+
+		Gtid_Set copy();
+		void clear();
+
+		bool add(const std::string& uuid, const gtid_interval_t& iv);
+		bool add(const std::string& uuid, const gtid_t& gtid);
+		bool add(const std::string& uuid, const gtid_t& start, const gtid_t& end);
+		bool add(const std::string& uuid, const char *s);
+		bool add(const std::string& uuid, const std::string &s);
+
+		const bool has_gtid(const std::string& uuid, const gtid_t gtid);
+		const std::string to_string(void);
 };
-*/
+typedef Gtid_Set gtid_set_t;
 
 #endif /* PROXYSQL_GTID */

--- a/lib/GTID_Server_Data.cpp
+++ b/lib/GTID_Server_Data.cpp
@@ -261,21 +261,7 @@ bool GTID_Server_Data::readall() {
 
 
 bool GTID_Server_Data::gtid_exists(char *gtid_uuid, uint64_t gtid_trxid) {
-	std::string s = gtid_uuid;
-	auto it = gtid_executed.find(s);
-//	fprintf(stderr,"Checking if server %s:%d has GTID %s:%lu ... ", address, port, gtid_uuid, gtid_trxid);
-	if (it == gtid_executed.end()) {
-//		fprintf(stderr,"NO\n");
-		return false;
-	}
-	for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
-		if (itr->contains((int64_t)gtid_trxid)) {
-//			fprintf(stderr,"YES\n");
-			return true;
-		}
-	}
-//	fprintf(stderr,"NO\n");
-	return false;
+	return gtid_executed.has_gtid((std::string)gtid_uuid, (gtid_t)gtid_trxid);
 }
 
 void GTID_Server_Data::read_all_gtids() {
@@ -313,6 +299,13 @@ bool GTID_Server_Data::writeout() {
 	return ret;
 }
 
+/*
+ * The wire format for the binlogreader is three distinct messages, in plaintext:
+ *
+ * ST=<uuid>:<gtid>[-<gtid>][,<uuid>:<gtid>[-<gtid>], ...] : Bootstrap message, providing individual GTID or GTID ranges for all seen UUID servers.
+ * I1=<uuid>:<gtid>[-<gtid>]                               : Latest seen GTID/GTID ranges for a given UUID.
+ * I2=<gtid>[-<gtid>]                                      : Latest seen GTID/GTID ranges.
+ */
 bool GTID_Server_Data::read_next_gtid() {
 	if (len==0) {
 		return false;
@@ -358,10 +351,8 @@ bool GTID_Server_Data::read_next_gtid() {
 						}
 					}
 				} else { // we are reading the trxids
-					std::string s = uuid_server;
-					gtid_interval_t iv = Gtid_Interval(subtoken);
-					updated = addGtidInterval(s, iv, gtid_executed) || updated;
-			   }
+					updated = gtid_executed.add((std::string)uuid_server, subtoken) || updated;
+				}
 			}
 		}
 		pos += l+1;
@@ -375,7 +366,6 @@ bool GTID_Server_Data::read_next_gtid() {
 		pos += l+1;
 		rec_msg[l] = 0;
 		if (rec_msg[0]=='I') {
-			uint64_t rec_trxid = 0;
 			char *a = NULL;
 			int ul = 0;
 			switch (rec_msg[1]) {
@@ -384,89 +374,17 @@ bool GTID_Server_Data::read_next_gtid() {
 					ul = a-rec_msg-3;
 					strncpy(uuid_server,rec_msg+3,ul);
 					uuid_server[ul] = 0;
-					rec_trxid=atoll(a+1);
+					gtid_executed.add((std::string)uuid_server, a+1);
 					break;
 				case '2':
-					rec_trxid=atoll(rec_msg+3);
+					gtid_executed.add((std::string)uuid_server, rec_msg+3);
 					break;
 				default:
 					break;
 			}
-			std::string s = uuid_server;
-			gtid_interval_t iv = Gtid_Interval(rec_trxid);
-			addGtidInterval(s, iv, gtid_executed);
 			events_read++;
 		}
 	}
-	return true;
-}
-
-std::string gtid_executed_to_string(gtid_set_t& gtid_executed) {
-	std::string gtid_set;
-	for (auto it=gtid_executed.begin(); it!=gtid_executed.end(); ++it) {
-		std::string s = it->first;
-		s.insert(8,"-");
-		s.insert(13,"-");
-		s.insert(18,"-");
-		s.insert(23,"-");
-		s = s + ":";
-		for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
-			gtid_set += s + itr->to_string() + ",";
-		}
-	}
-	// Extract latest comma only in case 'gtid_executed' isn't empty
-	if (gtid_set.empty() == false) {
-		gtid_set.pop_back();
-	}
-	return gtid_set;
-}
-
-
-// Merges a GTID interval into a gitd_executed instance. Returns true if gtid_executed was updated, false otherwise.
-bool addGtidInterval(const std::string& uuid, const gtid_interval_t &iv, gtid_set_t& gtid_executed) {
-	auto it = gtid_executed.find(uuid);
-	if (it == gtid_executed.end()) {
-		// new UUID entry
-		gtid_executed[uuid].emplace_back(iv);
-		return true;
-	}
-
-	if (!it->second.empty()) {
-		if (it->second.back().append(iv)) {
-			// if appending to the last GTID range succeded, gtid_executed was modified, but remains optimized - nothing else to do
-			return true;
-		}
-	}
-
-	// insert/merge GTID interval...
-	auto pos = it->second.begin();
-	for (; pos != it->second.end(); ++pos) {
-		if (pos->contains(iv)) {
-			// GTID interval is already present, nothing to do
-			return false;
-		}
-		if (pos->merge(iv))
-			break;
-	}
-	if (pos == it->second.end()) {
-		it->second.emplace_back(iv);
-	}
-
-	// ...and merge overlapping GTID ranges, if any
-	it->second.sort();
-	auto a = it->second.begin();
-	while (a != it->second.end()) {
-		auto b = std::next(a);
-		if (b == it->second.end()) {
-			break;
-		}
-		if (a->merge(*b)) {
-				it->second.erase(b);
-				continue;
-		}
-		a++;
-	}
-
 	return true;
 }
 

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -5538,7 +5538,7 @@ SQLite3_result * MySQL_HostGroups_Manager::get_stats_mysql_gtid_executed() {
 			sprintf(buf,"%d", (int)gtid_si->mysql_port);
 			pta[1]=strdup(buf);
 			//sprintf(buf,"%d", mysrvc->port);
-			string s1 = gtid_executed_to_string(gtid_si->gtid_executed);
+			string s1 = gtid_si->gtid_executed.to_string();
 			pta[2]=strdup(s1.c_str());
 			sprintf(buf,"%llu", gtid_si->events_read);
 			pta[3]=strdup(buf);

--- a/lib/proxysql_gtid.cpp
+++ b/lib/proxysql_gtid.cpp
@@ -2,18 +2,22 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <sstream>
 
 #include "proxysql_gtid.h"
 
+// Initializes a UUID:GTID pair.
+Uuid_Gtid::Uuid_Gtid(const std::string _uuid, const gtid_t _gtid) : uuid(_uuid), gtid(_gtid) {
+}
 
-// Initializes a GTID interval from a single GTID.
-Gtid_Interval::Gtid_Interval(const int64_t gtid) {
-	start = gtid;
-	end = gtid;
+// Copies a UUID:GTID pair.
+Uuid_Gtid Uuid_Gtid::copy() {
+	return Uuid_Gtid(uuid, gtid);
+
 }
 
 // Initializes a GTID interval from a range.
-Gtid_Interval::Gtid_Interval(const int64_t _start, const int64_t _end) {
+Gtid_Interval::Gtid_Interval(const gtid_t _start, const gtid_t _end) {
 	start = _start;
 	end = _end;
 
@@ -22,14 +26,17 @@ Gtid_Interval::Gtid_Interval(const int64_t _start, const int64_t _end) {
 	}
 }
 
-// Initializes a GTID interval from a string buffer, in [gtid]{-[gtid]} format.
-Gtid_Interval::Gtid_Interval(const char *s) {
-	uint64_t _start = 0, _end = 0;
+Gtid_Interval::Gtid_Interval(const gtid_t gtid) : Gtid_Interval(gtid, gtid) {
+}
 
-	if (sscanf(s, "%lu-%lu", &_start, &_end) == 2) {
+// Initializes a GTID interval from a C string buffer, in [gtid]{-[gtid]} format.
+Gtid_Interval::Gtid_Interval(const char *s) {
+	gtid_t _start = 0, _end = 0;
+
+	if (sscanf(s, "%ld-%ld", &_start, &_end) == 2) {
 		start = _start;
 		end = _end;
-	} else if (sscanf(s, "%lu", &_start) == 1) {
+	} else if (sscanf(s, "%ld", &_start) == 1) {
 		start = _start;
 		end = _start;
 	}
@@ -39,6 +46,7 @@ Gtid_Interval::Gtid_Interval(const char *s) {
 	}
 }
 
+// Initializes a GTID interval from a string, in [gtid]{-[gtid]} format.
 Gtid_Interval::Gtid_Interval(const std::string& s) : Gtid_Interval(s.c_str()) {
 }
 
@@ -48,7 +56,7 @@ const bool Gtid_Interval::contains(const Gtid_Interval& other) {
 }
 
 // Checks if a given GTID is contained in this interval.
-const bool Gtid_Interval::contains(int64_t gtid) {
+const bool Gtid_Interval::contains(gtid_t gtid) {
 	return (gtid >= start && gtid <= end);
 }
 
@@ -124,4 +132,128 @@ const bool Gtid_Interval::operator==(const Gtid_Interval& other) {
 
 const bool Gtid_Interval::operator!=(const Gtid_Interval& other) {
 	return cmp(other) != 0;
+}
+
+// Initializes a GTID interval set.
+Gtid_Set::Gtid_Set() {}
+
+// Creates a copy of this GTID interval set.
+Gtid_Set Gtid_Set::copy() {
+	auto cp = Gtid_Set();
+
+	for (auto const& x : map) {
+		for (auto const& iv : x.second) {
+			cp.map[x.first].emplace_back(iv);
+		}
+	}
+
+	return cp;
+}
+
+// Clears all GTID interval set entries.
+void Gtid_Set::clear() {
+	map.clear();
+}
+
+// Adds a new GTID interval for a given UUID. Returns true if the set was modified, false otherwise.
+bool Gtid_Set::add(const std::string& uuid, const gtid_interval_t& iv) {
+	auto it = map.find(uuid);
+	if (it == map.end()) {
+		// new UUID entry
+		map[uuid].emplace_back(iv);
+		return true;
+	}
+
+	if (!it->second.empty()) {
+		if (it->second.back().append(iv)) {
+			// if appending to the last GTID range succeded, gtid_executed was modified, but remains optimized - nothing else to do
+			return true;
+		}
+	}
+
+	// insert/merge GTID interval...
+	auto pos = it->second.begin();
+	for (; pos != it->second.end(); ++pos) {
+		if (pos->contains(iv)) {
+			// GTID interval is already present, nothing to do
+			return false;
+		}
+		if (pos->merge(iv))
+			break;
+	}
+	if (pos == it->second.end()) {
+		it->second.emplace_back(iv);
+	}
+
+	// ...and merge overlapping GTID ranges, if any
+	it->second.sort();
+	auto a = it->second.begin();
+	while (a != it->second.end()) {
+		auto b = std::next(a);
+		if (b == it->second.end()) {
+			break;
+		}
+		if (a->merge(*b)) {
+				it->second.erase(b);
+				continue;
+		}
+		a++;
+	}
+
+	return true;
+}
+
+// Adds a single GTID for a given UUID. Returns true if the set was modified, false otherwise.
+bool Gtid_Set::add(const std::string& uuid, const gtid_t& gtid) {
+	return add(uuid, gtid_interval_t(gtid));
+}
+
+// Adds a new GTID range for a given UUID. Returns true if the set was modified, false otherwise.
+bool Gtid_Set::add(const std::string& uuid, const gtid_t& start, const gtid_t& end) {
+	return add(uuid, gtid_interval_t(start, end));
+}
+
+// Adds a new GTID range for a given UUID, as a C string buffer. Returns true if the set was modified, false otherwise.
+bool Gtid_Set::add(const std::string& uuid, const char *s) {
+	return add(uuid, gtid_interval_t(s));
+}
+
+// Adds a new GTID range for a given UUID, as a string. Returns true if the set was modified, false otherwise.
+bool Gtid_Set::add(const std::string& uuid, const std::string& s) {
+	return add(uuid, gtid_interval_t(s));
+}
+
+// Evaluates whether a GTID is present in any of the intervals for a given UUID.
+const bool Gtid_Set::has_gtid(const std::string& uuid, const gtid_t gtid) {
+	auto it = map.find(uuid);
+	if (it == map.end()) {
+		return false;
+	}
+	for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+		if (itr->contains(gtid)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// Yields a string representation for a GTID interval set.
+const std::string Gtid_Set::to_string(void) {
+	std::stringstream out;
+	for (auto it=map.begin(); it!=map.end(); ++it) {
+		std::string uuid = it->first;
+		uuid.insert(8,"-");
+		uuid.insert(13,"-");
+		uuid.insert(18,"-");
+		uuid.insert(23,"-");
+		for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+			if(itr != it->second.begin()) {
+				out << ",";
+			}
+			out << uuid << ":" << itr->to_string();
+		}
+	}
+
+	return out.str();
 }

--- a/test/tap/tests/unit-gtid_interval-t.cpp
+++ b/test/tap/tests/unit-gtid_interval-t.cpp
@@ -7,11 +7,13 @@
 using std::string;
 
 int testGtidIntervalFromString_Count() {
-    return 2;
+    return 4;
 }
 void testGtidIntervalFromString() {
-	ok(gtid_interval_t("123-456") == gtid_interval_t(123, 456), "GTID interval from range string");
-	ok(gtid_interval_t("111") == gtid_interval_t(111, 111), "GTID interval from single GTID string");
+	ok(gtid_interval_t("123-456") == gtid_interval_t(123, 456), "GTID interval from range C string");
+	ok(gtid_interval_t(std::string("789-1234")) == gtid_interval_t(789, 1234), "GTID interval from range C++ string");
+	ok(gtid_interval_t("111") == gtid_interval_t(111, 111), "GTID interval from single GTID C string");
+	ok(gtid_interval_t(std::string("222")) == gtid_interval_t(222, 222), "GTID interval from single GTID C++ string");
 }
 
 int testGtidIntervalContains_Count() {
@@ -45,22 +47,6 @@ void testGtidIntervalAppend() {
 	iv = gtid_interval_t(123, 456);
 	ok(iv.append(gtid_interval_t(200, 600)), "append with overlap");
 	ok(iv.to_string() == "123-600", "append with overlap result");
-}
-
-int testAddGtidInterval_Count() {
-	return 8;
-}
-void testAddGtidInterval() {
-	gtid_set_t gtid_set;
-
-	ok(addGtidInterval("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_interval_t(10, 20), gtid_set), "new GTID range for server A");
-	ok(addGtidInterval("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_interval_t(9, 22), gtid_set), "new GTID range with partial overlap for server A");
-	ok(addGtidInterval("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_interval_t(18, 30), gtid_set), "new GTID range with partial overlap for server A");
-	ok(!addGtidInterval("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_interval_t(15, 22), gtid_set), "GTID range is already fully contained for server A");
-	ok(addGtidInterval("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_interval_t(40, 50), gtid_set), "new GTID range with gap for server A");
-	ok(addGtidInterval("bbbbbbbb333344445555bbbbbbbbbbbb", gtid_interval_t(10, 30), gtid_set), "new GTID range for server B");
-	ok(addGtidInterval("bbbbbbbb333344445555bbbbbbbbbbbb", gtid_interval_t(31, 50), gtid_set), "new GTID range for server B");
-	ok(gtid_set_to_string(gtid_set) == "aaaaaaaa-0000-1111-2222-aaaaaaaaaaaa:10-30,aaaaaaaa-0000-1111-2222-aaaaaaaaaaaa:40-50,bbbbbbbb-3333-4444-5555-bbbbbbbbbbbb:10-50", "add interval result");
 }
 
 int testGtidIntervalMerge_Count() {
@@ -100,19 +86,72 @@ void testGtidIntervalMerge() {
 	ok(iv == want, "merge append at end result");
 }
 
+int testGtidSetAdd_Count() {
+	return 9;
+}
+void testGtidSetAdd() {
+	gtid_set_t gtid_set;
+
+	ok(gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_interval_t(10, 20)), "new GTID range for server A");
+	ok(!gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_t(14)), "single GTID range for server A, contained");
+	ok(gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", "9-22"), "new GTID range with partial overlap for server A");
+	ok(gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", std::string("18-30")), "new GTID range with partial overlap for server A");
+	ok(!gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_interval_t(15, 22)), "GTID range is already fully contained for server A");
+	ok(gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", gtid_t(40), gtid_t(50)), "new GTID range with gap for server A");
+	ok(gtid_set.add("bbbbbbbb333344445555bbbbbbbbbbbb", gtid_interval_t(10, 30)), "new GTID range for server B");
+	ok(gtid_set.add("bbbbbbbb333344445555bbbbbbbbbbbb", "31-50"), "new GTID range for server B");
+
+	ok(gtid_set.to_string() == "aaaaaaaa-0000-1111-2222-aaaaaaaaaaaa:10-30,aaaaaaaa-0000-1111-2222-aaaaaaaaaaaa:40-50,bbbbbbbb-3333-4444-5555-bbbbbbbbbbbb:10-50", "add interval result");
+}
+
+int testGtidSetContains_Count() {
+	return 19;
+}
+void testGtidSetContains() {
+	gtid_set_t gtid_set;
+
+	ok(gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", "10-20"), "new GTID range for server A");
+	ok(gtid_set.add("aaaaaaaa000011112222aaaaaaaaaaaa", "30-40"), "split GTID range for server A");
+	ok(gtid_set.add("bbbbbbbb333344445555bbbbbbbbbbbb", gtid_interval_t(100, 200)), "new GTID range for server B");
+
+	ok(!gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 7), "before GTID range for server A");
+	ok(gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 10), "in GTID range for server A");
+	ok(gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 16), "in GTID range for server A");
+	ok(gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 20), "in GTID range for server A");
+	ok(!gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 55), "past GTID range for server A");
+
+	ok(!gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 74), "before GTID range for server B");
+	ok(gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 100), "in GTID range for server B");
+	ok(gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 168), "in GTID range for server B");
+	ok(gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 200), "in GTID range for server B");
+	ok(!gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 201), "past GTID range for server B");
+
+	gtid_set.clear();
+
+	ok(!gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 7), "no GTID ranges after clear for server A");
+	ok(!gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 16), "no GTID ranges after clear for server A");
+	ok(!gtid_set.has_gtid("aaaaaaaa000011112222aaaaaaaaaaaa", 55), "no GTID ranges after clear for server A");
+
+	ok(!gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 74), "no GTID ranges after clear for server B");
+	ok(!gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 168), "no GTID ranges after clear for server B");
+	ok(!gtid_set.has_gtid("bbbbbbbb333344445555bbbbbbbbbbbb", 345), "no GTID ranges after clear for server B");
+}
+
 std::function<int(void)> testFunctionCounts[] = {
 	testGtidIntervalFromString_Count,
 	testGtidIntervalContains_Count,
 	testGtidIntervalAppend_Count,
 	testGtidIntervalMerge_Count,
-	testAddGtidInterval_Count,
+	testGtidSetAdd_Count,
+	testGtidSetContains_Count,
 };
 std::function<void(void)> testFunctions[] = {
 	testGtidIntervalFromString,
 	testGtidIntervalContains,
 	testGtidIntervalAppend,
 	testGtidIntervalMerge,
-	testAddGtidInterval,
+	testGtidSetAdd,
+	testGtidSetContains,
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Following up on https://github.com/sysown/proxysql/pull/5224, this PR adds full support for ranges in `proxysql_mysqlbinlog` update messages, while also improving efficiency when dealing with GTID gaps for any given UUID.

Single GTID updates are transparently supported, so older `proxysql_mysqlbinlog` version will continue to work with newer ProxySQL releases.

See https://github.com/sysown/proxysql_mysqlbinlog/issues/33 for details.

Once this change is merged, i'll upload the last PR to batch GTID updates as ranges in `proxysql_mysqlbinlog`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GTID management capabilities with improved methods for building and querying transaction identifier sets

* **Refactor**
  * Restructured internal GTID handling with simplified and more consistent API for managing transaction identifiers
  * Removed deprecated public methods from public interfaces

* **Tests**
  * Expanded test coverage for GTID set operations and interval parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->