### PR TITLE
fix: minor build fixes and improvements

### DIFF
--- a/common_mk/openssl_flags.mk
+++ b/common_mk/openssl_flags.mk
@@ -22,28 +22,28 @@ ifeq ($(CUSTOM_OPENSSL_PATH),)
     ifeq ($(OPENSSL_PACKAGE),openssl3)
         SSL_IDIR := $(shell pkg-config --cflags $(OPENSSL_PACKAGE) | sed -E 's/-I/ /g' | awk '{for(i=1;i<=NF;i++) if($$i ~ /^\//) print $$i}' | head -n 1)
         SSL_LDIR := $(shell pkg-config --variable=libdir $(OPENSSL_PACKAGE))
-        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so.3" 2>/dev/null | head -n 1)
-        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so.3" 2>/dev/null | head -n 1)
+        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.so.3" 2>/dev/null | head -n 1)
+        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.so.3" 2>/dev/null | head -n 1)
     else
         SSL_IDIR := $(shell export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1; export PKG_CONFIG_ALLOW_SYSTEM_LIBS=1; pkg-config --cflags $(OPENSSL_PACKAGE) | sed -E 's/-I/ /g' | awk '{for(i=1;i<=NF;i++) if($$i ~ /^\//) print $$i}' | head -n 1)
         SSL_LDIR := $(shell pkg-config --variable=libdir $(OPENSSL_PACKAGE))
 ifeq ($(UNAME_S),Darwin)
-        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.dylib" 2>/dev/null | head -n 1)
+        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.dylib" 2>/dev/null | head -n 1)
         ifeq ($(LIB_SSL_PATH),)
-            LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.a" 2>/dev/null | head -n 1)
+            LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.a" 2>/dev/null | head -n 1)
         endif
-        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.dylib" 2>/dev/null | head -n 1)
+        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.dylib" 2>/dev/null | head -n 1)
         ifeq ($(LIB_CRYPTO_PATH),)
-            LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.a" 2>/dev/null | head -n 1)
+            LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.a" 2>/dev/null | head -n 1)
         endif
 else
-        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so*" 2>/dev/null | head -n 1)
+        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.so*" 2>/dev/null | head -n 1)
         ifeq ($(LIB_SSL_PATH),)
-            LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.a" 2>/dev/null | head -n 1)
+            LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.a" 2>/dev/null | head -n 1)
         endif
-        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so*" 2>/dev/null | head -n 1)
+        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.so*" 2>/dev/null | head -n 1)
         ifeq ($(LIB_CRYPTO_PATH),)
-            LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.a" 2>/dev/null | head -n 1)
+            LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.a" 2>/dev/null | head -n 1)
         endif
 endif
     endif
@@ -55,22 +55,22 @@ else
     SSL_LDIR := $(CUSTOM_OPENSSL_PATH)/lib64
 endif
 ifeq ($(UNAME_S),Darwin)
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.dylib" 2>/dev/null | head -n 1)
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.dylib" 2>/dev/null | head -n 1)
     ifeq ($(LIB_SSL_PATH),)
-        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.a" 2>/dev/null | head -n 1)
+        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.a" 2>/dev/null | head -n 1)
     endif
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.dylib" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.dylib" 2>/dev/null | head -n 1)
     ifeq ($(LIB_CRYPTO_PATH),)
-        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.a" 2>/dev/null | head -n 1)
+        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.a" 2>/dev/null | head -n 1)
     endif
 else
-    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.so" 2>/dev/null | head -n 1)
+    LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.so" 2>/dev/null | head -n 1)
     ifeq ($(LIB_SSL_PATH),)
-        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -name "libssl.a" 2>/dev/null | head -n 1)
+        LIB_SSL_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libssl.a" 2>/dev/null | head -n 1)
     endif
-    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.so" 2>/dev/null | head -n 1)
+    LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.so" 2>/dev/null | head -n 1)
     ifeq ($(LIB_CRYPTO_PATH),)
-        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -name "libcrypto.a" 2>/dev/null | head -n 1)
+        LIB_CRYPTO_PATH := $(shell find $(SSL_LDIR) -maxdepth 1 -name "libcrypto.a" 2>/dev/null | head -n 1)
     endif
 endif
     $(info Using custom OpenSSL path: $(CUSTOM_OPENSSL_PATH))

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -128,7 +128,7 @@ ev: libev/libev/.libs/libev.a
 coredumper/coredumper/src/libcoredumper.a:
 	cd coredumper && rm -rf coredumper-*/ || true
 	cd coredumper && tar -zxf coredumper-*.tar.gz
-	cd coredumper/coredumper && cmake . -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug
+	cd coredumper/coredumper && cmake . -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 	cd coredumper/coredumper && CC=${CC} CXX=${CXX} ${MAKE}
 
 coredumper: coredumper/coredumper/src/libcoredumper.a

--- a/test/deps/Makefile
+++ b/test/deps/Makefile
@@ -53,7 +53,10 @@ ifeq ($(UNAME_S),Darwin)
 	cd mysql-connector-c/mysql-connector-c && cmake . -DWITH_BOOST=./boost -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O0 -ggdb -DNDEBUG -fPIC" -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DWITH_SSL=$$(brew --prefix openssl@3) -DOPENSSL_ROOT_DIR=$$(brew --prefix openssl@3)
 else
 	cd mysql-connector-c && ln -fsT $$(ls -1d mysql-5.7.*/) mysql-connector-c
-	cd mysql-connector-c/mysql-connector-c && cmake . -DWITH_BOOST=./boost -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O0 -ggdb -DNDEBUG -fPIC" -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+	cd mysql-connector-c/mysql-connector-c && cmake3 . -DWITH_BOOST=./boost \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS="-Wno-incompatible-pointer-types" \
+		-DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O0 -ggdb -DNDEBUG -fPIC -Wno-incompatible-pointer-types" \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 endif
 ifeq ($(UNAME_S),Darwin)
 	cd mysql-connector-c/mysql-connector-c && CC=${CC} CXX=${CXX} ${MAKE} -j1 mysqlclient mysql

--- a/test/deps/Makefile
+++ b/test/deps/Makefile
@@ -6,6 +6,7 @@ DEPS_PATH := $(PROXYSQL_PATH)/deps
 include $(PROXYSQL_PATH)/include/makefiles_vars.mk
 include $(PROXYSQL_PATH)/include/makefiles_paths.mk
 
+CMAKE3 ?= cmake3
 
 .DEFAULT: default
 .PHONY: default
@@ -50,10 +51,13 @@ ifeq ($(UNAME_S),Darwin)
 		sed -i '' 's/CMAKE_POLICY(SET CMP0075 OLD)/CMAKE_POLICY(SET CMP0075 NEW)/' $${mysql_dir}CMakeLists.txt && \
 		sed -i '' 's/#      ifndef fdopen/#      if !defined(fdopen) \&\& !defined(__APPLE__)/' $${mysql_dir}extra/zlib/zlib-1.2.13/zutil.h
 	cd mysql-connector-c && ln -fsh $$(ls -1d mysql-5.7.*/) mysql-connector-c
-	cd mysql-connector-c/mysql-connector-c && cmake . -DWITH_BOOST=./boost -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O0 -ggdb -DNDEBUG -fPIC" -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DWITH_SSL=$$(brew --prefix openssl@3) -DOPENSSL_ROOT_DIR=$$(brew --prefix openssl@3)
+	cd mysql-connector-c/mysql-connector-c && cmake . -DWITH_BOOST=./boost -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_C_FLAGS="-Wno-incompatible-pointer-types" \
+		-DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O0 -ggdb -DNDEBUG -fPIC -Wno-incompatible-pointer-types" \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DWITH_SSL=$$(brew --prefix openssl@3) -DOPENSSL_ROOT_DIR=$$(brew --prefix openssl@3)
 else
 	cd mysql-connector-c && ln -fsT $$(ls -1d mysql-5.7.*/) mysql-connector-c
-	cd mysql-connector-c/mysql-connector-c && cmake3 . -DWITH_BOOST=./boost \
+	cd mysql-connector-c/mysql-connector-c && $(CMAKE3) . -DWITH_BOOST=./boost \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS="-Wno-incompatible-pointer-types" \
 		-DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O0 -ggdb -DNDEBUG -fPIC -Wno-incompatible-pointer-types" \
 		-DCMAKE_POLICY_VERSION_MINIMUM=3.5


### PR DESCRIPTION
## Purpose

This PR holds minor fixes for compilation:

- Speed up regular builds by avoiding unnecessary directory searches for OpenSSL libs f88dddaefb4e9067f5e1562e78e7e1ad1e6b7e00.
- Minor fixes for compilation in future CMake versions.

## Details

One of the fixes 2bfa23665bfbcd9d43ec0523b04231759b68626c, which is required for the testing dependencies, relies on the existence of `cmake3` binary. This should be a fixed version of CMake from the old `3` releases, the package `cmake3` from Arch Linux can be used as a reference for this https://aur.archlinux.org/packages/cmake3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Constrained library discovery to top-level directories to reduce unintended matches and speed up configuration.
  * Set a minimum build policy version to improve build consistency across environments.
  * Introduced an alternate CMake invocation variable and adjusted compiler flag handling for more reliable dependency builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->