### PR TITLE
Build improvements for 3.1.6 and 4.0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ifeq ($(PROXYSQL31),1)
 endif
 
 # Only increment version at the top-level make to avoid double-incrementing in recursive makes
-GIT_VERSION := $(GIT_VERSION_BASE)
+GIT_VERSION ?= $(GIT_VERSION_BASE)
 ifeq ($(MAKELEVEL),0)
 # Normalize GIT_VERSION by stripping leading 'v' for arithmetic
 GIT_VERSION_NORM := $(shell echo "$(GIT_VERSION_BASE)" | sed 's/^v//')

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@
 ### export GIT_VERSION=3.x.y-dev
 ### ```
 
-GIT_VERSION ?= $(shell git describe --long --abbrev=7 2>/dev/null || git describe --long --abbrev=7 --always)
-ifndef GIT_VERSION
-    $(error GIT_VERSION is not set)
+GIT_VERSION_BASE := $(shell git describe --long --abbrev=7 2>/dev/null || git describe --long --abbrev=7 --always)
+ifndef GIT_VERSION_BASE
+    $(error GIT_VERSION_BASE is not set)
 endif
 
 ### RELEASE TIERS & FEATURE FLAGS:
@@ -54,9 +54,10 @@ ifeq ($(PROXYSQL31),1)
 endif
 
 # Only increment version at the top-level make to avoid double-incrementing in recursive makes
+GIT_VERSION := $(GIT_VERSION_BASE)
 ifeq ($(MAKELEVEL),0)
 # Normalize GIT_VERSION by stripping leading 'v' for arithmetic
-GIT_VERSION_NORM := $(shell echo "$(GIT_VERSION)" | sed 's/^v//')
+GIT_VERSION_NORM := $(shell echo "$(GIT_VERSION_BASE)" | sed 's/^v//')
 # If PROXYSQLGENAI is enabled, increment the major version number by 1
 ifeq ($(PROXYSQLGENAI),1)
 	GIT_VERSION := $(shell echo "$(GIT_VERSION_NORM)" | awk -F. '{printf "%d.%s", $$1+1, substr($$0, length($$1)+2)}')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 ####################################################################################################
   _build:
     image: none
-    network_mode: bridge
+    network_mode: host
     privileged: true
     environment:
       - MAKE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - WITHASAN
       - BLD_NAME
       - PROXYSQLGENAI
+      - PROXYSQL31
+      - PROXYSQLFFTO
+      - PROXYSQLTSDB
       - GIT_VERSION
     command: bash -l -c /opt/entrypoint/entrypoint.bash
 


### PR DESCRIPTION
This PR fixes issues in the build process:
1. Switched build containers to `network_mode: host` to allow internet access (required for Rust/Cargo in 4.0.6).
2. Passed `PROXYSQL31`, `PROXYSQLFFTO`, and `PROXYSQLTSDB` into the build container to ensure 3.1.6 is correctly compiled with its specific defines.
3. Updated the `touch` command in the Makefile to exclude large/protected directories like `ci_infra_logs`, `binaries`, and `deps`, preventing permission errors during build setup.
4. Fixed the `docker compose` project name by ensuring all dots in the version string are substituted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched build service networking to host mode to improve connectivity and deployment behavior.
  * Added three environment variables to enable additional proxy integrations.
  * Refined release versioning: introduced a base git-derived version source and updated normalization and conditional increment logic to correctly handle different build scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->