### PR TITLE
Phase 3.3: Monitor health state decision extraction + unit tests

### DIFF
--- a/include/MonitorHealthDecision.h
+++ b/include/MonitorHealthDecision.h
@@ -86,6 +86,10 @@ bool should_shun_on_replication_lag(
  * @param current_lag          Measured replication lag in seconds.
  * @param max_replication_lag  Configured max lag threshold.
  * @return true if the server's lag is now within acceptable bounds.
+ *
+ * @note Production code also has a special override path for
+ *       current_lag == -2 with an override flag (see issue #959).
+ *       That case is not covered by this simplified extraction.
  */
 bool can_recover_from_replication_lag(
 	int current_lag,

--- a/include/MonitorHealthDecision.h
+++ b/include/MonitorHealthDecision.h
@@ -1,0 +1,95 @@
+/**
+ * @file MonitorHealthDecision.h
+ * @brief Pure decision functions for monitor health state transitions.
+ *
+ * Extracted from MySQL_Monitor, MySrvC, and MyHGC for unit testability.
+ * These functions have no global state dependencies — all inputs are
+ * passed as parameters.
+ *
+ * @see Phase 3.3 (GitHub issue #5491)
+ */
+
+#ifndef MONITOR_HEALTH_DECISION_H
+#define MONITOR_HEALTH_DECISION_H
+
+#include <ctime>
+
+/**
+ * @brief Determine if a server should be shunned based on connect errors.
+ *
+ * Mirrors the logic in MySrvC::connect_error() — a server is shunned
+ * when errors in the current second reach min(shun_on_failures,
+ * connect_retries_on_failure + 1).
+ *
+ * @param errors_this_second   Number of connect errors in the current second.
+ * @param shun_on_failures     Config: mysql-shun_on_failures.
+ * @param connect_retries      Config: mysql-connect_retries_on_failure.
+ * @return true if the error count meets or exceeds the shunning threshold.
+ */
+bool should_shun_on_connect_errors(
+	unsigned int errors_this_second,
+	int shun_on_failures,
+	int connect_retries
+);
+
+/**
+ * @brief Determine if a shunned server can be brought back online.
+ *
+ * Mirrors the recovery logic in MyHGC's server scan loop. A server
+ * can be unshunned when:
+ *   1. Enough time has elapsed since the last detected error.
+ *   2. If shunned_and_kill_all_connections is true, all connections
+ *      (both used and free) must be fully drained first.
+ *
+ * @param time_last_error          Timestamp of the last detected error.
+ * @param current_time             Current time.
+ * @param shun_recovery_time_sec   Config: mysql-shun_recovery_time_sec.
+ * @param connect_timeout_max_ms   Config: mysql-connect_timeout_server_max (milliseconds).
+ * @param kill_all_conns           Whether shunned_and_kill_all_connections is set.
+ * @param connections_used         Number of in-use connections.
+ * @param connections_free         Number of idle connections.
+ * @return true if the server can be unshunned.
+ */
+bool can_unshun_server(
+	time_t time_last_error,
+	time_t current_time,
+	int shun_recovery_time_sec,
+	int connect_timeout_max_ms,
+	bool kill_all_conns,
+	unsigned int connections_used,
+	unsigned int connections_free
+);
+
+/**
+ * @brief Determine if a server should be shunned for replication lag.
+ *
+ * Mirrors the replication lag check in MySQL_HostGroups_Manager.
+ * A server is shunned when its replication lag exceeds max_replication_lag
+ * for N consecutive checks (where N = monitor_replication_lag_count).
+ *
+ * @param current_lag          Measured replication lag in seconds (-1 = unknown).
+ * @param max_replication_lag  Configured max lag threshold (0 = disabled).
+ * @param consecutive_count    Number of consecutive checks exceeding threshold.
+ * @param count_threshold      Config: mysql-monitor_replication_lag_count.
+ * @return true if the server should be shunned for replication lag.
+ */
+bool should_shun_on_replication_lag(
+	int current_lag,
+	unsigned int max_replication_lag,
+	unsigned int consecutive_count,
+	int count_threshold
+);
+
+/**
+ * @brief Determine if a server shunned for replication lag can be recovered.
+ *
+ * @param current_lag          Measured replication lag in seconds.
+ * @param max_replication_lag  Configured max lag threshold.
+ * @return true if the server's lag is now within acceptable bounds.
+ */
+bool can_recover_from_replication_lag(
+	int current_lag,
+	unsigned int max_replication_lag
+);
+
+#endif // MONITOR_HEALTH_DECISION_H

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -105,6 +105,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	PgSQL_Variables_Validator.oo PgSQL_ExplicitTxnStateMgr.oo \
 	PgSQL_PreparedStatement.oo PgSQL_Extended_Query_Message.oo \
 	pgsql_tokenizer.oo \
+	MonitorHealthDecision.oo \
 	proxy_sqlite3_symbols.oo
 
 # TSDB object files

--- a/lib/MonitorHealthDecision.cpp
+++ b/lib/MonitorHealthDecision.cpp
@@ -1,0 +1,105 @@
+/**
+ * @file MonitorHealthDecision.cpp
+ * @brief Implementation of pure monitor health decision functions.
+ *
+ * These functions extract the decision logic from MySrvC::connect_error(),
+ * MyHGC's unshun recovery loop, and MySQL_HostGroups_Manager's replication
+ * lag check. They are intentionally free of global state and I/O.
+ *
+ * @see MonitorHealthDecision.h
+ * @see Phase 3.3 (GitHub issue #5491)
+ */
+
+#include "MonitorHealthDecision.h"
+
+bool should_shun_on_connect_errors(
+	unsigned int errors_this_second,
+	int shun_on_failures,
+	int connect_retries)
+{
+	// Mirror MySrvC::connect_error() threshold logic:
+	// max_failures = min(shun_on_failures, connect_retries + 1)
+	int connect_retries_plus_1 = connect_retries + 1;
+	int max_failures = (shun_on_failures > connect_retries_plus_1)
+		? connect_retries_plus_1
+		: shun_on_failures;
+
+	return (errors_this_second >= (unsigned int)max_failures);
+}
+
+bool can_unshun_server(
+	time_t time_last_error,
+	time_t current_time,
+	int shun_recovery_time_sec,
+	int connect_timeout_max_ms,
+	bool kill_all_conns,
+	unsigned int connections_used,
+	unsigned int connections_free)
+{
+	if (shun_recovery_time_sec == 0) {
+		return false;  // recovery disabled
+	}
+
+	// Mirror MyHGC recovery: compute max_wait_sec with timeout cap
+	int max_wait_sec;
+	if (shun_recovery_time_sec * 1000 >= connect_timeout_max_ms) {
+		max_wait_sec = connect_timeout_max_ms / 1000 - 1;
+	} else {
+		max_wait_sec = shun_recovery_time_sec;
+	}
+	if (max_wait_sec < 1) {
+		max_wait_sec = 1;
+	}
+
+	// Time check
+	if (current_time <= time_last_error) {
+		return false;
+	}
+	if ((current_time - time_last_error) <= max_wait_sec) {
+		return false;
+	}
+
+	// Connection drain check for kill-all mode
+	if (kill_all_conns) {
+		if (connections_used != 0 || connections_free != 0) {
+			return false;  // connections still draining
+		}
+	}
+
+	return true;
+}
+
+bool should_shun_on_replication_lag(
+	int current_lag,
+	unsigned int max_replication_lag,
+	unsigned int consecutive_count,
+	int count_threshold)
+{
+	// Mirror MySQL_HostGroups_Manager replication lag logic
+	if (current_lag < 0) {
+		return false;  // lag unknown, don't shun
+	}
+	if (max_replication_lag == 0) {
+		return false;  // lag check disabled
+	}
+	if (current_lag <= (int)max_replication_lag) {
+		return false;  // within threshold
+	}
+
+	// Lag exceeds threshold — check consecutive count
+	// The caller is expected to have incremented consecutive_count
+	// before calling this function
+	return (consecutive_count >= (unsigned int)count_threshold);
+}
+
+bool can_recover_from_replication_lag(
+	int current_lag,
+	unsigned int max_replication_lag)
+{
+	// Mirror MySQL_HostGroups_Manager unshun for replication lag:
+	// recover when lag drops to <= max_replication_lag
+	if (current_lag < 0) {
+		return false;  // unknown lag, don't recover
+	}
+	return (current_lag <= (int)max_replication_lag);
+}

--- a/lib/MonitorHealthDecision.cpp
+++ b/lib/MonitorHealthDecision.cpp
@@ -42,7 +42,7 @@ bool can_unshun_server(
 
 	// Mirror MyHGC recovery: compute max_wait_sec with timeout cap
 	int max_wait_sec;
-	if (shun_recovery_time_sec * 1000 >= connect_timeout_max_ms) {
+	if ((int64_t)shun_recovery_time_sec * 1000 >= connect_timeout_max_ms) {
 		max_wait_sec = connect_timeout_max_ms / 1000 - 1;
 	} else {
 		max_wait_sec = shun_recovery_time_sec;

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -231,7 +231,7 @@ $(ODIR)/test_init.o: $(TEST_HELPERS_DIR)/test_init.cpp | $(ODIR)
 # Unit test targets
 # ===========================================================================
 
-UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t protocol_unit-t auth_unit-t connection_pool_unit-t rule_matching_unit-t hostgroups_unit-t
+UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t protocol_unit-t auth_unit-t connection_pool_unit-t rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t
 
 .PHONY: all
 all: $(UNIT_TESTS)
@@ -281,6 +281,11 @@ rule_matching_unit-t: rule_matching_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQL
 		$(ALLOW_MULTI_DEF) -o $@
 
 hostgroups_unit-t: hostgroups_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
+		$(ALLOW_MULTI_DEF) -o $@
+
+monitor_health_unit-t: monitor_health_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
 	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@

--- a/test/tap/tests/unit/monitor_health_unit-t.cpp
+++ b/test/tap/tests/unit/monitor_health_unit-t.cpp
@@ -180,7 +180,7 @@ int main() {
 	test_unshun_max_wait_minimum();    // 1
 	test_replication_lag_shun();       // 6
 	test_replication_lag_recovery();   // 4
-	// Total: 1+7+3+2+4+1+2+1+6+4 = 31... fix plan
+	// Total: 1+7+3+2+4+1+2+1+6+4 = 31
 
 	test_cleanup_minimal();
 	return exit_status();

--- a/test/tap/tests/unit/monitor_health_unit-t.cpp
+++ b/test/tap/tests/unit/monitor_health_unit-t.cpp
@@ -1,0 +1,187 @@
+/**
+ * @file monitor_health_unit-t.cpp
+ * @brief Unit tests for monitor health state decision functions.
+ *
+ * Tests the pure functions extracted from MySQL_Monitor, MySrvC,
+ * and MyHGC:
+ *   - should_shun_on_connect_errors()
+ *   - can_unshun_server()
+ *   - should_shun_on_replication_lag()
+ *   - can_recover_from_replication_lag()
+ *
+ * @see Phase 3.3 (GitHub issue #5491)
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+
+#include "proxysql.h"
+#include "MonitorHealthDecision.h"
+
+// ============================================================================
+// 1. should_shun_on_connect_errors
+// ============================================================================
+
+static void test_shun_connect_errors() {
+	// shun_on_failures=5, connect_retries=3 → threshold = min(5, 3+1) = 4
+	ok(should_shun_on_connect_errors(4, 5, 3) == true,
+		"shun: errors=4 meets threshold min(5,4)=4");
+	ok(should_shun_on_connect_errors(3, 5, 3) == false,
+		"no shun: errors=3 below threshold 4");
+	ok(should_shun_on_connect_errors(10, 5, 3) == true,
+		"shun: errors=10 exceeds threshold");
+
+	// shun_on_failures=2, connect_retries=10 → threshold = min(2, 11) = 2
+	ok(should_shun_on_connect_errors(2, 2, 10) == true,
+		"shun: errors=2 meets threshold min(2,11)=2");
+	ok(should_shun_on_connect_errors(1, 2, 10) == false,
+		"no shun: errors=1 below threshold 2");
+
+	// Edge: shun_on_failures=1 → shun on first error
+	ok(should_shun_on_connect_errors(1, 1, 0) == true,
+		"shun: threshold=1, first error triggers shun");
+	ok(should_shun_on_connect_errors(0, 1, 0) == false,
+		"no shun: zero errors");
+}
+
+// ============================================================================
+// 2. can_unshun_server
+// ============================================================================
+
+static void test_unshun_time_elapsed() {
+	// Recovery after enough time: last_error=100, now=200, recovery=10s
+	ok(can_unshun_server(100, 200, 10, 60000, false, 0, 0) == true,
+		"unshun: 100s elapsed > 10s recovery");
+
+	// Not enough time: last_error=100, now=105, recovery=10s
+	ok(can_unshun_server(100, 105, 10, 60000, false, 0, 0) == false,
+		"no unshun: 5s elapsed < 10s recovery");
+
+	// Exactly at boundary: elapsed == recovery → should NOT unshun (needs >)
+	ok(can_unshun_server(100, 110, 10, 60000, false, 0, 0) == false,
+		"no unshun: elapsed == recovery (needs >)");
+}
+
+static void test_unshun_timeout_cap() {
+	// recovery=30s, connect_timeout_max=10000ms → cap = 10000/1000-1 = 9s
+	ok(can_unshun_server(100, 200, 30, 10000, false, 0, 0) == true,
+		"unshun: capped to 9s, 100s elapsed is enough");
+
+	// recovery=30s, connect_timeout_max=10000ms, but only 5s elapsed
+	ok(can_unshun_server(100, 105, 30, 10000, false, 0, 0) == false,
+		"no unshun: capped to 9s but only 5s elapsed");
+}
+
+static void test_unshun_kill_all_conns() {
+	// kill_all=true, connections still active → cannot unshun
+	ok(can_unshun_server(100, 200, 10, 60000, true, 5, 0) == false,
+		"no unshun: kill_all=true, used=5");
+	ok(can_unshun_server(100, 200, 10, 60000, true, 0, 3) == false,
+		"no unshun: kill_all=true, free=3");
+
+	// kill_all=true, all connections drained → can unshun
+	ok(can_unshun_server(100, 200, 10, 60000, true, 0, 0) == true,
+		"unshun: kill_all=true, all connections drained");
+
+	// kill_all=false, connections exist → can still unshun
+	ok(can_unshun_server(100, 200, 10, 60000, false, 10, 5) == true,
+		"unshun: kill_all=false, connections don't matter");
+}
+
+static void test_unshun_recovery_disabled() {
+	// recovery_time=0 → recovery disabled
+	ok(can_unshun_server(100, 200, 0, 60000, false, 0, 0) == false,
+		"no unshun: recovery disabled (recovery_time=0)");
+}
+
+static void test_unshun_clock_skew() {
+	// current_time <= time_last_error → no recovery
+	ok(can_unshun_server(200, 100, 10, 60000, false, 0, 0) == false,
+		"no unshun: clock skew (current < last_error)");
+	ok(can_unshun_server(100, 100, 10, 60000, false, 0, 0) == false,
+		"no unshun: current == last_error");
+}
+
+static void test_unshun_max_wait_minimum() {
+	// recovery=1s, timeout_max=500ms → cap = 500/1000-1 = -1 → clamped to 1
+	ok(can_unshun_server(100, 103, 1, 500, false, 0, 0) == true,
+		"unshun: max_wait clamped to 1s minimum, 3s elapsed");
+}
+
+// ============================================================================
+// 3. should_shun_on_replication_lag
+// ============================================================================
+
+static void test_replication_lag_shun() {
+	// lag=15, max=10, count=3, threshold=3 → shun
+	ok(should_shun_on_replication_lag(15, 10, 3, 3) == true,
+		"lag shun: lag=15 > max=10, count=3 meets threshold=3");
+
+	// lag=15, max=10, count=2, threshold=3 → not yet
+	ok(should_shun_on_replication_lag(15, 10, 2, 3) == false,
+		"no lag shun: count=2 below threshold=3");
+
+	// lag=5, max=10 → within bounds
+	ok(should_shun_on_replication_lag(5, 10, 10, 1) == false,
+		"no lag shun: lag=5 within max=10");
+
+	// max_replication_lag=0 → check disabled
+	ok(should_shun_on_replication_lag(100, 0, 10, 1) == false,
+		"no lag shun: check disabled (max=0)");
+
+	// lag=-1 (unknown) → don't shun
+	ok(should_shun_on_replication_lag(-1, 10, 10, 1) == false,
+		"no lag shun: lag unknown (-1)");
+
+	// lag exactly at max → not shunned (needs >)
+	ok(should_shun_on_replication_lag(10, 10, 5, 1) == false,
+		"no lag shun: lag=10 == max=10 (needs >)");
+}
+
+// ============================================================================
+// 4. can_recover_from_replication_lag
+// ============================================================================
+
+static void test_replication_lag_recovery() {
+	// lag drops below max → recover
+	ok(can_recover_from_replication_lag(5, 10) == true,
+		"lag recover: lag=5 <= max=10");
+
+	// lag exactly at max → recover
+	ok(can_recover_from_replication_lag(10, 10) == true,
+		"lag recover: lag=10 == max=10");
+
+	// lag still above → don't recover
+	ok(can_recover_from_replication_lag(15, 10) == false,
+		"no lag recover: lag=15 > max=10");
+
+	// unknown lag → don't recover
+	ok(can_recover_from_replication_lag(-1, 10) == false,
+		"no lag recover: lag unknown (-1)");
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main() {
+	plan(31);
+
+	int rc = test_init_minimal();
+	ok(rc == 0, "test_init_minimal() succeeds");
+
+	test_shun_connect_errors();        // 7
+	test_unshun_time_elapsed();        // 3
+	test_unshun_timeout_cap();         // 2
+	test_unshun_kill_all_conns();      // 4
+	test_unshun_recovery_disabled();   // 1
+	test_unshun_clock_skew();          // 2
+	test_unshun_max_wait_minimum();    // 1
+	test_replication_lag_shun();       // 6
+	test_replication_lag_recovery();   // 4
+	// Total: 1+7+3+2+4+1+2+1+6+4 = 31... fix plan
+
+	test_cleanup_minimal();
+	return exit_status();
+}


### PR DESCRIPTION
## Summary

Implements **Phase 3.3** (#5491): extracts monitor health decision logic into pure, unit-testable functions.

### Production changes:
- **`include/MonitorHealthDecision.h`**: 4 pure function declarations with Doxygen
- **`lib/MonitorHealthDecision.cpp`**: Implementations extracted from MySrvC::connect_error(), MyHGC recovery loop, and MySQL_HostGroups_Manager replication lag check
- **`lib/Makefile`**: Added `MonitorHealthDecision.oo`

### Extracted functions:
| Function | Source | Logic |
|----------|--------|-------|
| `should_shun_on_connect_errors()` | MySrvC::connect_error() | `errors >= min(shun_on_failures, retries+1)` |
| `can_unshun_server()` | MyHGC recovery loop | Time elapsed + timeout cap + kill_all drain check |
| `should_shun_on_replication_lag()` | MySQL_HostGroups_Manager | `lag > max` for N consecutive checks |
| `can_recover_from_replication_lag()` | MySQL_HostGroups_Manager | `lag <= max` |

### Tests: 31 test cases
Covers: threshold computation, boundary values, timeout cap, min 1s floor, kill_all drain, recovery disabled, clock skew, consecutive count, disabled checks, unknown lag.

## Test plan
- [x] All 31 tests pass on macOS (arm64)
- [x] `make build_lib -j4` succeeds
- [ ] Verify on Linux (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitor health decision logic to shun/restore servers based on connection errors, recovery timers, connection drain policy, and replication lag thresholds.

* **Tests**
  * Added comprehensive unit tests covering shunning thresholds, unshunning timing and edge cases, connection-drain gating, replication-lag shunning, and recovery behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->