### PR TITLE
ci: disable CI-unittests caller temporarily

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -1,11 +1,40 @@
 name: CI-unittests
 run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
+# DISABLED FOR NOW (2026-04-11)
+#
+# The automatic workflow_run trigger is intentionally removed. CI-unittests
+# cannot be run as part of the normal CI cascade right now because the
+# ci-builds.yml _test cache no longer includes the compiled unit test
+# binaries — they're stripped in CI-builds (after compilation, which still
+# catches compile errors) to keep the cache under GitHub's 10 GB per-repo
+# quota. See sysown/proxysql#5603 for the cache-shrink story.
+#
+# Unit tests are still being compiled in every CI-builds run (the
+# `UNIT_COUNT > 0` check in ci-builds.yml ensures this). Only their
+# binaries are pruned before the cache save.
+#
+# To re-enable CI-unittests:
+#   1. Decide how it will obtain the unit test binaries. Options:
+#        a) docker compose up ubuntu22_dbg_build inside ci-unittests.yml
+#           (self-contained, ~15 min overhead per run)
+#        b) Expand _src cache to include lib/libproxysql.a + deps/*/lib/*.a
+#           + test/tap/tap/ and run an incremental `make` in ci-unittests
+#           (faster, more complex)
+#        c) Use upload-artifact / download-artifact for the unit binaries
+#           (different quota, requires run-id plumbing)
+#   2. Update .github/workflows/ci-unittests.yml on GH-Actions accordingly
+#   3. Restore the workflow_run trigger below (uncomment the block)
+#
+# The workflow_dispatch trigger is kept so the workflow can still be
+# invoked manually from the Actions tab (e.g. to test a re-enablement
+# branch), but no automatic runs will fire.
+
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [ CI-trigger ]
-    types: [ completed ]
+  # workflow_run:
+  #   workflows: [ CI-trigger ]
+  #   types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}


### PR DESCRIPTION
## Summary

Removes the \`workflow_run\` trigger from \`.github/workflows/CI-unittests.yml\`, so \`CI-unittests\` stops firing automatically on every PR/push. Keeps \`workflow_dispatch\` so it can still be invoked manually.

Inline comment block at the top of the file documents **why** it's disabled, and lists the three options for re-enabling it later.

## Why

Companion PR sysown/proxysql#5603 on \`GH-Actions\` strips the unit test binaries from the \`_test\` cache payload (they're 8.8 GB of 52 binaries at 170 MB each and they blow out GitHub's 10 GB per-repo cache quota when combined with concurrent cascades). Unit tests are still compiled in \`ci-builds.yml\` — a \`UNIT_COUNT > 0\` check guards the strip so compile errors still fail the build — but the binaries don't ship in the cache.

\`CI-unittests\` uses the \`SKIP_PROXYSQL\` host-only path in \`run-tests-isolated.bash\`, which expects the unit test binaries to exist on disk after the cache restore. They won't, so the workflow would fail with either:

1. \`Cache restore test\` failure (if the rest of \`_test\` also happens to be evicted)
2. \`SAFETY NET FAIL: zero TAP test binaries were discovered\` from the \`proxysql-tester.py\` safety net added in #5602 (if the rest of \`_test\` restores fine and only the unit binaries are missing)

Either way the result is a consistently red \`CI-unittests\` on every cascade, which is noise and actively confusing.

Disabling the automatic trigger removes the noise. The workflow file stays in place so re-enabling is a small PR later when we have a rebuild strategy.

## Re-enable instructions (inline comment in the caller)

To re-enable \`CI-unittests\`:

1. Decide how it will obtain the unit test binaries. Options:
   - **a)** \`docker compose up ubuntu22_dbg_build\` inside \`ci-unittests.yml\` on \`GH-Actions\` (self-contained, ~15 min overhead per run)
   - **b)** Expand \`_src\` cache to include \`lib/libproxysql.a\` + \`deps/*/lib/*.a\` + \`test/tap/tap/\` and run an incremental \`make\` in \`ci-unittests\` (faster, more complex cache design)
   - **c)** Use \`upload-artifact\` / \`download-artifact\` for the unit binaries (different quota, requires \`run-id\` plumbing from the \`workflow_run\` chain)
2. Update \`.github/workflows/ci-unittests.yml\` on \`GH-Actions\` accordingly
3. Restore the \`workflow_run\` trigger (uncomment the block in this file)

## Diff

One file, +32 / -3. Comment block + comment out the \`workflow_run:\` lines.

## Test plan

- [ ] Merge this PR into \`v3.0\`.
- [ ] Merge the companion sysown/proxysql#5603 (strips unit binaries from \`_test\` cache).
- [ ] Push an empty commit to any PR branch.
- [ ] Verify \`CI-unittests\` does NOT appear in the PR's Checks tab as a workflow_run-triggered run.
- [ ] Verify \`CI-legacy-g*\` / \`CI-mysql84-g*\` workflows successfully restore \`_test\` from cache (now fitting under the 10 GB quota) and actually run tests.

## Out of scope

- Re-enabling \`CI-unittests\` with a working rebuild strategy (separate effort)
- Deleting the \`ci-unittests.yml\` reusable on \`GH-Actions\` — it's dormant when no caller invokes it, so there's no cost to leaving it in place and re-enabling becomes a smaller diff later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI/CD workflow configuration for unit tests. Automatic trigger upon completion of prior workflow has been disabled, while manual workflow execution remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->