### PR TITLE
test(read_only_offline_hard): set default_hostgroup to WHG, not hardcoded 0

### DIFF
--- a/test/tap/tests/test_read_only_actions_offline_hard_servers-t.cpp
+++ b/test/tap/tests/test_read_only_actions_offline_hard_servers-t.cpp
@@ -223,10 +223,19 @@ int test_scenario_1(MYSQL* proxy_admin, const CommandLine& cl) {
 	MYSQL_QUERY__(proxy_admin, "DELETE FROM mysql_replication_hostgroups");
 	MYSQL_QUERY__(proxy_admin, "LOAD MYSQL SERVERS TO RUNTIME");
 
-	// Set default_hostgroup=0 to match writer_hostgroup used in this test
+	// Set default_hostgroup to match writer_hostgroup (WHG) used in this
+	// test. WHG defaults to 0 for the legacy infra but is overridden to
+	// 2900 by the mysql84-g4 group via TAP_MYSQL8_BACKEND_HG — see
+	// init_hostgroups() above. If we hardcode 0 here, the mysql84 group
+	// routes the test's BEGIN query to an empty hostgroup 0 and times
+	// out at 10 s. A previous fix (26c5a2572) hardcoded 0 because it
+	// predated the mysql84 hostgroup migration in 4f9ab49e7 — this
+	// commit finishes that fix by making the default_hostgroup follow
+	// WHG at runtime.
 	{
 		std::string update_user;
-		string_format("UPDATE mysql_users SET default_hostgroup=0 WHERE username='%s'", update_user, cl.root_username);
+		string_format("UPDATE mysql_users SET default_hostgroup=%d WHERE username='%s'",
+		              update_user, WHG, cl.root_username);
 		MYSQL_QUERY__(proxy_admin, update_user.c_str());
 		MYSQL_QUERY__(proxy_admin, "LOAD MYSQL USERS TO RUNTIME");
 	}
@@ -384,10 +393,19 @@ int test_scenario_2(MYSQL* proxy_admin, const CommandLine& cl) {
 	MYSQL_QUERY__(proxy_admin, "DELETE FROM mysql_replication_hostgroups");
 	MYSQL_QUERY__(proxy_admin, "LOAD MYSQL SERVERS TO RUNTIME");
 
-	// Set default_hostgroup=0 to match writer_hostgroup used in this test
+	// Set default_hostgroup to match writer_hostgroup (WHG) used in this
+	// test. WHG defaults to 0 for the legacy infra but is overridden to
+	// 2900 by the mysql84-g4 group via TAP_MYSQL8_BACKEND_HG — see
+	// init_hostgroups() above. If we hardcode 0 here, the mysql84 group
+	// routes the test's BEGIN query to an empty hostgroup 0 and times
+	// out at 10 s. A previous fix (26c5a2572) hardcoded 0 because it
+	// predated the mysql84 hostgroup migration in 4f9ab49e7 — this
+	// commit finishes that fix by making the default_hostgroup follow
+	// WHG at runtime.
 	{
 		std::string update_user;
-		string_format("UPDATE mysql_users SET default_hostgroup=0 WHERE username='%s'", update_user, cl.root_username);
+		string_format("UPDATE mysql_users SET default_hostgroup=%d WHERE username='%s'",
+		              update_user, WHG, cl.root_username);
 		MYSQL_QUERY__(proxy_admin, update_user.c_str());
 		MYSQL_QUERY__(proxy_admin, "LOAD MYSQL USERS TO RUNTIME");
 	}


### PR DESCRIPTION
Part of #5610 — third of four tests from the flake tracking issue.

**Correction to #5610's premise:** like `pgsql-ssl_keylog-t` in PR #5612, this turned out to be a **deterministic failure miscategorized as a flake**. Reproduced 0/3 failing locally before the fix, 3/3 passing after. Not a timing race.

## Root cause — an incomplete hostgroup migration

Two commits on v3.0 main set up the stage:

1. **`26c5a2572`** ("Fix read_only test assuming `default_hostgroup=0`"): fixed the ORIGINAL bug where the test's writer hostgroup was 0 but the CI infra set `user.default_hostgroup` to 1300. The fix ran `UPDATE mysql_users SET default_hostgroup=0` at the start of each scenario to point the user at the test's servers.

2. **`4f9ab49e7`** ("Fix hardcoded hostgroups in TAP tests for mysql84"): introduced `TAP_MYSQL8_BACKEND_HG` env var so the test's writer/reader hostgroups could be overridden — `WHG=2900, RHG=2901` in the `mysql84-g4` group. `init_hostgroups()` at file scope reads this env var into the file-scope `WHG`/`RHG` static symbols.

The second commit updated the `INSERT INTO mysql_servers` calls to use `WHG/RHG` — but **missed the `UPDATE mysql_users SET default_hostgroup=0`** added by the first commit. So on `mysql84-g4`:

- `insert_mysql_servers_records()` puts servers in hostgroup 2900 (`WHG`)
- The legacy `UPDATE mysql_users SET default_hostgroup=0` still runs, pointing the user at hostgroup 0, which has **no servers**
- The test opens a proxy connection as that user, runs `BEGIN`, and ProxySQL routes `BEGIN` to hostgroup 0 — empty
- **10 seconds later:** `Max connect timeout reached while reaching hostgroup 0 after 10000ms`
- Test aborts at subtest 4 of 18

Verified in the running proxysql during a failing run:

```sql
SELECT username, default_hostgroup FROM mysql_users;
-- root     | 0       <-- still 0 after the setup step tried to match
-- user     | 2900
-- testuser | 2900
-- ...
```

## Fix

Change the two `string_format("UPDATE mysql_users SET default_hostgroup=0 ...")` calls (in `test_scenario_1` and `test_scenario_2`) to use the `WHG` static symbol — already populated from `TAP_MYSQL8_BACKEND_HG` by `init_hostgroups()` earlier in the same file. Zero behavior change on the legacy infra (where `WHG` defaults to 0, so the literal value is unchanged); correct behavior on the mysql84 infra (where `WHG=2900`).

Diff is ~10 lines of real change plus a comment explaining the history so the next maintainer doesn't hit this again.

## Local verification

3 consecutive iterations in `mysql84-g4 + TEST_PY_TAP_INCL=test_read_only_actions_offline_hard_servers-t`:

```
attempt 1: PASS
attempt 2: PASS
attempt 3: PASS
=== read_only_actions: 3/3 ===
```

**Pre-fix:** 0/3 — every run hit `Max connect timeout reached while reaching hostgroup 0 after 10000ms` and aborted at subtest 4 of 18.

**Post-fix:** all 18 subtests run and pass on every iteration. Test log confirms `ok 18` is reached.

## Test plan

- [x] `c++ -c` compiles cleanly (no `string_format` template issues with the new `WHG` int argument)
- [x] 3/3 local passes in `mysql84-g4`, all 18 subtests executed per run
- [x] Not regressed on `legacy-g4` (where `WHG` defaults to 0 and the produced SQL is identical to the pre-fix literal)
- [ ] CI green on `CI-mysql84-g4` against this PR's HEAD
- [ ] CI still green on `CI-legacy-g4` against this PR's HEAD (defensive check)

## Related

- **#5611** (merged) — `test_flush_logs-t` poll-instead-of-sleep. The only actually flaky test of the four.
- **#5612** (open) — `pgsql-ssl_keylog-t` path + regex fixes. Ships alongside this PR.
- **Still open in #5610:** `pgsql-servers_ssl_params-t` and subtest 7 of `pgsql-ssl_keylog-t` both fail under the same underlying pgsql monitor behavior (monitor doesn't make SSL connections under `UPDATE pgsql_servers SET use_ssl=1`). That needs proxysql source-level investigation and is out of scope for these test-side fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test scenarios to properly validate writer hostgroup routing behavior in offline server conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->