### PR TITLE
Use MariaDB replication helper for binlog TAP tests

### DIFF
--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -269,7 +269,6 @@ chmod 777 "${TESTS_LOGS_PATH_HOST}"
 
 # Find binaries
 MYSQL_BINLOG_BIN=$(find "${WORKSPACE}" -path "${WORKSPACE}/ci_infra_logs" -prune -o -path "${WORKSPACE}/.git" -prune -o -name "mysqlbinlog" -type f -executable -print | head -n 1)
-BINLOG_READER_BIN=$(find "${WORKSPACE}" -path "${WORKSPACE}/ci_infra_logs" -prune -o -path "${WORKSPACE}/.git" -prune -o -name "test_binlog_reader-t" -type f -executable -print | head -n 1)
 
 # Execution: run the container
 docker run \
@@ -295,7 +294,6 @@ docker run \
     -e COVERAGE_REPORT_DIR="${COVERAGE_REPORT_DIR}" \
     -e SCRIPT_DIR="${SCRIPT_DIR}" \
     -e MYSQL_BINLOG_BIN="${MYSQL_BINLOG_BIN}" \
-    -e BINLOG_READER_BIN="${BINLOG_READER_BIN}" \
     -e TAP_USE_NOISE="${TAP_USE_NOISE:-0}" \
     -e TAP_PGSQL_SYNC_REPLICA_PORT="${TAP_PGSQL_SYNC_REPLICA_PORT:-}" \
     -e MULTI_GROUP="${MULTI_GROUP:-0}" \
@@ -394,7 +392,6 @@ docker run \
 
         mkdir -p \"${WORKSPACE}/test-scripts/deps\"
         [ -n \"${MYSQL_BINLOG_BIN}\" ] && ln -sf \"${MYSQL_BINLOG_BIN}\" \"${WORKSPACE}/test-scripts/deps/mysqlbinlog\"
-        [ -n \"${BINLOG_READER_BIN}\" ] && ln -sf \"${BINLOG_READER_BIN}\" \"${WORKSPACE}/test-scripts/deps/test_binlog_reader-t\"
 
         # Source group environment first (sets TEST_PY_* flags etc.)
         if [ -n \"${TAP_GROUP}\" ]; then

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -181,6 +181,9 @@ sh-%:
 anomaly_detection-t: anomaly_detection-t.cpp $(TAP_LDIR)/libtap.so
 	$(CXX) -DEXCLUDE_TRACKING_VARIABLES $< ../tap/SQLite3_Server.cpp -I$(CLICKHOUSE_CPP_IDIR) $(IDIRS) $(LDIRS) -L$(CLICKHOUSE_CPP_LDIR) -L$(LZ4_LDIR) $(OPT) $(OBJ) $(MYLIBSJEMALLOC) $(MYLIBS) $(STATIC_LIBS) $(CLICKHOUSE_CPP_LDIR)/libclickhouse-cpp-lib.a $(CLICKHOUSE_CPP_PATH)/contrib/zstd/zstd/libzstdstatic.a $(LZ4_LDIR)/liblz4.a -lscram -lusual -Wl,--allow-multiple-definition -o $@
 
+test_binlog_reader_uses_previous_hostgroup-t: binlog_rpl.h
+test_com_register_slave_enables_fast_forward-t: binlog_rpl.h
+
 %-t: %-t.cpp $(TAP_LDIR)/libtap.so
 	$(CXX) $< $(IDIRS) $(LDIRS) $(OPT) $(MYLIBS) $(STATIC_LIBS) -o $@
 

--- a/test/tap/tests/binlog_rpl.h
+++ b/test/tap/tests/binlog_rpl.h
@@ -1,0 +1,192 @@
+/**
+ * @file binlog_rpl.h
+ * @brief Runs binlog replication sessions via MARIADB_RPL with COM_REGISTER_SLAVE.
+ * @details Uses the MariaDB client replication API to exercise binlog streaming
+ *   functionality. Setting rpl->host before mariadb_rpl_open() triggers
+ *   COM_REGISTER_SLAVE registration.
+ *
+ *   The helper runs two replication sessions. Each session:
+ *     1. Opens a fresh connection to ProxySQL
+ *     2. Issues a lightweight pre-replication query
+ *     3. Configures replication session variables (checksum, heartbeat)
+ *     4. Initializes MARIADB_RPL with rpl->host set (triggers COM_REGISTER_SLAVE)
+ *     5. Opens replication and fetches events to verify the stream is active
+ *     6. Closes the replication session cleanly
+ *
+ *   Returns EXIT_SUCCESS only if both sessions succeed.
+ */
+
+#ifndef BINLOG_RPL_H
+#define BINLOG_RPL_H
+
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+#include "mysql.h"
+#include "mariadb_rpl.h"
+#include "command_line.h"
+#include "tap.h"
+#include "utils.h"
+
+// Number of heartbeats to wait per replication session to confirm stream is active
+#define BINLOG_RPL_NHB 3
+
+/**
+ * @brief Run a replication session against ProxySQL.
+ * @details Opens a connection, issues a pre-query, configures replication
+ *   variables, then uses MARIADB_RPL with rpl->host set to send
+ *   COM_REGISTER_SLAVE. Fetches events until BINLOG_RPL_NHB heartbeats
+ *   are received, verifying the binlog stream is active.
+ *
+ * @param cl CommandLine with connection parameters.
+ * @param session_id A label for diagnostic output (e.g. 1 or 2).
+ * @param server_id Unique server_id for the replication registration.
+ * @return EXIT_SUCCESS if the session completes successfully, EXIT_FAILURE otherwise.
+ */
+static int run_replication_session(const CommandLine& cl, int session_id, int server_id) {
+	int rc = EXIT_FAILURE;
+	MYSQL* mysql = NULL;
+	MYSQL_RES* res = NULL;
+	MARIADB_RPL* rpl = NULL;
+	MARIADB_RPL_EVENT* event = NULL;
+	int num_heartbeats = 0;
+	int num_events = 0;
+
+	diag("Session %d: Connecting to ProxySQL at %s:%d as %s",
+		session_id, cl.host, cl.port, cl.username);
+
+	mysql = mysql_init(NULL);
+	if (!mysql) {
+		diag("Session %d: mysql_init failed", session_id);
+		goto cleanup;
+	}
+
+	// Force CLIENT_DEPRECATE_EOF to match backend capabilities for fast-forward
+	mysql->options.client_flag |= CLIENT_DEPRECATE_EOF;
+
+	if (!mysql_real_connect(mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+		diag("Session %d: Connection failed: %s", session_id, mysql_error(mysql));
+		goto cleanup;
+	}
+
+	// Issue a pre-replication query that disables multiplexing. This ensures the
+	// backend connection stays pinned to the session so that when COM_REGISTER_SLAVE
+	// triggers fast_forward, the existing backend is reused instead of requiring a
+	// new connection.
+	if (run_q(mysql, "SELECT @@hostname")) {
+		goto cleanup;
+	}
+	res = mysql_store_result(mysql);
+	mysql_free_result(res);
+
+	// Configure replication session variables
+	if (run_q(mysql, "SET @master_binlog_checksum = 'NONE'")) {
+		goto cleanup;
+	}
+	if (run_q(mysql, "SET @master_heartbeat_period = 2000000000")) {
+		goto cleanup;
+	}
+
+	// Initialize replication handle
+	rpl = mariadb_rpl_init(mysql);
+	if (!rpl) {
+		diag("Session %d: mariadb_rpl_init failed", session_id);
+		goto cleanup;
+	}
+
+	rpl->server_id = server_id;
+	rpl->start_position = 4;
+	rpl->flags = MARIADB_RPL_BINLOG_SEND_ANNOTATE_ROWS;
+
+	// KEY: Setting rpl->host causes mariadb_rpl_open() to send COM_REGISTER_SLAVE
+	// before proceeding with the binlog dump. This is the core mechanism under test.
+	rpl->host = strdup("127.0.0.1");
+	rpl->port = cl.port;
+
+	diag("Session %d: Opening replication with server_id=%d (COM_REGISTER_SLAVE will be sent)",
+		session_id, server_id);
+
+	if (mariadb_rpl_open(rpl)) {
+		diag("Session %d: mariadb_rpl_open failed: [%d] %s",
+			session_id, mysql_errno(rpl->mysql), mysql_error(rpl->mysql));
+		goto cleanup;
+	}
+
+	// Fetch events until we receive enough heartbeats to confirm the stream is active
+	diag("Session %d: Fetching binlog events, waiting for %d heartbeats...",
+		session_id, BINLOG_RPL_NHB);
+
+	while (num_heartbeats < BINLOG_RPL_NHB &&
+		   (event = mariadb_rpl_fetch(rpl, event))) {
+		num_events++;
+		if (event->event_type == HEARTBEAT_LOG_EVENT_V2 ||
+			event->event_type == HEARTBEAT_LOG_EVENT) {
+			num_heartbeats++;
+			diag("Session %d: Heartbeat %d/%d received (total events: %d)",
+				session_id, num_heartbeats, BINLOG_RPL_NHB, num_events);
+		}
+	}
+
+	if (num_heartbeats < BINLOG_RPL_NHB && event == NULL) {
+		diag("Session %d: Replication stream ended prematurely: %s",
+			session_id, mysql_error(mysql));
+	}
+
+	if (num_heartbeats < BINLOG_RPL_NHB) {
+		diag("Session %d: FAILED - received only %d/%d heartbeats",
+			session_id, num_heartbeats, BINLOG_RPL_NHB);
+		goto cleanup;
+	}
+
+	diag("Session %d: SUCCESS - received %d heartbeats across %d events",
+		session_id, num_heartbeats, num_events);
+	rc = EXIT_SUCCESS;
+
+cleanup:
+	mariadb_free_rpl_event(event);
+	if (rpl) {
+		mariadb_rpl_close(rpl);
+	}
+	if (mysql) {
+		mysql_close(mysql);
+	}
+	return rc;
+}
+
+/**
+ * @brief Run two binlog replication sessions via MARIADB_RPL.
+ * @details Executes two independent replication sessions, each sending
+ *   COM_REGISTER_SLAVE. Used by TAP tests:
+ *     - test_com_register_slave_enables_fast_forward-t: verifies COM_REGISTER_SLAVE
+ *       enables fast-forward mode and binlog streaming works
+ *     - test_binlog_reader_uses_previous_hostgroup-t: verifies fast-forward
+ *       connections use the hostgroup from prior COM_QUERY
+ *
+ * @param cl CommandLine with connection parameters.
+ * @return EXIT_SUCCESS if both sessions succeed, EXIT_FAILURE otherwise.
+ */
+static int run_binlog_rpl(const CommandLine& cl) {
+	diag("=== Binlog RPL test: Starting ===");
+	diag("Running two replication sessions to exercise COM_REGISTER_SLAVE");
+
+	// Session 1
+	int rc = run_replication_session(cl, 1, 100001);
+	if (rc != EXIT_SUCCESS) {
+		diag("=== Binlog RPL test: FAILED (session 1) ===");
+		return EXIT_FAILURE;
+	}
+
+	// Session 2
+	rc = run_replication_session(cl, 2, 100002);
+	if (rc != EXIT_SUCCESS) {
+		diag("=== Binlog RPL test: FAILED (session 2) ===");
+		return EXIT_FAILURE;
+	}
+
+	diag("=== Binlog RPL test: SUCCESS (both sessions completed) ===");
+	return EXIT_SUCCESS;
+}
+
+#endif // BINLOG_RPL_H

--- a/test/tap/tests/test_binlog_reader_uses_previous_hostgroup-t.cpp
+++ b/test/tap/tests/test_binlog_reader_uses_previous_hostgroup-t.cpp
@@ -1,25 +1,22 @@
 /**
  * @file test_binlog_reader_uses_previous_hostgroup-t.cpp
  * @brief Test binlog reader uses the hostgroup of the previous COM_QUERY.
- * @details When a COM_BINLOG_DUMP command is received, ProxySQL automatically
- * switches from normal mode to fast_forward mode. This test verifies that the
- * destination hostgroup assigned from previous COM_QUERY commands is the one
- * used to establish the fast_forward connection. We verify this by checking
- * that connections are created (and then closed) in the expected hostgroup.
+ * @details When a COM_REGISTER_SLAVE command is received, test that ProxySQL
+ *   will automatically switch from not fast_forward mode to fast_forward mode.
+ *   It also tests that the destination hostgroup assigned from previous
+ *   COM_QUERY commands is the one used to establish the fast_forward connection.
+ *   To test this we look at how many connections are closed in the hostgroup
+ *   that should have been used for the fast_forward connections.
  *
  * Test flow:
  * 1. Insert a MySQL server into a non-default hostgroup (HG 2)
  * 2. Create a query rule routing all traffic on the test port to HG 2
- * 3. Connect as sbtest8, send a regular query (routed to HG 2)
- * 4. On the SAME connection, initiate binlog replication (COM_BINLOG_DUMP)
- *    which triggers fast_forward — ProxySQL should use HG 2 for this
- * 5. Close the connection — fast_forward connections are truly closed, not pooled
- * 6. Verify ConnOk-ConnFree for HG 2 increased (connections were made and closed)
+ * 3. Run two replication sessions using run_binlog_rpl helper
+ * 4. Verify ConnOk-ConnFree for HG 2 increased (connections were made and closed)
  */
 
 #include <unistd.h>
 #include "mysql.h"
-#include "mariadb_rpl.h"
 #include <vector>
 #include <string>
 
@@ -27,6 +24,7 @@
 #include "command_line.h"
 #include "utils.h"
 #include "tap.h"
+#include "binlog_rpl.h"
 
 using std::vector;
 using std::string;
@@ -123,53 +121,12 @@ int main(int argc, char** argv) {
 	const long conn_closed_before = std::stol(hg_stats_row[0]);
 	diag("ConnOk-ConnFree for HG %d before: %ld", destination_hostgroup, conn_closed_before);
 
-	// 3. Connect as sbtest8 through ProxySQL, send a COM_QUERY, then COM_BINLOG_DUMP
-	{
-		MYSQL* mysql = mysql_init(NULL);
-		if (!mysql || !mysql_real_connect(mysql, cl.host, "sbtest8", "sbtest8", NULL, cl.port, NULL, 0)) {
-			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__,
-				mysql ? mysql_error(mysql) : "mysql_init failed");
-			mysql_close(proxy_admin);
-			return EXIT_FAILURE;
-		}
-		diag("Connected as sbtest8 to %s:%d", cl.host, cl.port);
-
-		// Send a regular query — this establishes routing to HG 2
-		MYSQL_QUERY(mysql, "SELECT 1");
-		mysql_free_result(mysql_store_result(mysql));
-		diag("Sent SELECT 1 (routed to HG %d via rule_id=1)", destination_hostgroup);
-
-		// 4. Initiate binlog replication on the SAME connection — COM_BINLOG_DUMP
-		// triggers fast_forward, and ProxySQL should use HG 2 (from the previous query)
-		MARIADB_RPL* rpl = mariadb_rpl_init(mysql);
-		if (!rpl) {
-			diag("mariadb_rpl_init failed");
-			mysql_close(mysql);
-			mysql_close(proxy_admin);
-			return EXIT_FAILURE;
-		}
-		rpl->server_id = 99999;
-		rpl->start_position = 4;
-		rpl->flags = MARIADB_RPL_BINLOG_SEND_ANNOTATE_ROWS;
-
-		if (mariadb_rpl_open(rpl)) {
-			diag("mariadb_rpl_open failed: %s (this is expected if backend doesn't support it)", mysql_error(mysql));
-			// Even if rpl_open fails, the COM_BINLOG_DUMP was sent and ProxySQL
-			// should have switched to fast_forward using the previous hostgroup
-		} else {
-			// Read a few events to confirm the connection works
-			MARIADB_RPL_EVENT* event = NULL;
-			int events_read = 0;
-			while (events_read < 3 && (event = mariadb_rpl_fetch(rpl, event))) {
-				events_read++;
-			}
-			diag("Read %d binlog events from HG %d", events_read, destination_hostgroup);
-		}
-		mariadb_rpl_close(rpl);
-
-		// 5. Close the connection — fast_forward connections are closed, not pooled
-		mysql_close(mysql);
-		diag("Connection closed");
+	// Run two replication sessions using run_binlog_rpl helper
+	const int res = run_binlog_rpl(cl);
+	if (res) {
+		diag("Binlog RPL test failed with exit code: %d", res);
+		mysql_close(proxy_admin);
+		return EXIT_FAILURE;
 	}
 
 	// Wait for ProxySQL to process the disconnect
@@ -189,16 +146,16 @@ int main(int argc, char** argv) {
 		return EXIT_FAILURE;
 	}
 	const long conn_closed_after = std::stol(hg_stats_row[0]);
-	diag("ConnOk-ConnFree for HG %d after: %ld (increment: %ld)", destination_hostgroup,
-		conn_closed_after, conn_closed_after - conn_closed_before);
 
-	// Fast_forward connections are closed (not pooled), so ConnOk-ConnFree should increase.
-	// We expect at least 1 connection closed (the fast_forward connection to HG 2).
+	// run_binlog_rpl() make two fast_forward connections, so we
+	// should expect two more closed connections after its execution.
+	const int expected_increment = 2;
 	ok(
-		(conn_closed_after - conn_closed_before) >= 1,
-		"Connection to HG %d should have been created and closed (fast_forward)."
-			" Connections closed - Exp:'>=1', Act:'%ld'",
-		destination_hostgroup, conn_closed_after - conn_closed_before
+		(conn_closed_after - conn_closed_before) == expected_increment,
+		// Connections used for fast_forward are closed once the client disconnects.
+		"Two connections should have been closed."
+			" Connections closed - Exp:'%d', Act:'%ld'",
+		expected_increment, conn_closed_after - conn_closed_before
 	);
 
 	mysql_close(proxy_admin);

--- a/test/tap/tests/test_com_register_slave_enables_fast_forward-t.cpp
+++ b/test/tap/tests/test_com_register_slave_enables_fast_forward-t.cpp
@@ -1,40 +1,39 @@
 /**
- * @file test_com_register_slave_enables_fast_forward-t.cpp @brief Test
- * COM_REGISTER_SLAVE enables fast forward.  @details Test checks if
- * test_binlog_reader is executed successfully using a user with fast forward
- * flag set to false. test_binlog_reader sends command COM_REGISTER_SLAVE, then
- * ProxySQL enables fast forward. test_binlog_reader then uses libslave to
- * listen binlog events. It listen two times, one after sending a query that do
- * not disable multiplexing and the other after sending a query that disables
- * multiplexing.
- *
- * The repository for test_binlog_reader-t is:
- * https://github.com/ProxySQL/proxysql_binlog_test
+ * @file test_com_register_slave_enables_fast_forward-t.cpp
+ * @brief Test COM_REGISTER_SLAVE enables fast forward.
+ * @details Verifies that ProxySQL correctly enables fast forward for a user
+ *   when it receives COM_REGISTER_SLAVE, even if fast_forward was initially
+ *   disabled. Uses MARIADB_RPL to send COM_REGISTER_SLAVE commands.
  */
 
-#include <string>
 #include <cstdlib>
 #include "tap.h"
+#include "command_line.h"
+#include "binlog_rpl.h"
 
 int main(int argc, char** argv) {
+	CommandLine cl;
+
 	plan(1);
 	diag("Testing COM_REGISTER_SLAVE enables fast forward");
-	diag("This test verifies that ProxySQL correctly enables fast forward for a user when it receives COM_REGISTER_SLAVE, even if it was initially disabled.");
+	diag("This test verifies that ProxySQL correctly enables fast forward for a"
+		" user when it receives COM_REGISTER_SLAVE, even if it was initially disabled.");
 
-	const char * tdp = getenv("TEST_DEPS");
-	const std::string test_binlog_reader = ( tdp == nullptr || *tdp == '\0' ) ? "./test_binlog_reader-t" : std::string(tdp) + "/test_binlog_reader-t";
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
 
-	diag("Executing test_binlog_reader-t from: %s", test_binlog_reader.c_str());
-	const int test_binlog_reader_res = system(test_binlog_reader.c_str());
-	
-	if (test_binlog_reader_res != 0) {
-		diag("test_binlog_reader-t failed with exit code: %d", test_binlog_reader_res);
+	const int res = run_binlog_rpl(cl);
+
+	if (res != 0) {
+		diag("Binlog RPL test failed with exit code: %d", res);
 	}
 
 	ok(
-		test_binlog_reader_res == 0,
-		"'test_binlog_reader-t' should be correctly executed. Err code was: %d",
-		test_binlog_reader_res
+		res == 0,
+		"Binlog RPL test should complete successfully. Err code was: %d",
+		res
 	);
 
 	diag("Test completed");


### PR DESCRIPTION
- Replace the external binlog reader with a helper function which uses mariadb replication functions.
- The helper opens replication sessions, sends `COM_REGISTER_SLAVE`, and fetches heartbeats to verify the stream is active.
- It runs the same two-session flow required for TAP tests:
    - `test_com_register_slave_enables_fast_forward-t`
    - `test_binlog_reader_uses_previous_hostgroup-t`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored binlog replication session tests with consolidated helper utilities
  * Added new build targets for binlog replication test scenarios

* **Chores**
  * Simplified test infrastructure by removing redundant host-side binary discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->