### PR TITLE
ci: fix misleading mysql57 label on ci-mysql84-g{1..5} check runs

### DIFF
--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        infradb: [ 'mysql57' ]
+        infradb: [ 'mysql84' ]
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
       MATRIX: '(${{ matrix.infradb }})'

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        infradb: [ 'mysql57' ]
+        infradb: [ 'mysql84' ]
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
       MATRIX: '(${{ matrix.infradb }})'

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        infradb: [ 'mysql57' ]
+        infradb: [ 'mysql84' ]
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
       MATRIX: '(${{ matrix.infradb }})'

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        infradb: [ 'mysql57' ]
+        infradb: [ 'mysql84' ]
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
       MATRIX: '(${{ matrix.infradb }})'

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        infradb: [ 'mysql57' ]
+        infradb: [ 'mysql84' ]
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
       MATRIX: '(${{ matrix.infradb }})'


### PR DESCRIPTION
## Summary

Five one-line fixes: \`infradb: [ 'mysql57' ]\` → \`infradb: [ 'mysql84' ]\` in each of \`ci-mysql84-g{1..5}.yml\`.

## Why

The five \`ci-mysql84-g*.yml\` reusables introduced in #5597 inherited \`infradb: [ 'mysql57' ]\` from the \`ci-legacy-g4.yml\` template I \`sed\`'d them from. That value is interpolated into \`env.MATRIX\`:

\`\`\`yaml
env:
  MATRIX: '(\${{ matrix.infradb }})'
\`\`\`

…and \`env.MATRIX\` is interpolated into the \`LouisBrunner/checks-action\` step's \`name\` field:

\`\`\`yaml
name: '\${{ github.workflow }} / \${{ github.job }} \${{ env.MATRIX }}'
\`\`\`

So on a real mysql84-g3 run the PR UI would display the check as:

\`\`\`
CI-mysql84-g3 / tests (mysql57)     ← misleading
\`\`\`

…even though the tests themselves are correctly running against \`infra-mysql84\`. The infrastructure resolution path is unaffected: \`ensure-infras.bash\` strips the \`-gN\` suffix from \`TAP_GROUP=mysql84-g3\` to get \`BASE_GROUP=mysql84\`, which resolves to \`test/tap/groups/mysql84/infras.lst\` which lists \`infra-mysql84\`. The backend is right — only the label was wrong.

## Caught by

[gemini-code-assist review on #5598](https://github.com/sysown/proxysql/pull/5598) (their inline comment on the sibling-file-cutting documentation). I also updated the docs in a companion commit on #5598 to call out \`matrix.infradb\` explicitly in the checklist, so future contributors don't repeat the mistake.

## Test plan

- [ ] Merge this PR into \`GH-Actions\`.
- [ ] On the next push/PR that kicks off the CI cascade, verify that the \`CI-mysql84-g*\` check runs in the PR UI display as \`(mysql84)\`, not \`(mysql57)\`.
- [ ] Verify the runs themselves still succeed (this is a label-only change; no behaviour change).

## Files

\`\`\`
.github/workflows/ci-mysql84-g1.yml
.github/workflows/ci-mysql84-g2.yml
.github/workflows/ci-mysql84-g3.yml
.github/workflows/ci-mysql84-g4.yml
.github/workflows/ci-mysql84-g5.yml
\`\`\`

Five files, one line changed in each, +5/-5 total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to test against MySQL 8.4 instead of MySQL 5.7 across multiple job configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->