### PR TITLE
Phase 3.8: Transaction state tracking extraction + unit tests

### DIFF
--- a/include/TransactionState.h
+++ b/include/TransactionState.h
@@ -14,7 +14,8 @@
 /**
  * @brief Update transaction_persistent_hostgroup based on backend state.
  *
- * Mirrors the logic in MySQL_Session/PgSQL_Session (~lines 9276-9293):
+ * Mirrors the transaction persistence logic in MySQL_Session and
+ * PgSQL_Session (near handler_rc0_Process_Resultset):
  * - When a transaction starts on a backend, lock to the current HG
  * - When a transaction ends, unlock (-1)
  *
@@ -34,9 +35,9 @@ int update_transaction_persistent_hostgroup(
 /**
  * @brief Check if a transaction has exceeded the maximum allowed time.
  *
- * @param transaction_started_at  Timestamp when transaction started (0 = none).
- * @param current_time            Current timestamp.
- * @param max_transaction_time_ms Maximum transaction time in milliseconds (0 = no limit).
+ * @param transaction_started_at  Timestamp when transaction started, in microseconds (0 = none).
+ * @param current_time            Current timestamp, in microseconds.
+ * @param max_transaction_time_ms Maximum transaction time in milliseconds (0 or negative = no limit).
  * @return true if the transaction has exceeded the time limit.
  */
 bool is_transaction_timed_out(

--- a/include/TransactionState.h
+++ b/include/TransactionState.h
@@ -1,0 +1,48 @@
+/**
+ * @file TransactionState.h
+ * @brief Pure transaction state tracking logic for unit testability.
+ *
+ * Extracted from MySQL_Session/PgSQL_Session transaction persistence
+ * logic. The decision is identical for both protocols.
+ *
+ * @see Phase 3.8 (GitHub issue #5496)
+ */
+
+#ifndef TRANSACTION_STATE_H
+#define TRANSACTION_STATE_H
+
+/**
+ * @brief Update transaction_persistent_hostgroup based on backend state.
+ *
+ * Mirrors the logic in MySQL_Session/PgSQL_Session (~lines 9276-9293):
+ * - When a transaction starts on a backend, lock to the current HG
+ * - When a transaction ends, unlock (-1)
+ *
+ * @param transaction_persistent         Whether transaction persistence is enabled.
+ * @param transaction_persistent_hostgroup Current persistent HG (-1 = none).
+ * @param current_hostgroup              HG where the query executed.
+ * @param backend_in_transaction         Whether the backend has an active transaction.
+ * @return Updated transaction_persistent_hostgroup value.
+ */
+int update_transaction_persistent_hostgroup(
+	bool transaction_persistent,
+	int transaction_persistent_hostgroup,
+	int current_hostgroup,
+	bool backend_in_transaction
+);
+
+/**
+ * @brief Check if a transaction has exceeded the maximum allowed time.
+ *
+ * @param transaction_started_at  Timestamp when transaction started (0 = none).
+ * @param current_time            Current timestamp.
+ * @param max_transaction_time_ms Maximum transaction time in milliseconds (0 = no limit).
+ * @return true if the transaction has exceeded the time limit.
+ */
+bool is_transaction_timed_out(
+	unsigned long long transaction_started_at,
+	unsigned long long current_time,
+	int max_transaction_time_ms
+);
+
+#endif // TRANSACTION_STATE_H

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -106,6 +106,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	PgSQL_PreparedStatement.oo PgSQL_Extended_Query_Message.oo \
 	pgsql_tokenizer.oo \
 	MonitorHealthDecision.oo \
+	TransactionState.oo \
 	proxy_sqlite3_symbols.oo
 
 # TSDB object files

--- a/lib/TransactionState.cpp
+++ b/lib/TransactionState.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file TransactionState.cpp
+ * @brief Implementation of pure transaction state tracking.
+ *
+ * @see TransactionState.h
+ * @see Phase 3.8 (GitHub issue #5496)
+ */
+
+#include "TransactionState.h"
+
+int update_transaction_persistent_hostgroup(
+	bool transaction_persistent,
+	int transaction_persistent_hostgroup,
+	int current_hostgroup,
+	bool backend_in_transaction)
+{
+	if (!transaction_persistent) {
+		return -1;  // persistence disabled
+	}
+
+	if (transaction_persistent_hostgroup == -1) {
+		// Not currently locked — lock if transaction just started
+		if (backend_in_transaction) {
+			return current_hostgroup;
+		}
+	} else {
+		// Currently locked — unlock if transaction just ended
+		if (!backend_in_transaction) {
+			return -1;
+		}
+	}
+
+	return transaction_persistent_hostgroup;  // no change
+}
+
+bool is_transaction_timed_out(
+	unsigned long long transaction_started_at,
+	unsigned long long current_time,
+	int max_transaction_time_ms)
+{
+	if (transaction_started_at == 0) {
+		return false;  // no active transaction
+	}
+	if (max_transaction_time_ms <= 0) {
+		return false;  // no time limit
+	}
+
+	unsigned long long elapsed_ms = 0;
+	if (current_time > transaction_started_at) {
+		elapsed_ms = (current_time - transaction_started_at) / 1000;
+		// transaction_started_at and current_time are in microseconds
+	}
+
+	return (elapsed_ms > (unsigned long long)max_transaction_time_ms);
+}

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -231,7 +231,10 @@ $(ODIR)/test_init.o: $(TEST_HELPERS_DIR)/test_init.cpp | $(ODIR)
 # Unit test targets
 # ===========================================================================
 
-UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t protocol_unit-t auth_unit-t connection_pool_unit-t rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t
+UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
+	protocol_unit-t auth_unit-t connection_pool_unit-t \
+	rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t \
+	transaction_state_unit-t
 
 .PHONY: all
 all: $(UNIT_TESTS)
@@ -245,47 +248,8 @@ ifneq ($(UNAME_S),Darwin)
 	ALLOW_MULTI_DEF := -Wl,--allow-multiple-definition
 endif
 
-smoke_test-t: smoke_test-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-query_cache_unit-t: query_cache_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-query_processor_unit-t: query_processor_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-protocol_unit-t: protocol_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-auth_unit-t: auth_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-connection_pool_unit-t: connection_pool_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-rule_matching_unit-t: rule_matching_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-hostgroups_unit-t: hostgroups_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
-		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
-		$(ALLOW_MULTI_DEF) -o $@
-
-monitor_health_unit-t: monitor_health_unit-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+# Pattern rule: all unit tests use the same compile + link flags.
+%-t: %-t.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
 	$(CXX) $< $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@

--- a/test/tap/tests/unit/transaction_state_unit-t.cpp
+++ b/test/tap/tests/unit/transaction_state_unit-t.cpp
@@ -43,6 +43,10 @@ static void test_no_change() {
 	// Active txn, already locked → stays locked
 	ok(update_transaction_persistent_hostgroup(true, 5, 5, true) == 5,
 		"no change: already locked, stays locked");
+	// Already locked on HG 5, txn still active on different current_hostgroup
+	// → stays locked on original HG (doesn't change to new HG)
+	ok(update_transaction_persistent_hostgroup(true, 5, 10, true) == 5,
+		"no change: locked HG stays even if current_hostgroup differs");
 }
 
 static void test_txn_lifecycle() {
@@ -73,6 +77,12 @@ static void test_timeout_not_exceeded() {
 		"no timeout: 2s elapsed < 5s limit");
 }
 
+static void test_timeout_boundary() {
+	// Exactly at limit: 5000ms elapsed, limit 5000ms → NOT timed out (needs >)
+	ok(is_transaction_timed_out(1000000, 6000000, 5000) == false,
+		"no timeout: elapsed == limit (strict > comparison)");
+}
+
 static void test_timeout_no_transaction() {
 	ok(is_transaction_timed_out(0, 99000000, 5000) == false,
 		"no timeout: no active transaction (started_at=0)");
@@ -86,20 +96,21 @@ static void test_timeout_no_limit() {
 }
 
 int main() {
-	plan(17);
+	plan(19);
 	int rc = test_init_minimal();
 	ok(rc == 0, "test_init_minimal() succeeds");
 
 	test_persistence_disabled();   // 2
 	test_txn_start_locks();        // 2
 	test_txn_end_unlocks();        // 2
-	test_no_change();              // 2
+	test_no_change();              // 3
 	test_txn_lifecycle();          // 3
 	test_timeout_exceeded();       // 1
 	test_timeout_not_exceeded();   // 1
+	test_timeout_boundary();       // 1
 	test_timeout_no_transaction(); // 1
 	test_timeout_no_limit();       // 2
-	// Total: 1+2+2+2+2+3+1+1+1+2 = 17
+	// Total: 1+2+2+2+3+3+1+1+1+1+2 = 19
 
 	test_cleanup_minimal();
 	return exit_status();

--- a/test/tap/tests/unit/transaction_state_unit-t.cpp
+++ b/test/tap/tests/unit/transaction_state_unit-t.cpp
@@ -1,0 +1,106 @@
+/**
+ * @file transaction_state_unit-t.cpp
+ * @brief Unit tests for transaction state tracking logic.
+ *
+ * @see Phase 3.8 (GitHub issue #5496)
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+#include "proxysql.h"
+#include "TransactionState.h"
+
+// ============================================================================
+// 1. update_transaction_persistent_hostgroup
+// ============================================================================
+
+static void test_persistence_disabled() {
+	ok(update_transaction_persistent_hostgroup(false, -1, 5, true) == -1,
+		"disabled: returns -1 even with active txn");
+	ok(update_transaction_persistent_hostgroup(false, 3, 5, true) == -1,
+		"disabled: clears existing lock");
+}
+
+static void test_txn_start_locks() {
+	ok(update_transaction_persistent_hostgroup(true, -1, 5, true) == 5,
+		"txn start: locks to current HG");
+	ok(update_transaction_persistent_hostgroup(true, -1, 0, true) == 0,
+		"txn start: locks to HG 0");
+}
+
+static void test_txn_end_unlocks() {
+	ok(update_transaction_persistent_hostgroup(true, 5, 5, false) == -1,
+		"txn end: unlocks when txn completes");
+	ok(update_transaction_persistent_hostgroup(true, 3, 10, false) == -1,
+		"txn end: unlocks regardless of current HG");
+}
+
+static void test_no_change() {
+	// No txn, no existing lock → stays unlocked
+	ok(update_transaction_persistent_hostgroup(true, -1, 5, false) == -1,
+		"no change: no txn, stays unlocked");
+	// Active txn, already locked → stays locked
+	ok(update_transaction_persistent_hostgroup(true, 5, 5, true) == 5,
+		"no change: already locked, stays locked");
+}
+
+static void test_txn_lifecycle() {
+	int state = -1;
+	// BEGIN
+	state = update_transaction_persistent_hostgroup(true, state, 7, true);
+	ok(state == 7, "lifecycle: BEGIN locks to HG 7");
+	// Mid-transaction query
+	state = update_transaction_persistent_hostgroup(true, state, 7, true);
+	ok(state == 7, "lifecycle: mid-txn stays locked");
+	// COMMIT
+	state = update_transaction_persistent_hostgroup(true, state, 7, false);
+	ok(state == -1, "lifecycle: COMMIT unlocks");
+}
+
+// ============================================================================
+// 2. is_transaction_timed_out
+// ============================================================================
+
+static void test_timeout_exceeded() {
+	// started 10s ago, limit 5s (in ms), times in microseconds
+	ok(is_transaction_timed_out(1000000, 11000000, 5000) == true,
+		"timeout: 10s elapsed > 5s limit");
+}
+
+static void test_timeout_not_exceeded() {
+	ok(is_transaction_timed_out(1000000, 3000000, 5000) == false,
+		"no timeout: 2s elapsed < 5s limit");
+}
+
+static void test_timeout_no_transaction() {
+	ok(is_transaction_timed_out(0, 99000000, 5000) == false,
+		"no timeout: no active transaction (started_at=0)");
+}
+
+static void test_timeout_no_limit() {
+	ok(is_transaction_timed_out(1000000, 99000000, 0) == false,
+		"no timeout: limit disabled (max=0)");
+	ok(is_transaction_timed_out(1000000, 99000000, -1) == false,
+		"no timeout: limit disabled (max=-1)");
+}
+
+int main() {
+	plan(17);
+	int rc = test_init_minimal();
+	ok(rc == 0, "test_init_minimal() succeeds");
+
+	test_persistence_disabled();   // 2
+	test_txn_start_locks();        // 2
+	test_txn_end_unlocks();        // 2
+	test_no_change();              // 2
+	test_txn_lifecycle();          // 3
+	test_timeout_exceeded();       // 1
+	test_timeout_not_exceeded();   // 1
+	test_timeout_no_transaction(); // 1
+	test_timeout_no_limit();       // 2
+	// Total: 1+2+2+2+2+3+1+1+1+2 = 17
+
+	test_cleanup_minimal();
+	return exit_status();
+}


### PR DESCRIPTION
## Summary
Implements **Phase 3.8** (#5496): extracts transaction state tracking into pure functions.

- **`include/TransactionState.h`**: `update_transaction_persistent_hostgroup()` + `is_transaction_timed_out()`
- **`lib/TransactionState.cpp`**: implementations
- **17 test cases**: persistence disabled, txn start/end, no-change, full lifecycle, timeout exceeded/not/disabled

Logic is identical for MySQL and PgSQL (shared via Base_Session).

## Test plan
- [x] All 17 tests pass on macOS (arm64), process exits cleanly
- [x] `make build_lib -j4` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent hostgroup locking during transactions to maintain connection affinity, plus configurable transaction timeout detection to identify and end transactions that exceed the allowed duration.

* **Tests**
  * New unit tests validating transaction lifecycle, hostgroup-locking behaviors (including edge cases) and timeout semantics to ensure correct runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->