### PR TITLE
Document DNS cache bypass limitation for resolution_family

### DIFF
--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -959,6 +959,10 @@ char * MySQL_Connection::connect_start_DNS_lookup() {
 		host_ip = connected_host_details.ip;
 	}
 	else {
+		// NOTE: DNS cache miss — hostname is passed directly to
+		// mysql_real_connect which resolves via the MariaDB client library
+		// using AF_UNSPEC. The mysql-resolution_family setting does NOT
+		// apply here; it only governs the DNS cache resolver thread.
 		host_ip = parent->address;
 	}
 	return host_ip;


### PR DESCRIPTION
## Summary
- Add code comment in `mysql_connection.cpp` documenting that `mysql-resolution_family` does not apply when the DNS cache misses and the hostname falls through to `mysql_real_connect` (which uses the MariaDB client library's hardcoded `AF_UNSPEC`)

Follow-up to #5554. Tracked in #5555 for future enhancement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified DNS resolution behavior in connection handling to improve code maintainability.

**Note:** This release contains no user-visible changes or functional updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->