### PR TITLE
test: fail proxysql-tester.py TAP runs when zero binaries are discovered (safety net)

### DIFF
--- a/test/scripts/bin/proxysql-tester.py
+++ b/test/scripts/bin/proxysql-tester.py
@@ -1089,6 +1089,50 @@ CREATE TABLE stats_history.mysql_server_read_only_log (
         # Restore the original environment config
         os.environ['TAP_WORKDIR'] = orig_workdir
 
+        # Safety net: if glob(*-t) in every TAP workdir returned zero
+        # binaries, ret_summary is empty. That almost always means the
+        # TAP test binaries were never built (e.g. CI-builds running the
+        # wrong make target, docker-compose volume not writing through
+        # to the host, or a broken sed rewrite of the build command),
+        # not that there are legitimately no tests to run. Before this
+        # safety net existed the pipeline would silently report 0/0
+        # PASS and exit 0, producing a fake-green TAP suite that hid
+        # real regressions for weeks.
+        #
+        # Rule: if TAP_GROUP is set and groups.json declares that group
+        # has N > 0 tests, but zero binaries were discovered across all
+        # workdirs, treat it as a hard failure. Version-filter skips and
+        # INCL/EXCL filters still produce summary entries with rc=None,
+        # so legitimate "everything skipped" runs are not affected -- only
+        # the "nothing was even found on disk" case trips the safety net.
+        if len(ret_summary) == 0:
+            tap_group = os.environ.get('TAP_GROUP', '')
+            expected_tests = 0
+            if tap_group:
+                groups_json_path = f"{WORKSPACE}/test/tap/groups/groups.json"
+                if os.path.isfile(groups_json_path):
+                    try:
+                        with open(groups_json_path) as jf:
+                            groups = json.load(jf)
+                        expected_tests = sum(
+                            1 for _, test_groups in groups.items()
+                            if tap_group in test_groups
+                        )
+                    except Exception as e:
+                        log.warning(f"Safety net: could not parse groups.json: {e}")
+            if not tap_group or expected_tests > 0:
+                log.critical(
+                    f"SAFETY NET FAIL: zero TAP test binaries were discovered "
+                    f"across all workdirs. TAP_GROUP='{tap_group}' "
+                    f"expects {expected_tests} tests per groups.json. "
+                    f"This typically means test/tap/tests/**/*-t binaries "
+                    f"were never built -- check the CI-builds log for "
+                    f"'dirname: missing operand' right after the build "
+                    f"container exits, or verify make ubuntu22-tap "
+                    f"actually produced binaries on the host filesystem."
+                )
+                ret_rc = max(ret_rc, 1)
+
         return ret_rc, ret_logs, ret_summary
 
     def run_internal_tap_tests(self):


### PR DESCRIPTION
## Summary

Adds a defence-in-depth safety net to \`test/scripts/bin/proxysql-tester.py\` so that a TAP run with **zero discovered test binaries** fails loudly instead of silently reporting green.

Depends conceptually on sysown/proxysql#5601 (GH-Actions), which fixes the underlying build regression. This PR is the backstop that will catch any future regression of the same class.

## Why

Up until now, if CI-builds produced no \`test/tap/tests/**/*-t\` binaries on the host (for any reason -- wrong make target, broken docker-compose mount, typo in a rewrite, removal of a build target), \`proxysql-tester.py\` would walk the three TAP workdirs (\`tests\`, \`tests_with_deps/deprecate_eof_support\`, \`tests/unit\`), \`glob(*-t)\` would return zero in each, and the tester would print:

\`\`\`
SUMMARY: 'tests' PASS 0/0 : FAIL 0/0 : SKIP 0/0
SUMMARY: 'deprecate_eof_support' PASS 0/0 : FAIL 0/0 : SKIP 0/0
SUMMARY: 'unit' PASS 0/0 : FAIL 0/0 : SKIP 0/0
SUMMARY: ret_rc = [0]
\`\`\`

Zero failures out of zero tests is \"success\" by the old logic, so the workflow turns green.

That is exactly what happened during the multi-week silent regression on the \`GH-Actions\` branch after commit \`6e7d93229\` landed the wrong \`make\` target in \`ci-builds.yml\`. The entire TAP test suite -- CI-legacy-g*, CI-mysql84-g*, CI-basictests, CI-taptests-pgsql-cluster, CI-legacy-clickhouse-g1, CI-legacy-g2-genai -- was reporting green every commit while running **zero** tests. The build-target fix is in sysown/proxysql#5601. This PR is the guard that means the next regression of this kind surfaces immediately instead of hiding.

## What the safety net does

At the end of \`Psqlt.run_tap_tests\`, after the workdir loop completes, it checks \`len(ret_summary)\`.

The \`summary\` tuple \`(cmd, rc)\` is populated for every discovered binary, including ones that end up skipped by version filter, group membership, or \`TEST_PY_TAP_INCL/EXCL\` regexes -- those get \`rc=None\` rather than being absent from the summary. So \`len(ret_summary) == 0\` is a strict \"\`glob(*-t)\` found nothing in any workdir\" signal.

When that happens, the safety net looks up \`TAP_GROUP\` in \`test/tap/groups/groups.json\` and counts how many tests that group is expected to contain. If the expected count is > 0 (or \`TAP_GROUP\` is unset, meaning we're running the full TAP suite), the safety net logs a \`SAFETY NET FAIL\` message and bumps \`ret_rc\` to at least 1, making the workflow fail.

**What does NOT trip the safety net:**

- Version-filter skips: version-filtered tests still appear in the summary (\`rc=None\`), so \`len(ret_summary) > 0\` and the guard is silent.
- \`INCL/EXCL\` regex skips: same as above.
- A group legitimately declared with zero tests in \`groups.json\`: \`expected_tests == 0\`, guard is silent.

Only the \"nothing was even on disk\" case trips it. That's the case that used to silently report green and must stop doing so.

## Test plan

- [ ] Merge into \`v3.0\`.
- [ ] After sysown/proxysql#5601 merges into \`GH-Actions\`, push an empty commit to a PR branch and confirm the downstream TAP workflows actually run tests (expected to take 10+ minutes each, not 2 seconds).
- [ ] Optional negative test: temporarily break the build target on a scratch branch, push, and confirm the safety net fails the run with \`SAFETY NET FAIL\`.

## Trade-offs

- **False positives:** a group that genuinely should run nothing because all its tests are gated on a newer ProxySQL version would still populate \`ret_summary\` via the version-filter path, so it's not affected. The only false positive would be a TAP_GROUP that's in \`groups.json\` pointing at tests with names that don't exist on disk yet -- but that's exactly the condition worth failing on.
- **Log noise:** when legitimately running the full suite with no specific group, and someone's working on a dev branch that deleted all tap tests, this will fail. I consider that desired behavior.
- **Edge case:** if \`groups.json\` is unreadable or malformed, the safety net logs a warning and treats \`expected_tests\` as 0. If \`TAP_GROUP\` is set in that case, the guard is silent. I can tighten this if you'd like it louder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation to prevent false positive outcomes when no tests are discovered, ensuring the pipeline properly reports failures in such cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->