### PR TITLE
Fix TAP tests for CI migration to per-container hostnames

### DIFF
--- a/test/infra/README.md
+++ b/test/infra/README.md
@@ -17,6 +17,25 @@ cd ../../../
 **Note:** Using `--network host` is recommended if you encounter DNS resolution hangs during the build process.
 
 ---
+
+## 0.1. Building ProxySQL (Debug Mode)
+
+Some tests require ProxySQL to be compiled in debug mode (e.g., for `LOAD DEBUG FROM DISK` support). If you encounter errors like `near "LOAD": syntax error` when the test runner tries to execute `LOAD DEBUG FROM DISK`, you need to rebuild ProxySQL in debug mode:
+
+```bash
+export PROXYSQLGENAI=1
+make -j$(nproc) build_deps && make -j$(nproc) debug && make -j$(nproc) build_deps && make -j$(nproc) build_tap_test_debug
+```
+
+This will:
+1. Build all dependencies
+2. Compile ProxySQL with debug symbols and the DEBUG module enabled
+3. Rebuild dependencies (if needed for debug mode)
+4. Build TAP test executables in debug mode
+
+**Note:** After rebuilding, restart your infrastructure with a fresh `INFRA_ID` to use the new binary.
+
+---
 ## 1. Core Concepts
 
 The Unified CI system is designed around three pillars:
@@ -31,12 +50,20 @@ The Unified CI system is designed around three pillars:
 The infrastructure management and test execution are strictly separated.
 
 ### Step 1: Global Setup
+
+**IMPORTANT:** `INFRA_ID` must be unique for each test run to avoid conflicts. Use a timestamp to ensure uniqueness:
+
 ```bash
 export WORKSPACE=$(pwd)
-export INFRA_ID="dev-$USER"
+export INFRA_ID="test-$(date +%s)"   # Unique ID using timestamp
 export TAP_GROUP="mysql84-g1"
 source test/infra/common/env.sh
 ```
+
+**Why unique INFRA_ID?**
+- Prevents port collisions when multiple tests run on the same host
+- Ensures clean isolation between test environments
+- Avoids conflicts with existing Docker containers and networks
 
 ### Step 2: Start ProxySQL & Backends
 You can use the helper script to automatically start all required components for a group:
@@ -84,7 +111,7 @@ The `docker-compose-init.bash` scripts implement a strict **non-destructive poli
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
-| `INFRA_ID` | `dev-$USER` | **Required**. Unique namespace for Docker containers/networks. |
+| `INFRA_ID` | `dev-$USER` | **Required**. Unique namespace for Docker containers/networks. **Must be unique** - use a timestamp for isolation: `export INFRA_ID="test-$(date +%s)"` |
 | `WORKSPACE` | Repo Root | Root path of the ProxySQL repository. |
 | `TAP_GROUP` | (none) | Run a specific group defined in `test/tap/groups/groups.json`. |
 | `TEST_PY_TAP_INCL` | (none) | Filter tests within the group (regex matching test names). |
@@ -98,7 +125,7 @@ The `docker-compose-init.bash` scripts implement a strict **non-destructive poli
 ### Example 1: Run a single test in a MySQL 8.4 environment
 If you are developing a fix and only want to run one specific test:
 ```bash
-export INFRA_ID="fix-123"
+export INFRA_ID="fix-123-$(date +%s)"  # Unique ID with timestamp
 export TAP_GROUP="mysql84-g1"
 export TEST_PY_TAP_INCL="admin_various_commands-t"
 export SKIP_CLUSTER_START=1
@@ -109,7 +136,7 @@ export SKIP_CLUSTER_START=1
 
 ### Example 2: Run all MariaDB 10 tests in parallel with another run
 ```bash
-export INFRA_ID="mariadb-test"
+export INFRA_ID="mariadb-test-$(date +%s)"  # Unique ID with timestamp
 export TAP_GROUP="mariadb10-g1"
 ./test/infra/control/ensure-infras.bash
 ./test/infra/control/run-tests-isolated.bash
@@ -117,7 +144,7 @@ export TAP_GROUP="mariadb10-g1"
 
 ### Example 3: Debugging a failing PostgreSQL test in the Legacy group
 ```bash
-export INFRA_ID="debug-legacy"
+export INFRA_ID="debug-legacy-$(date +%s)"  # Unique ID with timestamp
 export TAP_GROUP="legacy-g1"
 export TEST_PY_TAP_INCL="pgsql-.*" # Run only PGSQL tests in legacy
 ./test/infra/control/ensure-infras.bash

--- a/test/infra/infra-clickhouse23/conf/proxysql/infra-config.sql
+++ b/test/infra/infra-clickhouse23/conf/proxysql/infra-config.sql
@@ -1,4 +1,4 @@
-SET clickhouse-mysql_ifaces='127.0.0.1:6090';
+SET clickhouse-mysql_ifaces='0.0.0.0:6090';
 SET clickhouse-hostname='clickhouse.${INFRA}';
 SET clickhouse-port=9000;
 LOAD CLICKHOUSE VARIABLES TO RUNTIME;

--- a/test/tap/tap/noise_utils.cpp
+++ b/test/tap/tap/noise_utils.cpp
@@ -489,7 +489,9 @@ void internal_noise_rest_prometheus_poller(const CommandLine& cl, const NoiseOpt
 
     // Port defaults to 6070
     int port = get_opt_int(opt, "port", 6070);
-    std::string endpoint = "http://localhost:" + std::to_string(port) + "/metrics";
+    // Use cl.host so the endpoint is reachable in containerized CI environments
+    // where ProxySQL may not be on localhost.
+    std::string endpoint = "http://" + std::string(cl.host) + ":" + std::to_string(port) + "/metrics";
     std::string auth = std::string(cl.admin_username) + ":" + std::string(cl.admin_password);
     if (opt.find("endpoint") != opt.end()) {
         endpoint = opt.at("endpoint");

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -1418,7 +1418,13 @@ const char t_restapi_insert[] {
 		"VALUES (1,%ld,'%s','%s','%s','comm')",
 };
 
-const string base_address { "http://proxysql:6070/sync/" };
+// Use TAP_HOST environment variable so the REST API address works in both
+// local (127.0.0.1) and container-isolated (hostname) CI environments.
+static string build_restapi_base_address() {
+	const char* tap_host = getenv("TAP_HOST");
+	return string("http://") + (tap_host ? tap_host : "proxysql") + ":6070/sync/";
+}
+const string base_address { build_restapi_base_address() };
 
 int configure_endpoints(
 	MYSQL* admin,

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -1424,8 +1424,18 @@ static string build_restapi_base_address() {
 	const char* tap_host = getenv("TAP_HOST");
 	return string("http://") + (tap_host ? tap_host : "proxysql") + ":6070/sync/";
 }
-const string base_address { build_restapi_base_address() };
 
+struct RestapiBaseAddress {
+	std::string value() const {
+		return build_restapi_base_address();
+	}
+
+	operator std::string() const {
+		return value();
+	}
+};
+
+static RestapiBaseAddress base_address{};
 int configure_endpoints(
 	MYSQL* admin,
 	const string& script_base_path,

--- a/test/tap/tests/mysql_query_logging_memory-t.cpp
+++ b/test/tap/tests/mysql_query_logging_memory-t.cpp
@@ -302,7 +302,12 @@ int main() {
 
     if (mysql_query(nonExistentSchemaConn, "SELECT /* create_new_connection=1 */ 1")) {
         int error_code = mysql_errno(nonExistentSchemaConn);
-        ok(error_code == 1044, "Query on non-existent schema returned expected error (1044): %d", error_code);
+        // MySQL returns 1049 (Unknown database) when a user with full privileges connects
+        // to a non-existent schema, or 1044 (Access denied) in older/restricted setups.
+        ok(
+            error_code == 1044 || error_code == 1049,
+            "Query on non-existent schema returned expected error (1044 or 1049): %d", error_code
+        );
     } else {
         diag("Query on non-existent schema succeeded unexpectedly.");
         mysql_close(nonExistentSchemaConn);

--- a/test/tap/tests/reg_test_3223-restapi_return_codes-t.cpp
+++ b/test/tap/tests/reg_test_3223-restapi_return_codes-t.cpp
@@ -31,7 +31,9 @@ using std::vector;
 using hrc = std::chrono::high_resolution_clock;
 using nlohmann::json;
 
-const string base_address { "http://proxysql:6070/sync/" };
+// base_address is constructed at runtime using the ProxySQL host from the environment.
+// It is defined as a mutable global so check functions at file scope can access it.
+static string base_address { "http://proxysql:6070/sync/" };
 
 const vector<honest_req_t> honest_requests {
 	{ { "valid_output_script", "%s.py", "POST", 1000 }, { "{}" } },
@@ -125,6 +127,11 @@ int main(int argc, char** argv) {
 		diag("Failed to get the required environmental variables.");
 		return EXIT_FAILURE;
 	}
+
+	// Build the RESTAPI base address using the actual ProxySQL host from the environment.
+	// This ensures the test works in both local and containerized CI environments.
+	base_address = string("http://") + string(cl.host) + ":6070/sync/";
+	diag("Using RESTAPI base address: %s", base_address.c_str());
 
 	diag("=== Regression Test #3223: RESTAPI Script Execution & Return Codes ===");
 	diag("");

--- a/test/tap/tests/reg_test_3317-lock_hostgroup_special_queries-t.cpp
+++ b/test/tap/tests/reg_test_3317-lock_hostgroup_special_queries-t.cpp
@@ -3,8 +3,9 @@
  * @brief This test verifies that after locking on a hostgroup, ProxySQL forwards
  *  several simple special queries in a proper way, forwarding them to the backend
  *  connection.
- * Note: queries have hostgroup=0 to avoid getting lock on hostgroup 0 and
- *       attempting to run queries on hostgroup 1
+ * Note: After locking on a hostgroup via a failing SET, all subsequent queries are
+ *       forwarded to the locked hostgroup. No hostgroup hint is needed because
+ *       lock_hostgroup prevents re-routing to reader hostgroups.
  */
 
 #include <cstring>
@@ -33,7 +34,7 @@ void check_set_names(MYSQL* proxysql_mysql) {
 		return;
 	}
 
-	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@character_set_client, @@character_set_results, @@character_set_connection");
+	query_res = mysql_query(proxysql_mysql, "SELECT @@character_set_client, @@character_set_results, @@character_set_connection");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -77,7 +78,7 @@ void check_set_names(MYSQL* proxysql_mysql) {
  * @param proxysql_mysql A MYSQL handle to an already stablished MySQL connection.
  */
 void check_autocommit(MYSQL* proxysql_mysql) {
-	int query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@autocommit");
+	int query_res = mysql_query(proxysql_mysql, "SELECT @@autocommit");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -104,7 +105,7 @@ void check_autocommit(MYSQL* proxysql_mysql) {
 	}
 
 	// Check new status on @@autocommit
-	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@autocommit");
+	query_res = mysql_query(proxysql_mysql, "SELECT @@autocommit");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -139,7 +140,7 @@ void check_session_character_set_server(MYSQL* proxysql_mysql) {
 		return;
 	}
 
-	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@character_set_server");
+	query_res = mysql_query(proxysql_mysql, "SELECT @@character_set_server");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;
@@ -178,7 +179,7 @@ void check_session_character_set_results(MYSQL* proxysql_mysql) {
 		return;
 	}
 
-	query_res = mysql_query(proxysql_mysql, "SELECT /* ;hostgroup=0 */ @@character_set_results");
+	query_res = mysql_query(proxysql_mysql, "SELECT @@character_set_results");
 	if (query_res) {
 		diag("Query failed with error: %s", mysql_error(proxysql_mysql));
 		return;

--- a/test/tap/tests/reg_test_3591-restapi_num_fds-t.cpp
+++ b/test/tap/tests/reg_test_3591-restapi_num_fds-t.cpp
@@ -97,8 +97,9 @@ int main(int argc, char** argv) {
 	}
 	diag("Connections established.");
 
-	diag("Verifying RESTAPI /metrics endpoint via proxysql:6070...");
-	int endpoint_timeout = wait_get_enpoint_ready("http://proxysql:6070/metrics/", 1000, 100);
+	const string metrics_url { string("http://") + string(cl.host) + ":6070/metrics/" };
+	diag("Verifying RESTAPI /metrics endpoint via %s...", metrics_url.c_str());
+	int endpoint_timeout = wait_get_enpoint_ready(metrics_url, 1000, 100);
 	ok(endpoint_timeout == 0, "The endpoint should be available instead of timing out.");
 
 	diag("Closing connections and cleaning up...");

--- a/test/tap/tests/reg_test_3625-sqlite3_session_client_error_limit-t.cpp
+++ b/test/tap/tests/reg_test_3625-sqlite3_session_client_error_limit-t.cpp
@@ -68,6 +68,16 @@ int main(int argc, char** argv) {
 			goto cleanup;
 		}
 
+		// When ProxySQL reports a wildcard listen address (0.0.0.0 or ::), replace it with
+		// the actual ProxySQL host so tests running in separate containers can connect.
+		if (host_port.first == "0.0.0.0" || host_port.first == "::" || host_port.first == "*") {
+			diag(
+				"SQLite3 server reported wildcard address '%s'; using ProxySQL host '%s' instead",
+				host_port.first.c_str(), cl.host
+			);
+			host_port.first = std::string(cl.host);
+		}
+
 		MYSQL* proxysql_sqlite3 = mysql_init(NULL);
 
 		// Enable 'client_error_limit'

--- a/test/tap/tests/reg_test_3838-restapi_eintr-t.cpp
+++ b/test/tap/tests/reg_test_3838-restapi_eintr-t.cpp
@@ -35,7 +35,8 @@ using std::string;
 using std::vector;
 
 const int SIGNAL_NUM = 5;
-const string base_address { "http://proxysql:6070/sync/" };
+// base_address is constructed at runtime using the ProxySQL host from the environment.
+static string base_address { "http://proxysql:6070/sync/" };
 
 using params = std::string;
 using signal_t = int;
@@ -55,6 +56,9 @@ int main(int argc, char** argv) {
 		diag("Failed to get the required environmental variables.");
 		return EXIT_FAILURE;
 	}
+
+	// Build the RESTAPI base address using the actual ProxySQL host from the environment.
+	base_address = string("http://") + string(cl.host) + ":6070/sync/";
 
 	diag("=== Regression Test #3838: RESTAPI Script Execution & Signals ===");
 	diag("This test verifies that scripts executed via ProxySQL RESTAPI");

--- a/test/tap/tests/reg_test_4001-restapi_scripts_num_fds-t.cpp
+++ b/test/tap/tests/reg_test_4001-restapi_scripts_num_fds-t.cpp
@@ -28,7 +28,9 @@ using std::string;
 using std::vector;
 
 const int NUM_CONNECTIONS = 1300;
-const string base_address { "http://proxysql:6070/sync/" };
+// base_address is constructed at runtime using the ProxySQL host from the environment.
+// It is defined as a mutable global so check functions at file scope can access it.
+static string base_address { "http://proxysql:6070/sync/" };
 
 const vector<honest_req_t> honest_requests {
 	{ { "valid_output_script", "%s.py", "POST", 5000 }, { "{}" } },
@@ -50,9 +52,13 @@ int main(int argc, char** argv) {
 		return EXIT_FAILURE;
 	}
 
+	// Build the RESTAPI base address using the actual ProxySQL host from the environment.
+	base_address = string("http://") + string(cl.host) + ":6070/sync/";
+
 	diag("Connection Context:");
 	diag("  - Target Host: %s", cl.host);
 	diag("  - Admin Port:  %d", cl.admin_port);
+	diag("  - RESTAPI Base: %s", base_address.c_str());
 
 	const char* ws_env = getenv("WORKSPACE");
 	if (!ws_env) {

--- a/test/tap/tests/reg_test_4055_restapi-t.cpp
+++ b/test/tap/tests/reg_test_4055_restapi-t.cpp
@@ -116,8 +116,9 @@ int main(int argc, char** argv) {
 	uint64_t curl_res_code = 0;
 	string curl_res_data {};
 
-	diag("Verifying RESTAPI /metrics endpoint responsiveness via proxysql:6070...");
-	CURLcode code = perform_simple_get("http://proxysql:6070/metrics/", curl_res_code, curl_res_data);
+	diag("Verifying RESTAPI /metrics endpoint responsiveness via %s:6070...", cl.host);
+	const string metrics_url { string("http://") + string(cl.host) + ":6070/metrics/" };
+	CURLcode code = perform_simple_get(metrics_url, curl_res_code, curl_res_data);
 
 	ok(
 		code == CURLE_OK && curl_res_code == 200,

--- a/test/tap/tests/reg_test_4556-ssl_error_queue-t.cpp
+++ b/test/tap/tests/reg_test_4556-ssl_error_queue-t.cpp
@@ -579,9 +579,11 @@ const uint32_t PING_INTV_MS { 1000 };
 pair<int,double> fetch_metric_val(CommandLine& cl, const string& metric_id) {
 	uint64_t curl_res_code = 0;
 	string curl_res_data {};
-	const char URL[] { "http://proxysql:6070/metrics/" };
+	// Use cl.host so the URL works in containerized CI environments.
+	const string URL { string("http://") + string(cl.host) + ":6070/metrics/" };
+	const char* pURL = URL.c_str();
 
-	diag("Fetching metric values via RESTAPI   URL=%s", URL);
+	diag("Fetching metric values via RESTAPI   URL=%s", pURL);
 	CURLcode code = perform_simple_get(URL, curl_res_code, curl_res_data);
 
 	if (code != CURLE_OK || curl_res_code != 200) {

--- a/test/tap/tests/test_cluster_sync-t.cpp
+++ b/test/tap/tests/test_cluster_sync-t.cpp
@@ -1203,8 +1203,20 @@ int main(int, char**) {
 	MYSQL_QUERY(proxy_admin, "CREATE TABLE proxysql_servers_sync_test_backup_2687 AS SELECT * FROM proxysql_servers");
 
 	// 2. Remove primary from Core nodes
-	MYSQL_QUERY(proxy_admin, "DELETE FROM proxysql_servers WHERE hostname=='127.0.0.1' AND PORT==6032");
-	MYSQL_QUERY(proxy_admin, "DELETE FROM proxysql_servers WHERE hostname=='127.0.0.1' AND PORT==16062");
+	// CI-isolated: Use cl.host and cl.admin_port instead of hardcoded values
+	std::string delete_primary_query1;
+	string_format(
+		"DELETE FROM proxysql_servers WHERE hostname='%s' AND port=%d",
+		delete_primary_query1, cl.host, cl.admin_port
+	);
+	MYSQL_QUERY(proxy_admin, delete_primary_query1.c_str());
+	// Also remove the secondary node with the same hostname but different port
+	std::string delete_primary_query2;
+	string_format(
+		"DELETE FROM proxysql_servers WHERE hostname='%s' AND port=%d",
+		delete_primary_query2, cl.host, 16062
+	);
+	MYSQL_QUERY(proxy_admin, delete_primary_query2.c_str());
 	MYSQL_QUERY(proxy_admin, "LOAD PROXYSQL SERVERS TO RUNTIME");
 
 	pair<int,vector<srv_addr_t>> nodes_fetch { fetch_cluster_nodes(proxy_admin) };

--- a/test/tap/tests/test_cluster_sync_mysql_servers-t.cpp
+++ b/test/tap/tests/test_cluster_sync_mysql_servers-t.cpp
@@ -779,7 +779,13 @@ int main(int, char**) {
 	MYSQL_QUERY(proxy_admin, "CREATE TABLE proxysql_servers_sync_test_backup_2687 AS SELECT * FROM proxysql_servers");
 
 	// 2. Remove primary from Core nodes
-	MYSQL_QUERY(proxy_admin, "DELETE FROM proxysql_servers WHERE hostname=='127.0.0.1' AND PORT==6032");
+	// CI-isolated: Use cl.host and cl.admin_port instead of hardcoded values
+	std::string delete_primary_query;
+	string_format(
+		"DELETE FROM proxysql_servers WHERE hostname='%s' AND port=%d",
+		delete_primary_query, cl.host, cl.admin_port
+	);
+	MYSQL_QUERY(proxy_admin, delete_primary_query.c_str());
 	MYSQL_QUERY(proxy_admin, "LOAD PROXYSQL SERVERS TO RUNTIME");
 
 	pair<int,vector<srv_addr_t>> core_nodes { fetch_cluster_nodes(proxy_admin) };

--- a/test/tap/tests/test_read_only_actions_offline_hard_servers-t.cpp
+++ b/test/tap/tests/test_read_only_actions_offline_hard_servers-t.cpp
@@ -473,7 +473,13 @@ int test_read_only_offline_hard_servers(MYSQL* proxy_admin, const CommandLine& c
 		MYSQL_QUERY__(proxy_admin, "CREATE TABLE proxysql_servers_sync_test_backup_2687 AS SELECT * FROM proxysql_servers");
 
 		// 2. Remove primary from Core nodes
-		MYSQL_QUERY__(proxy_admin, "DELETE FROM proxysql_servers WHERE hostname=='127.0.0.1' AND PORT==6032");
+		// CI-isolated: Use cl.host and cl.admin_port instead of hardcoded values
+		std::string delete_primary_query;
+		string_format(
+			"DELETE FROM proxysql_servers WHERE hostname='%s' AND port=%d",
+			delete_primary_query, cl.host, cl.admin_port
+		);
+		MYSQL_QUERY__(proxy_admin, delete_primary_query.c_str());
 		MYSQL_QUERY__(proxy_admin, "LOAD PROXYSQL SERVERS TO RUNTIME");
 
 		core_nodes = fetch_cluster_nodes(proxy_admin);

--- a/test/tap/tests/test_simple_embedded_HTTP_server-t.cpp
+++ b/test/tap/tests/test_simple_embedded_HTTP_server-t.cpp
@@ -105,9 +105,11 @@ int main() {
 	MYSQL_QUERY(proxysql_admin, "SET admin-web_port=6080");
 	MYSQL_QUERY(proxysql_admin, "LOAD ADMIN VARIABLES TO RUNTIME");
 
-	run_request("https://127.0.0.1:6080");
-	run_request("https://127.0.0.1:6080/stats?metric=system");
-	run_request("https://127.0.0.1:6080/stats?metric=mysql");
-	run_request("https://127.0.0.1:6080/stats?metric=cache");
+	// CI-isolated: Use cl.host instead of hardcoded 127.0.0.1 for HTTP requests
+	string base_url = "https://" + string(cl.host) + ":6080";
+	run_request((base_url).c_str());
+	run_request((base_url + "/stats?metric=system").c_str());
+	run_request((base_url + "/stats?metric=mysql").c_str());
+	run_request((base_url + "/stats?metric=cache").c_str());
 	return exit_status();
 }


### PR DESCRIPTION
## Summary

This PR fixes TAP tests that were failing in the legacy/legacy-g1 test groups after the CI migration to per-container hostnames. The changes replace hardcoded `127.0.0.1` and `proxysql` host references with environment-driven host/port configuration, enabling tests to work correctly in containerized environments where ProxySQL runs on different hostnames.

## Changes

### Core Test Infrastructure Fixes

**1. REST API Base Address Construction (test/tap/tap/utils.cpp)**
- Replaced hardcoded `http://proxysql:6070/sync/` with runtime construction using `TAP_HOST` environment variable
- Falls back to `proxysql` if `TAP_HOST` is not set, maintaining backward compatibility

**2. Prometheus Metrics Endpoint (test/tap/tap/noise_utils.cpp)**
- Updated `internal_noise_rest_prometheus_poller` to use `cl.host` instead of hardcoded `localhost`
- Enables Prometheus metrics collection in containerized CI environments

### Individual Test Fixes

**3. test_cluster_sync-t.cpp**
- Replaced hardcoded `127.0.0.1:6032` and `127.0.0.1:16062` DELETE queries with dynamic construction using `cl.host` and `cl.admin_port`

**4. test_cluster_sync_mysql_servers-t.cpp**
- Updated DELETE query to use `cl.host` and `cl.admin_port` instead of hardcoded values

**5. test_read_only_actions_offline_hard_servers-t.cpp**
- Same fix as above for cluster node removal queries

**6. test_simple_embedded_HTTP_server-t.cpp**
- Replaced hardcoded `https://127.0.0.1:6080` with dynamic URL construction using `cl.host`

**7. reg_test_3223-restapi_return_codes-t.cpp**
- Converted `base_address` from `const` to `static` for runtime initialization
- Builds address using `cl.host` at startup

**8. reg_test_3591-restapi_num_fds-t.cpp**
- Updated metrics URL to use `cl.host` instead of hardcoded `proxysql`

**9. reg_test_3625-sqlite3_session_client_error_limit-t.cpp**
- Added logic to replace wildcard listen addresses (`0.0.0.0`, `::`, `*`) with the actual ProxySQL host

**10. reg_test_3838-restapi_eintr-t.cpp**
- Converted `base_address` to `static` for runtime initialization with `cl.host`

**11. reg_test_4001-restapi_scripts_num_fds-t.cpp**
- Converted `base_address` to `static` for runtime initialization
- Added diagnostic output showing the actual RESTAPI base address being used

**12. reg_test_4055_restapi-t.cpp**
- Updated metrics URL to use `cl.host` instead of hardcoded `proxysql`

**13. reg_test_4556-ssl_error_queue-t.cpp**
- Updated metrics fetching URL to use `cl.host`

**14. mysql_query_logging_memory-t.cpp**
- Expanded error code acceptance to include both 1044 (Access denied) and 1049 (Unknown database) for non-existent schema queries
- Different MySQL versions/configurations may return either error code

**15. reg_test_3317-lock_hostgroup_special_queries-t.cpp**
- Removed unnecessary `/* ;hostgroup=0 */` hints from queries
- Updated comments to clarify that after hostgroup locking, queries are automatically forwarded to the locked hostgroup

### Infrastructure Documentation Updates

**16. test/infra/README.md**
- Added section on building ProxySQL in debug mode (required for `LOAD DEBUG FROM DISK` support)
- Emphasized the importance of unique `INFRA_ID` using timestamps to prevent port collisions
- Updated all examples to include `$(date +%s)` for unique infrastructure IDs

**17. infra-clickhouse23/conf/proxysql/infra-config.sql**
- Changed `clickhouse-mysql_ifaces` from `127.0.0.1:6090` to `0.0.0.0:6090` for containerized environments

## Test Plan

These changes affect the following test groups:
- `legacy-g1`: Tests using hardcoded localhost references
- `mysql84-g1`: Cluster sync and RESTAPI tests

The `CommandLine` class reads from `TAP_ADMINHOST` and `TAP_ADMINPORT` environment variables set by the CI infrastructure, enabling tests to work in both:
- Local development environments (127.0.0.1)
- Containerized CI environments (dynamic hostnames)

## Related Issues

- Fixes CI test failures after migration to per-container hostnames
- Maintains backward compatibility for local test execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified infrastructure setup and rebuild steps; require unique, timestamped INFRA_ID per test run.

* **Bug Fixes**
  * Broadened error expectations for certain DB error cases.
  * Made tests more resilient to differing runtime hosts.

* **Configuration**
  * Tests and endpoints now derive target hosts at runtime (environment/CLI) instead of using fixed addresses.
  * ProxySQL listener exposure updated to accept external host bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->