### PR TITLE
doc(test): document per-test log paths and flaky-test debugging recipe

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -66,8 +66,94 @@ Common test groups (defined in `tap/groups/groups.json`):
    make -j$(nproc) && make -j$(nproc) build_tap_test
    ```
 
+## Where logs actually live after a run
+
+Once a run finishes (passed or failed), everything it produced lives under
+`ci_infra_logs/${INFRA_ID}/`. The layout is:
+
+```
+ci_infra_logs/${INFRA_ID}/
+├── infra-mysql57/                      # per-backend logs (mysql, mariadb, pgsql, ...)
+│   └── mysql1/
+│       ├── error.log
+│       └── general.log
+├── infra-mariadb10/
+│   └── ...
+├── proxysql/                           # ProxySQL side
+│   ├── proxysql.log
+│   └── proxysql_audit.log
+└── tests/
+    └── proxysql-tester.py/
+        └── tests/
+            ├── test_flush_logs-t.log.gz             # per-test captured stdout+stderr
+            ├── test_flush_logs-t.proxysql.log.gz    # ProxySQL log during that test
+            ├── pgsql-servers_ssl_params-t.log.gz
+            └── ...                                  # one .log.gz per test attempt
+```
+
+**All the per-test `.log.gz` files are gzipped** to save space — read them with
+`zcat` or `zless`, not `cat`:
+
+```bash
+# Read the captured TAP output of a specific test
+zless ci_infra_logs/${INFRA_ID}/tests/proxysql-tester.py/tests/test_flush_logs-t.log.gz
+
+# Or the ProxySQL server log captured during that test
+zless ci_infra_logs/${INFRA_ID}/tests/proxysql-tester.py/tests/test_flush_logs-t.proxysql.log.gz
+
+# Grep across every test's TAP output for a pattern
+zgrep -H 'not ok\|FAIL' ci_infra_logs/${INFRA_ID}/tests/proxysql-tester.py/tests/*.log.gz
+```
+
+## Debugging a flaky test
+
+A test that passes locally but fails intermittently on CI is usually racing
+against a timeout or a slow backend. The recipe to reproduce and stress-test
+it locally is:
+
+```bash
+# Bring infra up once, run the same test N times back-to-back against the
+# same running ProxySQL, capture each attempt's log under a separate subdir.
+export WORKSPACE=$(pwd)
+export TAP_GROUP="legacy-g3"
+export TEST_PY_TAP_INCL="test_flush_logs-t"     # regex of the test(s) to focus on
+export SKIP_CLUSTER_START=1
+source test/infra/common/env.sh
+
+# One infra lifecycle, many test runs:
+export INFRA_ID="flake-$(date +%s)"
+./test/infra/control/ensure-infras.bash
+
+for i in $(seq 1 20); do
+    echo "===== attempt $i ====="
+    ./test/infra/control/run-tests-isolated.bash 2>&1 | tee /tmp/flake-$i.log
+    # stash the per-test log before the next attempt overwrites it
+    mkdir -p /tmp/flake-runs/$i
+    cp -a ci_infra_logs/${INFRA_ID}/tests/proxysql-tester.py/tests/ /tmp/flake-runs/$i/
+done
+
+./test/infra/control/stop-proxysql-isolated.bash
+```
+
+Then inspect which attempts failed and diff their per-test logs:
+
+```bash
+# Which attempts had any FAIL?
+grep -l 'FAIL [1-9]' /tmp/flake-*.log
+
+# Compare the TAP output of a failing attempt against a passing one
+zdiff /tmp/flake-runs/3/tests/test_flush_logs-t.log.gz \
+      /tmp/flake-runs/7/tests/test_flush_logs-t.log.gz
+```
+
+If 20 attempts all pass locally but CI still fails, the race is probably
+CI-runner-specific (slow I/O on the shared runner, docker volume consistency
+delays, etc.) rather than a bug in the test or the code. That diagnosis is
+useful information even if it doesn't point at a fix.
+
 ## Troubleshooting
 
-- **"Directory Not Empty"**: Run `./test/infra/control/stop-proxysql-isolated.bash` with the same `INFRA_ID`
-- **Container issues**: Check logs in `ci_infra_logs/${INFRA_ID}/`
-- **Test failures**: Check logs in `ci_infra_logs/${INFRA_ID}/tests/`
+- **"Directory Not Empty"**: Run `./test/infra/control/stop-proxysql-isolated.bash` with the same `INFRA_ID` that was used when you started the infra. If you lost the ID, `docker network ls` will show you active `*_backend` networks — each one is a stuck infra; the name before `_backend` is the `INFRA_ID`.
+- **Container issues**: Check logs in `ci_infra_logs/${INFRA_ID}/infra-*/` (per-backend) and `ci_infra_logs/${INFRA_ID}/proxysql/` (ProxySQL side).
+- **Test failures**: Read the per-test `.log.gz` files under `ci_infra_logs/${INFRA_ID}/tests/proxysql-tester.py/tests/` with `zless` or `zcat` — see the "Where logs actually live" section above for the full layout.
+- **Stale docker state**: `docker ps -a | grep "${INFRA_ID}"` shows any leftover containers; `docker network prune` after stopping infras cleans up dangling networks.

--- a/test/README.md
+++ b/test/README.md
@@ -71,7 +71,7 @@ Common test groups (defined in `tap/groups/groups.json`):
 Once a run finishes (passed or failed), everything it produced lives under
 `ci_infra_logs/${INFRA_ID}/`. The layout is:
 
-```
+```text
 ci_infra_logs/${INFRA_ID}/
 ├── infra-mysql57/                      # per-backend logs (mysql, mariadb, pgsql, ...)
 │   └── mysql1/
@@ -138,8 +138,11 @@ done
 Then inspect which attempts failed and diff their per-test logs:
 
 ```bash
-# Which attempts had any FAIL?
-grep -l 'FAIL [1-9]' /tmp/flake-*.log
+# Which attempts had any failure? Matches both the TAP "not ok" marker and
+# proxysql-tester.py's own "FAIL N/M" summary line, so we don't miss a test
+# that failed at the TAP level but didn't produce a non-zero FAIL count in
+# the summary (e.g. when the test binary itself crashes).
+grep -lE 'not ok|FAIL [1-9]' /tmp/flake-*.log
 
 # Compare the TAP output of a failing attempt against a passing one
 zdiff /tmp/flake-runs/3/tests/test_flush_logs-t.log.gz \
@@ -156,4 +159,4 @@ useful information even if it doesn't point at a fix.
 - **"Directory Not Empty"**: Run `./test/infra/control/stop-proxysql-isolated.bash` with the same `INFRA_ID` that was used when you started the infra. If you lost the ID, `docker network ls` will show you active `*_backend` networks — each one is a stuck infra; the name before `_backend` is the `INFRA_ID`.
 - **Container issues**: Check logs in `ci_infra_logs/${INFRA_ID}/infra-*/` (per-backend) and `ci_infra_logs/${INFRA_ID}/proxysql/` (ProxySQL side).
 - **Test failures**: Read the per-test `.log.gz` files under `ci_infra_logs/${INFRA_ID}/tests/proxysql-tester.py/tests/` with `zless` or `zcat` — see the "Where logs actually live" section above for the full layout.
-- **Stale docker state**: `docker ps -a | grep "${INFRA_ID}"` shows any leftover containers; `docker network prune` after stopping infras cleans up dangling networks.
+- **Stale docker state**: `docker ps -a | grep "${INFRA_ID}"` shows any leftover containers; prefer targeted cleanup of just this infra's network with `docker network rm "${INFRA_ID}_backend"` over the global `docker network prune`, which would also wipe unrelated project networks on the same host.


### PR DESCRIPTION
## Summary

Fixes two documentation gaps in `test/README.md` that surfaced while investigating the flaky TAP test failures reported on PR #5596.

## Gap 1: per-test log paths were undocumented

The README said *"Check logs in `ci_infra_logs/\${INFRA_ID}/tests/`"* but did not document what's actually under that directory. Per-test TAP output lives three directories deep at:

```
ci_infra_logs/${INFRA_ID}/tests/proxysql-tester.py/tests/<test>-t.log.gz
```

and the files are **gzipped**. A maintainer opening one with `cat` or `vim` without knowing to use `zless` burns minutes figuring it out.

**Fix:** new section "Where logs actually live after a run" showing the full directory tree (per-backend, per-ProxySQL, per-test subdirs) and the concrete `zless` / `zcat` / `zgrep` / `zdiff` one-liners for reading the gzipped output.

## Gap 2: no guidance for reproducing flaky tests locally

Until today there was no canonical answer to *"this test passed locally and failed on CI — is it really flaky, or is it my environment?"*. The natural recipe (reuse one infra, loop N runs against the same running ProxySQL, snapshot per-run logs, diff) was nowhere in the repo.

**Fix:** new section "Debugging a flaky test" with a copy-pasteable loop that runs the same test 20 times against one infra lifecycle, stashes per-attempt per-test logs under `/tmp/flake-runs/\$i/`, and shows the `zdiff` idiom for comparing a failing attempt's TAP output against a passing one.

## Other small improvements

- **Troubleshooting bullet list** expanded with:
  - How to recover from a lost `INFRA_ID` (via `docker network ls` — each `*_backend` network is a stuck infra).
  - Where each flavor of log lives (per-backend under `infra-*/`, per-ProxySQL under `proxysql/`, per-test under `tests/proxysql-tester.py/tests/`).
  - How to clean up dangling docker state (`docker ps -a | grep`, `docker network prune`).

## Test plan

- [x] `test/README.md` parses as valid markdown, line count went from 73 → 159 (+89 net)
- [ ] Visual review in GitHub's rendered markdown once the PR is open

No code or workflow changes. Doc-only.

## Related

- PR #5608 (GH-Actions branch): fixes the upload-artifact EACCES issue that was *also* blocking maintainers from seeing CI failure logs. With both PRs merged, a maintainer investigating a flaky test can now: (a) see the `.log.gz` in CI-uploaded artifacts (PR #5608 fix), or (b) reproduce locally following this doc's new recipe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Specifies exact on-disk log locations and layout (per-backend, ProxySQL, per-test gzipped artifacts).
  * Adds concrete inspection commands for gzipped logs (zless, zcat, zgrep, zdiff).
  * Expands flaky-test troubleshooting with a reuseable infra lifecycle, per-attempt log capture/stash, and comparison workflow.
  * Clarifies detection and cleanup of stale docker networks using docker network ls and docker network rm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->