### PR TITLE
ci: fix upload-artifact EACCES in all downstream test reusables

### DIFF
--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -94,6 +94,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -101,6 +101,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -102,6 +102,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -101,6 +101,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -101,6 +101,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -100,6 +100,18 @@ jobs:
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -107,6 +107,18 @@ jobs:
         sudo chmod -R 777 ${{ github.workspace }}/*
         exit $RCS
         
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -127,6 +127,18 @@ jobs:
         
         sudo chmod -R 777 ${{ github.workspace }}/*
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -103,6 +103,18 @@ jobs:
         sudo chmod -R 777 ${{ github.workspace }}/*
         exit $RC
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-taptests-asan.yml
+++ b/.github/workflows/ci-taptests-asan.yml
@@ -304,6 +304,18 @@ jobs:
         sudo chmod -R 777 ${{ github.workspace }}/*
         echo "${{ matrix.testgroup }}" | tr -d '*|' | sed 's|.*/||' | xargs -0 printf 'TESTGROUP=%s' >> $GITHUB_ENV
           
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-taptests-groups.yml
+++ b/.github/workflows/ci-taptests-groups.yml
@@ -335,6 +335,23 @@ jobs:
         sudo chmod -R 777 ${{ github.workspace }}/*
         echo "${{ matrix.testgroup }}" | tr -d '*|' | sed 's|.*/||' | xargs -0 printf 'TESTGROUP=%s' >> $GITHUB_ENV
           
+    # Security note: this step runs a static chmod command against a path
+    # under proxysql/; no untrusted user input is interpolated. The chmod
+    # target is a fixed literal, the only variable substitution is inside
+    # an if: expression that uses workflow-run state (failure/cancelled),
+    # not event body fields.
+    - name: Fix artifact permissions
+      if: ${{ failure() || cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
 #      if: ${{ failure() && !cancelled() }}
       if: ${{ failure() || cancelled() }}

--- a/.github/workflows/ci-taptests-old.yml
+++ b/.github/workflows/ci-taptests-old.yml
@@ -308,6 +308,18 @@ jobs:
         sudo chmod -R 777 ${{ github.workspace }}/*
         echo "${{ matrix.testgroup }}" | tr -d '*|' | xargs -0 printf 'TESTGROUP=%s' >> $GITHUB_ENV
         
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-taptests-ssl.yml
+++ b/.github/workflows/ci-taptests-ssl.yml
@@ -319,6 +319,18 @@ jobs:
         sudo chmod -R 777 ${{ github.workspace }}/*
         echo "${{ matrix.taptests }}" | tr -d '*|' | xargs -0 printf 'TAPTESTS=%s' >> $GITHUB_ENV
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-taptests.yml
+++ b/.github/workflows/ci-taptests.yml
@@ -256,6 +256,18 @@ jobs:
         sudo chmod -R 777 ${{ github.workspace }}/*
         echo "${{ matrix.taptests }}" | tr -d '*|' | xargs -0 printf 'TAPTESTS=%s' >> $GITHUB_ENV
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -71,6 +71,18 @@ jobs:
         export TAP_GROUP="unit-tests-g1"
         test/infra/control/run-tests-isolated.bash
 
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Every downstream test reusable on `GH-Actions` (`ci-legacy-g*`, `ci-mysql84-g*`, `ci-basictests`, `ci-repltests`, `ci-shuntest`, etc.) uploads `proxysql/ci_*_logs/` as a post-mortem artifact when a test fails, via `actions/upload-artifact@v4` inside `if: failure() && !cancelled()`. **That upload dies every single time** with:

```
##[error]EACCES: permission denied, scandir '/home/runner/work/proxysql/proxysql/proxysql/ci_infra_logs/infra-mariadb10-ci-legacy-g3/mariadb1/mysql'
```

because `ci_*_logs/` contains files that the docker build containers wrote as root, and the host-side runner user cannot `scandir` into those directories.

**Net effect:** for every failed test in the CI cascade, **zero artifacts are uploaded**. Maintainers trying to investigate CI failures from the Actions page get "no artifacts found" and have to reproduce locally.

Concrete proof case from today: runs `24281031531`, `24281031522`, `24281031524` on PR #5596 (commit `09b97547f`) — all three failed with real TAP test failures (`test_flush_logs-t`, `pgsql-servers_ssl_params-t`, `pgsql-ssl_keylog-t`, `test_read_only_actions_offline_hard_servers-t`), and all three have `artifacts: []` when queried via `gh api`. The TAP `.log.gz` files that would have told us *why* the tests failed were lost.

## Fix

Insert a new `Fix artifact permissions` step before every `actions/upload-artifact@v4` step whose path is `proxysql/ci_*_logs/`. The new step runs:

```bash
sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
```

- `sudo` because the files are root-owned (created inside docker containers)
- `a+rX` makes everything world-readable, with directory-traverse on directories (capital X)
- `2>/dev/null || true` because the path may not exist on some failure paths (e.g. a cache-restore failure before any test runs)

Same pattern as the `sudo rm -rf test/deps` + `sudo find ... -delete` fix we shipped in PR #5605 for `ci-builds.yml`.

## Files touched (22)

- `ci-basictests.yml`
- `ci-legacy-clickhouse-g1.yml`
- `ci-legacy-g1.yml`, `ci-legacy-g2.yml`, `ci-legacy-g2-genai.yml`, `ci-legacy-g3.yml`, `ci-legacy-g4.yml`, `ci-legacy-g5.yml`
- `ci-mysql84-g1.yml` through `ci-mysql84-g5.yml`
- `ci-repltests.yml`, `ci-shuntest.yml`, `ci-selftests.yml`
- `ci-taptests.yml`, `ci-taptests-asan.yml`, `ci-taptests-old.yml`, `ci-taptests-ssl.yml`, `ci-taptests-groups.yml`
- `ci-unittests.yml`

## Files intentionally NOT touched

- `ci-maketest.yml` — uploads `./build-*.log`, created by the runner user outside docker, no EACCES risk
- `ci-3p-*.yml` — these do not upload `ci_*_logs/`; their artifact uploads (if any) target 3p-specific paths created outside docker
- `ci-builds.yml` — already handled by PR #5605

## Test plan

- [x] All 22 patched files pass `yaml.safe_load` (no syntax breakage from the insertion)
- [x] Spot-checked `ci-legacy-g1.yml` manually — insertion is at the correct indentation and immediately precedes the existing `Archive artifacts logs` step
- [ ] After merge, next failed CI test run should show a non-empty `artifacts: [...]` in `gh api repos/sysown/proxysql/actions/runs/<id>/artifacts`, with the `ci_*_logs/` tarball containing the per-test `.log.gz` files
- [ ] The Node.js 20 deprecation warning from `actions/upload-artifact@v4` is unchanged — this PR is orthogonal to that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple CI workflows to improve artifact upload reliability by ensuring log directories have appropriate read permissions before archival. This prevents permission-related failures during log collection on workflow failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->