### PR TITLE
ci: fix TAP build target so test binaries are actually produced (critical)

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -149,7 +149,11 @@ jobs:
           # build tap tests
           #sed -i "s/^build_tap_test_debug: build_src_debug$/build_tap_test_debug: build_src_debug_clickhouse/" Makefile
           #sed -i "/command/c \    command: bash -l -c 'cd /opt/proxysql && make -j$(nproc) build_tap_test_debug'" docker-compose.yml
-          make ${{ matrix.dist }}-dbg | tee ci_build_log/build-tap.log
+          # NOTE: target must be -tap (not -dbg): entrypoint.bash routes on BLD_NAME
+          # matching \-test|\-tap and selects build_tap_test_debug; -dbg takes the else
+          # branch which only builds src/proxysql, leaving test/tap/tests/**/*-t unbuilt
+          # (silent false-green — see v3.0 doc/GH-Actions/README.md debugging section).
+          make ${{ matrix.dist }}-tap | tee ci_build_log/build-tap.log
           
           # create matrix of all test folders containing *-t
           echo "[ "$(find test/tap/ -name '*-t' | xargs -n1 dirname | uniq | sed 's|test/tap/||' | xargs -I{} -n1 echo -n "'{}', ")"]" > tap-matrix.json


### PR DESCRIPTION
## TL;DR

Single-character fix. Change \`make \${{ matrix.dist }}-dbg\` to \`make \${{ matrix.dist }}-tap\` in \`ci-builds.yml\`. Resolves a latent bug that has caused **every TAP test workflow on this repo to silently report green while running zero tests** for the past several weeks.

## The bug

On [PR #5596](https://github.com/sysown/proxysql/pull/5596), the user noticed \`CI-legacy-g1\` completing in 1 minute and expected 30-60 minutes. Investigation of [run 24276110706](https://github.com/sysown/proxysql/actions/runs/24276110706) showed the \`Run legacy-g1 tests\` step took **2 seconds** and its proxysql-tester.py log said:

\`\`\`
[proxysql-tester.py:1071] Discovered 3 workdirs.
[proxysql-tester.py:648] Group 'legacy-g1' has associated tests in groups.json
[proxysql-tester.py:1305] SUMMARY: 'tests' PASS 0/0 : FAIL 0/0 : SKIP 0/0
[proxysql-tester.py:1305] SUMMARY: 'deprecate_eof_support' PASS 0/0 : FAIL 0/0 : SKIP 0/0
[proxysql-tester.py:1305] SUMMARY: 'unit' PASS 0/0 : FAIL 0/0 : SKIP 0/0
[proxysql-tester.py:1824] SUMMARY: ret_rc = [0]
\`\`\`

Zero tests ran in every workdir, but exit code 0 (0 failures ÷ 0 tests = success). This is **not** a recent regression — every \`CI-legacy-g4\` run on v3.0 HEAD since at least 2026-03-22 shows the same 2-second test-step duration and the same \`PASS 0/0\` summary. The entire TAP pipeline has been fake-green for weeks.

## Root cause

\`ci-builds.yml\` for the \`-tap\` matrix entries ran:

\`\`\`yaml
make \${{ matrix.dist }}-dbg
\`\`\`

which sets \`BLD_NAME=ubuntu22-dbg\`, invokes \`docker compose up ubuntu22_dbg_build\`, which runs \`/opt/entrypoint/entrypoint.bash\` inside the container. That script routes the build based on \`BLD_NAME\`:

\`\`\`bash
elif [[ \${BLD_NAME} =~ \\-test|\\-tap ]]; then
    build_target=\"build_tap_test_debug\"
else
    build_target=\"\$PROXYSQL_BUILD_TYPE\"   # \"debug\"
fi
\`\`\`

\`ubuntu22-dbg\` doesn't match \`\\-test|\\-tap\`, so the else branch runs \`make debug\` — which builds \`lib/\` + \`src/proxysql\` but **not** \`test/tap/tests/**/*-t\`. The TAP test binaries are never built. After the container exits, \`find test/tap/ -name '*-t'\` returns nothing (visible as \`dirname: missing operand\` in the CI-builds log right after the container exit), and the \`_test\` cache is ~2 MB of source files only. Downstream test workflows restore a cache with zero binaries, \`proxysql-tester.py\` walks it, finds nothing matching \`groups.json\`, reports \`PASS 0/0\`, exits 0. Green workflow, zero tests run.

## History

- **2023 (commit [\`9235fa492\`](https://github.com/sysown/proxysql/commit/9235fa492)):** original \`ci-builds.yml\` used a two-stage \`sed\` hack to rewrite the \`docker-compose.yml\` \`command:\` directive before invoking \`make\`, forcing the container to run \`make build_tap_test_debug\`. This worked.
- **2025-04-25 (commit [\`8c1a7cfa1\`](https://github.com/sysown/proxysql/commit/8c1a7cfa1) by @miro-stauder):** moved the TAP-build routing into \`entrypoint.bash\` so callers no longer need the sed hack; the caller just has to pass \`BLD_NAME\` with \`-tap\` in it, and the entrypoint takes over.
- **2026-03-22 (commit [\`6e7d93229\`](https://github.com/sysown/proxysql/commit/6e7d93229) — this is where it broke):** re-added \`ci-builds.yml\` on the \`GH-Actions\` branch with the \`sed\` lines **commented out** but the make target left at \`-dbg\`. Neither mechanism is active after this commit — no sed override, and \`BLD_NAME=ubuntu22-dbg\` doesn't trigger the entrypoint's tap branch.

## The fix

```diff
-          make \${{ matrix.dist }}-dbg | tee ci_build_log/build-tap.log
+          # NOTE: target must be -tap (not -dbg): entrypoint.bash routes on BLD_NAME
+          # matching \\-test|\\-tap and selects build_tap_test_debug; -dbg takes the else
+          # branch which only builds src/proxysql, leaving test/tap/tests/**/*-t unbuilt
+          # (silent false-green — see v3.0 doc/GH-Actions/README.md debugging section).
+          make \${{ matrix.dist }}-tap | tee ci_build_log/build-tap.log
```

\`make ubuntu22-tap\` sets \`BLD_NAME=ubuntu22-tap\`, which matches \`\\-tap\` in the entrypoint, which selects \`build_tap_test_debug\`. That target recursively builds \`build_src_debug\` (producing \`src/proxysql\`) and then runs \`cd test/tap && \${MAKE} debug\` to build **all** TAP test binaries under \`test/tap/tests/**/*-t\`. The workspace bind-mount (\`./:/opt/proxysql/\`) makes those binaries visible on the host after the container exits.

Mechanically, \`make ubuntu22-tap\` hits the same Makefile \`ubuntu%: build-ubuntu%\` catch-all that \`make ubuntu22-dbg\` hits, invokes the same docker service (\`ubuntu22_dbg_build\`, since \`PKG_TYPE=-dbg\` in both cases via the regex on line 451 of the Makefile), and the only observable difference inside the container is \`BLD_NAME\`. Low-risk, targeted change.

## Expected post-fix behaviour

After this lands, any push that kicks off CI-builds should produce:

- \`find test/tap/ -name '*-t'\` in the CI-builds log returns 300+ results
- \`tap-matrix.json\` is non-empty
- \`_test\` cache grows from ~2 MB to something proportional to TAP binary count
- Downstream \`CI-legacy-g*\`, \`CI-mysql84-g*\`, \`CI-basictests\` runs take 10-60 minutes instead of 2 seconds
- \`proxysql-tester.py\` reports non-zero test counts and actual pass/fail numbers
- Actual bugs that have been hiding behind the false green start surfacing (likely)

## Test plan

- [ ] Merge this PR into \`GH-Actions\`.
- [ ] Push an empty commit on an existing PR branch (e.g. #5596) and watch the \`CI-builds\` run.
- [ ] Confirm the \`CI-builds\` log shows \`>>>tap-matrix.txt<<<\` is non-empty, with dozens of entries.
- [ ] Confirm the \`_test\` cache size in the CI-builds log is much larger than ~2 MB.
- [ ] Confirm the downstream \`CI-legacy-g*\` / \`CI-mysql84-g*\` workflows show \`PASS N/N\` with a nonzero N in their proxysql-tester.py log.
- [ ] Expect some test runs to take 10-60 minutes and expect some of them to fail on real regressions that have been hiding behind the false green.

## Follow-up

Separately I am opening a PR on \`v3.0\` that adds a zero-discovery safety net to \`proxysql-tester.py\` — it will treat \"group has N > 0 tests in groups.json but discovery found 0 matching binaries\" as a hard failure, so this class of silent false-green can't recur even if some other future change breaks the build target again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build workflow configuration to use TAP-related build targets for specific matrix entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->