### PR TITLE
ci: shrink _test cache by dropping unit binaries and test/deps (critical)

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -171,7 +171,81 @@ jobs:
             cat tap-matrix-${TESTS##*/}.txt
             echo "===================="
           done
-          
+
+          # ------------------------------------------------------------
+          # Cache size control: prune artifacts the _test cache doesn't
+          # need before it gets saved. Without this pruning, the _test
+          # cache grows to ~4 GB compressed (~16 GB uncompressed), and
+          # two concurrent cascades (each saving one ubuntu22-tap cache
+          # and one ubuntu24-tap-genai-gcov cache) exceed GitHub's 10 GB
+          # per-repo cache quota. LRU eviction then deletes caches
+          # between when CI-builds saves them and when downstream test
+          # workflows try to restore them, causing "Cache restore test"
+          # to fail and the entire TAP pipeline to break.
+          # ------------------------------------------------------------
+
+          # Compile-time safety check: make sure unit tests actually got
+          # built. If they didn't, the build step above silently ignored
+          # a compile error and the delete below would "succeed" on an
+          # empty set. Fail loudly instead.
+          UNIT_COUNT=$(find test/tap/tests/unit -type f -name '*-t' -executable 2>/dev/null | wc -l)
+          echo ">>> Compiled ${UNIT_COUNT} unit test binaries"
+          if [ "${UNIT_COUNT}" -lt 1 ]; then
+            echo "ERROR: no unit test binaries found at test/tap/tests/unit/*-t"
+            echo "       This typically means a unit test failed to compile."
+            exit 1
+          fi
+
+          # Delete unit test binaries before the cache save. Each is ~170 MB
+          # because they statically link libproxysql.a in debug mode
+          # (52 binaries × 170 MB = 8.8 GB). CI-unittests on v3.0 is
+          # disabled for now; when it's re-enabled it will need its own
+          # rebuild strategy (probably a full docker-compose rebuild).
+          find test/tap/tests/unit -type f -name '*-t' -delete
+          echo ">>> Deleted ${UNIT_COUNT} unit test binaries from the cache payload"
+
+          # Delete test/deps (~2.8 GB on disk). These are the test-framework
+          # dependencies (mariadb-connector-c, mysql-connector-c 5.7,
+          # mysql-connector-c 8.4) that TAP binaries statically link against
+          # at build time. Nothing at runtime looks at test/deps — the code
+          # it contains already lives inside the compiled *-t binaries.
+          # Dropping it from the cache saves ~700 MB per variant after
+          # zstd compression.
+          #
+          # Safety check: verify no TAP binary dynamically links against
+          # libraries that would be under test/deps, or has a RUNPATH /
+          # RPATH pointing at test/deps. If this check fails, someone has
+          # added a test that dynamically links to a test/deps library
+          # and deleting test/deps will break that test at runtime (with
+          # a cryptic .so-not-found error). Fail loudly in CI-builds now
+          # instead of silently corrupting the cache.
+          BAD_BINS=""
+          while IFS= read -r b; do
+            deps_needed=$(readelf -d "$b" 2>/dev/null | grep -E "NEEDED.*\b(libmysqlclient|libjson_binlog|libstrings_shared|libmariadbclient)\.so" || true)
+            deps_rpath=$(readelf -d "$b" 2>/dev/null | grep -E "R(UN)?PATH.*test/deps" || true)
+            if [ -n "${deps_needed}" ] || [ -n "${deps_rpath}" ]; then
+              BAD_BINS="${BAD_BINS}${b}\n"
+              echo ">>> UNSAFE: $(basename ${b})"
+              [ -n "${deps_needed}" ] && echo "    ${deps_needed}"
+              [ -n "${deps_rpath}" ] && echo "    ${deps_rpath}"
+            fi
+          done < <(find test/tap/tests test/tap/tests_with_deps -type f -name '*-t' 2>/dev/null)
+          if [ -n "${BAD_BINS}" ]; then
+            echo "ERROR: the following TAP binaries depend on test/deps at runtime:"
+            printf "${BAD_BINS}"
+            echo "       Cannot drop test/deps from the _test cache without"
+            echo "       breaking these tests. Fix the Makefile to link"
+            echo "       them statically, or update ci-builds.yml to keep"
+            echo "       test/deps in the cache."
+            exit 1
+          fi
+          echo ">>> test/deps runtime-dependency check passed"
+
+          if [ -d test/deps ]; then
+            rm -rf test/deps
+            echo ">>> Deleted test/deps from the cache payload"
+          fi
+
         elif [[ "${{ matrix.type }}" =~ "-test" ]]; then
           TYPE=${{ matrix.type }}
           # build TYPE


### PR DESCRIPTION
## TL;DR

\`ci-builds.yml\` adds a post-build cleanup step that:
1. Verifies unit tests compiled (fails loud if zero), then deletes \`test/tap/tests/unit/*-t\` before cache save
2. Runs a runtime-dependency safety check against every TAP binary via \`readelf -d\`, then deletes \`test/deps/\` before cache save

Result: \`_test\` cache shrinks from **~4 GB compressed** to **~1 GB compressed**, fitting GitHub's 10 GB per-repo cache quota even with three concurrent cascades.

## The bug this fixes

After #5601 landed (\"fix TAP build target\"), \`_test\` went from ~2 MB (empty / broken) to ~4 GB (full build tree including all TAP binaries). Good — that's what we wanted. But with two or three cascades running concurrently, each saving _test for both \`ubuntu22-tap\` and \`ubuntu24-tap-genai-gcov\` variants, the total in flight exceeds the 10 GB per-repo cache quota. GitHub evicts caches LRU to make room, and by the time downstream test workflows try to restore \`_test\` the cache is gone. \`fail-on-cache-miss: true\` on the restore step then fast-fails every legacy/mysql84 test workflow with:

\`\`\`
run / tests (mysql57)         FAILURE
  Cache restore test          FAILURE (cache not found)
  Verify binary               SKIPPED
  Build CI base image         SKIPPED
  Start infrastructure        SKIPPED
  Run legacy-g4 tests         SKIPPED
\`\`\`

…in about 5 minutes, which is exactly what the safety-net branch cascade exhibited earlier today.

## Root cause of the bloat

The 4 GB \`_test\` cache compressed (~16 GB uncompressed) is dominated by two chunks:

| Chunk | Size (uncompressed) | What it is |
|---|---|---|
| \`test/tap/tests/unit/*-t\` | **8.8 GB** | 52 unit test binaries × 170 MB avg (static link to \`libproxysql.a\`) |
| \`test/deps/\` | **2.8 GB** | mariadb/mysql client source + build outputs (static link targets) |
| everything else (binaries + libtap + configs) | **~4 GB** | the actually-needed content |

Dropping the first two cuts the cache to ~4 GB uncompressed (~1 GB compressed). Budget math with the cut:

\`\`\`
1 GB × 2 variants × 3 cascades = 6 GB total concurrent _test footprint
10 GB repo cache quota
→ ~4 GB headroom
\`\`\`

## Why it's safe to drop these two

### Unit test binaries

They're only consumed by \`CI-unittests\`. Currently broken, being disabled in a companion PR against \`v3.0\` (removing the \`workflow_run\` trigger from the caller). When we re-enable \`CI-unittests\` later, it will need its own rebuild strategy — most likely a full \`docker compose up ubuntu22_dbg_build\` inside the CI-unittests workflow itself, at ~15 min cost per run.

**Compile-time validation is preserved**: the build still runs \`make ${dist}-tap\` which compiles all 52 unit tests. A compile error in a unit test .cpp file fails CI-builds, as today. The \`UNIT_COUNT > 0\` check before the delete guarantees we fail loud if the compile silently produces nothing.

### \`test/deps/\`

This was less obvious and I investigated it carefully before proposing the delete:

**Contents:**
- \`test/deps/mariadb-connector-c\` — 13 MB, contains \`libmariadbclient.a\` (static only)
- \`test/deps/mysql-connector-c\` — 625 MB, contains \`libmysqlclient.a\` (static only, MySQL 5.7 path)
- \`test/deps/mysql-connector-c-8.4.0\` — 2.2 GB, contains BOTH \`libmysqlclient.a\` AND \`libmysqlclient.so\` (shared lives at \`mysql-8.4.0/library_output_directory/\`, which is outside the path \`TEST_MYSQL8_LDIR\` points at)

**Why dropping it is safe for the 380 TAP binaries that currently exist:**

1. **Makefile rules link static.** \`test/tap/tests/Makefile\` line 259 uses explicit \`-Wl,-Bstatic -lmysqlclient\`. The other rules (lines 298/301/304/310) don't force static but \`TEST_MYSQL_LDIR\` points at \`test/deps/mysql-connector-c/mysql-connector-c/libmysql\` which only has \`libmysqlclient.a\` — so the linker has no \`.so\` to prefer.

2. **Empirical check via readelf on all 380 TAP binaries:**
   - \`NEEDED libmysqlclient.so\`:    0 / 380
   - \`NEEDED libjson_binlog.so\`:    0 / 380
   - \`NEEDED libstrings_shared.so\`: 0 / 380
   - \`NEEDED libmariadbclient.so\`:  0 / 380
   - \`RUNPATH/RPATH → test/deps/\`:  0 / 380

3. **No runtime-harness reference.** \`proxysql-tester.py:810\` sets \`LD_LIBRARY_PATH\` to \`\$TEST_DEPS_PATH:\$TAP_DEPS_PATH\`, but \`TEST_DEPS_PATH\` at *runtime* is set by \`test/infra/control/env-isolated.bash:60\` to \`\${WORKSPACE}/test-scripts/deps\` — a different path than the Makefile's \`TEST_DEPS_PATH := \$(PROXYSQL_PATH)/test/deps\`. The runtime path is a nearly-empty \`test-scripts/deps/\` directory, unrelated to the \`test/deps/\` build tree we're deleting.

4. **Zero script references.** Grep for \`test/deps\` in \`test/tap/\`, \`test/infra/\`, \`test/scripts/\` across \`.py\`, \`.sh\`, \`.bash\` files: no matches. Only Makefiles reference it (build-time) and binary debug symbols embed the path (post-mortem debug info only).

**Defense in depth:** this PR doesn't just delete \`test/deps\` blindly. It runs a readelf sweep of every \`*-t\` binary in \`test/tap/tests\` + \`test/tap/tests_with_deps\` and fails the build if **any** of them has a \`NEEDED\` entry for one of the test/deps shared libs or a \`RUNPATH\`/\`RPATH\` pointing at \`test/deps\`. Today's state passes cleanly (verified locally against the full set of 380 binaries). If someone ever adds a dynamically-linked test in the future, they hit this check and get a clear error in CI-builds telling them exactly what broke and why — instead of a cryptic \"Cache restore test failed\" days later when eviction bites.

## Diff summary

Only \`.github/workflows/ci-builds.yml\` changes. +75 / -1. All changes are inside the \`if [[ \"\${{ matrix.type }}\" =~ \"-tap\" ]]; then\` branch, after the existing tap-matrix.txt generation and before the cache-save step.

## Test plan

- [ ] Merge this PR into \`GH-Actions\`.
- [ ] Merge the companion \`v3.0\` PR that disables \`CI-unittests\` (removes its \`workflow_run\` trigger) so the disabled-for-now state is in place.
- [ ] Push an empty commit to any PR branch (e.g., #5596).
- [ ] Verify the CI-builds log shows:
  - \`>>> Compiled N unit test binaries\` with N > 0
  - \`>>> Deleted N unit test binaries from the cache payload\`
  - \`>>> test/deps runtime-dependency check passed\`
  - \`>>> Deleted test/deps from the cache payload\`
- [ ] Verify the \`_test\` cache save reports a smaller size (~1 GB instead of ~4 GB).
- [ ] Verify at least one \`CI-legacy-g*\` / \`CI-mysql84-g*\` run in the cascade gets past the \`Cache restore test\` step and actually runs its \`Run <group> tests\` step for realistic duration (10+ minutes, not 2 seconds or 0 seconds).
- [ ] Expect the TAP test runs to produce \`PASS N/N\` with N > 0 in \`proxysql-tester.py\` output. Some may fail on real regressions that were previously masked — those are bug reports, not CI infra issues.

## Follow-ups

- **Re-enable \`CI-unittests\`** once a rebuild strategy is in place (separate effort, tracked separately)
- **Cache quota observability**: add a step in CI-builds that logs current cache usage after the save, so we can monitor headroom over time and catch creeping growth before it hits the quota again
- **Consider the \`_bin\` cache** (~650 MB per variant) — it contains \`.git/\` which is almost certainly not needed by anything downstream, another ~400 MB per cache of free savings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI build infrastructure with enhanced validation checks and optimized caching for more reliable and efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->