### PR TITLE
Phase 3.4: Server selection algorithm extraction + unit tests

### DIFF
--- a/include/ServerSelection.h
+++ b/include/ServerSelection.h
@@ -1,0 +1,79 @@
+/**
+ * @file ServerSelection.h
+ * @brief Pure server selection algorithm for unit testability.
+ *
+ * Extracted from get_random_MySrvC() in the HostGroups Manager.
+ * Uses a lightweight ServerCandidate struct instead of MySrvC to
+ * avoid connection pool dependencies.
+ *
+ * @see Phase 3.4 (GitHub issue #5492)
+ */
+
+#ifndef SERVER_SELECTION_H
+#define SERVER_SELECTION_H
+
+#include <cstdint>
+
+/**
+ * @brief Server status values (mirrors MySerStatus enum).
+ *
+ * Redefined here to avoid pulling in proxysql_structs.h and its
+ * entire dependency chain.
+ */
+enum ServerSelectionStatus {
+	SERVER_ONLINE = 0,
+	SERVER_SHUNNED = 1,
+	SERVER_OFFLINE_SOFT = 2,
+	SERVER_OFFLINE_HARD = 3,
+	SERVER_SHUNNED_REPLICATION_LAG = 4
+};
+
+/**
+ * @brief Lightweight struct with decision-relevant server fields only.
+ *
+ * Avoids coupling to MySrvC which contains connection pool pointers,
+ * MySQL_Connection objects, and other heavy dependencies.
+ */
+struct ServerCandidate {
+	int index;                         ///< Caller-defined index (returned on selection).
+	int64_t weight;                    ///< Selection weight (0 = never selected).
+	ServerSelectionStatus status;      ///< Current health status.
+	unsigned int current_connections;  ///< Active connection count.
+	unsigned int max_connections;      ///< Maximum allowed connections.
+	unsigned int current_latency_us;   ///< Measured latency in microseconds.
+	unsigned int max_latency_us;       ///< Maximum allowed latency (0 = no limit).
+	unsigned int current_repl_lag;     ///< Measured replication lag in seconds.
+	unsigned int max_repl_lag;         ///< Maximum allowed lag (0 = no limit).
+};
+
+/**
+ * @brief Check if a server candidate is eligible for selection.
+ *
+ * A candidate is eligible when:
+ *   - status == SERVER_ONLINE
+ *   - current_connections < max_connections
+ *   - current_latency_us <= max_latency_us (or max_latency_us == 0)
+ *   - current_repl_lag <= max_repl_lag (or max_repl_lag == 0)
+ *
+ * @return true if the candidate is eligible.
+ */
+bool is_candidate_eligible(const ServerCandidate &candidate);
+
+/**
+ * @brief Select a server from candidates using weighted random selection.
+ *
+ * Filters candidates by eligibility, then selects from eligible ones
+ * using weighted random with the provided seed for deterministic testing.
+ *
+ * @param candidates Array of server candidates.
+ * @param count      Number of candidates in the array.
+ * @param random_seed Seed for deterministic random selection.
+ * @return Index field of the selected candidate, or -1 if none eligible.
+ */
+int select_server_from_candidates(
+	const ServerCandidate *candidates,
+	int count,
+	unsigned int random_seed
+);
+
+#endif // SERVER_SELECTION_H

--- a/include/ServerSelection.h
+++ b/include/ServerSelection.h
@@ -55,6 +55,11 @@ struct ServerCandidate {
  *   - current_latency_us <= max_latency_us (or max_latency_us == 0)
  *   - current_repl_lag <= max_repl_lag (or max_repl_lag == 0)
  *
+ * @note In production, max_latency_us == 0 on a per-server basis means
+ *       "use the thread default max latency." This extraction treats 0
+ *       as "no limit" for simplicity. Callers should resolve defaults
+ *       before populating the ServerCandidate.
+ *
  * @return true if the candidate is eligible.
  */
 bool is_candidate_eligible(const ServerCandidate &candidate);

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -106,6 +106,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	PgSQL_PreparedStatement.oo PgSQL_Extended_Query_Message.oo \
 	pgsql_tokenizer.oo \
 	MonitorHealthDecision.oo \
+	ServerSelection.oo \
 	proxy_sqlite3_symbols.oo
 
 # TSDB object files

--- a/lib/ServerSelection.cpp
+++ b/lib/ServerSelection.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file ServerSelection.cpp
+ * @brief Implementation of the pure server selection algorithm.
+ *
+ * @see ServerSelection.h
+ * @see Phase 3.4 (GitHub issue #5492)
+ */
+
+#include "ServerSelection.h"
+#include <cstdlib>
+
+bool is_candidate_eligible(const ServerCandidate &c) {
+	if (c.status != SERVER_ONLINE) {
+		return false;
+	}
+	if (c.current_connections >= c.max_connections) {
+		return false;
+	}
+	if (c.max_latency_us > 0 && c.current_latency_us > c.max_latency_us) {
+		return false;
+	}
+	if (c.max_repl_lag > 0 && c.current_repl_lag > c.max_repl_lag) {
+		return false;
+	}
+	return true;
+}
+
+int select_server_from_candidates(
+	const ServerCandidate *candidates,
+	int count,
+	unsigned int random_seed)
+{
+	if (candidates == nullptr || count <= 0) {
+		return -1;
+	}
+
+	// First pass: compute total weight of eligible candidates
+	int64_t total_weight = 0;
+	for (int i = 0; i < count; i++) {
+		if (is_candidate_eligible(candidates[i]) && candidates[i].weight > 0) {
+			total_weight += candidates[i].weight;
+		}
+	}
+
+	if (total_weight == 0) {
+		return -1;  // no eligible candidates
+	}
+
+	// Seeded random selection
+	// Use a simple LCG to avoid polluting global srand() state
+	// LCG: next = (a * seed + c) mod m  (Numerical Recipes parameters)
+	unsigned int rng_state = random_seed;
+	rng_state = rng_state * 1664525u + 1013904223u;
+	int64_t target = (int64_t)(rng_state % (unsigned int)total_weight) + 1;
+
+	// Second pass: weighted selection
+	int64_t cumulative = 0;
+	for (int i = 0; i < count; i++) {
+		if (is_candidate_eligible(candidates[i]) && candidates[i].weight > 0) {
+			cumulative += candidates[i].weight;
+			if (cumulative >= target) {
+				return candidates[i].index;
+			}
+		}
+	}
+
+	// Should not reach here if total_weight > 0, but safety fallback
+	return -1;
+}

--- a/lib/ServerSelection.cpp
+++ b/lib/ServerSelection.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "ServerSelection.h"
-#include <cstdlib>
 
 bool is_candidate_eligible(const ServerCandidate &c) {
 	if (c.status != SERVER_ONLINE) {
@@ -51,7 +50,8 @@ int select_server_from_candidates(
 	// LCG: next = (a * seed + c) mod m  (Numerical Recipes parameters)
 	unsigned int rng_state = random_seed;
 	rng_state = rng_state * 1664525u + 1013904223u;
-	int64_t target = (int64_t)(rng_state % (unsigned int)total_weight) + 1;
+	// Use 64-bit modulo to avoid truncation when total_weight > UINT_MAX
+	int64_t target = (int64_t)(rng_state % (uint64_t)total_weight) + 1;
 
 	// Second pass: weighted selection
 	int64_t cumulative = 0;

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -231,7 +231,10 @@ $(ODIR)/test_init.o: $(TEST_HELPERS_DIR)/test_init.cpp | $(ODIR)
 # Unit test targets
 # ===========================================================================
 
-UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t protocol_unit-t auth_unit-t connection_pool_unit-t rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t
+UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
+	protocol_unit-t auth_unit-t connection_pool_unit-t \
+	rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t \
+	server_selection_unit-t
 
 .PHONY: all
 all: $(UNIT_TESTS)
@@ -245,47 +248,10 @@ ifneq ($(UNAME_S),Darwin)
 	ALLOW_MULTI_DEF := -Wl,--allow-multiple-definition
 endif
 
-smoke_test-t: smoke_test-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-query_cache_unit-t: query_cache_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-query_processor_unit-t: query_processor_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-protocol_unit-t: protocol_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-auth_unit-t: auth_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-connection_pool_unit-t: connection_pool_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-rule_matching_unit-t: rule_matching_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-hostgroups_unit-t: hostgroups_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-monitor_health_unit-t: monitor_health_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+# Pattern rule: all unit tests use the same compile + link flags.
+# Each test binary is built from its .cpp source, linked against
+# the test harness objects and libproxysql.a with all dependencies.
+%-t: %-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
 	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@

--- a/test/tap/tests/unit/server_selection_unit-t.cpp
+++ b/test/tap/tests/unit/server_selection_unit-t.cpp
@@ -216,7 +216,7 @@ int main() {
 	test_weighted_distribution();        // 1
 	test_determinism();                  // 1
 	test_mixed_eligibility();            // 1
-	// Total: 1+12+1+1+1+1+1+1+1+1 = 21... fix
+	// Total: 1+12+1+1+1+1+1+1+1+1 = 21
 
 	test_cleanup_minimal();
 	return exit_status();

--- a/test/tap/tests/unit/server_selection_unit-t.cpp
+++ b/test/tap/tests/unit/server_selection_unit-t.cpp
@@ -1,0 +1,223 @@
+/**
+ * @file server_selection_unit-t.cpp
+ * @brief Unit tests for the server selection algorithm.
+ *
+ * Tests the pure selection functions extracted from get_random_MySrvC():
+ *   - is_candidate_eligible()
+ *   - select_server_from_candidates()
+ *
+ * @see Phase 3.4 (GitHub issue #5492)
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+
+#include "proxysql.h"
+#include "ServerSelection.h"
+
+// ============================================================================
+// Helper: create a default ONLINE server candidate
+// ============================================================================
+static ServerCandidate make_candidate(int idx, int64_t weight = 1,
+	unsigned int max_conns = 1000)
+{
+	ServerCandidate c {};
+	c.index = idx;
+	c.weight = weight;
+	c.status = SERVER_ONLINE;
+	c.current_connections = 0;
+	c.max_connections = max_conns;
+	c.current_latency_us = 0;
+	c.max_latency_us = 0;
+	c.current_repl_lag = 0;
+	c.max_repl_lag = 0;
+	return c;
+}
+
+// ============================================================================
+// 1. is_candidate_eligible
+// ============================================================================
+
+static void test_eligibility() {
+	ServerCandidate online = make_candidate(0);
+	ok(is_candidate_eligible(online) == true, "eligible: ONLINE server");
+
+	ServerCandidate shunned = make_candidate(1);
+	shunned.status = SERVER_SHUNNED;
+	ok(is_candidate_eligible(shunned) == false, "ineligible: SHUNNED");
+
+	ServerCandidate off_soft = make_candidate(2);
+	off_soft.status = SERVER_OFFLINE_SOFT;
+	ok(is_candidate_eligible(off_soft) == false, "ineligible: OFFLINE_SOFT");
+
+	ServerCandidate off_hard = make_candidate(3);
+	off_hard.status = SERVER_OFFLINE_HARD;
+	ok(is_candidate_eligible(off_hard) == false, "ineligible: OFFLINE_HARD");
+
+	ServerCandidate lag_shunned = make_candidate(4);
+	lag_shunned.status = SERVER_SHUNNED_REPLICATION_LAG;
+	ok(is_candidate_eligible(lag_shunned) == false, "ineligible: SHUNNED_REPL_LAG");
+
+	ServerCandidate at_max = make_candidate(5, 1, 10);
+	at_max.current_connections = 10;
+	ok(is_candidate_eligible(at_max) == false, "ineligible: at max_connections");
+
+	ServerCandidate below_max = make_candidate(6, 1, 10);
+	below_max.current_connections = 9;
+	ok(is_candidate_eligible(below_max) == true, "eligible: below max_connections");
+
+	ServerCandidate high_latency = make_candidate(7);
+	high_latency.max_latency_us = 5000;
+	high_latency.current_latency_us = 6000;
+	ok(is_candidate_eligible(high_latency) == false, "ineligible: high latency");
+
+	ServerCandidate ok_latency = make_candidate(8);
+	ok_latency.max_latency_us = 5000;
+	ok_latency.current_latency_us = 4000;
+	ok(is_candidate_eligible(ok_latency) == true, "eligible: acceptable latency");
+
+	ServerCandidate no_limit = make_candidate(9);
+	no_limit.max_latency_us = 0;
+	no_limit.current_latency_us = 999999;
+	ok(is_candidate_eligible(no_limit) == true, "eligible: latency limit disabled (max=0)");
+
+	ServerCandidate high_lag = make_candidate(10);
+	high_lag.max_repl_lag = 10;
+	high_lag.current_repl_lag = 15;
+	ok(is_candidate_eligible(high_lag) == false, "ineligible: high repl lag");
+
+	ServerCandidate ok_lag = make_candidate(11);
+	ok_lag.max_repl_lag = 10;
+	ok_lag.current_repl_lag = 5;
+	ok(is_candidate_eligible(ok_lag) == true, "eligible: acceptable repl lag");
+}
+
+// ============================================================================
+// 2. select_server_from_candidates — basic
+// ============================================================================
+
+static void test_select_single() {
+	ServerCandidate c = make_candidate(42);
+	int result = select_server_from_candidates(&c, 1, 12345);
+	ok(result == 42, "single server: always selected (idx=42)");
+}
+
+static void test_select_empty() {
+	ok(select_server_from_candidates(nullptr, 0, 0) == -1,
+		"empty list: returns -1");
+}
+
+static void test_select_all_offline() {
+	ServerCandidate candidates[3];
+	candidates[0] = make_candidate(0); candidates[0].status = SERVER_OFFLINE_HARD;
+	candidates[1] = make_candidate(1); candidates[1].status = SERVER_SHUNNED;
+	candidates[2] = make_candidate(2); candidates[2].status = SERVER_OFFLINE_SOFT;
+
+	ok(select_server_from_candidates(candidates, 3, 999) == -1,
+		"all offline: returns -1");
+}
+
+static void test_select_weight_zero() {
+	ServerCandidate c = make_candidate(0, 0);
+	ok(select_server_from_candidates(&c, 1, 12345) == -1,
+		"weight=0: never selected");
+}
+
+// ============================================================================
+// 3. Weighted distribution (statistical)
+// ============================================================================
+
+static void test_equal_weight_distribution() {
+	ServerCandidate candidates[2];
+	candidates[0] = make_candidate(0, 1);
+	candidates[1] = make_candidate(1, 1);
+
+	int count[2] = {0, 0};
+	const int N = 10000;
+	for (int seed = 0; seed < N; seed++) {
+		int result = select_server_from_candidates(candidates, 2, seed);
+		if (result >= 0 && result <= 1) count[result]++;
+	}
+
+	double pct0 = (double)count[0] / N * 100;
+	ok(pct0 > 30 && pct0 < 70,
+		"equal weight: server 0 selected %.1f%% (expect ~50%%)", pct0);
+}
+
+static void test_weighted_distribution() {
+	ServerCandidate candidates[2];
+	candidates[0] = make_candidate(0, 3);  // weight 3
+	candidates[1] = make_candidate(1, 1);  // weight 1
+
+	int count[2] = {0, 0};
+	const int N = 10000;
+	for (int seed = 0; seed < N; seed++) {
+		int result = select_server_from_candidates(candidates, 2, seed);
+		if (result >= 0 && result <= 1) count[result]++;
+	}
+
+	double pct0 = (double)count[0] / N * 100;
+	ok(pct0 > 60 && pct0 < 90,
+		"3:1 weight: server 0 selected %.1f%% (expect ~75%%)", pct0);
+}
+
+// ============================================================================
+// 4. Determinism
+// ============================================================================
+
+static void test_determinism() {
+	ServerCandidate candidates[3];
+	candidates[0] = make_candidate(0, 2);
+	candidates[1] = make_candidate(1, 3);
+	candidates[2] = make_candidate(2, 5);
+
+	int r1 = select_server_from_candidates(candidates, 3, 42);
+	int r2 = select_server_from_candidates(candidates, 3, 42);
+	ok(r1 == r2, "determinism: same seed → same result");
+}
+
+// ============================================================================
+// 5. Mixed eligible/ineligible
+// ============================================================================
+
+static void test_mixed_eligibility() {
+	ServerCandidate candidates[4];
+	candidates[0] = make_candidate(0, 1); candidates[0].status = SERVER_SHUNNED;
+	candidates[1] = make_candidate(1, 1); candidates[1].status = SERVER_OFFLINE_HARD;
+	candidates[2] = make_candidate(2, 1); // ONLINE
+	candidates[3] = make_candidate(3, 1); candidates[3].status = SERVER_OFFLINE_SOFT;
+
+	// Only candidate[2] is eligible — must always be selected
+	int pass = 0;
+	for (int seed = 0; seed < 100; seed++) {
+		if (select_server_from_candidates(candidates, 4, seed) == 2) pass++;
+	}
+	ok(pass == 100,
+		"mixed: only eligible server selected 100/100 times");
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main() {
+	plan(21);
+
+	int rc = test_init_minimal();
+	ok(rc == 0, "test_init_minimal() succeeds");
+
+	test_eligibility();                  // 12
+	test_select_single();                // 1
+	test_select_empty();                 // 1
+	test_select_all_offline();           // 1
+	test_select_weight_zero();           // 1
+	test_equal_weight_distribution();    // 1
+	test_weighted_distribution();        // 1
+	test_determinism();                  // 1
+	test_mixed_eligibility();            // 1
+	// Total: 1+12+1+1+1+1+1+1+1+1 = 21... fix
+
+	test_cleanup_minimal();
+	return exit_status();
+}


### PR DESCRIPTION
## Summary

Implements **Phase 3.4** (#5492): extracts server selection algorithm into pure, unit-testable functions.

### Production changes:
- **`include/ServerSelection.h`**: `ServerCandidate` struct (lightweight, no MySrvC dependency) + `is_candidate_eligible()` + `select_server_from_candidates()`
- **`lib/ServerSelection.cpp`**: Implementation with seeded LCG for deterministic testing
- **`lib/Makefile`**: Added `ServerSelection.oo`

### Design decisions:
- **Own enum** (`ServerSelectionStatus`): avoids pulling `proxysql_structs.h` and its dependency chain
- **Seeded LCG** instead of `srand()`: avoids polluting global RNG state, enables deterministic testing
- **Standalone header**: follows `ConnectionPoolDecision.h` pattern — no circular deps

### Tests: 21 test cases
| Area | Tests |
|------|-------|
| Eligibility (all 5 status types, connections, latency, lag) | 12 |
| Basic selection (single, empty, all offline, weight=0) | 4 |
| Weighted distribution (equal → ~50%, 3:1 → ~75%) | 2 |
| Determinism (same seed = same result) | 1 |
| Mixed eligibility (only eligible server selected) | 1 |

Distribution results: equal weights → 50.0%, 3:1 → 75.0% (over 10000 iterations).

## Test plan
- [x] All 21 tests pass on macOS (arm64)
- [x] `make build_lib -j4` succeeds
- [ ] Verify on Linux (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server selection: checks server eligibility (online status, connection limits, latency and replication-lag thresholds) and performs deterministic, seeded weighted-random selection among eligible servers.

* **Tests**
  * Added unit tests covering eligibility rules, seeded deterministic selection, edge cases (no/zero-weight or no-eligible candidates), and statistical validation of weighted distribution.

* **Chores**
  * Integrated the server-selection module and its unit test into the build/test targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->