### PR TITLE
Fix #5306 - SHOW WARNINGS with inline comments incorrectly sets warning_count

### DIFF
--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -1839,6 +1839,9 @@ handler_again:
 						const char* dig_text = myds->sess->CurrentQuery.QueryParserArgs.digest_text;
 						const size_t dig_len = strlen(dig_text);
 						is_show_warnings = (dig_len == 13 && strncasecmp(dig_text, "SHOW WARNINGS", 13) == 0);
+					} else {
+						// Fallback to raw query when digest is unavailable (digests disabled)
+						is_show_warnings = (query.length == 13 && strncasecmp(query.ptr, "SHOW WARNINGS", 13) == 0);
 					}
 					MyRS->add_eof(is_show_warnings);
 					NEXT_IMMEDIATE(ASYNC_QUERY_END);

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -1834,7 +1834,13 @@ handler_again:
 					update_warning_count_from_connection();
 					// we reach here if there was no error
 					// exclude warning_count from the OK/EOF packet for the SHOW WARNINGS statement
-					MyRS->add_eof(query.length == 13 && strncasecmp(query.ptr, "SHOW WARNINGS", 13) == 0);
+					bool is_show_warnings = false;
+					if (myds && myds->sess && myds->sess->CurrentQuery.QueryParserArgs.digest_text) {
+						const char* dig_text = myds->sess->CurrentQuery.QueryParserArgs.digest_text;
+						const size_t dig_len = strlen(dig_text);
+						is_show_warnings = (dig_len == 13 && strncasecmp(dig_text, "SHOW WARNINGS", 13) == 0);
+					}
+					MyRS->add_eof(is_show_warnings);
 					NEXT_IMMEDIATE(ASYNC_QUERY_END);
 				}
 			}

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -185,6 +185,7 @@
   "reg_test_4935-caching_sha2-t" : [ "mysql84-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
   "reg_test_5212_tcp_keepalive_warnings-t" : [ "legacy-g1","mysql84-g1" ],
   "reg_test_5233_set_warning-t" : [ "legacy-g1","mysql84-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "reg_test_5306-show_warnings_with_comment-t" : [ "legacy-g2","mysql84-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2" ],
   "reg_test_5389-flush_logs_no_drop-t" : [ "legacy-g4","mysql84-g4" ],
   "reg_test__ssl_client_busy_wait-t" : [ "legacy-g2","mysql84-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2" ],
   "reg_test_compression_split_packets-t" : [ "legacy-g2","mysql84-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2" ],

--- a/test/tap/tests/reg_test_5306-show_warnings_with_comment-t.cpp
+++ b/test/tap/tests/reg_test_5306-show_warnings_with_comment-t.cpp
@@ -1,0 +1,94 @@
+/**
+ * @file reg_test_5306-show_warnings_with_comment-t.cpp
+ * @brief This test verifies that SHOW WARNINGS with inline comments does not incorrectly return warning_count in EOF packet.
+ */
+
+#include <stdio.h>
+#include "mysql.h"
+#include "mysqld_error.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	plan(4);
+
+	// Initialize Admin connection
+	MYSQL* proxysql_admin = mysql_init(NULL);
+	if (!proxysql_admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return -1;
+	}
+	// Connnect to ProxySQL Admin
+	if (!mysql_real_connect(proxysql_admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql_admin));
+		return -1;
+	}
+
+	MYSQL_QUERY(proxysql_admin, "SET mysql-handle_warnings=1");
+	MYSQL_QUERY(proxysql_admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+	// Initialize ProxySQL connection
+	MYSQL* proxysql = mysql_init(NULL);
+	if (!proxysql) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql));
+		return -1;
+	}
+
+	if (!mysql_real_connect(proxysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql));
+		return exit_status();
+	}
+
+	// Query that produces a warning (truncation warning)
+	const char* WARNING_QUERY = "SELECT CAST('abc' AS DOUBLE)";
+
+	// Test cases: SHOW WARNINGS without and with comment
+	const char* show_warnings_queries[] = {
+		"SHOW WARNINGS",
+		"SHOW /* comment */ WARNINGS"
+	};
+
+	for (const char* show_query : show_warnings_queries) {
+		MYSQL_QUERY(proxysql, WARNING_QUERY);
+		MYSQL_RES* res = mysql_store_result(proxysql);
+		if (!res) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql));
+			return exit_status();
+		}
+		mysql_free_result(res);
+
+		unsigned int warning_count_after_query = mysql_warning_count(proxysql);
+		diag("After WARNING_QUERY: warning_count=%u", warning_count_after_query);
+
+		MYSQL_QUERY(proxysql, show_query);
+		res = mysql_store_result(proxysql);
+		if (!res) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(proxysql));
+			return exit_status();
+		}
+		unsigned int row_count = mysql_num_rows(res);
+		mysql_free_result(res);
+
+		unsigned int warning_count_after_show = mysql_warning_count(proxysql);
+		diag("After '%s': warning_count=%u, rows=%u", show_query, warning_count_after_show, row_count);
+
+		ok(warning_count_after_query == 1,
+			"WARNING_QUERY should produce warning. warning_count=%u", warning_count_after_query);
+
+		ok(warning_count_after_show == 0,
+			"'%s' should return warning_count=0 in EOF packet. Actual=%u", show_query, warning_count_after_show);
+	}
+
+	mysql_close(proxysql);
+	mysql_close(proxysql_admin);
+
+	return exit_status();
+}


### PR DESCRIPTION
## Summary

Fixes #5306

When `SHOW WARNINGS` queries contain inline comments (e.g., `SHOW /* comment */ WARNINGS`),
ProxySQL incorrectly returns `warning_count`

This PR fixes the issue by using `digest_text` (which has comments stripped) instead of raw query text for SHOW WARNINGS detection,
following the existing pattern used in `update_warning_count_from_connection()`.

## Changes

- **lib/mysql_connection.cpp**: Use `digest_text` to detect SHOW WARNINGS for `add_eof()` call
- **test/tap/tests/reg_test_5306-show_warnings_with_comment-t.cpp**: Add regression test
- **test/tap/groups/groups.json**: Register new test

## Test

The regression test verifies that both `SHOW WARNINGS` and `SHOW /* comment */ WARNINGS` return
`warning_count=0` in the EOF packet after a query that produces warnings.

The test is excluded from `mysql-query_digests=0` and `mysql-query_digests_keep_comment=1` groups,
because `digest_text` is unavailable or contains comments in these configurations.

This is consistent with other `digest_text`-based detection logic in the codebase (e.g., `update_warning_count_from_connection()`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of SHOW WARNINGS statements that include inline comments so warning counts are reported accurately after execution.

* **Tests**
  * Added a regression test that verifies SHOW WARNINGS (with and without inline comments) does not leave spurious warnings, ensuring warning counters are cleared as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->