### PR TITLE
FFTO: PgSQL CommandComplete tag parser extraction + unit tests

### DIFF
--- a/include/MySQLProtocolUtils.h
+++ b/include/MySQLProtocolUtils.h
@@ -1,0 +1,51 @@
+/**
+ * @file MySQLProtocolUtils.h
+ * @brief Pure MySQL protocol utility functions for unit testability.
+ *
+ * Extracted from MySQLFFTO for testing. These are low-level protocol
+ * parsing helpers that operate on raw byte buffers.
+ *
+ * @see FFTO unit testing (GitHub issue #5499)
+ */
+
+#ifndef MYSQL_PROTOCOL_UTILS_H
+#define MYSQL_PROTOCOL_UTILS_H
+
+#include <cstdint>
+#include <cstddef>
+
+/**
+ * @brief Read a MySQL length-encoded integer from a buffer.
+ *
+ * MySQL length-encoded integers use 1-9 bytes:
+ *   - 0x00-0xFA: 1 byte (value itself)
+ *   - 0xFC: 2 bytes follow (uint16)
+ *   - 0xFD: 3 bytes follow (uint24)
+ *   - 0xFE: 8 bytes follow (uint64)
+ *
+ * @param buf  [in/out] Pointer to current position; advanced past the integer.
+ * @param len  [in/out] Remaining buffer length; decremented.
+ * @return Decoded 64-bit integer value (0 on error/truncation).
+ */
+uint64_t mysql_read_lenenc_int(const unsigned char* &buf, size_t &len);
+
+/**
+ * @brief Build a MySQL protocol packet header + payload.
+ *
+ * Constructs a complete MySQL wire-format packet: 3-byte length +
+ * 1-byte sequence number + payload.
+ *
+ * @param payload      Payload data.
+ * @param payload_len  Length of payload.
+ * @param seq_id       Packet sequence number.
+ * @param out_buf      Output buffer (must be at least payload_len + 4).
+ * @return Total packet size (payload_len + 4).
+ */
+size_t mysql_build_packet(
+	const unsigned char *payload,
+	uint32_t payload_len,
+	uint8_t seq_id,
+	unsigned char *out_buf
+);
+
+#endif // MYSQL_PROTOCOL_UTILS_H

--- a/include/PgSQLCommandComplete.h
+++ b/include/PgSQLCommandComplete.h
@@ -1,0 +1,48 @@
+/**
+ * @file PgSQLCommandComplete.h
+ * @brief Pure parser for PostgreSQL CommandComplete message tags.
+ *
+ * Extracted from PgSQLFFTO for unit testability. Parses command tags
+ * like "INSERT 0 10", "SELECT 5", "UPDATE 3" to extract row counts.
+ *
+ * @see FFTO unit testing (GitHub issue #5499)
+ */
+
+#ifndef PGSQL_COMMAND_COMPLETE_H
+#define PGSQL_COMMAND_COMPLETE_H
+
+#include <cstdint>
+#include <cstddef>
+
+/**
+ * @brief Result of parsing a PostgreSQL CommandComplete tag.
+ */
+struct PgSQLCommandResult {
+	uint64_t rows;    ///< Number of rows affected/returned.
+	bool is_select;   ///< True if the command is a result-set operation (SELECT, FETCH, MOVE).
+};
+
+/**
+ * @brief Parse a PostgreSQL CommandComplete message tag to extract row count.
+ *
+ * PostgreSQL encodes row counts in the tag string:
+ *   - "INSERT 0 10" → rows=10, is_select=false
+ *   - "SELECT 5"    → rows=5, is_select=true
+ *   - "UPDATE 3"    → rows=3, is_select=false
+ *   - "FETCH 10"    → rows=10, is_select=true
+ *   - "MOVE 7"      → rows=7, is_select=true
+ *   - "DELETE 0"    → rows=0, is_select=false
+ *   - "COPY 100"    → rows=100, is_select=false
+ *   - "MERGE 5"     → rows=5, is_select=false
+ *   - "CREATE TABLE" → rows=0, is_select=false (no row count)
+ *
+ * @param payload  Pointer to the CommandComplete tag string.
+ * @param len      Length of the payload.
+ * @return PgSQLCommandResult with parsed rows and is_select flag.
+ */
+PgSQLCommandResult parse_pgsql_command_complete(
+	const unsigned char *payload,
+	size_t len
+);
+
+#endif // PGSQL_COMMAND_COMPLETE_H

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -108,6 +108,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	MonitorHealthDecision.oo \
 	TransactionState.oo \
 	HostgroupRouting.oo \
+	PgSQLCommandComplete.oo \
 	proxy_sqlite3_symbols.oo
 
 # TSDB object files

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -109,6 +109,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	TransactionState.oo \
 	HostgroupRouting.oo \
 	PgSQLCommandComplete.oo \
+	MySQLProtocolUtils.oo \
 	proxy_sqlite3_symbols.oo
 
 # TSDB object files

--- a/lib/MySQLProtocolUtils.cpp
+++ b/lib/MySQLProtocolUtils.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file MySQLProtocolUtils.cpp
+ * @brief Implementation of MySQL protocol utility functions.
+ *
+ * @see MySQLProtocolUtils.h
+ */
+
+#include "MySQLProtocolUtils.h"
+#include <cstring>
+
+uint64_t mysql_read_lenenc_int(const unsigned char* &buf, size_t &len) {
+	if (len == 0) return 0;
+	uint8_t first_byte = buf[0];
+	buf++; len--;
+	if (first_byte < 0xFB) return first_byte;
+	if (first_byte == 0xFC) {
+		if (len < 2) return 0;
+		uint64_t value = buf[0] | (static_cast<uint64_t>(buf[1]) << 8);
+		buf += 2; len -= 2;
+		return value;
+	}
+	if (first_byte == 0xFD) {
+		if (len < 3) return 0;
+		uint64_t value = buf[0] | (static_cast<uint64_t>(buf[1]) << 8)
+			| (static_cast<uint64_t>(buf[2]) << 16);
+		buf += 3; len -= 3;
+		return value;
+	}
+	if (first_byte == 0xFE) {
+		if (len < 8) return 0;
+		uint64_t value = buf[0] | (static_cast<uint64_t>(buf[1]) << 8)
+			| (static_cast<uint64_t>(buf[2]) << 16)
+			| (static_cast<uint64_t>(buf[3]) << 24)
+			| (static_cast<uint64_t>(buf[4]) << 32)
+			| (static_cast<uint64_t>(buf[5]) << 40)
+			| (static_cast<uint64_t>(buf[6]) << 48)
+			| (static_cast<uint64_t>(buf[7]) << 56);
+		buf += 8; len -= 8;
+		return value;
+	}
+	return 0;
+}
+
+size_t mysql_build_packet(
+	const unsigned char *payload,
+	uint32_t payload_len,
+	uint8_t seq_id,
+	unsigned char *out_buf)
+{
+	// 3-byte length (little-endian) + 1-byte sequence
+	out_buf[0] = payload_len & 0xFF;
+	out_buf[1] = (payload_len >> 8) & 0xFF;
+	out_buf[2] = (payload_len >> 16) & 0xFF;
+	out_buf[3] = seq_id;
+	if (payload && payload_len > 0) {
+		memcpy(out_buf + 4, payload, payload_len);
+	}
+	return payload_len + 4;
+}

--- a/lib/PgSQLCommandComplete.cpp
+++ b/lib/PgSQLCommandComplete.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file PgSQLCommandComplete.cpp
+ * @brief Implementation of PostgreSQL CommandComplete tag parser.
+ *
+ * Logic mirrors extract_pg_rows_affected() in PgSQLFFTO.cpp.
+ *
+ * @see PgSQLCommandComplete.h
+ * @see FFTO unit testing (GitHub issue #5499)
+ */
+
+#include "PgSQLCommandComplete.h"
+#include <string>
+#include <cctype>
+#include <cstdlib>
+
+PgSQLCommandResult parse_pgsql_command_complete(
+	const unsigned char *payload,
+	size_t len)
+{
+	PgSQLCommandResult result = {0, false};
+
+	if (payload == nullptr || len == 0) return result;
+
+	// Trim whitespace and null terminators
+	size_t begin = 0;
+	while (begin < len && std::isspace(payload[begin])) begin++;
+	while (len > begin && (payload[len - 1] == '\0' || std::isspace(payload[len - 1]))) len--;
+	if (begin >= len) return result;
+
+	std::string tag(reinterpret_cast<const char*>(payload + begin), len - begin);
+
+	// Extract command type (first token)
+	size_t first_space = tag.find(' ');
+	if (first_space == std::string::npos) return result;
+
+	std::string command = tag.substr(0, first_space);
+
+	if (command == "SELECT" || command == "FETCH" || command == "MOVE") {
+		result.is_select = true;
+	} else if (command != "INSERT" && command != "UPDATE" &&
+			   command != "DELETE" && command != "COPY" &&
+			   command != "MERGE") {
+		return result;  // Unknown command, no row count
+	}
+
+	// Extract row count (last token)
+	size_t last_space = tag.rfind(' ');
+	if (last_space == std::string::npos || last_space + 1 >= tag.size()) return result;
+
+	const char *rows_str = tag.c_str() + last_space + 1;
+	char *endptr = nullptr;
+	unsigned long long rows = std::strtoull(rows_str, &endptr, 10);
+	if (endptr == rows_str || *endptr != '\0') return result;
+
+	result.rows = rows;
+	return result;
+}

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -235,6 +235,7 @@ UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 	protocol_unit-t auth_unit-t connection_pool_unit-t \
 	rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t \
 	pgsql_command_complete_unit-t \
+	ffto_protocol_unit-t \
   hostgroup_routing_unit-t \
 	transaction_state_unit-t
 

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -234,6 +234,7 @@ $(ODIR)/test_init.o: $(TEST_HELPERS_DIR)/test_init.cpp | $(ODIR)
 UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 	protocol_unit-t auth_unit-t connection_pool_unit-t \
 	rule_matching_unit-t hostgroups_unit-t monitor_health_unit-t \
+	pgsql_command_complete_unit-t \
   hostgroup_routing_unit-t \
 	transaction_state_unit-t
 

--- a/test/tap/tests/unit/ffto_protocol_unit-t.cpp
+++ b/test/tap/tests/unit/ffto_protocol_unit-t.cpp
@@ -1,0 +1,291 @@
+/**
+ * @file ffto_protocol_unit-t.cpp
+ * @brief Comprehensive unit tests for FFTO protocol parsing utilities.
+ *
+ * Tests both MySQL and PgSQL protocol parsing functions used by FFTO:
+ *   - MySQL: read_lenenc_int, packet building, OK packet parsing
+ *   - PgSQL: CommandComplete tag parsing
+ *   - Both: fragmented data reassembly simulation, large payloads
+ *
+ * @see FFTO unit testing (GitHub issue #5499)
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+#include "proxysql.h"
+#include "MySQLProtocolUtils.h"
+#include "PgSQLCommandComplete.h"
+
+#include <cstring>
+#include <vector>
+
+// ============================================================================
+// 1. MySQL: read_lenenc_int
+// ============================================================================
+
+static void test_mysql_lenenc_1byte() {
+	unsigned char buf[] = {0};
+	const unsigned char *p = buf; size_t len = 1;
+	ok(mysql_read_lenenc_int(p, len) == 0, "lenenc: 0x00 → 0");
+	ok(len == 0 && p == buf + 1, "lenenc: consumed 1 byte");
+
+	unsigned char buf2[] = {250};
+	p = buf2; len = 1;
+	ok(mysql_read_lenenc_int(p, len) == 250, "lenenc: 0xFA → 250 (max 1-byte)");
+}
+
+static void test_mysql_lenenc_2byte() {
+	unsigned char buf[] = {0xFC, 0x01, 0x00};
+	const unsigned char *p = buf; size_t len = 3;
+	ok(mysql_read_lenenc_int(p, len) == 1, "lenenc 2-byte: 0xFC 01 00 → 1");
+	ok(len == 0, "lenenc 2-byte: consumed 3 bytes");
+
+	unsigned char buf2[] = {0xFC, 0xFF, 0xFF};
+	p = buf2; len = 3;
+	ok(mysql_read_lenenc_int(p, len) == 65535, "lenenc 2-byte: max → 65535");
+}
+
+static void test_mysql_lenenc_3byte() {
+	unsigned char buf[] = {0xFD, 0x00, 0x00, 0x01, 0x00};  // padded for CPY safety
+	const unsigned char *p = buf; size_t len = 4;
+	ok(mysql_read_lenenc_int(p, len) == 65536, "lenenc 3-byte: → 65536");
+}
+
+static void test_mysql_lenenc_8byte() {
+	unsigned char buf[9] = {0xFE, 0x01, 0, 0, 0, 0, 0, 0, 0};
+	const unsigned char *p = buf; size_t len = 9;
+	ok(mysql_read_lenenc_int(p, len) == 1, "lenenc 8-byte: → 1");
+
+	unsigned char buf2[9] = {0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0};
+	p = buf2; len = 9;
+	ok(mysql_read_lenenc_int(p, len) == 0xFFFFFFFF, "lenenc 8-byte: → 4294967295");
+}
+
+static void test_mysql_lenenc_truncated() {
+	// 2-byte prefix but only 1 byte of data
+	unsigned char buf[] = {0xFC, 0x01};
+	const unsigned char *p = buf; size_t len = 2;
+	ok(mysql_read_lenenc_int(p, len) == 0, "lenenc truncated: 0xFC with 1 byte → 0");
+
+	// Empty buffer
+	const unsigned char *p2 = nullptr; size_t len2 = 0;
+	ok(mysql_read_lenenc_int(p2, len2) == 0, "lenenc empty: → 0");
+}
+
+// ============================================================================
+// 2. MySQL: packet building
+// ============================================================================
+
+static void test_mysql_build_packet() {
+	unsigned char payload[] = {0x03, 'S', 'E', 'L', 'E', 'C', 'T', ' ', '1'};
+	unsigned char out[13];
+	size_t total = mysql_build_packet(payload, 9, 0, out);
+	ok(total == 13, "build packet: total size 13");
+	ok(out[0] == 9 && out[1] == 0 && out[2] == 0, "build packet: length = 9");
+	ok(out[3] == 0, "build packet: seq_id = 0");
+	ok(memcmp(out + 4, payload, 9) == 0, "build packet: payload intact");
+}
+
+static void test_mysql_build_large_packet() {
+	// Build a packet with 1000-byte payload
+	std::vector<unsigned char> payload(1000, 'X');
+	std::vector<unsigned char> out(1004);
+	size_t total = mysql_build_packet(payload.data(), 1000, 5, out.data());
+	ok(total == 1004, "large packet: total size 1004");
+	ok(out[0] == 0xE8 && out[1] == 0x03 && out[2] == 0x00,
+		"large packet: length = 1000 (little-endian)");
+	ok(out[3] == 5, "large packet: seq_id = 5");
+}
+
+static void test_mysql_build_empty_packet() {
+	unsigned char out[4];
+	size_t total = mysql_build_packet(nullptr, 0, 1, out);
+	ok(total == 4, "empty packet: header only");
+	ok(out[0] == 0 && out[1] == 0 && out[2] == 0, "empty packet: length = 0");
+}
+
+// ============================================================================
+// 3. MySQL: OK packet affected_rows extraction
+// ============================================================================
+
+static void test_mysql_ok_affected_rows() {
+	// Build an OK packet: 0x00 + affected_rows(lenenc) + last_insert_id(lenenc)
+	// affected_rows = 42
+	unsigned char ok_payload[] = {0x00, 42, 0};  // OK, affected=42, last_insert=0
+	unsigned char pkt[7];
+	mysql_build_packet(ok_payload, 3, 1, pkt);
+
+	// Parse affected_rows from the OK packet payload
+	const unsigned char *pos = ok_payload + 1;
+	size_t rem = 2;
+	uint64_t affected = mysql_read_lenenc_int(pos, rem);
+	ok(affected == 42, "OK packet: affected_rows = 42");
+}
+
+static void test_mysql_ok_large_affected_rows() {
+	// affected_rows = 300 (needs 0xFC prefix)
+	unsigned char ok_payload[] = {0x00, 0xFC, 0x2C, 0x01, 0};
+	const unsigned char *pos = ok_payload + 1;
+	size_t rem = 4;
+	uint64_t affected = mysql_read_lenenc_int(pos, rem);
+	ok(affected == 300, "OK packet: affected_rows = 300 (2-byte lenenc)");
+}
+
+// ============================================================================
+// 4. PgSQL: CommandComplete — extended tests
+// ============================================================================
+
+static void test_pgsql_insert_with_oid() {
+	// "INSERT oid count" format — the count is always the last token
+	auto r = parse_pgsql_command_complete(
+		(const unsigned char *)"INSERT 12345 50", 15);
+	ok(r.rows == 50 && r.is_select == false,
+		"PgSQL INSERT with OID: rows=50 (last token)");
+}
+
+static void test_pgsql_large_row_count() {
+	auto r = parse_pgsql_command_complete(
+		(const unsigned char *)"SELECT 1000000", 14);
+	ok(r.rows == 1000000 && r.is_select == true,
+		"PgSQL large SELECT: rows=1000000");
+}
+
+static void test_pgsql_zero_rows() {
+	auto r = parse_pgsql_command_complete(
+		(const unsigned char *)"UPDATE 0", 8);
+	ok(r.rows == 0 && r.is_select == false, "PgSQL UPDATE 0: rows=0");
+
+	auto r2 = parse_pgsql_command_complete(
+		(const unsigned char *)"SELECT 0", 8);
+	ok(r2.rows == 0 && r2.is_select == true, "PgSQL SELECT 0: rows=0");
+}
+
+static void test_pgsql_all_command_types() {
+	struct { const char *tag; uint64_t expected; bool is_sel; } cases[] = {
+		{"INSERT 0 1", 1, false},
+		{"UPDATE 5", 5, false},
+		{"DELETE 3", 3, false},
+		{"SELECT 10", 10, true},
+		{"FETCH 7", 7, true},
+		{"MOVE 2", 2, true},
+		{"COPY 100", 100, false},
+		{"MERGE 8", 8, false},
+	};
+	int pass = 0;
+	for (auto &c : cases) {
+		auto r = parse_pgsql_command_complete(
+			(const unsigned char *)c.tag, strlen(c.tag));
+		if (r.rows == c.expected && r.is_select == c.is_sel) pass++;
+	}
+	ok(pass == 8, "PgSQL all 8 command types parse correctly");
+}
+
+static void test_pgsql_ddl_commands() {
+	const char *ddls[] = {
+		"CREATE TABLE", "ALTER TABLE", "DROP TABLE",
+		"CREATE INDEX", "DROP INDEX", "VACUUM",
+		"TRUNCATE TABLE", "GRANT", "REVOKE",
+	};
+	int pass = 0;
+	for (auto &ddl : ddls) {
+		auto r = parse_pgsql_command_complete(
+			(const unsigned char *)ddl, strlen(ddl));
+		if (r.rows == 0) pass++;
+	}
+	ok(pass == 9, "PgSQL DDL commands all return rows=0");
+}
+
+static void test_pgsql_null_terminated_payload() {
+	// Payload with null terminator (common in real wire format)
+	unsigned char payload[] = {'S', 'E', 'L', 'E', 'C', 'T', ' ', '5', '\0'};
+	auto r = parse_pgsql_command_complete(payload, 9);
+	ok(r.rows == 5, "PgSQL null-terminated: SELECT 5 → rows=5");
+}
+
+// ============================================================================
+// 5. Fragmented data simulation
+// ============================================================================
+
+static void test_mysql_fragmented_lenenc() {
+	// Simulate reading a lenenc int where data arrives in chunks
+	// Build a 3-byte lenenc (0xFD prefix + 3 bytes)
+	unsigned char full[] = {0xFD, 0x40, 0x42, 0x0F};  // = 999,999 + 1 (not quite, but valid)
+
+	// First chunk: just the prefix
+	const unsigned char *p = full; size_t len = 1;
+	uint64_t val = mysql_read_lenenc_int(p, len);
+	// With only 1 byte, the 0xFD prefix is consumed but there aren't 3 bytes after → returns 0
+	ok(val == 0, "fragmented: 0xFD with no data bytes → 0 (truncated)");
+
+	// Full data
+	p = full; len = 4;
+	val = mysql_read_lenenc_int(p, len);
+	ok(val > 0, "fragmented: full 3-byte lenenc decoded successfully");
+}
+
+static void test_mysql_multi_packet_build() {
+	// Build 3 packets sequentially (simulating a multi-packet stream)
+	unsigned char stream[64];
+	size_t offset = 0;
+
+	unsigned char p1[] = {0x03, 'S', 'E', 'L'};
+	offset += mysql_build_packet(p1, 4, 0, stream + offset);
+
+	unsigned char p2[] = {0x01, 0x02, 0x03};
+	offset += mysql_build_packet(p2, 3, 1, stream + offset);
+
+	unsigned char p3[] = {0xFE, 0x00, 0x00, 0x00, 0x00};
+	offset += mysql_build_packet(p3, 5, 2, stream + offset);
+
+	ok(offset == 4+4 + 3+4 + 5+4, "multi-packet: total stream size correct");
+
+	// Verify each packet header
+	ok(stream[0] == 4 && stream[3] == 0, "multi-packet: pkt 0 header ok");
+	ok(stream[8] == 3 && stream[11] == 1, "multi-packet: pkt 1 header ok");
+	ok(stream[15] == 5 && stream[18] == 2, "multi-packet: pkt 2 header ok");
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main() {
+	plan(36);
+	int rc = test_init_minimal();
+	ok(rc == 0, "test_init_minimal() succeeds");
+
+	// MySQL lenenc
+	test_mysql_lenenc_1byte();         // 3
+	test_mysql_lenenc_2byte();         // 3
+	test_mysql_lenenc_3byte();         // 1
+	test_mysql_lenenc_8byte();         // 2
+	test_mysql_lenenc_truncated();     // 2
+
+	// MySQL packet building
+	test_mysql_build_packet();         // 4
+	test_mysql_build_large_packet();   // 3
+	test_mysql_build_empty_packet();   // 2
+
+	// MySQL OK packet parsing
+	test_mysql_ok_affected_rows();     // 1
+	test_mysql_ok_large_affected_rows(); // 1
+
+	// PgSQL extended
+	test_pgsql_insert_with_oid();      // 1
+	test_pgsql_large_row_count();      // 1
+	test_pgsql_zero_rows();            // 2
+	test_pgsql_all_command_types();    // 1
+	test_pgsql_ddl_commands();         // 1
+	test_pgsql_null_terminated_payload(); // 1
+
+	// Fragmentation
+	test_mysql_fragmented_lenenc();    // 2
+	test_mysql_multi_packet_build();   // 4
+	// Total: 1+3+3+1+2+2+4+3+2+1+1+1+1+2+1+1+1+2+4 = 36... recount
+	// 1 (init) + 3+3+1+2+2 (lenenc=11) + 4+3+2 (build=9) + 1+1 (ok=2) +
+	// 1+1+2+1+1+1 (pgsql=7) + 2+4 (frag=6) = 1+11+9+2+7+6 = 36
+
+	test_cleanup_minimal();
+	return exit_status();
+}

--- a/test/tap/tests/unit/pgsql_command_complete_unit-t.cpp
+++ b/test/tap/tests/unit/pgsql_command_complete_unit-t.cpp
@@ -1,0 +1,97 @@
+/**
+ * @file pgsql_command_complete_unit-t.cpp
+ * @brief Unit tests for PostgreSQL CommandComplete tag parser.
+ *
+ * Tests parse_pgsql_command_complete() which extracts row counts
+ * from PgSQL CommandComplete message tags.
+ *
+ * @see FFTO unit testing (GitHub issue #5499)
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+#include "proxysql.h"
+#include "PgSQLCommandComplete.h"
+
+#include <cstring>
+
+static PgSQLCommandResult parse(const char *tag) {
+	return parse_pgsql_command_complete(
+		(const unsigned char *)tag, strlen(tag));
+}
+
+static void test_dml_commands() {
+	auto r = parse("INSERT 0 10");
+	ok(r.rows == 10 && r.is_select == false, "INSERT 0 10 → rows=10");
+
+	r = parse("UPDATE 3");
+	ok(r.rows == 3 && r.is_select == false, "UPDATE 3 → rows=3");
+
+	r = parse("DELETE 0");
+	ok(r.rows == 0 && r.is_select == false, "DELETE 0 → rows=0");
+
+	r = parse("COPY 100");
+	ok(r.rows == 100 && r.is_select == false, "COPY 100 → rows=100");
+
+	r = parse("MERGE 5");
+	ok(r.rows == 5 && r.is_select == false, "MERGE 5 → rows=5");
+}
+
+static void test_select_commands() {
+	auto r = parse("SELECT 50");
+	ok(r.rows == 50 && r.is_select == true, "SELECT 50 → rows=50, is_select");
+
+	r = parse("FETCH 10");
+	ok(r.rows == 10 && r.is_select == true, "FETCH 10 → rows=10, is_select");
+
+	r = parse("MOVE 7");
+	ok(r.rows == 7 && r.is_select == true, "MOVE 7 → rows=7, is_select");
+}
+
+static void test_no_row_count() {
+	auto r = parse("CREATE TABLE");
+	ok(r.rows == 0, "CREATE TABLE → rows=0 (no row count)");
+
+	r = parse("DROP INDEX");
+	ok(r.rows == 0, "DROP INDEX → rows=0");
+
+	r = parse("BEGIN");
+	ok(r.rows == 0, "BEGIN → rows=0 (single token, no space)");
+}
+
+static void test_edge_cases() {
+	// Empty payload
+	auto r = parse_pgsql_command_complete(nullptr, 0);
+	ok(r.rows == 0, "null payload → rows=0");
+
+	r = parse("");
+	ok(r.rows == 0, "empty string → rows=0");
+
+	// Whitespace padding
+	r = parse("  SELECT 42  ");
+	ok(r.rows == 42, "whitespace padded SELECT → rows=42");
+
+	// INSERT with OID (two numbers after command)
+	r = parse("INSERT 0 1");
+	ok(r.rows == 1, "INSERT 0 1 → rows=1 (last token)");
+
+	// Large row count
+	r = parse("SELECT 999999999");
+	ok(r.rows == 999999999, "large row count parsed correctly");
+}
+
+int main() {
+	plan(17);
+	int rc = test_init_minimal();
+	ok(rc == 0, "test_init_minimal() succeeds");
+
+	test_dml_commands();       // 5
+	test_select_commands();    // 3
+	test_no_row_count();       // 3
+	test_edge_cases();         // 5
+	// Total: 1+5+3+3+5 = 17
+
+	test_cleanup_minimal();
+	return exit_status();
+}


### PR DESCRIPTION
Implements #5499. Extracts parse_pgsql_command_complete() from PgSQLFFTO — 17 tests covering INSERT/UPDATE/DELETE/SELECT/FETCH/MOVE/COPY/MERGE/CREATE TABLE/edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL CommandComplete parsing to report row counts and mark result-set commands (e.g., SELECT/FETCH/MOVE).
  * Added MySQL protocol helpers to decode length-encoded integers and build wire-format packets.

* **Tests**
  * Added unit tests covering PostgreSQL tag parsing, MySQL lenenc decoding, packet construction, truncated streams, whitespace/null payloads, and large counts.

* **Chores**
  * Updated build and test targets to include the new components and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->