### PR TITLE
fix(pgsql-monitor): clamp next_*_at on LOAD PGSQL VARIABLES TO RUNTIME

### DIFF
--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -2575,24 +2575,36 @@ void* PgSQL_monitor_scheduler_thread() {
 				if (tasks_conf.ping.params.interval > 0) {
 					const uint64_t clamped = cur_intv_start + tasks_conf.ping.params.interval;
 					if (next_intvs.next_ping_at > clamped) {
+						proxy_debug(PROXY_DEBUG_MONITOR, 5,
+							"Clamped next_ping_at   old=%lu new=%lu interval=%d\n",
+							next_intvs.next_ping_at, clamped, tasks_conf.ping.params.interval);
 						next_intvs.next_ping_at = clamped;
 					}
 				}
 				if (tasks_conf.connect.params.interval > 0) {
 					const uint64_t clamped = cur_intv_start + tasks_conf.connect.params.interval;
 					if (next_intvs.next_connect_at > clamped) {
+						proxy_debug(PROXY_DEBUG_MONITOR, 5,
+							"Clamped next_connect_at   old=%lu new=%lu interval=%d\n",
+							next_intvs.next_connect_at, clamped, tasks_conf.connect.params.interval);
 						next_intvs.next_connect_at = clamped;
 					}
 				}
 				if (tasks_conf.readonly.params.interval > 0) {
 					const uint64_t clamped = cur_intv_start + tasks_conf.readonly.params.interval;
 					if (next_intvs.next_readonly_at > clamped) {
+						proxy_debug(PROXY_DEBUG_MONITOR, 5,
+							"Clamped next_readonly_at   old=%lu new=%lu interval=%d\n",
+							next_intvs.next_readonly_at, clamped, tasks_conf.readonly.params.interval);
 						next_intvs.next_readonly_at = clamped;
 					}
 				}
 				if (tasks_conf.repl_lag.params.interval > 0) {
 					const uint64_t clamped = cur_intv_start + tasks_conf.repl_lag.params.interval;
 					if (next_intvs.next_repl_lag_at > clamped) {
+						proxy_debug(PROXY_DEBUG_MONITOR, 5,
+							"Clamped next_repl_lag_at   old=%lu new=%lu interval=%d\n",
+							next_intvs.next_repl_lag_at, clamped, tasks_conf.repl_lag.params.interval);
 						next_intvs.next_repl_lag_at = clamped;
 					}
 				}

--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -2533,13 +2533,70 @@ void* PgSQL_monitor_scheduler_thread() {
 
 			// Check variable version changes; refresh if needed
 			unsigned int glover = GloPTH->get_global_version();
+			bool vars_refreshed = false;
 			if (PgSQL_Thread__variables_version < glover) {
 				PgSQL_Thread__variables_version = glover;
 				pgsql_thread->refresh_variables();
+				vars_refreshed = true;
 			}
 
 			// Fetch config for next task scheduling
 			tasks_conf_t tasks_conf { fetch_updated_conf(GloPgMon, PgHGM) };
+
+			// When runtime variables were just refreshed (i.e. someone did
+			// SET pgsql-monitor_*_interval=<smaller_value>; LOAD PGSQL
+			// VARIABLES TO RUNTIME;), the newly-read interval values may be
+			// smaller than the ones we used the last time we recomputed
+			// next_intvs. Without the clamp below, each next_<type>_at still
+			// points at the cycle that was scheduled under the OLD (larger)
+			// interval, so a LOAD doesn't visibly take effect until the old
+			// cycle elapses — which can be up to ~2 minutes for connect
+			// checks under the default pgsql-monitor_connect_interval=120000.
+			//
+			// Example of the surprise this avoids:
+			//
+			//   T=0    proxysql starts with monitor_connect_interval=120000,
+			//          next_connect_at is scheduled for T=120000ms.
+			//   T=5    user runs SET pgsql-monitor_connect_interval=2000;
+			//          LOAD PGSQL VARIABLES TO RUNTIME; expecting the next
+			//          connect cycle within ~2 seconds.
+			//   T=7    without this clamp, next_connect_at is still 120000
+			//          — no new connect fires for another 113 seconds.
+			//
+			// The fix: after every successful refresh, shrink any
+			// next_<type>_at that's now farther in the future than
+			// (now + new_interval). We never push next_<type>_at further
+			// into the future — growing the interval should not delay an
+			// already-imminent check — so the direction of the clamp is
+			// one-way (min()). Types whose interval is 0 (disabled) are
+			// skipped and handled by the existing compute_next_intvs()
+			// which sets them to ULONG_MAX.
+			if (vars_refreshed) {
+				if (tasks_conf.ping.params.interval > 0) {
+					const uint64_t clamped = cur_intv_start + tasks_conf.ping.params.interval;
+					if (next_intvs.next_ping_at > clamped) {
+						next_intvs.next_ping_at = clamped;
+					}
+				}
+				if (tasks_conf.connect.params.interval > 0) {
+					const uint64_t clamped = cur_intv_start + tasks_conf.connect.params.interval;
+					if (next_intvs.next_connect_at > clamped) {
+						next_intvs.next_connect_at = clamped;
+					}
+				}
+				if (tasks_conf.readonly.params.interval > 0) {
+					const uint64_t clamped = cur_intv_start + tasks_conf.readonly.params.interval;
+					if (next_intvs.next_readonly_at > clamped) {
+						next_intvs.next_readonly_at = clamped;
+					}
+				}
+				if (tasks_conf.repl_lag.params.interval > 0) {
+					const uint64_t clamped = cur_intv_start + tasks_conf.repl_lag.params.interval;
+					if (next_intvs.next_repl_lag_at > clamped) {
+						next_intvs.next_repl_lag_at = clamped;
+					}
+				}
+			}
 
 			// Perform table maintenance
 			maint_mon_tables(tasks_conf, next_intvs, cur_intv_start);

--- a/test/tap/tests/pgsql-servers_ssl_params-t.cpp
+++ b/test/tap/tests/pgsql-servers_ssl_params-t.cpp
@@ -648,16 +648,24 @@ int main(int argc, char** argv) {
 	// Configure monitor: use 'postgres' user which is accepted by the
 	// backend, set a tight connect_interval so cycles run within the test
 	// wait window. Restore original values afterwards.
+	//
+	// We deliberately do NOT change pgsql-monitor_username /
+	// pgsql-monitor_password. An earlier version of this test set them
+	// to 'postgres'/'postgres' on the assumption that the backend had a
+	// postgres user with password 'postgres', but the actual CI infra
+	// (docker-pgsql16-single) randomizes POSTGRES_PASSWORD per container
+	// startup (e.g. "05e792e51d"), so the hardcoded credentials never
+	// authenticated and every monitor connect failed with
+	//   FATAL: password authentication failed for user "postgres"
+	// The default monitor/monitor user works against the infra's
+	// pg_hba.conf and is what the initial (pre-test) connect check
+	// already uses successfully.
 	long original_connect_interval = getConnectInterval(a);
 	std::string original_monitor_username = exec_scalar(a,
 		"SELECT Variable_Value FROM global_variables WHERE Variable_Name='pgsql-monitor_username'");
-	std::string original_monitor_password = exec_scalar(a,
-		"SELECT Variable_Value FROM global_variables WHERE Variable_Name='pgsql-monitor_password'");
 	diag("Original monitor: user=%s interval=%ld ms",
 		original_monitor_username.c_str(), original_connect_interval);
 
-	exec_ok(a, "SET pgsql-monitor_username='postgres'");
-	exec_ok(a, "SET pgsql-monitor_password='postgres'");
 	setConnectInterval(a, 2000);
 	exec_ok(a, "UPDATE pgsql_servers SET use_ssl=1");
 	exec_ok(a, "LOAD PGSQL SERVERS TO RUNTIME");
@@ -666,15 +674,9 @@ int main(int argc, char** argv) {
 	test_monitor_ssl_with_per_server_params(a);
 	test_monitor_uses_per_server_row(a);
 
-	// Restore original monitor settings
-	{
-		std::stringstream q;
-		q << "SET pgsql-monitor_username='" << original_monitor_username << "'";
-		exec_ok(a, q.str().c_str());
-		q.str("");
-		q << "SET pgsql-monitor_password='" << original_monitor_password << "'";
-		exec_ok(a, q.str().c_str());
-	}
+	// Restore original connect interval. Monitor username/password are
+	// no longer touched by this test - see comment above - so there's
+	// nothing to restore there.
 	setConnectInterval(a, (int)original_connect_interval);
 
 	// Part 3: Cluster query support

--- a/test/tap/tests/pgsql-servers_ssl_params-t.cpp
+++ b/test/tap/tests/pgsql-servers_ssl_params-t.cpp
@@ -661,10 +661,11 @@ int main(int argc, char** argv) {
 	// pg_hba.conf and is what the initial (pre-test) connect check
 	// already uses successfully.
 	long original_connect_interval = getConnectInterval(a);
-	std::string original_monitor_username = exec_scalar(a,
+	// Read current monitor username for diagnostic logging only.
+	std::string monitor_username = exec_scalar(a,
 		"SELECT Variable_Value FROM global_variables WHERE Variable_Name='pgsql-monitor_username'");
-	diag("Original monitor: user=%s interval=%ld ms",
-		original_monitor_username.c_str(), original_connect_interval);
+	diag("Current monitor: user=%s interval=%ld ms",
+		monitor_username.c_str(), original_connect_interval);
 
 	setConnectInterval(a, 2000);
 	exec_ok(a, "UPDATE pgsql_servers SET use_ssl=1");


### PR DESCRIPTION
Closes the `pgsql-servers_ssl_params-t` line item on #5610. Fourth and final of the four tests from that issue.

**This PR is code + test together** because the scheduler fix alone wouldn't make the test pass, and the test fix alone is useless without the scheduler fix. Reviewable in two distinct blocks below.

---

## 1 / 2 — `lib/PgSQL_Monitor.cpp`: scheduler clamp on interval change

### Problem

`pgsql-servers_ssl_params-t` subtests 32 and 34 expect `PgSQL_Monitor_ssl_connections_OK` to increase a few seconds after:

```
SET pgsql-monitor_connect_interval=2000;
LOAD PGSQL VARIABLES TO RUNTIME;
UPDATE pgsql_servers SET use_ssl=1;
LOAD PGSQL SERVERS TO RUNTIME;
```

but the counter stays at 0 for ~2 minutes. Root cause is state caching in `PgSQL_monitor_scheduler_thread()`:

| t | event |
|---|---|
| T=0 | proxysql starts. default `connect_interval=120000`. Scheduler's first tick schedules initial connect check; `compute_next_intvs()` sets `next_connect_at = T + 120000 ms`. |
| T+~30s | test does `SET connect_interval=2000; LOAD PGSQL VARIABLES TO RUNTIME;`. `fetch_updated_conf()` now returns `interval=2000` on next iteration, BUT `next_connect_at` still points at `T+120s`. |
| T+~35s | test reads `ssl_connections_OK` — still 0 because the next scheduled connect check is ~85 seconds away. |

`compute_next_intvs()` only advances `next_<type>_at` when the type has *just fired*. It never recomputes in response to a variable change, so shortening an interval at runtime has zero effect until the already-scheduled (long) cycle naturally elapses.

### Fix

In the scheduler loop, after `fetch_updated_conf()` when runtime variables were just refreshed (tracked by comparing `PgSQL_Thread__variables_version` against the global version), clamp each `next_<type>_at` down to `cur_intv_start + new_interval` when that would schedule the next check sooner than the currently-cached value:

```cpp
if (vars_refreshed) {
    if (tasks_conf.ping.params.interval > 0) {
        const uint64_t clamped = cur_intv_start + tasks_conf.ping.params.interval;
        if (next_intvs.next_ping_at > clamped) {
            next_intvs.next_ping_at = clamped;
        }
    }
    // ... same for connect, readonly, repl_lag
}
```

Properties:

- **One-way**: the clamp only shrinks `next_<type>_at`, never pushes it out. Growing the interval at runtime does not delay an already-imminent check.
- **Idempotent**: if the interval didn't change, the clamp is a no-op.
- **Interval=0 safe**: disabled intervals (`interval == 0`) are skipped and continue to be handled by `compute_next_intvs()` which sets them to `ULONG_MAX`.
- **Applied to all 4 task types** (ping, connect, readonly, repl_lag) — the same class of bug affected all of them; fixing only `connect` would leave latent issues for tests that change `ping_interval`, `read_only_interval`, or `replication_lag_interval` at runtime.

### Raw verification (before the test fix)

Direct experiment against the patched binary, no test file involved:

```bash
# fresh proxysql, default interval=120000
SET pgsql-monitor_connect_interval=2000;
LOAD PGSQL VARIABLES TO RUNTIME;
UPDATE pgsql_servers SET use_ssl=1;
LOAD PGSQL SERVERS TO RUNTIME;
```

Before the fix: `ssl_connections_OK` stuck at 0 for ~2 minutes.
After the fix: `ssl_connections_OK` goes `0 → 2 → 6` over 2 seconds, matching the 2000 ms interval × 2 monitor threads.

---

## 2 / 2 — `test/tap/tests/pgsql-servers_ssl_params-t.cpp`: drop hardcoded `postgres`/`postgres` credentials

### Problem

With only the scheduler fix applied, the test was still failing because its `main()` did:

```cpp
exec_ok(a, "SET pgsql-monitor_username='postgres'");
exec_ok(a, "SET pgsql-monitor_password='postgres'");
```

on the assumption that the backend had a postgres user with password `"postgres"`. But **the actual CI infra** (`test/infra/docker-pgsql16-single`) **randomizes `POSTGRES_PASSWORD` on every container startup**:

```
$ docker exec $BACKEND env | grep PASS
POSTGRES_PASSWORD=05e792e51d
```

So the hardcoded `"postgres"` password never authenticated, and every monitor connect failed with:

```
PgSQL_Monitor.cpp:803: [ERROR] Monitor connect failed
  addr='pgsql1.docker-pgsql16-single:5432'
  error='FATAL: password authentication failed for user "postgres"'
```

These auth failures incremented `connect_check_ERR` instead of `ssl_connections_OK`. **After** the scheduler fix, the auth failures fire every 2 seconds (proof the scheduler fix works!) but they're still failures, so the counter the test is checking never advances.

### Fix

Remove the monitor username/password switch entirely. The default `monitor`/`monitor` user is already configured in the infra's `pg_hba.conf` and authenticates successfully (verified manually via `docker exec psql 'host=... user=monitor password=monitor sslmode=require'` from both inside and outside the proxysql container). Also remove the paired "restore original values" block since there's nothing to restore.

---

## Local verification (both fixes together)

3 consecutive iterations of the full test in fresh `legacy-g4` infra using the `test/README.md` §"Debugging a flaky test" recipe:

```
attempt 1: PASS
attempt 2: PASS
attempt 3: PASS
=== pgsql-servers_ssl_params-t: 3/3 pass ===
```

Subtest-level confirmation from the final attempt's TAP log:

```
# Original monitor: user=monitor interval=120000 ms
# Initial PgSQL_Monitor_ssl_connections_OK: 33
# After PgSQL_Monitor_ssl_connections_OK: 36           ← +3 in 5 sec
ok 32 - Monitor SSL counter increased with use_ssl=1 and no per-server row

# With TLSv1 per-server pin, ssl OK before wait: 39
# With TLSv1 per-server pin, ssl OK after wait:  39 (delta=0)
ok 33 - Monitor per-server: SSL OK counter does NOT advance when per-server
        row pins ssl_protocol_version_range to TLSv1

# After cleanup, ssl OK recovered from 41 to 44        ← +3 in 5 sec
ok 34 - Monitor per-server: SSL OK counter resumes advancing after removing
        the per-server row
```

All three monitor-SSL subtests now exercise the real code path (SSL handshake, counter incrementing, per-server pin blocking SSL as designed). Pre-fix the counters were observing a no-op and the test was deterministically failing.

## Side effect on PR #5612

Subtest 7 of `pgsql-ssl_keylog-t` was marked as SKIP in #5612 because it tripped on the same "pgsql monitor isn't making SSL connections" symptom. With this PR merged, the skip's runtime condition (`lines_before_monitor == lines_after_monitor`) evaluates to *false* once the monitor is actually producing SSL handshakes, and the test falls into the real `ok(...)` branch automatically. No separate change to `pgsql-ssl_keylog-t` is needed — the skip was defensive and becomes dead code after this fix.

## Scope

- Scoped to the **pgsql monitor** only (`lib/PgSQL_Monitor.cpp`). The mysql monitor (`lib/MySQL_Monitor.cpp`) has a different scheduling architecture (per-thread timers, not a centralized scheduler) and may or may not have the same class of bug — **out of scope** for this PR. Anyone investigating similar symptoms on the mysql side should use this fix as a template but verify the scheduling model before porting.
- Does **not** touch any other test. The credential fix is localized to `pgsql-servers_ssl_params-t.cpp`.

## Test plan

- [x] Raw experiment proving scheduler fix works independently of the test: counter advances at 2000 ms cadence after `SET + LOAD`
- [x] Full test run 3/3 passing in fresh infra with both fixes applied
- [x] TAP output confirms subtests 32, 33, 34 all exercise the real SSL handshake path (not fallback to plaintext or no-op)
- [x] Sanity: subtest 33 (TLSv1 pin blocks SSL) still correctly shows `delta=0` — the fix does not accidentally make failing cases "succeed"
- [ ] CI green on `CI-legacy-g4` against this PR's HEAD
- [ ] Side-check: CI-legacy-g4 run should ALSO show `pgsql-ssl_keylog-t` subtest 7 passing (no longer hitting its skip fallback), confirming the side-effect on PR #5612 is real

## Closes

- #5610 for `pgsql-servers_ssl_params-t` (4th and final test from the tracking issue; #5611, #5612, #5613 handled the other three)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Monitoring now applies reduced PostgreSQL check intervals immediately during the current cycle when runtime scheduling is refreshed, improving responsiveness to configuration changes. Debug logging for these immediate adjustments has been added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->