### PR TITLE
test(flush_logs): harden timing race — poll instead of fixed sleep

### DIFF
--- a/test/tap/tests/test_flush_logs-t.sh
+++ b/test/tap/tests/test_flush_logs-t.sh
@@ -74,18 +74,34 @@ fn_signal () {
 		fi
 	fi
 
-	# The Scheduler Hack: If we can't use docker, we ask ProxySQL to kill itself
-	# ProxySQL scheduler waits for the first interval before execution.
-	# We use /bin/sh -c to find the correct PID (worker process) and signal it.
+	# The Scheduler Hack: If we can't use docker (e.g. we're running
+	# inside the test-runner container, which has no docker CLI), we ask
+	# ProxySQL to kill itself. We install a scheduler row with interval
+	# 500ms so it fires very quickly. We use /bin/sh -c to find the
+	# correct PID (worker process) and signal it.
+	#
+	# NOTE: the caller is responsible for tearing the scheduler row down
+	# via fn_signal_cleanup() after it has observed the effect it was
+	# waiting for. We intentionally do NOT delete the row here - that
+	# would race against the scheduler actually firing.
 	echo "msg: # Using Scheduler Hack to send ${sig} to ProxySQL..."
-	fn_padmin "INSERT OR REPLACE INTO scheduler (id, active, interval_ms, filename, arg1, arg2) VALUES (9999, 1, 2000, '/bin/sh', '-c', 'kill -${sig#SIG} \$(pidof proxysql)');"
+	fn_padmin "INSERT OR REPLACE INTO scheduler (id, active, interval_ms, filename, arg1, arg2) VALUES (9999, 1, 500, '/bin/sh', '-c', 'kill -${sig#SIG} \$(pidof proxysql)');"
 	fn_padmin "LOAD SCHEDULER TO RUNTIME;"
-	sleep 4
-	fn_padmin "DELETE FROM scheduler WHERE id=9999; LOAD SCHEDULER TO RUNTIME;"
+}
+
+fn_signal_cleanup () {
+	# Tear down any scheduler row installed by fn_signal. Safe to call
+	# unconditionally - if fn_signal used the docker path instead of the
+	# scheduler hack, this is a no-op on a non-existent row.
+	fn_padmin "DELETE FROM scheduler WHERE id=9999;" >/dev/null 2>&1 || true
+	fn_padmin "LOAD SCHEDULER TO RUNTIME;" >/dev/null 2>&1 || true
 }
 
 fn_get_rotations () {
-	sleep 1
+	# Raw count of rotation markers in the current proxysql.log. No
+	# sleep() here - callers that are racing against an in-progress
+	# rotation should use fn_wait_for_rotation_at_least instead, which
+	# polls in a bounded loop rather than relying on a fixed sleep.
 	# Try local mount first (most efficient in CI)
 	if [ -f "$PROXYSQL_LOGS/proxysql.log" ]; then
 		cat "$PROXYSQL_LOGS/proxysql.log" | grep '\[INFO\] ProxySQL version' | wc -l
@@ -99,14 +115,53 @@ fn_get_rotations () {
 	fi
 }
 
+fn_wait_for_rotation_at_least () {
+	# Poll fn_get_rotations every 500 ms until the observed count is
+	# >= $1, or until $2 seconds have elapsed. Prints the final observed
+	# count to stdout so the caller can compare against its expected
+	# value (even on timeout).
+	#
+	# This replaces the `fn_padmin COMMAND ; sleep N ; count` pattern
+	# that used to race on slow CI runners: the sleep window was fixed
+	# at 1-5 s but the actual rotation latency varies with runner load,
+	# and any sleep just shy of the latency silently produced a false
+	# failure. By polling we convert a timing race into a max-latency
+	# bound - on a fast machine the test is as quick as before, on a
+	# slow one it waits up to max_seconds instead of failing.
+	local target=${1}
+	local max_seconds=${2:-30}
+	local i=0
+	local count=0
+	local max_iterations=$(( max_seconds * 2 ))
+	while [ $i -lt $max_iterations ]; do
+		count=$(fn_get_rotations)
+		if [ "$count" -ge "$target" ]; then
+			echo $count
+			return 0
+		fi
+		sleep 0.5
+		i=$(( i + 1 ))
+	done
+	# Timeout. Emit whatever we last observed so fn_check_res will
+	# report a useful "BASELINE X expected Y got Z" message rather than
+	# an empty RES.
+	echo $count
+	return 1
+}
+
 fn_check_res () {
 	DONE=$(( $DONE + 1 ))
 	PLAN=$([[ $PLAN -lt $DONE ]] && echo $DONE || echo $PLAN)
-	if [[ $RES -ne $(( $BASELINE + 1)) ]]; then
-		echo "msg: not ok $DONE - command '$1' - initial BASELINE: $BASELINE - expected BASELINE + 1 : got $RES"
+	# Accept any count >= BASELINE+1. The test asks "did this command
+	# trigger at least one rotation" - two rotations (e.g. if the
+	# scheduler hack fired twice before fn_signal_cleanup tore it down)
+	# is still a pass signal. It used to be `-ne` which was stricter
+	# than the actual test semantics and contributed to flakiness.
+	if [[ $RES -lt $(( $BASELINE + 1)) ]]; then
+		echo "msg: not ok $DONE - command '$1' - BASELINE: $BASELINE - expected at least $(( $BASELINE + 1)) : got $RES"
 		FAIL=$(( $FAIL + 1 ))
 	else
-		echo "msg: ok $DONE - command '$1' - initial BASELINE: $BASELINE - expected BASELINE + 1 : got $RES"
+		echo "msg: ok $DONE - command '$1' - BASELINE: $BASELINE - got $RES (>= BASELINE + 1)"
 	fi
 }
 
@@ -118,13 +173,14 @@ fn_plan
 # test PROXYSQL FLUSH LOGS
 BASELINE=$(fn_get_rotations)
 fn_padmin "PROXYSQL FLUSH LOGS;"
-RES=$(fn_get_rotations)
+RES=$(fn_wait_for_rotation_at_least $(( $BASELINE + 1 )) 30)
 fn_check_res "PROXYSQL FLUSH LOGS;"
 
 # test SIGUSR1 signal
 BASELINE=$(fn_get_rotations)
 fn_signal "SIGUSR1"
-RES=$(fn_get_rotations)
+RES=$(fn_wait_for_rotation_at_least $(( $BASELINE + 1 )) 30)
+fn_signal_cleanup
 fn_check_res "kill -s SIGUSR1 \$PID"
 
 


### PR DESCRIPTION
Closes #5610 (partial — one of four tests).

## Summary

Fixes `test_flush_logs-t` by replacing fixed sleeps with bounded polling. The old code depended on specific wall-clock windows (`sleep 1`, `sleep 4`) that occasionally slipped past on slow / contended GH runners, producing false failures on CI while the same code passed cleanly on every local workstation and on commit-after-commit empty retriggers in PR #5596.

## Root cause

`test_flush_logs-t.sh` measures "did this command rotate `proxysql.log`?" by counting the number of `[INFO] ProxySQL version` marker lines before and after. The old flow was timing-dependent:

```bash
BASELINE=$(fn_get_rotations)       # includes sleep 1
fn_padmin "PROXYSQL FLUSH LOGS;"
RES=$(fn_get_rotations)            # sleep 1, then count
fn_check_res                       # strict equality
```

For the SIGUSR1 subtest it was worse because the signal was delivered via a "Scheduler Hack" (a 2000ms-interval scheduler row that `kill -USR1 $(pidof proxysql)`), plus a fixed `sleep 4`, plus the inner `sleep 1` — total 5 s budget from signal scheduling to reading the log. Three async stages could slip past that window: the scheduler's first interval firing slightly late, the SIGUSR1 handler queueing the rotation on a worker thread, and the host-side volume bind-mount read lag. Any one blew the budget → `RES != BASELINE+1` → false failure.

A secondary issue: strict `-ne` equality check would also fail if the scheduler hack fired twice before the cleanup tore its row down (interval 2000ms, sleep 4s → exactly one extra fire window). Two rotations from one signal is still a pass semantically.

## Fix

Three changes in `test/tap/tests/test_flush_logs-t.sh`:

1. **Replace fixed sleeps with bounded polling.** New helper `fn_wait_for_rotation_at_least <target> <max_seconds>` polls `fn_get_rotations` every 500 ms until the count reaches the target or the timeout expires. `fn_get_rotations` is now sleepless (callers that need to race wait use the new helper). Max budget raised to 30 s (was effectively 5 s) — on fast machines the poll still terminates within one 500 ms cycle.

2. **Accept "at least BASELINE+1" instead of exact equality.** `fn_check_res` uses `-lt` instead of `-ne`. The test asks "did it trigger at least one rotation?" — two rotations from one signal is still a pass.

3. **Split `fn_signal` into `fn_signal` (install only) and `fn_signal_cleanup` (teardown).** Caller now races cleanly:
   ```bash
   fn_signal SIGUSR1
   RES=$(fn_wait_for_rotation_at_least $((BASELINE+1)) 30)
   fn_signal_cleanup                # tear down AFTER rotation observed
   fn_check_res
   ```
   Scheduler row exists only for the bounded window between install and observation. Also dropped the scheduler interval from 2000 ms to 500 ms so the first fire happens quickly.

## Local verification (dogfooding the new flake-debug recipe from #5609)

Reproduced the original PR #5596 failure context (`legacy-g3` group with just `test_flush_logs-t` via `TEST_PY_TAP_INCL`), 10 back-to-back iterations against one infra lifecycle per `test/README.md` §"Debugging a flaky test":

```
attempt 1:  PASS
attempt 2:  PASS
…
attempt 10: PASS

=== total: 10/10 pass ===
```

**Per-attempt wall time dropped from ~9 s to ~1 s** because we're no longer burning fixed sleeps. Confirmed the new code path is active via the new TAP message format in the captured log:

```
msg: ok 1 - command 'PROXYSQL FLUSH LOGS;' - BASELINE: 58 - got 59 (>= BASELINE + 1)
msg: ok 2 - command 'kill -s SIGUSR1 $PID' - BASELINE: 59 - got 60 (>= BASELINE + 1)
msg: Test took 1 sec
```

## Scope

**Just this one test.** The other three flaky tests listed in #5610 (`pgsql-servers_ssl_params-t`, `pgsql-ssl_keylog-t`, `test_read_only_actions_offline_hard_servers-t`) are C++ and each warrants its own investigation + PR — not worth batching into one "fix all flakes" mega-patch.

## Test plan

- [x] `bash -n test/tap/tests/test_flush_logs-t.sh` — script syntax valid
- [x] Local stress test: 10/10 passes in `legacy-g3 + TEST_PY_TAP_INCL=test_flush_logs-t`
- [x] TAP output shows new message format, confirming polling code is executing
- [x] Wall time dropped from 9 s to 1 s (evidence that fixed sleeps are gone, not just more tolerant)
- [ ] CI green on `CI-legacy-g3` against this PR's HEAD
- [ ] After merge, watch 5-10 subsequent runs of `CI-legacy-g3` on v3.0 main — expect the `test_flush_logs-t` row to disappear from the flake list

## Note on the `-t` vs `.sh` file duality

For anyone who finds this PR puzzling: `test/tap/tests/test_flush_logs-t` is NOT the same file as `test_flush_logs-t.sh`. The `-t` file is a copy produced by the `sh-%` rule in `test/tap/tests/Makefile` (literally `cp test_flush_logs-t.sh test_flush_logs-t && chmod +x`). The runner invokes `*-t`, not `*.sh`, and the `-t` files are gitignored. So the only tracked source of truth is `test_flush_logs-t.sh`, and this PR modifies only that file. The `-t` copy is regenerated by `make tests-sh` or the top-level TAP build. I hit this the hard way during local verification — documented here so the next person doesn't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for log flushing operations with improved timing reliability and robustness
  * Replaced fixed timing assumptions with dynamic polling mechanisms for more consistent test execution
  * Added helper utilities for cleaner test setup and teardown procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->