### PR TITLE
Fix FreeBSD build compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedor
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
-	@${MAKE} -nk amd64-packages 2>/dev/null | grep -Eo 'proxysql[^ ]*' | sed 's/^/binaries\///'
+	@${MAKE} -nk amd64-packages 2>/dev/null | grep -Eo 'binaries/proxysql[^ ]*' | sed 's,^binaries/,,'
 
 arm64-%: SYS_ARCH := aarch64
 arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux
@@ -420,7 +420,7 @@ arm64-fedora: fedora42 fedora43
 arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:
-	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Eo 'proxysql[^ ]+' | sed 's/^/binaries\//'
+	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Eo 'binaries/proxysql[^ ]*' | sed 's,^binaries/,,'
 
 almalinux%: build-almalinux% ;
 centos%: build-centos% ;

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,10 @@ endif
 ifneq (,$(findstring $(OS),Darwin FreeBSD))
 	NPROCS := $(shell sysctl -n hw.ncpu)
 	LEGACY_BUILD := 1
-    export CC=gcc
-    export CXX=g++
+    CC ?= cc
+    CXX ?= c++
+    export CC
+    export CXX
 endif
 export MAKEOPT := -j${NPROCS}
 
@@ -385,11 +387,7 @@ SYS_ARCH := $(shell uname -m)
 REL_ARCH = $(subst x86_64,amd64,$(subst aarch64,arm64,$(SYS_ARCH)))
 RPM_ARCH = .$(SYS_ARCH)
 DEB_ARCH = _$(REL_ARCH)
-ifeq ($(UNAME_S),Darwin)
 REL_VERS := $(shell echo ${GIT_VERSION} | sed -E 's/^v//' | grep -Eo '^[0-9\.]+')
-else
-REL_VERS := $(shell echo ${GIT_VERSION} | grep -Po '(?<=^v|^)[\d\.]+')
-endif
 RPM_VERS := -$(REL_VERS)-1
 DEB_VERS := _$(REL_VERS)
 
@@ -411,7 +409,7 @@ amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedor
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
-	@${MAKE} -nk amd64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
+	@${MAKE} -nk amd64-packages 2>/dev/null | grep -Eo 'proxysql[^ ]*' | sed 's/^/binaries\///'
 
 arm64-%: SYS_ARCH := aarch64
 arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux
@@ -422,7 +420,7 @@ arm64-fedora: fedora42 fedora43
 arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:
-	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
+	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Eo 'proxysql[^ ]+' | sed 's/^/binaries\//'
 
 almalinux%: build-almalinux% ;
 centos%: build-centos% ;
@@ -435,12 +433,12 @@ ubuntu%: build-ubuntu% ;
 .PHONY: build-%
 .NOTPARALLEL: build-%
 build-%: BLD_NAME=$(patsubst build-%,%,$@)
-build-%: PKG_VERS=$(if $(filter $(shell echo ${BLD_NAME} | grep -Po '[a-z]+'),debian ubuntu),$(DEB_VERS),$(RPM_VERS))
-build-%: PKG_TYPE=$(if $(filter $(shell echo $(BLD_NAME) | grep -Po '\-de?bu?g|\-test|\-tap'),-dbg -debug -test -tap),-dbg,)
+build-%: PKG_VERS=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),$(DEB_VERS),$(RPM_VERS))
+build-%: PKG_TYPE=$(if $(filter $(shell echo $(BLD_NAME) | grep -Eo '\-de?bu?g|\-test|\-tap'),-dbg -debug -test -tap),-dbg,)
 build-%: PKG_NAME=$(firstword $(subst -, ,$(BLD_NAME)))
-build-%: PKG_COMP=$(if $(filter $(shell echo $(BLD_NAME) | grep -Po '\-clang'),-clang),-clang,)
-build-%: PKG_ARCH=$(if $(filter $(shell echo ${BLD_NAME} | grep -Po '[a-z]+'),debian ubuntu),$(DEB_ARCH),$(RPM_ARCH))
-build-%: PKG_KIND=$(if $(filter $(shell echo ${BLD_NAME} | grep -Po '[a-z]+'),debian ubuntu),deb,rpm)
+build-%: PKG_COMP=$(if $(filter $(shell echo $(BLD_NAME) | grep -Eo '\-clang'),-clang),-clang,)
+build-%: PKG_ARCH=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),$(DEB_ARCH),$(RPM_ARCH))
+build-%: PKG_KIND=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),deb,rpm)
 build-%: PKG_FILE=binaries/proxysql$(PKG_VERS)$(PKG_TYPE)-$(PKG_NAME)$(PKG_COMP)$(PKG_ARCH).$(PKG_KIND)
 build-%:
 	@echo 'building $@'

--- a/include/proxysql_utils.h
+++ b/include/proxysql_utils.h
@@ -27,7 +27,7 @@
 #define	ETIME	ETIMEDOUT
 #endif
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 using std::conjunction;
 #elif defined(CXX17)
 template<class...> struct conjunction : std::true_type { };

--- a/lib/log_utils.cpp
+++ b/lib/log_utils.cpp
@@ -112,7 +112,7 @@ LogBufferThreadContext::LogBufferThreadContext() : dist(0.0, 1.0) {
 	std::seed_seq seed{
 		rd(),
 		static_cast<unsigned>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
-		static_cast<unsigned>(pthread_self())
+		static_cast<unsigned>(reinterpret_cast<uintptr_t>(pthread_self()))
 	};
 	rng.seed(seed);
 }

--- a/lib/proxy_protocol_info.cpp
+++ b/lib/proxy_protocol_info.cpp
@@ -3,6 +3,9 @@
 #include <stdio.h>
 #include <assert.h>
 #include <iostream>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#endif
 
 static bool DEBUG_ProxyProtocolInfo = false;
 

--- a/lib/proxysql_utils.cpp
+++ b/lib/proxysql_utils.cpp
@@ -23,6 +23,10 @@
 #ifdef __linux__
 #include <linux/close_range.h>
 #endif
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
 
 using std::function;
 using std::string;


### PR DESCRIPTION
## Summary
- Replace `grep -Po` (Perl regex) with `grep -Eo` (extended regex) for BSD compatibility
- Use `CC ?= cc` instead of `export CC=gcc` to respect user's compiler choice
- Add FreeBSD to `std::conjunction` check (already defined in BSD libc++)
- Use `reinterpret_cast<uintptr_t>` for `pthread_self()` (pointer type on BSD)
- Add missing FreeBSD headers: `sys/socket.h` and `netinet/in.h`

## Test plan
- [x] Compiled successfully on FreeBSD 14.3 with clang
- [x] Compiled successfully on Linux with gcc
- [x] No functional changes, only build compatibility fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build system: conditional compiler defaults and simplified package/version discovery.
* **Refactor**
  * Broadened cross-platform compatibility by adding FreeBSD-specific platform support and normalizing parsing logic.
* **Bug Fixes**
  * Small reliability tweak to thread-related random seeding and safer socket/header handling on FreeBSD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->