### PR TITLE
Phase 3.7: MySQL error classification + unit tests

### DIFF
--- a/include/MySQLErrorClassifier.h
+++ b/include/MySQLErrorClassifier.h
@@ -15,7 +15,6 @@
  * @brief Action to take after a MySQL backend query error.
  */
 enum MySQLErrorAction {
-	MYSQL_ERROR_CONTINUE,            ///< Error handled, continue processing.
 	MYSQL_ERROR_RETRY_ON_NEW_CONN,   ///< Reconnect and retry on a new server.
 	MYSQL_ERROR_REPORT_TO_CLIENT     ///< Send error to client, no retry.
 };
@@ -35,7 +34,7 @@ enum MySQLErrorAction {
  *   - multiplex not disabled
  *
  * @param error_code              MySQL error number.
- * @param retries_remaining       Number of retries left.
+ * @param retries_remaining       Number of retries left (> 0 to allow retry).
  * @param connection_reusable     Whether the connection can be reused.
  * @param in_active_transaction   Whether a transaction is in progress.
  * @param multiplex_disabled      Whether multiplexing is disabled.
@@ -57,7 +56,7 @@ MySQLErrorAction classify_mysql_error(
  * conditions are met.
  *
  * @param server_offline          Whether the backend server is offline.
- * @param retries_remaining       Number of retries left.
+ * @param retries_remaining       Number of retries left (> 0 to allow retry).
  * @param connection_reusable     Whether the connection can be reused.
  * @param in_active_transaction   Whether a transaction is in progress.
  * @param multiplex_disabled      Whether multiplexing is disabled.

--- a/include/MySQLErrorClassifier.h
+++ b/include/MySQLErrorClassifier.h
@@ -1,0 +1,76 @@
+/**
+ * @file MySQLErrorClassifier.h
+ * @brief Pure MySQL error classification for retry decisions.
+ *
+ * Extracted from MySQL_Session handler_ProcessingQueryError_CheckBackendConnectionStatus()
+ * and handler_minus1_HandleErrorCodes().
+ *
+ * @see Phase 3.7 (GitHub issue #5495)
+ */
+
+#ifndef MYSQL_ERROR_CLASSIFIER_H
+#define MYSQL_ERROR_CLASSIFIER_H
+
+/**
+ * @brief Action to take after a MySQL backend query error.
+ */
+enum MySQLErrorAction {
+	MYSQL_ERROR_CONTINUE,            ///< Error handled, continue processing.
+	MYSQL_ERROR_RETRY_ON_NEW_CONN,   ///< Reconnect and retry on a new server.
+	MYSQL_ERROR_REPORT_TO_CLIENT     ///< Send error to client, no retry.
+};
+
+/**
+ * @brief Classify a MySQL error code to determine retry eligibility.
+ *
+ * Mirrors the logic in handler_minus1_HandleErrorCodes():
+ * - Error 1047 (WSREP not ready): retryable if conditions permit
+ * - Error 1053 (server shutdown): retryable if conditions permit
+ * - Other errors: report to client
+ *
+ * Retry is only possible when:
+ *   - query_retries_on_failure > 0
+ *   - connection is reusable
+ *   - no active transaction
+ *   - multiplex not disabled
+ *
+ * @param error_code              MySQL error number.
+ * @param retries_remaining       Number of retries left.
+ * @param connection_reusable     Whether the connection can be reused.
+ * @param in_active_transaction   Whether a transaction is in progress.
+ * @param multiplex_disabled      Whether multiplexing is disabled.
+ * @return MySQLErrorAction indicating what to do.
+ */
+MySQLErrorAction classify_mysql_error(
+	unsigned int error_code,
+	int retries_remaining,
+	bool connection_reusable,
+	bool in_active_transaction,
+	bool multiplex_disabled
+);
+
+/**
+ * @brief Check if a backend query can be retried on a new connection.
+ *
+ * Mirrors handler_ProcessingQueryError_CheckBackendConnectionStatus().
+ * A retry is possible when the server is offline AND all retry
+ * conditions are met.
+ *
+ * @param server_offline          Whether the backend server is offline.
+ * @param retries_remaining       Number of retries left.
+ * @param connection_reusable     Whether the connection can be reused.
+ * @param in_active_transaction   Whether a transaction is in progress.
+ * @param multiplex_disabled      Whether multiplexing is disabled.
+ * @param transfer_started        Whether result transfer has already begun.
+ * @return true if the query should be retried on a new connection.
+ */
+bool can_retry_on_new_connection(
+	bool server_offline,
+	int retries_remaining,
+	bool connection_reusable,
+	bool in_active_transaction,
+	bool multiplex_disabled,
+	bool transfer_started
+);
+
+#endif // MYSQL_ERROR_CLASSIFIER_H

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -108,6 +108,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	MonitorHealthDecision.oo \
 	TransactionState.oo \
 	HostgroupRouting.oo \
+	MySQLErrorClassifier.oo \
 	proxy_sqlite3_symbols.oo
 
 # TSDB object files

--- a/lib/MySQLErrorClassifier.cpp
+++ b/lib/MySQLErrorClassifier.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file MySQLErrorClassifier.cpp
+ * @brief Implementation of MySQL error classification.
+ *
+ * @see MySQLErrorClassifier.h
+ * @see Phase 3.7 (GitHub issue #5495)
+ */
+
+#include "MySQLErrorClassifier.h"
+
+MySQLErrorAction classify_mysql_error(
+	unsigned int error_code,
+	int retries_remaining,
+	bool connection_reusable,
+	bool in_active_transaction,
+	bool multiplex_disabled)
+{
+	// Check if this error code is retryable
+	bool retryable_error = false;
+	switch (error_code) {
+		case 1047:  // ER_UNKNOWN_COM_ERROR (WSREP not ready)
+		case 1053:  // ER_SERVER_SHUTDOWN
+			retryable_error = true;
+			break;
+		default:
+			break;
+	}
+
+	if (!retryable_error) {
+		return MYSQL_ERROR_REPORT_TO_CLIENT;
+	}
+
+	// Check retry conditions (mirrors handler_minus1_HandleErrorCodes)
+	if (retries_remaining > 0
+		&& connection_reusable
+		&& !in_active_transaction
+		&& !multiplex_disabled) {
+		return MYSQL_ERROR_RETRY_ON_NEW_CONN;
+	}
+
+	return MYSQL_ERROR_REPORT_TO_CLIENT;
+}
+
+bool can_retry_on_new_connection(
+	bool server_offline,
+	int retries_remaining,
+	bool connection_reusable,
+	bool in_active_transaction,
+	bool multiplex_disabled,
+	bool transfer_started)
+{
+	if (!server_offline) {
+		return false;  // server is fine, no retry needed
+	}
+
+	// Mirror handler_ProcessingQueryError_CheckBackendConnectionStatus
+	if (retries_remaining > 0
+		&& connection_reusable
+		&& !in_active_transaction
+		&& !multiplex_disabled
+		&& !transfer_started) {
+		return true;
+	}
+
+	return false;
+}

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -235,7 +235,8 @@ UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 	protocol_unit-t auth_unit-t connection_pool_unit-t \
 	rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t \
   hostgroup_routing_unit-t \
-	transaction_state_unit-t
+	transaction_state_unit-t \
+	mysql_error_classifier_unit-t
 
 .PHONY: all
 all: $(UNIT_TESTS)

--- a/test/tap/tests/unit/mysql_error_classifier_unit-t.cpp
+++ b/test/tap/tests/unit/mysql_error_classifier_unit-t.cpp
@@ -1,0 +1,98 @@
+/**
+ * @file mysql_error_classifier_unit-t.cpp
+ * @brief Unit tests for MySQL error classification.
+ *
+ * @see Phase 3.7 (GitHub issue #5495)
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+#include "proxysql.h"
+#include "MySQLErrorClassifier.h"
+
+// ============================================================================
+// 1. classify_mysql_error
+// ============================================================================
+
+static void test_retryable_errors() {
+	// 1047 (WSREP not ready) with retry conditions met
+	ok(classify_mysql_error(1047, 3, true, false, false) == MYSQL_ERROR_RETRY_ON_NEW_CONN,
+		"1047: retryable when conditions met");
+	// 1053 (server shutdown) with retry conditions met
+	ok(classify_mysql_error(1053, 1, true, false, false) == MYSQL_ERROR_RETRY_ON_NEW_CONN,
+		"1053: retryable when conditions met");
+}
+
+static void test_retryable_but_blocked() {
+	// 1047 but no retries left
+	ok(classify_mysql_error(1047, 0, true, false, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"1047: not retried when retries=0");
+	// 1047 but connection not reusable
+	ok(classify_mysql_error(1047, 3, false, false, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"1047: not retried when connection not reusable");
+	// 1047 but in active transaction
+	ok(classify_mysql_error(1047, 3, true, true, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"1047: not retried during active transaction");
+	// 1047 but multiplex disabled
+	ok(classify_mysql_error(1047, 3, true, false, true) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"1047: not retried when multiplex disabled");
+}
+
+static void test_non_retryable_errors() {
+	// Common MySQL errors — always report to client
+	ok(classify_mysql_error(1045, 3, true, false, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"1045 (access denied): always report");
+	ok(classify_mysql_error(1064, 3, true, false, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"1064 (syntax error): always report");
+	ok(classify_mysql_error(1146, 3, true, false, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"1146 (table not found): always report");
+	ok(classify_mysql_error(2006, 3, true, false, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"2006 (gone away): always report");
+	ok(classify_mysql_error(0, 3, true, false, false) == MYSQL_ERROR_REPORT_TO_CLIENT,
+		"0 (no error): report");
+}
+
+// ============================================================================
+// 2. can_retry_on_new_connection
+// ============================================================================
+
+static void test_retry_on_offline() {
+	ok(can_retry_on_new_connection(true, 3, true, false, false, false) == true,
+		"retry: server offline, all conditions met");
+}
+
+static void test_no_retry_server_online() {
+	ok(can_retry_on_new_connection(false, 3, true, false, false, false) == false,
+		"no retry: server is online");
+}
+
+static void test_no_retry_conditions() {
+	ok(can_retry_on_new_connection(true, 0, true, false, false, false) == false,
+		"no retry: no retries left");
+	ok(can_retry_on_new_connection(true, 3, false, false, false, false) == false,
+		"no retry: connection not reusable");
+	ok(can_retry_on_new_connection(true, 3, true, true, false, false) == false,
+		"no retry: active transaction");
+	ok(can_retry_on_new_connection(true, 3, true, false, true, false) == false,
+		"no retry: multiplex disabled");
+	ok(can_retry_on_new_connection(true, 3, true, false, false, true) == false,
+		"no retry: transfer already started");
+}
+
+int main() {
+	plan(19);
+	int rc = test_init_minimal();
+	ok(rc == 0, "test_init_minimal() succeeds");
+
+	test_retryable_errors();       // 2
+	test_retryable_but_blocked();  // 4
+	test_non_retryable_errors();   // 5
+	test_retry_on_offline();       // 1
+	test_no_retry_server_online(); // 1
+	test_no_retry_conditions();    // 5
+	// Total: 1+2+4+5+1+1+5 = 19
+
+	test_cleanup_minimal();
+	return exit_status();
+}


### PR DESCRIPTION
Implements #5495. Extracts classify_mysql_error() and can_retry_on_new_connection() — 19 tests covering retryable errors (1047/1053), blocking conditions, and offline retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced MySQL error handling: certain backend errors can now be automatically retried on a new connection when eligibility conditions are met (retries remaining, reusable connection, not in an active transaction, multiplexing enabled, and transfer not started), reducing transient failures.

* **Tests**
  * Added unit tests validating error classification and retry eligibility across success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->