### PR TITLE
Phase 3.6: Backend variable sync decisions + unit tests

### DIFF
--- a/include/BackendSyncDecision.h
+++ b/include/BackendSyncDecision.h
@@ -1,0 +1,48 @@
+/**
+ * @file BackendSyncDecision.h
+ * @brief Pure decision functions for backend variable synchronization.
+ *
+ * Extracted from MySQL_Session's verify chain (handler_again___verify_*).
+ * Determines what sync actions are needed before a query can execute
+ * on a backend connection.
+ *
+ * @see Phase 3.6 (GitHub issue #5494)
+ */
+
+#ifndef BACKEND_SYNC_DECISION_H
+#define BACKEND_SYNC_DECISION_H
+
+/**
+ * @brief Actions that may be needed to synchronize backend state.
+ */
+enum BackendSyncAction {
+	SYNC_NONE = 0,             ///< No synchronization needed.
+	SYNC_SCHEMA = 1,           ///< Schema (USE db) needs to be sent.
+	SYNC_USER = 2,             ///< Username mismatch, CHANGE USER required.
+	SYNC_AUTOCOMMIT = 4,       ///< Autocommit state needs to be synced.
+};
+
+/**
+ * @brief Determine what sync actions are needed for the backend.
+ *
+ * Checks client vs backend state and returns a bitmask of required
+ * actions. Mirrors the MySQL_Session verify chain logic.
+ *
+ * @param client_user       Client connection username.
+ * @param backend_user      Backend connection username.
+ * @param client_schema     Client connection schema.
+ * @param backend_schema    Backend connection schema.
+ * @param client_autocommit Client autocommit setting.
+ * @param backend_autocommit Backend autocommit setting.
+ * @return Bitmask of BackendSyncAction values.
+ */
+int determine_backend_sync_actions(
+	const char *client_user,
+	const char *backend_user,
+	const char *client_schema,
+	const char *backend_schema,
+	bool client_autocommit,
+	bool backend_autocommit
+);
+
+#endif // BACKEND_SYNC_DECISION_H

--- a/lib/BackendSyncDecision.cpp
+++ b/lib/BackendSyncDecision.cpp
@@ -1,0 +1,45 @@
+/**
+ * @file BackendSyncDecision.cpp
+ * @brief Implementation of backend variable sync decisions.
+ *
+ * @see BackendSyncDecision.h
+ * @see Phase 3.6 (GitHub issue #5494)
+ */
+
+#include "BackendSyncDecision.h"
+#include <cstring>
+
+int determine_backend_sync_actions(
+	const char *client_user,
+	const char *backend_user,
+	const char *client_schema,
+	const char *backend_schema,
+	bool client_autocommit,
+	bool backend_autocommit)
+{
+	int actions = SYNC_NONE;
+
+	// Username mismatch → CHANGE USER required
+	if (client_user && backend_user) {
+		if (strcmp(client_user, backend_user) != 0) {
+			actions |= SYNC_USER;
+		}
+	}
+
+	// Schema mismatch → USE <db> required
+	// Only check if usernames match (user change handles schema too)
+	if (!(actions & SYNC_USER)) {
+		if (client_schema && backend_schema) {
+			if (strcmp(client_schema, backend_schema) != 0) {
+				actions |= SYNC_SCHEMA;
+			}
+		}
+	}
+
+	// Autocommit mismatch → SET autocommit required
+	if (client_autocommit != backend_autocommit) {
+		actions |= SYNC_AUTOCOMMIT;
+	}
+
+	return actions;
+}

--- a/lib/BackendSyncDecision.cpp
+++ b/lib/BackendSyncDecision.cpp
@@ -20,7 +20,12 @@ int determine_backend_sync_actions(
 	int actions = SYNC_NONE;
 
 	// Username mismatch → CHANGE USER required
-	if (client_user && backend_user) {
+	// Asymmetric NULLs (one set, other not) count as mismatch
+	if (client_user == nullptr && backend_user != nullptr) {
+		actions |= SYNC_USER;
+	} else if (client_user != nullptr && backend_user == nullptr) {
+		actions |= SYNC_USER;
+	} else if (client_user && backend_user) {
 		if (strcmp(client_user, backend_user) != 0) {
 			actions |= SYNC_USER;
 		}
@@ -29,7 +34,11 @@ int determine_backend_sync_actions(
 	// Schema mismatch → USE <db> required
 	// Only check if usernames match (user change handles schema too)
 	if (!(actions & SYNC_USER)) {
-		if (client_schema && backend_schema) {
+		if (client_schema == nullptr && backend_schema != nullptr) {
+			actions |= SYNC_SCHEMA;
+		} else if (client_schema != nullptr && backend_schema == nullptr) {
+			actions |= SYNC_SCHEMA;
+		} else if (client_schema && backend_schema) {
 			if (strcmp(client_schema, backend_schema) != 0) {
 				actions |= SYNC_SCHEMA;
 			}

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -108,6 +108,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	MonitorHealthDecision.oo \
 	TransactionState.oo \
 	HostgroupRouting.oo \
+	BackendSyncDecision.oo \
 	proxy_sqlite3_symbols.oo
 
 # TSDB object files

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -235,7 +235,8 @@ UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 	protocol_unit-t auth_unit-t connection_pool_unit-t \
 	rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t \
   hostgroup_routing_unit-t \
-	transaction_state_unit-t
+	transaction_state_unit-t \
+	backend_sync_unit-t
 
 .PHONY: all
 all: $(UNIT_TESTS)

--- a/test/tap/tests/unit/backend_sync_unit-t.cpp
+++ b/test/tap/tests/unit/backend_sync_unit-t.cpp
@@ -1,0 +1,78 @@
+/**
+ * @file backend_sync_unit-t.cpp
+ * @brief Unit tests for backend variable sync decisions.
+ *
+ * @see Phase 3.6 (GitHub issue #5494)
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+#include "proxysql.h"
+#include "BackendSyncDecision.h"
+
+static void test_no_sync_needed() {
+	int a = determine_backend_sync_actions("user", "user", "db", "db", true, true);
+	ok(a == SYNC_NONE, "no sync: all match");
+
+	a = determine_backend_sync_actions("user", "user", "db", "db", false, false);
+	ok(a == SYNC_NONE, "no sync: autocommit both false");
+}
+
+static void test_schema_mismatch() {
+	int a = determine_backend_sync_actions("user", "user", "app_db", "other_db", true, true);
+	ok((a & SYNC_SCHEMA) != 0, "schema mismatch: SYNC_SCHEMA set");
+	ok((a & SYNC_USER) == 0, "schema mismatch: SYNC_USER not set");
+}
+
+static void test_user_mismatch() {
+	int a = determine_backend_sync_actions("alice", "bob", "db", "db", true, true);
+	ok((a & SYNC_USER) != 0, "user mismatch: SYNC_USER set");
+	// Schema check skipped when user differs (CHANGE USER handles schema)
+	ok((a & SYNC_SCHEMA) == 0, "user mismatch: SYNC_SCHEMA not set (handled by CHANGE USER)");
+}
+
+static void test_user_and_schema_mismatch() {
+	int a = determine_backend_sync_actions("alice", "bob", "db1", "db2", true, true);
+	ok((a & SYNC_USER) != 0, "user+schema: SYNC_USER set");
+	ok((a & SYNC_SCHEMA) == 0, "user+schema: schema handled by user change");
+}
+
+static void test_autocommit_mismatch() {
+	int a = determine_backend_sync_actions("user", "user", "db", "db", true, false);
+	ok((a & SYNC_AUTOCOMMIT) != 0, "autocommit mismatch: SYNC_AUTOCOMMIT set");
+	ok((a & SYNC_SCHEMA) == 0, "autocommit mismatch: no other sync");
+}
+
+static void test_multiple_mismatches() {
+	int a = determine_backend_sync_actions("user", "user", "db1", "db2", true, false);
+	ok((a & SYNC_SCHEMA) != 0, "multi: SYNC_SCHEMA set");
+	ok((a & SYNC_AUTOCOMMIT) != 0, "multi: SYNC_AUTOCOMMIT set");
+}
+
+static void test_null_handling() {
+	// null users — no crash
+	int a = determine_backend_sync_actions(nullptr, "user", "db", "db", true, true);
+	ok(a == SYNC_NONE || a >= 0, "null client_user: no crash");
+
+	a = determine_backend_sync_actions("user", nullptr, "db", "db", true, true);
+	ok(a == SYNC_NONE || a >= 0, "null backend_user: no crash");
+}
+
+int main() {
+	plan(15);
+	int rc = test_init_minimal();
+	ok(rc == 0, "test_init_minimal() succeeds");
+
+	test_no_sync_needed();           // 2
+	test_schema_mismatch();          // 2
+	test_user_mismatch();            // 2
+	test_user_and_schema_mismatch(); // 2
+	test_autocommit_mismatch();      // 2
+	test_multiple_mismatches();      // 2
+	test_null_handling();            // 2
+	// Total: 1+2+2+2+2+2+2+2 = 15
+
+	test_cleanup_minimal();
+	return exit_status();
+}

--- a/test/tap/tests/unit/backend_sync_unit-t.cpp
+++ b/test/tap/tests/unit/backend_sync_unit-t.cpp
@@ -52,15 +52,24 @@ static void test_multiple_mismatches() {
 
 static void test_null_handling() {
 	// null users — no crash
+	// Asymmetric NULL: one side null, other not → mismatch
 	int a = determine_backend_sync_actions(nullptr, "user", "db", "db", true, true);
-	ok(a == SYNC_NONE || a >= 0, "null client_user: no crash");
+	ok((a & SYNC_USER) != 0, "null client_user + non-null backend → SYNC_USER");
 
 	a = determine_backend_sync_actions("user", nullptr, "db", "db", true, true);
-	ok(a == SYNC_NONE || a >= 0, "null backend_user: no crash");
+	ok((a & SYNC_USER) != 0, "non-null client_user + null backend → SYNC_USER");
+
+	// Both null → no mismatch
+	a = determine_backend_sync_actions(nullptr, nullptr, "db", "db", true, true);
+	ok(a == SYNC_NONE, "both users null → no sync");
+
+	// Schema asymmetric null
+	a = determine_backend_sync_actions("user", "user", nullptr, "db", true, true);
+	ok((a & SYNC_SCHEMA) != 0, "null client_schema + non-null backend → SYNC_SCHEMA");
 }
 
 int main() {
-	plan(15);
+	plan(17);
 	int rc = test_init_minimal();
 	ok(rc == 0, "test_init_minimal() succeeds");
 
@@ -70,8 +79,8 @@ int main() {
 	test_user_and_schema_mismatch(); // 2
 	test_autocommit_mismatch();      // 2
 	test_multiple_mismatches();      // 2
-	test_null_handling();            // 2
-	// Total: 1+2+2+2+2+2+2+2 = 15
+	test_null_handling();            // 4
+	// Total: 1+2+2+2+2+2+2+4 = 17
 
 	test_cleanup_minimal();
 	return exit_status();


### PR DESCRIPTION
Implements #5494. Extracts determine_backend_sync_actions() — 15 tests covering user/schema/autocommit mismatch detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend synchronization decision logic to detect required sync steps for username, schema, and autocommit mismatches.

* **Tests**
  * Added comprehensive unit tests covering matching/mismatching states, combined cases, and null-handling edge cases.

* **Chores**
  * Integrated the new logic into the library build and enabled the corresponding unit test target in the test build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->