### PR TITLE
Resolve 3.0.6 build failures under FreeBSD

### DIFF
--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -228,9 +228,9 @@ public:
 #ifdef IDLE_THREADS
 	PtrArray* idle_mysql_sessions;
 	PtrArray* resume_mysql_sessions;
+	CopyCmdMatcher *copy_cmd_matcher;
 	pgsql_conn_exchange_t myexchange;
 #endif // IDLE_THREADS
-	CopyCmdMatcher *copy_cmd_matcher;
 
 	int pipefd[2];
 	PgSQL_Session_Interrupt_Queue_t sess_intrpt_queue;

--- a/lib/proxy_protocol_info.cpp
+++ b/lib/proxy_protocol_info.cpp
@@ -3,6 +3,9 @@
 #include <stdio.h>
 #include <assert.h>
 #include <iostream>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#endif
 
 static bool DEBUG_ProxyProtocolInfo = false;
 

--- a/lib/proxysql_utils.cpp
+++ b/lib/proxysql_utils.cpp
@@ -23,6 +23,10 @@
 #ifdef __linux__
 #include <linux/close_range.h>
 #endif
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
 
 using std::function;
 using std::string;


### PR DESCRIPTION
- Add missing includes (wrapped in ifdef)
- Fix IDLE_THREADS ifdef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility for FreeBSD platform deployments.
  * Refined internal conditional compilation configuration for enhanced system flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->