### PR TITLE
feat(ffto): record error details from fast-forward sessions

### DIFF
--- a/include/MySQLFFTO.hpp
+++ b/include/MySQLFFTO.hpp
@@ -108,6 +108,13 @@ private:
      * @param rows_sent Number of rows returned.
      */
     void report_query_stats(const std::string& query, unsigned long long duration_us, uint64_t affected_rows = 0, uint64_t rows_sent = 0);
+
+    /**
+     * @brief Records an error from a MySQL ERR packet into stats_mysql_errors.
+     * @param data Pointer to the ERR packet payload (starting with 0xFF).
+     * @param len Length of the payload.
+     */
+    void report_error(const unsigned char* data, size_t len);
 };
 
 #endif // MYSQL_FFTO_HPP

--- a/include/MySQLProtocolUtils.h
+++ b/include/MySQLProtocolUtils.h
@@ -48,4 +48,21 @@ size_t mysql_build_packet(
 	unsigned char *out_buf
 );
 
+/**
+ * @brief Parse a MySQL ERR packet payload to extract errno and error message.
+ *
+ * ERR packet format: 0xFF + errno(2) + ['#' + sqlstate(5)] + message
+ *
+ * @param payload    Full ERR packet payload (starting with 0xFF).
+ * @param len        Length of payload.
+ * @param out_errno  [out] MySQL error number.
+ * @param out_msg    [out] Pointer into payload where error message starts.
+ * @param out_msg_len [out] Length of error message.
+ * @return true if parsed successfully, false if payload too short.
+ */
+bool mysql_parse_err_packet(
+    const unsigned char* payload, size_t len,
+    uint16_t* out_errno, const char** out_msg, size_t* out_msg_len
+);
+
 #endif // MYSQL_PROTOCOL_UTILS_H

--- a/include/PgSQLErrorFields.h
+++ b/include/PgSQLErrorFields.h
@@ -1,0 +1,39 @@
+/**
+ * @file PgSQLErrorFields.h
+ * @brief Parser for PostgreSQL ErrorResponse message fields.
+ *
+ * Extracted for unit testability. Scans ErrorResponse payload for
+ * SQLSTATE ('C') and message ('M') fields.
+ *
+ * @see PostgreSQL Protocol: ErrorResponse message format
+ */
+
+#ifndef PGSQL_ERROR_FIELDS_H
+#define PGSQL_ERROR_FIELDS_H
+
+#include <cstdint>
+#include <cstddef>
+
+/**
+ * @brief Result of parsing a PostgreSQL ErrorResponse payload.
+ */
+struct PgSQLErrorResult {
+    bool parsed;              ///< True if payload was non-null and scanned.
+    char sqlstate[6];         ///< 5-char SQLSTATE + null terminator (empty if not found).
+    const char* message;      ///< Pointer into payload at 'M' field value (null if not found).
+    size_t message_len;       ///< Length of message string.
+};
+
+/**
+ * @brief Parse a PostgreSQL ErrorResponse payload to extract SQLSTATE and message.
+ *
+ * Scans the field-type/value pairs in the ErrorResponse payload.
+ * Field format: type_byte + null_terminated_string, repeated, ending with '\0'.
+ *
+ * @param payload  ErrorResponse message payload (after the 5-byte header).
+ * @param len      Length of the payload.
+ * @return PgSQLErrorResult with parsed fields.
+ */
+PgSQLErrorResult pgsql_parse_error_response(const unsigned char* payload, size_t len);
+
+#endif // PGSQL_ERROR_FIELDS_H

--- a/include/PgSQLFFTO.hpp
+++ b/include/PgSQLFFTO.hpp
@@ -118,6 +118,13 @@ private:
      * @param rows_sent Number of rows returned.
      */
     void report_query_stats(const std::string& query, unsigned long long duration_us, uint64_t affected_rows = 0, uint64_t rows_sent = 0);
+
+    /**
+     * @brief Records an error from a PostgreSQL ErrorResponse into stats_pgsql_errors.
+     * @param payload Pointer to the ErrorResponse message payload.
+     * @param len Length of the payload.
+     */
+    void report_error(const unsigned char* payload, size_t len);
 };
 
 #endif // PGSQL_FFTO_HPP

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -110,6 +110,7 @@ _OBJ_CXX := ProxySQL_GloVars.oo network.oo debug.oo configfile.oo Query_Cache.oo
 	TransactionState.oo \
 	HostgroupRouting.oo \
 	PgSQLCommandComplete.oo \
+	PgSQLErrorFields.oo \
 	MySQLProtocolUtils.oo \
 	PgSQLErrorClassifier.oo \
 	PgSQLMonitorDecision.oo \

--- a/lib/MySQLFFTO.cpp
+++ b/lib/MySQLFFTO.cpp
@@ -7,6 +7,7 @@
 #include "MySQL_Protocol.h"
 #include "MySQL_Variables.h"
 #include "MySQLFFTO.hpp"
+#include "MySQLProtocolUtils.h"
 #ifndef SPOOKYV2
 #include "SpookyV2.h"
 #define SPOOKYV2
@@ -17,6 +18,7 @@
 #include <algorithm>
 
 extern class MySQL_Query_Processor* GloMyQPro;
+extern MySQL_HostGroups_Manager* MyHGM;
 
 /**
  * @brief Helper function to read a length-encoded integer from a MySQL packet buffer.
@@ -187,6 +189,7 @@ void MySQLFFTO::process_server_packet(const unsigned char* data, size_t len) {
             m_state = IDLE;
             m_pending_prepare_query.clear();
         } else if (first_byte == 0xFF) {
+            report_error(data, len);
             m_state = IDLE;
             m_pending_prepare_query.clear();
         }
@@ -201,6 +204,7 @@ void MySQLFFTO::process_server_packet(const unsigned char* data, size_t len) {
         } else if (first_byte == 0xFF) { // ERR
             unsigned long long duration = monotonic_time() - m_query_start_time;
             report_query_stats(m_current_query, duration);
+            report_error(data, len);
             m_state = IDLE;
             clear_active_query();
         } else if (first_byte == 0xFE && len < 9) { // EOF
@@ -217,6 +221,7 @@ void MySQLFFTO::process_server_packet(const unsigned char* data, size_t len) {
         } else if (first_byte == 0xFF) { // ERR while reading column metadata
             unsigned long long duration = monotonic_time() - m_query_start_time;
             report_query_stats(m_current_query, duration);
+            report_error(data, len);
             m_state = IDLE;
             clear_active_query();
         }
@@ -234,6 +239,7 @@ void MySQLFFTO::process_server_packet(const unsigned char* data, size_t len) {
         } else if (first_byte == 0xFF) { // ERR
             unsigned long long duration = monotonic_time() - m_query_start_time;
             report_query_stats(m_current_query, duration, 0, m_rows_sent);
+            report_error(data, len);
             m_state = IDLE;
             clear_active_query();
         } else {
@@ -278,6 +284,47 @@ void MySQLFFTO::report_query_stats(const std::string& query, unsigned long long 
         if (digest_text != qp.buf) free(digest_text);
     }
     if (fst_cmnt) free(fst_cmnt);
+}
+
+void MySQLFFTO::report_error(const unsigned char* data, size_t len) {
+    if (!m_session || !MyHGM) return;
+    if (!m_session->client_myds || !m_session->client_myds->myconn ||
+        !m_session->client_myds->myconn->userinfo) return;
+
+    uint16_t err_no = 0;
+    const char* errmsg = nullptr;
+    size_t errmsg_len = 0;
+    if (!mysql_parse_err_packet(data, len, &err_no, &errmsg, &errmsg_len)) return;
+
+    auto* ui = m_session->client_myds->myconn->userinfo;
+    if (!ui->username || !ui->schemaname) return;
+
+    // Build a null-terminated copy of the error message
+    std::string msg(errmsg ? errmsg : "", errmsg_len);
+
+    // Get backend server info if available
+    char* hostname = (char*)"";
+    int port = 0;
+    int hostgroup = m_session->current_hostgroup;
+    if (m_session->mybe && m_session->mybe->server_myds &&
+        m_session->mybe->server_myds->myconn &&
+        m_session->mybe->server_myds->myconn->parent) {
+        auto* parent = m_session->mybe->server_myds->myconn->parent;
+        hostname = parent->address;
+        port = parent->port;
+        hostgroup = parent->myhgc->hid;
+    }
+
+    char* client_addr = (char*)"unknown";
+    if (m_session->client_myds->addr.addr) {
+        client_addr = m_session->client_myds->addr.addr;
+    }
+
+    MyHGM->add_mysql_errors(
+        hostgroup, hostname, port,
+        ui->username, client_addr, ui->schemaname,
+        err_no, (char*)msg.c_str()
+    );
 }
 
 std::size_t MySQLFFTO::get_buffered_size() const {

--- a/lib/MySQLProtocolUtils.cpp
+++ b/lib/MySQLProtocolUtils.cpp
@@ -57,3 +57,24 @@ size_t mysql_build_packet(
 	}
 	return payload_len + 4;
 }
+
+bool mysql_parse_err_packet(
+    const unsigned char* payload, size_t len,
+    uint16_t* out_errno, const char** out_msg, size_t* out_msg_len
+) {
+    // Minimum: 0xFF + 2 bytes errno = 3 bytes
+    if (!payload || len < 3 || payload[0] != 0xFF) return false;
+
+    *out_errno = payload[1] | (static_cast<uint16_t>(payload[2]) << 8);
+
+    if (len >= 9 && payload[3] == '#') {
+        // sqlstate at [4..8], message at [9..]
+        *out_msg = reinterpret_cast<const char*>(payload + 9);
+        *out_msg_len = len - 9;
+    } else {
+        // no sqlstate marker — message starts at [3]
+        *out_msg = reinterpret_cast<const char*>(payload + 3);
+        *out_msg_len = len - 3;
+    }
+    return true;
+}

--- a/lib/PgSQLErrorFields.cpp
+++ b/lib/PgSQLErrorFields.cpp
@@ -1,0 +1,37 @@
+#include "PgSQLErrorFields.h"
+#include <cstring>
+
+PgSQLErrorResult pgsql_parse_error_response(const unsigned char* payload, size_t len) {
+    PgSQLErrorResult result {};
+    result.parsed = false;
+    result.sqlstate[0] = '\0';
+    result.message = nullptr;
+    result.message_len = 0;
+
+    if (!payload || len == 0) return result;
+    result.parsed = true;
+
+    size_t pos = 0;
+    while (pos < len) {
+        char field_type = static_cast<char>(payload[pos]);
+        if (field_type == '\0') break;  // end of fields
+        pos++;  // skip field type byte
+
+        // Find the null terminator for this field's value
+        const char* value = reinterpret_cast<const char*>(payload + pos);
+        size_t value_len = strnlen(value, len - pos);
+        if (pos + value_len >= len) break;  // truncated
+
+        if (field_type == 'C' && value_len <= 5) {
+            memcpy(result.sqlstate, value, value_len);
+            result.sqlstate[value_len] = '\0';
+        } else if (field_type == 'M') {
+            result.message = value;
+            result.message_len = value_len;
+        }
+
+        pos += value_len + 1;  // skip value + null terminator
+    }
+
+    return result;
+}

--- a/lib/PgSQLFFTO.cpp
+++ b/lib/PgSQLFFTO.cpp
@@ -10,12 +10,14 @@
 #define SPOOKYV2
 #endif
 #include "c_tokenizer.h"
+#include "PgSQLErrorFields.h"
 #include <arpa/inet.h>
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
 
 extern class PgSQL_Query_Processor* GloPgQPro;
+extern PgSQL_HostGroups_Manager* PgHGM;
 
 /**
  * @brief Parses the PostgreSQL CommandComplete ('C') message payload to extract row counts.
@@ -266,6 +268,7 @@ void PgSQLFFTO::process_server_message(char type, const unsigned char* payload, 
             unsigned long long duration = monotonic_time() - m_query_start_time;
             report_query_stats(m_current_query, duration, m_affected_rows, m_rows_sent);
         }
+        report_error(payload, len);
         clear_current_query();
         m_pending_queries.clear();
         m_state = IDLE;
@@ -308,6 +311,46 @@ void PgSQLFFTO::report_query_stats(const std::string& query, unsigned long long 
         if (digest_text != qp.buf) free(digest_text);
     }
     if (fst_cmnt) free(fst_cmnt);
+}
+
+void PgSQLFFTO::report_error(const unsigned char* payload, size_t len) {
+    if (!m_session || !PgHGM) return;
+    if (!m_session->client_myds || !m_session->client_myds->myconn ||
+        !m_session->client_myds->myconn->userinfo) return;
+
+    PgSQLErrorResult err = pgsql_parse_error_response(payload, len);
+    if (!err.parsed) return;
+
+    auto* ui = m_session->client_myds->myconn->userinfo;
+    if (!ui->username || !ui->schemaname) return;
+
+    // Build a null-terminated copy of the error message
+    std::string msg(err.message ? err.message : "", err.message_len);
+
+    // Get backend server info if available
+    const char* hostname = "";
+    int port = 0;
+    int hostgroup = m_session->current_hostgroup;
+    if (m_session->mybe && m_session->mybe->server_myds &&
+        m_session->mybe->server_myds->myconn &&
+        m_session->mybe->server_myds->myconn->parent) {
+        auto* parent = m_session->mybe->server_myds->myconn->parent;
+        hostname = parent->address ? parent->address : "";
+        port = parent->port;
+        hostgroup = parent->myhgc->hid;
+    }
+
+    const char* client_addr = "unknown";
+    if (m_session->client_myds->addr.addr) {
+        client_addr = m_session->client_myds->addr.addr;
+    }
+
+    // ui->schemaname and ui->dbname are the same field (union in PgSQL_Connection_userinfo)
+    PgHGM->add_pgsql_errors(
+        hostgroup, hostname, port,
+        ui->username, client_addr, ui->schemaname,
+        err.sqlstate, msg.c_str()
+    );
 }
 
 std::size_t PgSQLFFTO::get_buffered_size() const {

--- a/test/tap/tests/test_ffto_mysql_errors-t.cpp
+++ b/test/tap/tests/test_ffto_mysql_errors-t.cpp
@@ -1,0 +1,185 @@
+/**
+ * @file test_ffto_mysql_errors-t.cpp
+ * @brief FFTO E2E TAP test -- MySQL error recording in stats_mysql_errors.
+ *
+ * Validates that errors occurring during MySQL fast-forward sessions
+ * are properly recorded in stats_mysql_errors with correct errno
+ * and error message.
+ *
+ * @par Test scenarios
+ *  1. Syntax error -> errno 1064 recorded
+ *  2. Table not found -> errno 1146 recorded
+ *  3. Recovery: successful query after error
+ */
+
+#include <string>
+#include <stdio.h>
+#include <cstring>
+#include <unistd.h>
+#include "mysql.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+static constexpr int kPlannedTests = 7;
+
+#define FAIL_AND_SKIP_REMAINING(cleanup_label, fmt, ...) \
+    do { \
+        diag(fmt, ##__VA_ARGS__); \
+        int remaining = kPlannedTests - tests_last(); \
+        if (remaining > 0) { \
+            skip(remaining, "Skipping remaining assertions after setup failure"); \
+        } \
+        goto cleanup_label; \
+    } while (0)
+
+/**
+ * @brief Check if a specific errno appears in stats_mysql_errors.
+ * Polls up to 2 seconds. Returns true if found.
+ */
+static bool verify_mysql_error(MYSQL* admin, int expected_errno, const char* expected_msg_substr) {
+    char query[1024];
+    snprintf(query, sizeof(query),
+        "SELECT err_no, last_error FROM stats_mysql_errors WHERE err_no = %d",
+        expected_errno);
+
+    for (int attempt = 0; attempt < 20; attempt++) {
+        if (mysql_query(admin, query) != 0) { usleep(100000); continue; }
+        MYSQL_RES* res = mysql_store_result(admin);
+        if (!res) { usleep(100000); continue; }
+        MYSQL_ROW row = mysql_fetch_row(res);
+        if (row) {
+            bool msg_ok = (expected_msg_substr == nullptr) ||
+                          (row[1] && strstr(row[1], expected_msg_substr));
+            mysql_free_result(res);
+            return msg_ok;
+        }
+        mysql_free_result(res);
+        usleep(100000);
+    }
+    return false;
+}
+
+int main(int argc, char** argv) {
+    CommandLine cl;
+    if (cl.getEnv()) { diag("Failed to get env vars."); return -1; }
+
+    diag("=== FFTO MySQL Error Recording Test ===");
+    plan(kPlannedTests);
+
+    MYSQL* admin = mysql_init(NULL);
+    MYSQL* conn = NULL;
+
+    if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+                           NULL, cl.admin_port, NULL, 0)) {
+        diag("Admin connection failed"); return -1;
+    }
+
+    // Configure FF mode
+    MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='true' "
+                       "WHERE variable_name='mysql-ffto_enabled'");
+    MYSQL_QUERY(admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+    {
+        char eu[256], ep[256];
+        mysql_real_escape_string(admin, eu, cl.mysql_username, strlen(cl.mysql_username));
+        mysql_real_escape_string(admin, ep, cl.mysql_password, strlen(cl.mysql_password));
+        char uq[1024];
+        snprintf(uq, sizeof(uq),
+            "INSERT OR REPLACE INTO mysql_users (username, password, fast_forward) "
+            "VALUES ('%s', '%s', 1)", eu, ep);
+        MYSQL_QUERY(admin, uq);
+        MYSQL_QUERY(admin, "LOAD MYSQL USERS TO RUNTIME");
+    }
+
+    // Reset error stats
+    MYSQL_QUERY(admin, "SELECT * FROM stats_mysql_errors_reset");
+    { MYSQL_RES* r = mysql_store_result(admin); if (r) mysql_free_result(r); }
+
+    // Connect through ProxySQL in FF mode
+    conn = mysql_init(NULL);
+    if (!mysql_real_connect(conn, cl.host, cl.mysql_username, cl.mysql_password,
+                           "information_schema", cl.mysql_port, NULL, 0)) {
+        FAIL_AND_SKIP_REMAINING(cleanup, "FF connection failed: %s", mysql_error(conn));
+    }
+    ok(conn != NULL, "Connected to MySQL via ProxySQL in FF mode");
+
+    /* Scenario 1: Syntax error -> errno 1064 */
+    diag("--- Scenario 1: syntax error ---");
+    mysql_query(conn, "SELEC BAD SYNTAX");  // intentional error
+    ok(verify_mysql_error(admin, 1064, "syntax"),
+       "Error 1064 recorded in stats_mysql_errors");
+
+    /* Scenario 2: Table not found -> errno 1146 */
+    diag("--- Scenario 2: table not found ---");
+    mysql_query(conn, "SELECT * FROM nonexistent_table_ffto_test");
+    ok(verify_mysql_error(admin, 1146, NULL),
+       "Error 1146 recorded in stats_mysql_errors");
+
+    /* Scenario 3: Recovery -- successful query after errors */
+    diag("--- Scenario 3: recovery after error ---");
+    {
+        MYSQL_QUERY(admin, "SELECT * FROM stats_mysql_query_digest_reset");
+        MYSQL_RES* r = mysql_store_result(admin); if (r) mysql_free_result(r);
+    }
+    if (mysql_query(conn, "SELECT 1") == 0) {
+        MYSQL_RES* r = mysql_store_result(conn);
+        if (r) mysql_free_result(r);
+    }
+
+    // Verify the successful query appears in digest stats
+    {
+        bool found = false;
+        for (int i = 0; i < 20; i++) {
+            if (mysql_query(admin, "SELECT count_star FROM stats_mysql_query_digest "
+                 "WHERE digest_text LIKE '%SELECT %'") != 0) { usleep(100000); continue; }
+            MYSQL_RES* res = mysql_store_result(admin);
+            MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+            if (row && atoi(row[0]) > 0) found = true;
+            if (res) mysql_free_result(res);
+            if (found) break;
+            usleep(100000);
+        }
+        ok(found, "Recovery: SELECT 1 recorded in digest after errors");
+    }
+
+    /* Verify error stats have count > 0 */
+    {
+        bool has_errors = false;
+        if (mysql_query(admin, "SELECT count_star FROM stats_mysql_errors") == 0) {
+            MYSQL_RES* res = mysql_store_result(admin);
+            MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+            if (row && atoi(row[0]) > 0) has_errors = true;
+            if (res) mysql_free_result(res);
+        }
+        ok(has_errors, "stats_mysql_errors has entries from FF session");
+    }
+
+    /* Verify errors have non-empty last_error message */
+    {
+        bool has_msg = false;
+        if (mysql_query(admin, "SELECT last_error FROM stats_mysql_errors LIMIT 1") == 0) {
+            MYSQL_RES* res = mysql_store_result(admin);
+            MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+            if (row && row[0] && strlen(row[0]) > 0) has_msg = true;
+            if (res) mysql_free_result(res);
+        }
+        ok(has_msg, "stats_mysql_errors entries have non-empty error messages");
+    }
+
+    /* Verify errors have valid err_no */
+    {
+        bool has_errno = false;
+        if (mysql_query(admin, "SELECT err_no FROM stats_mysql_errors LIMIT 1") == 0) {
+            MYSQL_RES* res = mysql_store_result(admin);
+            MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+            if (row && atoi(row[0]) > 0) has_errno = true;
+            if (res) mysql_free_result(res);
+        }
+        ok(has_errno, "stats_mysql_errors entries have non-zero err_no");
+    }
+
+cleanup:
+    if (conn) mysql_close(conn);
+    if (admin) mysql_close(admin);
+    return exit_status();
+}

--- a/test/tap/tests/test_ffto_pgsql_error_stats-t.cpp
+++ b/test/tap/tests/test_ffto_pgsql_error_stats-t.cpp
@@ -1,0 +1,152 @@
+/**
+ * @file test_ffto_pgsql_error_stats-t.cpp
+ * @brief FFTO E2E TAP test -- PostgreSQL error recording in stats_pgsql_errors.
+ *
+ * Validates that errors occurring during PostgreSQL fast-forward sessions
+ * are properly recorded in stats_pgsql_errors with correct SQLSTATE
+ * and error message.
+ *
+ * @par Test scenarios
+ *  1. Syntax error -> sqlstate 42601 recorded
+ *  2. Undefined table -> sqlstate 42P01 recorded
+ *  3. Error entries have non-empty messages and sqlstate
+ */
+
+#include <string>
+#include <stdio.h>
+#include <cstring>
+#include <unistd.h>
+#include "libpq-fe.h"
+#include "mysql.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+static constexpr int kPlannedTests = 5;
+
+#define FAIL_AND_SKIP_REMAINING(cleanup_label, fmt, ...) \
+    do { \
+        diag(fmt, ##__VA_ARGS__); \
+        int remaining = kPlannedTests - tests_last(); \
+        if (remaining > 0) { \
+            skip(remaining, "Skipping remaining assertions after setup failure"); \
+        } \
+        goto cleanup_label; \
+    } while (0)
+
+static bool verify_pgsql_error(MYSQL* admin, const char* expected_sqlstate) {
+    char query[1024];
+    snprintf(query, sizeof(query),
+        "SELECT sqlstate, last_error FROM stats_pgsql_errors WHERE sqlstate = '%s'",
+        expected_sqlstate);
+
+    for (int attempt = 0; attempt < 20; attempt++) {
+        if (mysql_query(admin, query) != 0) { usleep(100000); continue; }
+        MYSQL_RES* res = mysql_store_result(admin);
+        if (!res) { usleep(100000); continue; }
+        MYSQL_ROW row = mysql_fetch_row(res);
+        if (row) {
+            mysql_free_result(res);
+            return true;
+        }
+        mysql_free_result(res);
+        usleep(100000);
+    }
+    return false;
+}
+
+int main(int argc, char** argv) {
+    CommandLine cl;
+    if (cl.getEnv()) { diag("Failed to get env vars."); return -1; }
+
+    diag("=== FFTO PostgreSQL Error Stats Test ===");
+    plan(kPlannedTests);
+
+    MYSQL* admin = mysql_init(NULL);
+    PGconn* conn = NULL;
+
+    if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+                           NULL, cl.admin_port, NULL, 0)) {
+        diag("Admin connection failed"); return -1;
+    }
+
+    MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='true' "
+                       "WHERE variable_name='pgsql-ffto_enabled'");
+    MYSQL_QUERY(admin, "LOAD PGSQL VARIABLES TO RUNTIME");
+
+    {
+        char eu[256], ep[256];
+        mysql_real_escape_string(admin, eu, cl.pgsql_root_username, strlen(cl.pgsql_root_username));
+        mysql_real_escape_string(admin, ep, cl.pgsql_root_password, strlen(cl.pgsql_root_password));
+        char uq[1024];
+        snprintf(uq, sizeof(uq),
+            "INSERT OR REPLACE INTO pgsql_users (username, password, fast_forward) "
+            "VALUES ('%s', '%s', 1)", eu, ep);
+        MYSQL_QUERY(admin, uq);
+        MYSQL_QUERY(admin, "LOAD PGSQL USERS TO RUNTIME");
+    }
+    {
+        char sq[1024];
+        snprintf(sq, sizeof(sq),
+            "INSERT OR REPLACE INTO pgsql_servers (hostgroup_id, hostname, port) "
+            "VALUES (0, '%s', %d)", cl.pgsql_server_host, cl.pgsql_server_port);
+        MYSQL_QUERY(admin, sq);
+        MYSQL_QUERY(admin, "LOAD PGSQL SERVERS TO RUNTIME");
+    }
+
+    // Reset error stats
+    MYSQL_QUERY(admin, "SELECT * FROM stats_pgsql_errors_reset");
+    { MYSQL_RES* r = mysql_store_result(admin); if (r) mysql_free_result(r); }
+
+    {
+        char ci[1024];
+        snprintf(ci, sizeof(ci), "host=%s port=%d user=%s password=%s dbname=postgres sslmode=disable",
+                 cl.pgsql_host, cl.pgsql_port, cl.pgsql_root_username, cl.pgsql_root_password);
+        conn = PQconnectdb(ci);
+    }
+    if (PQstatus(conn) != CONNECTION_OK) {
+        FAIL_AND_SKIP_REMAINING(cleanup, "PG connection failed: %s", PQerrorMessage(conn));
+    }
+    ok(conn != NULL, "Connected to PostgreSQL via ProxySQL in FF mode");
+
+    /* Scenario 1: Syntax error -> SQLSTATE 42601 */
+    diag("--- Scenario 1: syntax error ---");
+    { PGresult* r = PQexec(conn, "SELEC BAD"); if (r) PQclear(r); }
+    ok(verify_pgsql_error(admin, "42601"),
+       "SQLSTATE 42601 recorded in stats_pgsql_errors");
+
+    /* Scenario 2: Undefined table -> SQLSTATE 42P01 */
+    diag("--- Scenario 2: undefined table ---");
+    { PGresult* r = PQexec(conn, "SELECT * FROM nonexistent_table_ffto_test"); if (r) PQclear(r); }
+    ok(verify_pgsql_error(admin, "42P01"),
+       "SQLSTATE 42P01 recorded in stats_pgsql_errors");
+
+    /* Verify entries have non-empty messages */
+    {
+        bool has_msg = false;
+        if (mysql_query(admin, "SELECT last_error FROM stats_pgsql_errors LIMIT 1") == 0) {
+            MYSQL_RES* res = mysql_store_result(admin);
+            MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+            if (row && row[0] && strlen(row[0]) > 0) has_msg = true;
+            if (res) mysql_free_result(res);
+        }
+        ok(has_msg, "stats_pgsql_errors entries have non-empty error messages");
+    }
+
+    /* Verify entries have non-empty sqlstate */
+    {
+        bool has_sqlstate = false;
+        if (mysql_query(admin, "SELECT sqlstate FROM stats_pgsql_errors LIMIT 1") == 0) {
+            MYSQL_RES* res = mysql_store_result(admin);
+            MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+            if (row && row[0] && strlen(row[0]) > 0) has_sqlstate = true;
+            if (res) mysql_free_result(res);
+        }
+        ok(has_sqlstate, "stats_pgsql_errors entries have non-empty sqlstate");
+    }
+
+cleanup:
+    if (conn) PQfinish(conn);
+    if (admin) mysql_close(admin);
+    return exit_status();
+}

--- a/test/tap/tests/unit/ffto_protocol_unit-t.cpp
+++ b/test/tap/tests/unit/ffto_protocol_unit-t.cpp
@@ -16,6 +16,7 @@
 #include "proxysql.h"
 #include "MySQLProtocolUtils.h"
 #include "PgSQLCommandComplete.h"
+#include "PgSQLErrorFields.h"
 
 #include <cstring>
 #include <vector>
@@ -310,11 +311,55 @@ static void test_mysql_err_packet_empty_message() {
 }
 
 // ============================================================================
+// 7. PgSQL: ErrorResponse field parsing
+// ============================================================================
+
+static void test_pgsql_error_fields_basic() {
+    unsigned char payload[] = {
+        'S','E','R','R','O','R','\0',
+        'C','4','2','6','0','1','\0',
+        'M','s','y','n','t','a','x',' ','e','r','r','o','r','\0',
+        '\0'
+    };
+    PgSQLErrorResult r = pgsql_parse_error_response(payload, sizeof(payload));
+    ok(r.parsed == true, "PgSQL error parse: basic parsed");
+    ok(strcmp(r.sqlstate, "42601") == 0, "PgSQL error parse: sqlstate = 42601");
+    ok(r.message != nullptr && strncmp(r.message, "syntax error", 12) == 0,
+       "PgSQL error parse: message starts with 'syntax error'");
+}
+
+static void test_pgsql_error_fields_missing_code() {
+    unsigned char payload[] = {
+        'S','E','R','R','O','R','\0',
+        'M','s','o','m','e',' ','e','r','r','\0',
+        '\0'
+    };
+    PgSQLErrorResult r = pgsql_parse_error_response(payload, sizeof(payload));
+    ok(r.parsed == true, "PgSQL error no-code: parsed");
+    ok(strlen(r.sqlstate) == 0, "PgSQL error no-code: empty sqlstate");
+    ok(r.message != nullptr && strncmp(r.message, "some err", 8) == 0,
+       "PgSQL error no-code: message correct");
+}
+
+static void test_pgsql_error_fields_empty() {
+    unsigned char payload[] = {'\0'};
+    PgSQLErrorResult r = pgsql_parse_error_response(payload, 1);
+    ok(r.parsed == true, "PgSQL error empty: parsed (no fields)");
+    ok(strlen(r.sqlstate) == 0, "PgSQL error empty: empty sqlstate");
+    ok(r.message == nullptr, "PgSQL error empty: null message");
+}
+
+static void test_pgsql_error_fields_zero_length() {
+    PgSQLErrorResult r = pgsql_parse_error_response(nullptr, 0);
+    ok(r.parsed == false, "PgSQL error null: returns false");
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
 int main() {
-	plan(46);
+	plan(56);
 	int rc = test_init_minimal();
 	ok(rc == 0, "test_init_minimal() succeeds");
 
@@ -354,6 +399,12 @@ int main() {
 	test_mysql_err_packet_no_sqlstate();    // 3
 	test_mysql_err_packet_truncated();      // 1
 	test_mysql_err_packet_empty_message();  // 3
+
+	// PgSQL ErrorResponse parsing
+	test_pgsql_error_fields_basic();        // 3
+	test_pgsql_error_fields_missing_code(); // 3
+	test_pgsql_error_fields_empty();        // 3
+	test_pgsql_error_fields_zero_length();  // 1
 
 	test_cleanup_minimal();
 	return exit_status();

--- a/test/tap/tests/unit/ffto_protocol_unit-t.cpp
+++ b/test/tap/tests/unit/ffto_protocol_unit-t.cpp
@@ -247,11 +247,74 @@ static void test_mysql_multi_packet_build() {
 }
 
 // ============================================================================
+// 6. MySQL: ERR packet parsing
+// ============================================================================
+
+static void test_mysql_err_packet_basic() {
+    unsigned char payload[] = {
+        0xFF,
+        0x15, 0x04,
+        '#',
+        '2','8','0','0','0',
+        'A','c','c','e','s','s',' ','d','e','n','i','e','d'
+    };
+    uint16_t err_no = 0;
+    const char* errmsg = nullptr;
+    size_t errmsg_len = 0;
+    bool ok_parse = mysql_parse_err_packet(payload, sizeof(payload), &err_no, &errmsg, &errmsg_len);
+    ok(ok_parse == true, "ERR parse: basic packet parsed successfully");
+    ok(err_no == 1045, "ERR parse: errno = 1045");
+    ok(errmsg_len == 13 && memcmp(errmsg, "Access denied", 13) == 0,
+       "ERR parse: message = 'Access denied'");
+}
+
+static void test_mysql_err_packet_no_sqlstate() {
+    unsigned char payload[] = {
+        0xFF,
+        0x01, 0x00,
+        'S','o','m','e',' ','e','r','r','o','r'
+    };
+    uint16_t err_no = 0;
+    const char* errmsg = nullptr;
+    size_t errmsg_len = 0;
+    bool ok_parse = mysql_parse_err_packet(payload, sizeof(payload), &err_no, &errmsg, &errmsg_len);
+    ok(ok_parse == true, "ERR parse no-sqlstate: parsed");
+    ok(err_no == 1, "ERR parse no-sqlstate: errno = 1");
+    ok(errmsg_len == 10 && memcmp(errmsg, "Some error", 10) == 0,
+       "ERR parse no-sqlstate: message correct");
+}
+
+static void test_mysql_err_packet_truncated() {
+    unsigned char payload[] = {0xFF};
+    uint16_t err_no = 0;
+    const char* errmsg = nullptr;
+    size_t errmsg_len = 0;
+    bool ok_parse = mysql_parse_err_packet(payload, 1, &err_no, &errmsg, &errmsg_len);
+    ok(ok_parse == false, "ERR parse truncated: returns false");
+}
+
+static void test_mysql_err_packet_empty_message() {
+    unsigned char payload[] = {
+        0xFF,
+        0x00, 0x04,
+        '#',
+        '4','2','0','0','0'
+    };
+    uint16_t err_no = 0;
+    const char* errmsg = nullptr;
+    size_t errmsg_len = 0;
+    bool ok_parse = mysql_parse_err_packet(payload, sizeof(payload), &err_no, &errmsg, &errmsg_len);
+    ok(ok_parse == true, "ERR parse empty msg: parsed");
+    ok(err_no == 1024, "ERR parse empty msg: errno = 1024");
+    ok(errmsg_len == 0, "ERR parse empty msg: empty message");
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
 int main() {
-	plan(36);
+	plan(46);
 	int rc = test_init_minimal();
 	ok(rc == 0, "test_init_minimal() succeeds");
 
@@ -285,6 +348,12 @@ int main() {
 	// Total: 1+3+3+1+2+2+4+3+2+1+1+1+1+2+1+1+1+2+4 = 36... recount
 	// 1 (init) + 3+3+1+2+2 (lenenc=11) + 4+3+2 (build=9) + 1+1 (ok=2) +
 	// 1+1+2+1+1+1 (pgsql=7) + 2+4 (frag=6) = 1+11+9+2+7+6 = 36
+
+	// MySQL ERR packet parsing
+	test_mysql_err_packet_basic();          // 3
+	test_mysql_err_packet_no_sqlstate();    // 3
+	test_mysql_err_packet_truncated();      // 1
+	test_mysql_err_packet_empty_message();  // 3
 
 	test_cleanup_minimal();
 	return exit_status();


### PR DESCRIPTION
## Summary

- Closes the blind spot where errors in fast-forward (FF) sessions are silently lost — they now appear in `stats_mysql_errors` and `stats_pgsql_errors`
- Adds lightweight wire-protocol parsers for MySQL ERR packets (errno + message) and PostgreSQL ErrorResponse fields (SQLSTATE + message)
- Wires the parsers into all FFTO error handlers (4 for MySQL, 1 for PostgreSQL) to call the existing `add_*_errors()` functions
- No new tables, no new config variables, no schema changes — reuses existing error stats infrastructure

## What was the problem?

In normal (non-FF) mode, query errors are recorded via `handler_minus1_LogErrorDuringQuery()` → `add_mysql_errors()`/`add_pgsql_errors()`. In fast-forward mode, this code path is entirely bypassed — the session layer simply relays packets without inspection. FFTO detects `0xFF` (MySQL) and `'E'` (PostgreSQL) error packets but previously discarded their contents, calling `report_query_stats()` with zero error context.

Result: `stats_mysql_errors` and `stats_pgsql_errors` had a complete blind spot for all FF traffic.

## How it works

1. **Pure parsers** (unit-testable, no ProxySQL dependencies):
   - `mysql_parse_err_packet()` — extracts errno and message from MySQL ERR packet bytes
   - `pgsql_parse_error_response()` — scans PostgreSQL ErrorResponse field pairs for SQLSTATE ('C') and message ('M')

2. **FFTO wiring** — each FFTO class gets a `report_error()` method that:
   - Calls the parser on the raw packet data already in the buffer
   - Resolves backend server info (hostname, port, hostgroup) from session state
   - Calls `MyHGM->add_mysql_errors()` / `PgHGM->add_pgsql_errors()` (mutex-protected, thread-safe)

3. **Coverage**: MySQL FFTO instruments all 4 ERR detection points (AWAITING_PREPARE_OK, AWAITING_RESPONSE, READING_COLUMNS, READING_ROWS). PostgreSQL FFTO instruments the single ErrorResponse handler.

## Files changed (12 files, +677 lines)

| File | Change |
|------|--------|
| `include/MySQLProtocolUtils.h` | `mysql_parse_err_packet()` declaration |
| `lib/MySQLProtocolUtils.cpp` | Implementation |
| `include/PgSQLErrorFields.h` | `pgsql_parse_error_response()` declaration + `PgSQLErrorResult` struct |
| `lib/PgSQLErrorFields.cpp` | Implementation |
| `lib/Makefile` | Add `PgSQLErrorFields.oo` |
| `include/MySQLFFTO.hpp` | `report_error()` declaration |
| `lib/MySQLFFTO.cpp` | `report_error()` impl + wiring at all 4 ERR handlers |
| `include/PgSQLFFTO.hpp` | `report_error()` declaration |
| `lib/PgSQLFFTO.cpp` | `report_error()` impl + wiring at ErrorResponse handler |
| `test/tap/tests/unit/ffto_protocol_unit-t.cpp` | 20 new unit test assertions for both parsers |
| `test/tap/tests/test_ffto_mysql_errors-t.cpp` | E2E: verify FF MySQL errors in `stats_mysql_errors` |
| `test/tap/tests/test_ffto_pgsql_error_stats-t.cpp` | E2E: verify FF PgSQL errors in `stats_pgsql_errors` |

## Test plan

- [ ] Unit tests pass: `cd test/tap/tests/unit && make ffto_protocol_unit-t && ./ffto_protocol_unit-t` (56 assertions)
- [ ] Full build succeeds: `make -j$(nproc)`
- [ ] E2E MySQL: `cd test/tap/tests && make test_ffto_mysql_errors-t && ./test_ffto_mysql_errors-t` (7 assertions, needs ProxySQL + MySQL)
- [ ] E2E PgSQL: `cd test/tap/tests && make test_ffto_pgsql_error_stats-t && ./test_ffto_pgsql_error_stats-t` (5 assertions, needs ProxySQL + PostgreSQL)
- [ ] Existing FFTO tests still pass (no behavioral changes to non-error paths)
- [ ] Verify `SELECT * FROM stats_mysql_errors` shows entries after triggering syntax errors through an FF session
- [ ] Verify `SELECT * FROM stats_pgsql_errors` shows entries with correct SQLSTATE after triggering errors through a PgSQL FF session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error tracking for MySQL queries in fast-forward mode, capturing error codes and messages into error statistics
  * Added error tracking for PostgreSQL queries in fast-forward mode, capturing error states and error messages into error statistics

* **Tests**
  * Added end-to-end tests for MySQL error recording in fast-forward sessions
  * Added end-to-end tests for PostgreSQL error recording in fast-forward sessions
  * Added unit tests for error parsing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->