### PR TITLE
PgSQL: fast-reject non-COPY queries in CopyCmdMatcher

### DIFF
--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -139,9 +139,8 @@ struct CopyCmdMatcher {
 	CopyCmdMatcher() : 
 		options(RE2::Quiet), 
 		pattern(
-			R"(((?is)(?:--.*?$|/\*[\s\S]*?\*/|\s)*\bCOPY\b\s+[^;]*?\bFROM\b\s+(?:STDIN|STDOUT)\b(?:\s+WITH\s*\([^)]*\))?))",
+			R"(((?is)\bCOPY\b[^;]*?\bFROM\b[^;]*?\b(?:STDIN|STDOUT)\b))",
 			options) {
-		//((?is)(?:--.*?$|/\*[\s\S]*?\*/|\s)*\bCOPY\b\s+[^;]*?\bFROM\b\s+STDIN\b(?:\s+WITH\s*\([^)]*\))?)
 	}
 
 	inline

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -3040,10 +3040,19 @@ handler_again:
 				}
 			}
 			if (status == PROCESSING_QUERY || status == PROCESSING_STMT_PREPARE) {
-				// Swtich to fast forward mode if the query matches copy ... stdin command
+				// Switch to fast forward mode if the query matches copy ... stdin command
 				re2::StringPiece matched;
-				const char* query_to_match = (CurrentQuery.get_digest_text() ? CurrentQuery.get_digest_text() : (char*)CurrentQuery.QueryPointer);
-				if (copy_cmd_matcher->match(query_to_match, &matched)) {
+				const char* digest_text = CurrentQuery.get_digest_text();
+				bool run_match = true;
+				const char* query_to_match;
+				if (digest_text) {
+					if (strcasestr(digest_text, "COPY ") == NULL)
+						run_match = false;
+					query_to_match = digest_text;
+				} else {
+					query_to_match = (char*)CurrentQuery.QueryPointer;
+				}
+				if (run_match && copy_cmd_matcher->match(query_to_match, &matched)) {
 
 					if (status == PROCESSING_STMT_PREPARE) {
 						reset_extended_query_frame();

--- a/test/tap/tests/pgsql-copy_from_test-t.cpp
+++ b/test/tap/tests/pgsql-copy_from_test-t.cpp
@@ -49,21 +49,25 @@ PGConnPtr createNewConnection(ConnType conn_type, bool with_ssl) {
 
 bool executeQueries(PGconn* conn, const std::vector<std::string>& queries) {
     auto fnResultType = [](const char* query) -> int {
-        const char* fs = strchr(query, ' ');
-        size_t qtlen = strlen(query);
-        if (fs != NULL) {
-            qtlen = (fs - query) + 1;
+        // Skip leading whitespace and /* ... */ comments to find the first keyword
+        const char* p = query;
+        while (*p) {
+            if (isspace(static_cast<unsigned char>(*p))) { p++; continue; }
+            if (p[0] == '/' && p[1] == '*') {
+                p += 2;
+                while (*p && !(p[0] == '*' && p[1] == '/')) p++;
+                if (*p) p += 2;
+                continue;
+            }
+            break;
         }
-        char buf[qtlen];
-        memcpy(buf, query, qtlen - 1);
-        buf[qtlen - 1] = 0;
 
-        if (strncasecmp(buf, "SELECT", sizeof("SELECT") - 1) == 0) {
+        if (strncasecmp(p, "SELECT", 6) == 0) {
             return PGRES_TUPLES_OK;
         }
-        else if (strncasecmp(buf, "COPY", sizeof("COPY") - 1) == 0) {
-			if (strstr(query, "FROM") && (strstr(query, "STDIN") || strstr(query, "STDOUT"))) {
-				return PGRES_COPY_IN;
+        else if (strncasecmp(p, "COPY", 4) == 0) {
+            if (strstr(query, "FROM") && (strstr(query, "STDIN") || strstr(query, "STDOUT"))) {
+                return PGRES_COPY_IN;
             }
         }
 
@@ -820,7 +824,79 @@ void testSTDOUT_TEXT_FORMAT(PGconn* admin_conn, PGconn* conn, std::fstream& f_pr
     ok(check_logs_for_command(f_proxysql_log, ".*\\[INFO\\] Switching back to Normal mode \\(Session Type:0x06\\).*"), "Switching back to Normal mode");
 }
 
+/**
+ * @brief Tests that COPY commands with leading SQL comments still trigger fast-forward mode.
+ *
+ * When digest is available, leading comments are stripped, so the strncasecmp
+ * prefix check sees "COPY ..." and allows the RE2 match to proceed. This test
+ * verifies that comment-prefixed COPY commands are not incorrectly rejected by
+ * the fast-reject optimization.
+ *
+ * @param admin_conn A pointer to the admin PGconn connection.
+ * @param conn A pointer to the PGconn connection.
+ * @param f_proxysql_log A reference to the fstream object for ProxySQL logs.
+ */
+void testCopyWithLeadingComments(PGconn* admin_conn, PGconn* conn, std::fstream& f_proxysql_log) {
+    if (!executeQueries(conn, {"/* leading comment */ COPY copy_in_test(column1,column2,column3,column4,column5) FROM STDIN (FORMAT TEXT)"}))
+        return;
+
+    ok(check_logs_for_command(f_proxysql_log, ".*\\[INFO\\].* Switching to Fast Forward mode \\(Session Type:0x06\\)"),
+        "COPY with leading comments should trigger fast forward mode");
+
+    bool success = true;
+    for (unsigned int i = 0; i < test_data.size(); i++) {
+        const char* data = test_data[i];
+        bool last = (i == (test_data.size() - 1));
+        if (!sendCopyData(conn, data, strlen(data), last)) {
+            success = false;
+            break;
+        }
+    }
+
+    ok(success, "Copy data transmission should be successful");
+
+    PGresult* res = PQgetResult(conn);
+    ok((PQresultStatus(res) == PGRES_COMMAND_OK), "Rows successfully inserted. %s", PQerrorMessage(conn));
+
+    const char* row_count_str = PQcmdTuples(res);
+    const int row_count = atoi(row_count_str);
+    ok(row_count == test_data.size(), "Total rows inserted: %d. Expected: %ld", row_count, test_data.size());
+    PQclear(res);
+
+    ok(check_logs_for_command(f_proxysql_log, ".*\\[INFO\\] Switching back to Normal mode \\(Session Type:0x06\\).*"),
+        "Switching back to Normal mode");
+}
+
+/**
+ * @brief Tests that SELECT containing COPY keywords in a string literal works correctly.
+ *
+ * With digest ON, string literals are normalized to '?', so the regex never sees
+ * COPY keywords. With digest OFF, the regex may match COPY inside a string literal.
+ * This test verifies that the query still executes correctly in either case.
+ *
+ * @param admin_conn A pointer to the admin PGconn connection.
+ * @param conn A pointer to the PGconn connection.
+ * @param f_proxysql_log A reference to the fstream object for ProxySQL logs.
+ */
+void testSelectWithCopyInStringLiteral(PGconn* admin_conn, PGconn* conn, std::fstream& f_proxysql_log) {
+    PGresult* res = PQexec(conn, "SELECT 'COPY x FROM STDIN'");
+    ok(PQresultStatus(res) == PGRES_TUPLES_OK, "SELECT with COPY in string literal should return TUPLES_OK. %s", PQerrorMessage(conn));
+
+    if (PQresultStatus(res) == PGRES_TUPLES_OK) {
+        int rows = PQntuples(res);
+        ok(rows == 1, "Expected 1 row. Actual: %d", rows);
+        char* value = PQgetvalue(res, 0, 0);
+        ok(strcmp(value, "COPY x FROM STDIN") == 0, "Expected 'COPY x FROM STDIN'. Actual: '%s'", value);
+    } else {
+        ok(0, "Skipped row count check - query failed");
+        ok(0, "Skipped value check - query failed");
+    }
+    PQclear(res);
+}
+
 std::vector<std::pair<std::string, void (*)(PGconn*, PGconn*, std::fstream& f_proxysql_log)>> tests = {
+    { "SELECT with COPY in string literal", testSelectWithCopyInStringLiteral },
+    { "COPY with leading comments", testCopyWithLeadingComments },
     { "COPY ... FROM STDIN Text Format", testSTDIN_TEXT_FORMAT },
     { "COPY ... FROM STDIN Binary Format", testSTDIN_TEXT_BINARY },
     { "COPY ... FROM STDIN Error", testSTDIN_ERROR },
@@ -832,7 +908,7 @@ std::vector<std::pair<std::string, void (*)(PGconn*, PGconn*, std::fstream& f_pr
 	{ "COPY ... FROM STDIN Permanent Fast Forward", testSTDIN_PERMANENT_FAST_FORWARD }
 };
 
-void execute_tests(bool with_ssl, bool diff_conn) {
+void execute_tests(bool with_ssl, bool diff_conn, bool query_digests = true) {
 
     PGConnPtr admin_conn_1 = createNewConnection(ConnType::ADMIN, with_ssl);
 
@@ -840,9 +916,13 @@ void execute_tests(bool with_ssl, bool diff_conn) {
            "DELETE FROM pgsql_query_rules",
            "LOAD PGSQL QUERY RULES TO RUNTIME",
            "UPDATE pgsql_users SET fast_forward=0" ,
-           "LOAD PGSQL USERS TO RUNTIME"
+           "LOAD PGSQL USERS TO RUNTIME",
+           query_digests ? "SET pgsql-query_digests='true'" : "SET pgsql-query_digests='false'",
+           "LOAD PGSQL VARIABLES TO RUNTIME"
         }))
         return;
+
+    diag(">>>> query_digests=%s <<<<", query_digests ? "true" : "false");
 
     std::string f_path{ get_env("REGULAR_INFRA_DATADIR") + "/proxysql.log" };
     std::fstream f_proxysql_log{};
@@ -906,13 +986,17 @@ int main(int argc, char** argv) {
 	spawn_internal_noise(cl, internal_noise_rest_prometheus_poller, {{"enable_rest_api", "true"}});
 
 	if (cl.use_noise) {
-		plan(51 * 2 + 3);
+		plan(59 * 4 + 3);
 	} else {
-		plan(51 * 2);
+		plan(59 * 4);
 	}
 
-    execute_tests(true, false);
-    execute_tests(false, false);
+    // query_digests ON: strncasecmp fast-reject path active
+    execute_tests(true, false, true);
+    execute_tests(false, false, true);
+    // query_digests OFF: falls back to full RE2 match
+    execute_tests(true, false, false);
+    execute_tests(false, false, false);
 
     return exit_status();
 }


### PR DESCRIPTION
## Summary
Addresses the CopyCmdMatcher part of #5568. Profiling showed RE2 running on every query just to check for COPY, so this adds a cheap pre-check and simplifies the regex.

### Changes

- **Regex fix**: old regex used `\s+` between COPY/FROM/STDIN which broke on inline comments like `COPY /*c*/ t FROM /*c*/ STDIN` when `query_digests` is disabled. Switched to `[^;]*?` between keywords and dropped the leading comment handling since `PartialMatch` already finds COPY anywhere in the string.

- **Fast-reject**: added a `strcasestr` check on the query digest for `"COPY "` before calling `CopyCmdMatcher::match()`. Non-COPY queries skip RE2 entirely. Falls through to RE2 when digest is disabled.

- **Tests**: added `testCopyWithLeadingComments` and `testSelectWithCopyInStringLiteral`. `execute_tests()` now runs 4 iterations covering SSL × digest on/off.

### Known limitation
When `query_digests` is disabled, the matcher can still match COPY inside a string literal (e.g. `SELECT 'COPY x FROM STDIN'`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and handling of PostgreSQL COPY FROM STDIN commands, particularly when comments or whitespace precede the statement
  * Enhanced query digest matching logic to ensure accurate command classification across various scenarios

* **Tests**
  * Added test coverage for COPY commands with leading block comments
  * Extended test harness to verify behavior across different query digest configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->