### PR TITLE
Rollback test_binlog_reader-t.cpp to tag v3.0.5

### DIFF
--- a/test/tap/tests/test_binlog_reader-t.cpp
+++ b/test/tap/tests/test_binlog_reader-t.cpp
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <utility>
 #include <vector>
-#include <numeric>
 
 #include "mysql.h"
 #include "mysqld_error.h"
@@ -46,7 +45,6 @@ using std::map;
 using nlohmann::json;
 
 int create_testing_tables(MYSQL* mysql_server) {
-	diag("Creating testing tables...");
 	// Create the testing database
 	MYSQL_QUERY(mysql_server, "CREATE DATABASE IF NOT EXISTS test");
 	MYSQL_QUERY(mysql_server, "DROP TABLE IF EXISTS test.gtid_test");
@@ -66,7 +64,6 @@ int create_testing_tables(MYSQL* mysql_server) {
 }
 
 int insert_random_data(MYSQL* proxysql_mysql, uint32_t rows) {
-	diag("Inserting %u rows of random data...", rows);
 	int rnd_a = rand() % 1000;
 	string rnd_c = random_string(rand() % 100 + 5);
 	string rnd_pad = random_string(rand() % 50 + 5);
@@ -128,7 +125,6 @@ map<uint32_t, pair<uint32_t,uint32_t>> extract_hosgtroups_stats(const vector<mys
 }
 
 int perform_rnd_selects(const CommandLine& cl, uint32_t NUM) {
-	diag("Performing %u random selects...", NUM);
 	// Check connections only performing select doesn't contribute to GITD count
 	MYSQL* select_conn = mysql_init(NULL);
 
@@ -159,7 +155,6 @@ int perform_rnd_selects(const CommandLine& cl, uint32_t NUM) {
 }
 
 int check_gitd_tracking(const CommandLine& cl, MYSQL* proxysql_mysql, MYSQL* proxysql_admin) {
-	diag("Checking GTID tracking stats...");
 	// Check that all queries were routed to the correct hostgroup
 	MYSQL_QUERY(proxysql_admin, "SELECT hostgroup, queries, Queries_GTID_sync FROM stats.stats_mysql_connection_pool");
 	MYSQL_RES* conn_pool_stats_myres = mysql_store_result(proxysql_admin);
@@ -184,7 +179,7 @@ int check_gitd_tracking(const CommandLine& cl, MYSQL* proxysql_mysql, MYSQL* pro
 		NUM_CHECKS;    // Updates (matching number of checks)
 	uint32_t hg_1200_exp_sync_queries = NUM_CHECKS - 1;
 
-	bool hg_1200_checks = hg_1200_queries == hg_1200_exp_queries && hg_1200_sync_queries == hg_1200_exp_sync_queries;
+	bool hg_1200_checks = hg_1200_exp_queries == hg_1200_queries && hg_1200_sync_queries == hg_1200_exp_sync_queries;
 	bool hg_1201_checks = hg_1201_queries == NUM_CHECKS && hg_1201_sync_queries == NUM_CHECKS;
 
 	ok(
@@ -252,31 +247,15 @@ int main(int argc, char** argv) {
 		plan(3);
 	}
 
-	diag("Initializing test_binlog_reader-t...");
-	diag("Connecting to ProxySQL Admin on %s:%d as %s", cl.host, cl.admin_port, cl.admin_username);
-	MYSQL* proxysql_admin = mysql_init(NULL);
-	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
-		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
-		return EXIT_FAILURE;
-	}
-
-	diag("Ensuring user 'sbtest8' exists in ProxySQL with fast_forward=0");
-	MYSQL_QUERY(proxysql_admin, "INSERT OR REPLACE INTO mysql_users (username, password, active, default_hostgroup, fast_forward) VALUES ('sbtest8', 'sbtest8', 1, 0, 0)");
-	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL USERS TO RUNTIME");
-
-	diag("Connecting to ProxySQL on %s:%d as sbtest8", cl.host, cl.port);
 	MYSQL* proxysql_mysql = mysql_init(NULL);
+	MYSQL* proxysql_admin = mysql_init(NULL);
+
 	if (!mysql_real_connect(proxysql_mysql, cl.host, "sbtest8", "sbtest8", NULL, cl.port, NULL, 0)) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_mysql));
-		diag("Access denied for user 'sbtest8'. Checking if it exists in runtime_mysql_users...");
-		MYSQL_QUERY(proxysql_admin, "SELECT * FROM runtime_mysql_users WHERE username='sbtest8'");
-		MYSQL_RES* res = mysql_store_result(proxysql_admin);
-		if (res) {
-			diag("User 'sbtest8' found in runtime_mysql_users with %llu rows", mysql_num_rows(res));
-			mysql_free_result(res);
-		} else {
-			diag("User 'sbtest8' NOT found in runtime_mysql_users!");
-		}
+		return EXIT_FAILURE;
+	}
+	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
 		return EXIT_FAILURE;
 	}
 
@@ -285,7 +264,6 @@ int main(int argc, char** argv) {
 	vector<mysql_res_row> reader_2_read {};
 
 	// Reset connection pool stats
-	diag("Resetting connection pool stats...");
 	int rc = mysql_query(proxysql_admin, "SELECT * FROM stats.stats_mysql_connection_pool_reset");
 	if (rc != EXIT_SUCCESS) { goto cleanup; }
 	mysql_free_result(mysql_store_result(proxysql_admin));
@@ -297,7 +275,6 @@ int main(int argc, char** argv) {
 	rc = insert_random_data(proxysql_mysql, NUM_ROWS);
 	if (rc != EXIT_SUCCESS) { goto cleanup; }
 
-	diag("Performing %u update/select pairs...", NUM_CHECKS);
 	for (uint32_t i = 0; i < NUM_CHECKS; i++) {
 		rc = perform_update(proxysql_mysql, NUM_ROWS);
 		if (rc != EXIT_SUCCESS) { goto cleanup; }
@@ -361,6 +338,5 @@ cleanup:
 	mysql_close(proxysql_mysql);
 	mysql_close(proxysql_admin);
 
-	diag("Test completed");
 	return exit_status();
 }


### PR DESCRIPTION
The test_binlog_reader-t.cpp test was previously modified to attempt fixing issues in the new CI infrastructure. However, these fixes depended on the 'proxysql_mysqlbinlog' tool which is currently missing or not correctly provisioned in the new environment.

As the previous attempts to workaround the missing tool by dynamically detecting hostgroups and enabling GTID ports did not lead to a passing test, we are rolling back this file to its known stable state from tag v3.0.5. This aligns with the requirement to maintain test integrity while the infrastructure provisioning for the binlog reader tool is addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure by removing diagnostic logging and streamlining connection initialization logic in the binlog reader test suite.
  * Corrected comparison logic in test validation to ensure consistent value orientation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->