### PR TITLE
ci: revert test workflows to listen on CI-trigger completion

### DIFF
--- a/.github/workflows/CI-3p-aiomysql.yml
+++ b/.github/workflows/CI-3p-aiomysql.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-django-framework.yml
+++ b/.github/workflows/CI-3p-django-framework.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
   
 concurrency:

--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-mariadb-connector-c.yml
+++ b/.github/workflows/CI-3p-mariadb-connector-c.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-mysql-connector-j.yml
+++ b/.github/workflows/CI-3p-mysql-connector-j.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-pgjdbc.yml
+++ b/.github/workflows/CI-3p-pgjdbc.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-php-pdo-mysql.yml
+++ b/.github/workflows/CI-3p-php-pdo-mysql.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/CI-3p-php-pdo-pgsql.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-postgresql.yml
+++ b/.github/workflows/CI-3p-postgresql.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-basictests.yml
+++ b/.github/workflows/CI-basictests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-legacy-clickhouse-g1.yml
+++ b/.github/workflows/CI-legacy-clickhouse-g1.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-legacy-g1.yml
+++ b/.github/workflows/CI-legacy-g1.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-legacy-g2-genai.yml
+++ b/.github/workflows/CI-legacy-g2-genai.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-legacy-g2.yml
+++ b/.github/workflows/CI-legacy-g2.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-legacy-g3.yml
+++ b/.github/workflows/CI-legacy-g3.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-legacy-g4.yml
+++ b/.github/workflows/CI-legacy-g4.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-legacy-g5.yml
+++ b/.github/workflows/CI-legacy-g5.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-maketest.yml
+++ b/.github/workflows/CI-maketest.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-mysql84-g1.yml
+++ b/.github/workflows/CI-mysql84-g1.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-mysql84-g2.yml
+++ b/.github/workflows/CI-mysql84-g2.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-mysql84-g3.yml
+++ b/.github/workflows/CI-mysql84-g3.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-mysql84-g4.yml
+++ b/.github/workflows/CI-mysql84-g4.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-mysql84-g5.yml
+++ b/.github/workflows/CI-mysql84-g5.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-repltests.yml
+++ b/.github/workflows/CI-repltests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-selftests.yml
+++ b/.github/workflows/CI-selftests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-shuntest.yml
+++ b/.github/workflows/CI-shuntest.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests-asan.yml
+++ b/.github/workflows/CI-taptests-asan.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests-groups.yml
+++ b/.github/workflows/CI-taptests-groups.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests-pgsql-cluster.yml
+++ b/.github/workflows/CI-taptests-pgsql-cluster.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests-ssl.yml
+++ b/.github/workflows/CI-taptests-ssl.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:

--- a/.github/workflows/CI-taptests.yml
+++ b/.github/workflows/CI-taptests.yml
@@ -4,7 +4,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ CI-builds ]
+    workflows: [ CI-trigger ]
     types: [ completed ]
 
 concurrency:


### PR DESCRIPTION
## Summary

- Reverts 32 test workflows to trigger on `CI-trigger` completion instead of `CI-builds` completion (as they were before commit 9671a414a3).
- Fixes PR CI runs that were checking out and testing `v3.0` HEAD instead of the PR commit.
- One-line change per file; no other logic touched.

## Root cause

Commit 9671a414a3 ("ci: comprehensive CI workflow and infrastructure fixes") changed 32 test workflows from:

```yaml
workflow_run:
  workflows: [ CI-trigger ]
```

to:

```yaml
workflow_run:
  workflows: [ CI-builds ]
```

A `workflow_run`-triggered workflow receives `github.event.workflow_run.head_sha` equal to the SHA of the workflow run that triggered it. Since `CI-builds` is itself `workflow_run`-triggered, it always runs on the default branch (`v3.0`) with its own `head_sha` pointing at `v3.0` HEAD — **not** at the PR commit. Chaining the test workflows off `CI-builds` therefore caused every test run to check out `v3.0` code instead of the PR code.

## Why listening on CI-trigger is safe

`CI-trigger` is `pull_request`-triggered, so its `head_sha` is the PR commit. It also contains a babysitter step (`gh run watch` on `CI-builds`) that blocks until `CI-builds` finishes, so test workflows gated on `CI-trigger` completion still wait for build artifacts to be ready.

## Evidence

Before this fix, on PR commits:
- `CI-trigger` ran on the PR branch (correct `head_sha`).
- `CI-builds` ran on default branch with `head_sha = v3.0` HEAD.
- All 32 chained test workflows inherited the v3.0 `head_sha` and tested v3.0 code.
- Visible symptom: PR commits only ran 3 workflows (CI-trigger, Claude Code Review, CI-lint-groups-json), while merge commits on v3.0 ran the full ~35 workflows.

## Note on testability

This PR itself will not exercise the fix — `workflow_run`-triggered workflows always read their YAML from the default branch, so the chained test workflows will continue to use the buggy `v3.0` version until this PR is merged. The fix will take effect automatically on all open PRs (including new pushes to existing PRs) once merged into `v3.0`.

## Test plan

- [ ] Review diff: confirm exactly 32 files changed, each with a single line `workflows: [ CI-builds ]` → `workflows: [ CI-trigger ]`.
- [ ] Merge into `v3.0`.
- [ ] Push a commit to any open PR and verify that the full suite of chained test workflows now runs with the PR's `head_sha`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reconfigured CI workflow triggers across all test suites to depend on a new upstream workflow for consistent test execution orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->