### PR TITLE
ci: use sudo for cache-prune cleanup to avoid root-owned file errors

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -201,7 +201,13 @@ jobs:
           # (52 binaries × 170 MB = 8.8 GB). CI-unittests on v3.0 is
           # disabled for now; when it's re-enabled it will need its own
           # rebuild strategy (probably a full docker-compose rebuild).
-          find test/tap/tests/unit -type f -name '*-t' -delete
+          #
+          # sudo is required: files under test/tap/tests/unit/ and test/deps/
+          # are created inside the docker build container running as root,
+          # and the host-side runner user can't always remove root-owned
+          # files under root-owned subdirectories (unlink needs write access
+          # to the parent directory, which the runner doesn't always have).
+          sudo find test/tap/tests/unit -type f -name '*-t' -delete
           echo ">>> Deleted ${UNIT_COUNT} unit test binaries from the cache payload"
 
           # Delete test/deps (~2.8 GB on disk). These are the test-framework
@@ -241,8 +247,11 @@ jobs:
           fi
           echo ">>> test/deps runtime-dependency check passed"
 
+          # sudo required: test/deps contents are owned by root (created
+          # inside the docker build container). See comment above on the
+          # unit test delete.
           if [ -d test/deps ]; then
-            rm -rf test/deps
+            sudo rm -rf test/deps
             echo ">>> Deleted test/deps from the cache payload"
           fi
 


### PR DESCRIPTION
## TL;DR

Two-line follow-up to #5603. Change:
- \`find test/tap/tests/unit -type f -name '*-t' -delete\` → \`sudo find ...\`
- \`rm -rf test/deps\` → \`sudo rm -rf test/deps\`

Fixes the CI-builds ubuntu22-tap job which failed on the first real run of the cache-prune cleanup with thousands of \"Permission denied\" errors from \`rm\`.

## Evidence from the failed run

Run [24279526543](https://github.com/sysown/proxysql/actions/runs/24279526543) (CI-builds on PR #5596 commit \`2abbc4f31\`):

\`\`\`
>>> Compiled 51 unit test binaries
>>> Deleted 51 unit test binaries from the cache payload     ← happened to work
>>> test/deps runtime-dependency check passed                 ← readelf sweep OK
rm: cannot remove 'test/deps/mariadb-connector-c/.../README': Permission denied
rm: cannot remove 'test/deps/mariadb-connector-c/.../zlib/gzclose.c': Permission denied
[... thousands of similar lines ...]
##[error]Process completed with exit code 1
\`\`\`

## Root cause

Files under \`test/deps/\` and (in some configurations) \`test/tap/tests/unit/\` are produced inside the docker build container (\`ubuntu22_dbg_build\`), which runs as \`root\` with the workspace bind-mounted. After the container exits, those files are on the host-side workspace with \`root:root\` ownership.

The GitHub-hosted runner user can't always \`rm -rf\` them:

- \`unlink(2)\` requires write access to the **parent directory**, not the file itself.
- Some leaf directories under \`test/deps/\` (e.g. \`mariadb-connector-c-3.1.9/zlib/\`) are themselves \`root\`-owned without world-write. The runner user can't enter them to delete files.

The unit test binary delete from #5603 happened to work in this run only because \`find -delete\` was operating on files whose immediate parent (\`test/tap/tests/unit/\`) happened to be runner-writable. That's fragile — the moment a future commit moves those binaries into a new subdirectory created inside the container, the silent success turns into a silent failure.

## The fix

Two \`sudo\` prefixes:

\`\`\`diff
-          find test/tap/tests/unit -type f -name '*-t' -delete
+          sudo find test/tap/tests/unit -type f -name '*-t' -delete
\`\`\`

\`\`\`diff
           if [ -d test/deps ]; then
-            rm -rf test/deps
+            sudo rm -rf test/deps
\`\`\`

GitHub-hosted ubuntu runners have passwordless sudo by default. This is routine for cleanup steps — not expanding the privilege scope of the job, just aligning the cleanup privilege level with what's needed to remove files another UID created.

## What I verified before committing

- [x] No other \`rm\`/\`find -delete\` in the cleanup block that would hit the same issue.
- [x] The readelf safety check earlier in the block doesn't need sudo (it only reads, and \`readelf 2>/dev/null\` swallows any permission errors).
- [x] The Makefile's own \`make -C test/deps cleanall\` target (which also does \`rm -rf\`) suppresses errors with \`|| true\`, so using it wouldn't actually solve the problem — it would just silently fail.
- [x] Added an inline comment explaining why sudo is there, so nobody removes it in the future thinking it's unnecessary.

## Test plan

- [ ] Merge this PR into \`GH-Actions\`.
- [ ] Push a new empty commit to PR #5596.
- [ ] Verify CI-builds for the new commit gets past the cleanup step and reports:
  - \`>>> Compiled N unit test binaries\`
  - \`>>> Deleted N unit test binaries from the cache payload\`
  - \`>>> test/deps runtime-dependency check passed\`
  - \`>>> Deleted test/deps from the cache payload\`     ← this is the new one we didn't see before
- [ ] Verify the \`_test\` cache save succeeds and reports a size around ~1 GB (down from 4 GB pre-cleanup).
- [ ] Verify at least one downstream test workflow (e.g. CI-legacy-g1) restores the cache and actually runs its tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI/CD build reliability through enhanced artifact cleanup procedures with updated permission handling and documentation for containerized build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->