### PR TITLE
Disable FFTO by default in 3.1.x, keep enabled in 4.0.x

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1362,7 +1362,11 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 	variables.ping_timeout_server=200;
 	variables.fast_forward_grace_close_ms=5000;
 #ifdef PROXYSQLFFTO
+#ifdef PROXYSQLGENAI
 	variables.ffto_enabled=true;
+#else
+	variables.ffto_enabled=false;
+#endif
 	variables.ffto_max_buffer_size=1048576;
 #endif
 	variables.default_schema=strdup((char *)"information_schema");

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -1039,7 +1039,11 @@ PgSQL_Threads_Handler::PgSQL_Threads_Handler() {
 	variables.shun_on_failures = 5;
 	variables.shun_recovery_time_sec = 10;
 #ifdef PROXYSQLFFTO
+#ifdef PROXYSQLGENAI
 	variables.ffto_enabled = true;
+#else
+	variables.ffto_enabled = false;
+#endif
 	variables.ffto_max_buffer_size = 1048576;
 #endif
 	variables.unshun_algorithm = 0;


### PR DESCRIPTION
## Summary
- Gate `ffto_enabled` default on `PROXYSQLGENAI` so 3.1.x builds ship with FFTO disabled
- 4.0.x builds remain unchanged (FFTO enabled by default)
- Users on 3.1.x can still opt in via `SET mysql-ffto_enabled='true'`

Fixes #5539

## Test plan
- [ ] Build with `PROXYSQL31=1` and verify `SELECT @@mysql-ffto_enabled` returns `false`
- [ ] Build with `PROXYSQLGENAI=1` and verify `SELECT @@mysql-ffto_enabled` returns `true`
- [ ] Default build (3.0.x) unaffected — FFTO block is not compiled in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified default feature initialization settings for MySQL and PostgreSQL components to align with build configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->