### PR TITLE
fix: reformat groups.json and add --fix to linter

### DIFF
--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -1,3073 +1,387 @@
 {
-  "admin-listen_on_unix-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "admin_disk_upgrade_unit-t": [
-    "unit-tests-g1"
-  ],
-  "admin_set_credentials_logging-t": [
-    "no-infra-g1"
-  ],
-  "admin_show_create_table-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "admin_show_fields_from-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "admin_show_table_status-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "admin_various_commands-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "admin_various_commands2-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "admin_various_commands3-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "ai_error_handling_edge_cases-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "ai_llm_retry_scenarios-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "ai_validation-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "anomaly_detection-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "anomaly_detection_integration-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "anomaly_detector_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "auth_unit-t": [
-    "unit-tests-g1"
-  ],
-  "backend_sync_unit-t": [
-    "unit-tests-g1"
-  ],
-  "basic-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "c_tokenizer_unit-t": [
-    "unit-tests-g1"
-  ],
-  "charset_find_unit-t": [
-    "unit-tests-g1"
-  ],
-  "charset_unsigned_int-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "clickhouse_php_conn-t": [
-    "legacy-clickhouse-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "config_validation_unit-t": [
-    "unit-tests-g1"
-  ],
-  "config_write_unit-t": [
-    "unit-tests-g1"
-  ],
-  "connection_pool_unit-t": [
-    "unit-tests-g1"
-  ],
-  "deprecate_eof_cache-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "envvars-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "eof_cache_mixed_flags-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "eof_conn_options_check-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "eof_fast_forward-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "eof_mixed_flags_queries-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "eof_packet_mixed_queries-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "ezoption_parser_unit-t": [
-    "unit-tests-g1"
-  ],
-  "fast_forward_grace_close_libmysql-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "fast_forward_switch_replication_deprecate_eof_libmysql-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "ffto_protocol_unit-t": [
-    "@proxysql_min_version:3.1",
-    "unit-tests-g1"
-  ],
-  "firewall_commands1-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "gen_utils_unit-t": [
-    "unit-tests-g1"
-  ],
-  "genai_anomaly_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_async-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_discovery_schema_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_embedding_rerank-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_fts_string_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_live_validation-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_llm_clients_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_mcp_endpoint_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_mcp_thread_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_module-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_mysql_catalog_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_query_handler_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_stats_parsing_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "genai_thread_unit-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "glovars_unit-t": [
-    "unit-tests-g1"
-  ],
-  "gtid_server_data_unit-t": [
-    "unit-tests-g1"
-  ],
-  "gtid_set_unit-t": [
-    "unit-tests-g1"
-  ],
-  "gtid_trxid_interval_unit-t": [
-    "unit-tests-g1"
-  ],
-  "hostgroup_routing_unit-t": [
-    "unit-tests-g1"
-  ],
-  "hostgroups_unit-t": [
-    "unit-tests-g1"
-  ],
-  "issue5384-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "kill_connection-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "kill_connection2-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "kill_connection3-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "listen_validator_unit-t": [
-    "unit-tests-g1"
-  ],
-  "listener_conflicts_validation-t": [
-    "no-infra-g1"
-  ],
-  "llm_bridge_accuracy-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "log_utils_unit-t": [
-    "unit-tests-g1"
-  ],
-  "max_connections_ff-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mcp_mixed_mysql_pgsql_concurrency_stress-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_mixed_stats_cap_churn-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_mixed_stats_profile_matrix-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_module-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_mysql_concurrency_stress-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_pgsql_concurrency_stress-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_query_rules-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_query_run_sql_readonly-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_runtime_variables-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_semantic_lifecycle-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_show_connections_commands_inmemory-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_show_queries_topk-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "mcp_stats_refresh-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "monitor_health_unit-t": [
-    "unit-tests-g1"
-  ],
-  "multiple_prepared_statements-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-fast_forward-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-init_connect-1-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "mysql-init_connect-2-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "mysql-last_insert_id-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql84-gr-g1",
-    "mysql90-g1",
-    "mysql90-gr-g1",
-    "mysql91-g1",
-    "mysql91-gr-g1",
-    "mysql92-g1",
-    "mysql92-gr-g1",
-    "mysql93-g1",
-    "mysql93-gr-g1",
-    "mysql95-g1",
-    "mysql95-gr-g1"
-  ],
-  "mysql-mirror1-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-protocol_compression_level-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-reg_test_4707_threshold_resultset_size-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-reg_test_4716_single_semicolon-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-reg_test_4723_query_cache_stores_empty_result-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-reg_test_4867_query_rules-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-select_version_without_backend-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-set_transaction-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-set_wait_timeout-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "mysql-show_ssl_version-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "mysql-sql_log_bin-error-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-test_malformed_packet-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-test_ssl_CA-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql-watchdog_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "mysql_encode_unit-t": [
-    "unit-tests-g1"
-  ],
-  "mysql_error_classifier_unit-t": [
-    "unit-tests-g1"
-  ],
-  "mysql_hostgroup_attributes-servers_defaults-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql_hostgroup_attributes_config_file-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql_query_logging_memory-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql_reconnect_libmariadb-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql_reconnect_libmysql-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql_resolution_unit-t": [
-    "unit-tests-g1"
-  ],
-  "mysql_stmt_send_long_data-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "mysql_stmt_send_long_data_large-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "nl2sql_integration-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "nl2sql_internal-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "nl2sql_model_selection-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "nl2sql_prompt_builder-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "nl2sql_unit_base-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "ok_packet_mixed_queries-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "pgsql-admin_metacmds-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-admin_metacmds_describe_all_tables-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-admin_metacmds_describe_queries-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-basic_tests-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-connection_parameters_test-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-copy_from_stdin_session_parameter-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-copy_from_test-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-copy_to_test-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-extended_query_protocol_query_rules_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-extended_query_protocol_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-issue5384-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-monitor_ssl_connections_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-multiplex_status_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-notice_test-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-options_startup_params-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-parameterized_kill_queries_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-proxysql_cmd_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-query_cache_soft_ttl_pct-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-query_cache_test-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-query_cancel_session_termination_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-query_digests_stages_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-query_rules_routing-t": [
-    "pgsql17-repl-g4"
-  ],
-  "pgsql-reg_test_4707_threshold_resultset_size-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-reg_test_4716_single_semicolon-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-reg_test_4867_query_rules-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-reg_test_5140_bind_param_fmt_mix-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-reg_test_5273_bind_parameter_format-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-reg_test_5284_frontend_ssl_enforcement-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-reg_test_5300_threshold_resultset_deadlock-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-reg_test_5352_prepared_statement_refcount_race-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-reg_test_5415_copy_error_recovery-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-servers_ssl_params-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-set_parameter_validation_test-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-set_statement_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-ssl_keylog-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-test_malformed_packet-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-transaction_state_comprehensive-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-transaction_variable_state_tracking-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql-unsupported_feature_test-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql-watchdog_test-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4"
-  ],
-  "pgsql_command_complete_unit-t": [
-    "unit-tests-g1"
-  ],
-  "pgsql_error_classifier_unit-t": [
-    "unit-tests-g1"
-  ],
-  "pgsql_error_helper_unit-t": [
-    "unit-tests-g1"
-  ],
-  "pgsql_monitor_unit-t": [
-    "unit-tests-g1"
-  ],
-  "pgsql_query_logging_autodump-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql_query_logging_memory-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1"
-  ],
-  "pgsql_servers_ssl_params_unit-t": [
-    "unit-tests-g1"
-  ],
-  "pgsql_tokenizer_unit-t": [
-    "unit-tests-g1"
-  ],
-  "pgsql_txn_state_unit-t": [
-    "unit-tests-g1"
-  ],
-  "pgsql_variables_validator_unit-t": [
-    "unit-tests-g1"
-  ],
-  "prepare_statement_err3024-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "prepare_statement_err3024_async-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "prepare_statement_err3024_libmysql-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "protocol_unit-t": [
-    "unit-tests-g1"
-  ],
-  "proxy_protocol_unit-t": [
-    "unit-tests-g1"
-  ],
-  "proxysql_utils_unit-t": [
-    "unit-tests-g1"
-  ],
-  "query_cache_unit-t": [
-    "unit-tests-g1"
-  ],
-  "query_processor_firewall_unit-t": [
-    "unit-tests-g1"
-  ],
-  "query_processor_unit-t": [
-    "unit-tests-g1"
-  ],
-  "reg_test_1493-mixed_compression-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_1574-mariadb_read_stmt_execute_response-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_1574-stmt_metadata-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_2233_mirror_fast_routing-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_2793-compression-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3184-set_wait_timeout-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3223-restapi_return_codes-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3247-mycli_support-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3273_ssl_con-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3317-lock_hostgroup_special_queries-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3327-process_query_set_status_flags-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3371_prepared_statement_crash-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3427-stmt_first_comment1-param-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3427-stmt_first_comment1-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3427-stmt_first_comment2-param-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3427-stmt_first_comment2-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3434-text_stmt_mix-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3493-USE_with_comment-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3504-change_user-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3546-stmt_empty_params-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3549-autocommit_tracking-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3585-stmt_metadata-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3591-restapi_num_fds-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3603-stmt_metadata-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3606-mysql_warnings-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3625-sqlite3_session_client_error_limit-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3690-admin_large_pkts-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_3765_ssl_pollout-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql84-g4",
-    "mysql90-g2",
-    "mysql90-g4",
-    "mysql95-g2",
-    "mysql95-g4"
-  ],
-  "reg_test_3838-restapi_eintr-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_3847_admin_lock-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_3992_fast_forward_malformed_packet-mysqlsh-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_3992_fast_forward_malformed_packet-pymysql-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_3992_fast_forward_malformed_packet-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4001-restapi_scripts_num_fds-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4055_restapi-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4072-show-warnings-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4158_change_user-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4264-commit_rollback-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4300-dollar_quote_check-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4399-stats_mysql_query_digest-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4402-mysql_fields-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4556-ssl_error_queue-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_4855_affected_rows_ddl-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_4935-caching_sha2-t": [
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "reg_test_5212_tcp_keepalive_warnings-t": [
-    "legacy-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_5233_set_warning-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_5306-show_warnings_with_comment-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_5389-flush_logs_no_drop-t": [
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "reg_test__ssl_client_busy_wait-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_com_change_user_malformed_packet-t": [
-    "mysql84-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_compression_split_packets-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_fast_forward_split_packet-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_handshake_response_unterminated_username-t": [
-    "mysql84-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_mariadb_metadata_check-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_mariadb_stmt_store_result-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_mariadb_stmt_store_result_async-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_mariadb_stmt_store_result_libmysql-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_proclist_use_after_free-t": [
-    "legacy-g1",
-    "mysql-auto_increment_delay_multiplex=0-g1",
-    "mysql-multiplexing=false-g1",
-    "mysql-query_digests=0-g1",
-    "mysql-query_digests_keep_comment=1-g1",
-    "mysql84-g1",
-    "mysql90-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_proxy_protocol_oversized_address-t": [
-    "mysql84-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_sql_calc_found_rows-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_stmt_close_short_packet-t": [
-    "mysql84-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_stmt_inv_param_offset-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_stmt_resultset_err_no_rows-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_stmt_resultset_err_no_rows_libmysql-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_stmt_resultset_err_no_rows_php-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "reg_test_stmt_send_long_data_short_packet-t": [
-    "mysql84-g1",
-    "mysql95-g1"
-  ],
-  "reg_test_unexp_ping_pkt-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "rule_matching_unit-t": [
-    "unit-tests-g1"
-  ],
-  "savepoint-3749-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "savepoint-948-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "server_selection_unit-t": [
-    "unit-tests-g1"
-  ],
-  "set_character_set-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "set_testing-240-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "set_testing-multi-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "set_testing-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "setparser_test-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "setparser_test2-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "setparser_test3-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "smoke_test-t": [
-    "unit-tests-g1"
-  ],
-  "sqlite3-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "sqlite3db_unit-t": [
-    "unit-tests-g1"
-  ],
-  "sqlite_autocommit-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "statistics_unit-t": [
-    "unit-tests-g1"
-  ],
-  "stmt_explain-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "test_PROXY_Protocol-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_admin_stats-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "test_auth_methods-t": [
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "test_auto_increment_delay_multiplex-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "test_backend_conn_ping-t": [
-    "legacy-g2",
-    "mysql-auto_increment_delay_multiplex=0-g2",
-    "mysql-multiplexing=false-g2",
-    "mysql-query_digests=0-g2",
-    "mysql-query_digests_keep_comment=1-g2",
-    "mysql84-g2",
-    "mysql90-g2",
-    "mysql95-g2"
-  ],
-  "test_binlog_dump_multi_backend_crash-t": [
-    "legacy-binlog-g1"
-  ],
-  "test_binlog_fast_forward-t": [
-    "legacy-binlog-g1",
-    "mysql84-binlog-g2",
-    "mysql90-binlog-g2",
-    "mysql95-binlog-g2"
-  ],
-  "test_binlog_reader-t": [
-    "legacy-binlog-g1",
-    "mysql84-binlog-g1",
-    "mysql90-binlog-g1",
-    "mysql95-binlog-g1"
-  ],
-  "test_binlog_reader_uses_previous_hostgroup-t": [
-    "legacy-binlog-g1",
-    "mysql84-g5",
-    "mysql90-g5",
-    "mysql95-g5"
-  ],
-  "test_cacert_load_and_verify_duration-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_change_user-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_clickhouse_server-t": [
-    "legacy-clickhouse-g1",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3"
-  ],
-  "test_clickhouse_server_libmysql-t": [
-    "legacy-clickhouse-g1",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3"
-  ],
-  "test_client_limit_error-t": [
-    "todo-g1"
-  ],
-  "test_cluster1-t": [
-    "legacy-g5",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g5",
-    "mysql90-g5",
-    "mysql95-g5"
-  ],
-  "test_cluster_sync-t": [
-    "legacy-g5",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g5",
-    "mysql90-g5",
-    "mysql95-g5"
-  ],
-  "test_cluster_sync_mysql_servers-t": [
-    "legacy-g5",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g5",
-    "mysql90-g5",
-    "mysql95-g5"
-  ],
-  "test_cluster_sync_pgsql-t": [
-    "legacy-g5",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3"
-  ],
-  "test_com_binlog_dump_enables_fast_forward-t": [
-    "legacy-binlog-g1",
-    "mysql84-binlog-g1",
-    "mysql90-binlog-g1",
-    "mysql95-binlog-g1"
-  ],
-  "test_com_register_slave_enables_fast_forward-t": [
-    "legacy-binlog-g1",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-binlog-g1",
-    "mysql90-binlog-g1",
-    "mysql95-binlog-g1"
-  ],
-  "test_com_reset_connection_com_change_user-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_connection_annotation-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_csharp_connector_support-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_debug_filters-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_default_conn_collation-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_default_value_transaction_isolation_attr-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_digest_umap_aux-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_dns_cache-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_empty_query-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_enforce_autocommit_on_reads-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_ffto_bypass-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql_bypass_recovery-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql_concurrent-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql_errors-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql_large_queries-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql_large_resultsets-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql_mixed_protocol-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_mysql_transactions-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ffto_pgsql-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_command_types-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_concurrent-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_error_stats-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_errors-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_large_resultsets-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_mixed_protocol-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_pipeline-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_ffto_pgsql_stmt_portal-t": [
-    "@proxysql_min_version:3.1",
-    "legacy-g4"
-  ],
-  "test_filtered_set_statements-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_firewall-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_flagOUT_weight-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_flush_logs-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_format_utils-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_greeting_capabilities-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_gtid_forwarding-t": [
-    "legacy-binlog-g1",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g5",
-    "mysql90-g5",
-    "mysql95-g5"
-  ],
-  "test_hostgroup_attributes_online_servers-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_ignore_min_gtid-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_keep_multiplexing_variables-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_load_from_config_prefix_stripping-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_load_from_config_validation-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_load_restapi_from_config_startup-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_log_last_insert_id-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_match_eof_conn_cap_libmariadb-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_match_eof_conn_cap_libmysql-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_max_transaction_time-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_mcp_claude_headless_flow-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "test_mcp_llm_discovery_phaseb-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "test_mcp_rag_metrics-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "test_mcp_static_harvest-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "test_mysql_connect_retries-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_mysql_connect_retries_delay-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_mysql_hostgroup_attributes-1-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_mysql_query_digests_stages-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_mysql_query_rules_fast_routing-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_mysqlsh-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_noise_injection-t": [
-    "legacy-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_pgsql_replication_lag-t": [
-    "pgsql-repl"
-  ],
-  "test_prepare_statement_memory_usage-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_prometheus_metrics-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_ps_async-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_ps_hg_routing-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_ps_large_result-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_ps_logging-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_ps_min_gtid-t": [
-    "legacy-binlog-g1"
-  ],
-  "test_ps_min_gtid_fc-t": [
-    "legacy-binlog-g1"
-  ],
-  "test_ps_no_store-t": [
-    "legacy-g3",
-    "mysql-auto_increment_delay_multiplex=0-g3",
-    "mysql-multiplexing=false-g3",
-    "mysql-query_digests=0-g3",
-    "mysql-query_digests_keep_comment=1-g3",
-    "mysql84-g3",
-    "mysql90-g3",
-    "mysql95-g3"
-  ],
-  "test_query_cache_soft_ttl_pct-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_query_rules_fast_routing_algorithm-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_query_rules_routing-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_query_timeout-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_read_only_actions_offline_hard_servers-t": [
-    "legacy-g5",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql84-g5",
-    "mysql90-g4",
-    "mysql90-g5",
-    "mysql95-g4",
-    "mysql95-g5"
-  ],
-  "test_rw_binary_data-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_server_sess_status-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_session_status_flags-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_set_character_results-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_set_collation-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_simple_embedded_HTTP_server-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_sqlite3_from_unixtime-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_sqlite3_pass_exts-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_sqlite3_server-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_sqlite3_server_and_fast_routing-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_sqlite3_special_queries_libmariadb-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_sqlite3_special_queries_libmysql-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_connect-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_fast_forward-1-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_fast_forward-2_libmariadb-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_fast_forward-2_libmysql-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_fast_forward-3_libmariadb-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_fast_forward-3_libmysql-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_large_query-1-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_ssl_large_query-2-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_stats_proxysql_message_metrics-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_thread_conn_dist-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_throttle_max_bytes_per_second_to_client-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_tls_stats-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_tsdb_api-t": [
-    "@proxysql_min_version:3.1",
-    "ai-g1"
-  ],
-  "test_tsdb_variables-t": [
-    "@proxysql_min_version:3.1",
-    "ai-g1"
-  ],
-  "test_unshun_algorithm-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_unsupported_queries-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_utf8mb4_as_ci-4841-t": [
-    "mysql84-g1",
-    "mysql95-g1"
-  ],
-  "test_warnings-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "test_wexecvp_syscall_failures-t": [
-    "legacy-g4",
-    "mysql-auto_increment_delay_multiplex=0-g4",
-    "mysql-multiplexing=false-g4",
-    "mysql-query_digests=0-g4",
-    "mysql-query_digests_keep_comment=1-g4",
-    "mysql84-g4",
-    "mysql90-g4",
-    "mysql95-g4"
-  ],
-  "transaction_state_unit-t": [
-    "unit-tests-g1"
-  ],
-  "unit-strip_schema_from_query-t": [
-    "unit-tests-g1"
-  ],
-  "vector_db_performance-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ],
-  "vector_features-t": [
-    "@proxysql_min_version:4.0",
-    "ai-g1"
-  ]
+  "admin-listen_on_unix-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "admin_disk_upgrade_unit-t" : [ "unit-tests-g1" ],
+  "admin_set_credentials_logging-t" : [ "no-infra-g1" ],
+  "admin_show_create_table-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "admin_show_fields_from-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "admin_show_table_status-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "admin_various_commands-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "admin_various_commands2-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "admin_various_commands3-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "ai_error_handling_edge_cases-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "ai_llm_retry_scenarios-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "ai_validation-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "anomaly_detection-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "anomaly_detection_integration-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "anomaly_detector_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "auth_unit-t" : [ "unit-tests-g1" ],
+  "backend_sync_unit-t" : [ "unit-tests-g1" ],
+  "basic-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "c_tokenizer_unit-t" : [ "unit-tests-g1" ],
+  "charset_find_unit-t" : [ "unit-tests-g1" ],
+  "charset_unsigned_int-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "clickhouse_php_conn-t" : [ "legacy-clickhouse-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "config_validation_unit-t" : [ "unit-tests-g1" ],
+  "config_write_unit-t" : [ "unit-tests-g1" ],
+  "connection_pool_unit-t" : [ "unit-tests-g1" ],
+  "deprecate_eof_cache-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "envvars-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "eof_cache_mixed_flags-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "eof_conn_options_check-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "eof_fast_forward-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "eof_mixed_flags_queries-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "eof_packet_mixed_queries-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "ezoption_parser_unit-t" : [ "unit-tests-g1" ],
+  "fast_forward_grace_close_libmysql-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "fast_forward_switch_replication_deprecate_eof_libmysql-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "ffto_protocol_unit-t" : [ "unit-tests-g1","@proxysql_min_version:3.1" ],
+  "firewall_commands1-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "gen_utils_unit-t" : [ "unit-tests-g1" ],
+  "genai_anomaly_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_async-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_discovery_schema_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_embedding_rerank-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_fts_string_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_live_validation-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_llm_clients_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_mcp_endpoint_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_mcp_thread_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_module-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_mysql_catalog_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_query_handler_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_stats_parsing_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "genai_thread_unit-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "glovars_unit-t" : [ "unit-tests-g1" ],
+  "gtid_server_data_unit-t" : [ "unit-tests-g1" ],
+  "gtid_set_unit-t" : [ "unit-tests-g1" ],
+  "gtid_trxid_interval_unit-t" : [ "unit-tests-g1" ],
+  "hostgroup_routing_unit-t" : [ "unit-tests-g1" ],
+  "hostgroups_unit-t" : [ "unit-tests-g1" ],
+  "issue5384-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "kill_connection-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "kill_connection2-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "kill_connection3-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "listen_validator_unit-t" : [ "unit-tests-g1" ],
+  "listener_conflicts_validation-t" : [ "no-infra-g1" ],
+  "llm_bridge_accuracy-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "log_utils_unit-t" : [ "unit-tests-g1" ],
+  "max_connections_ff-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mcp_mixed_mysql_pgsql_concurrency_stress-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_mixed_stats_cap_churn-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_mixed_stats_profile_matrix-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_module-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_mysql_concurrency_stress-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_pgsql_concurrency_stress-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_query_rules-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_query_run_sql_readonly-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_runtime_variables-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_semantic_lifecycle-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_show_connections_commands_inmemory-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_show_queries_topk-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "mcp_stats_refresh-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "monitor_health_unit-t" : [ "unit-tests-g1" ],
+  "multiple_prepared_statements-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-fast_forward-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-init_connect-1-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "mysql-init_connect-2-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "mysql-last_insert_id-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql91-g1","mysql91-gr-g1","mysql92-g1","mysql92-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "mysql-mirror1-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-protocol_compression_level-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-reg_test_4707_threshold_resultset_size-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-reg_test_4716_single_semicolon-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-reg_test_4723_query_cache_stores_empty_result-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-reg_test_4867_query_rules-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-select_version_without_backend-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-set_transaction-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-set_wait_timeout-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "mysql-show_ssl_version-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "mysql-sql_log_bin-error-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-test_malformed_packet-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-test_ssl_CA-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql-watchdog_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "mysql_encode_unit-t" : [ "unit-tests-g1" ],
+  "mysql_error_classifier_unit-t" : [ "unit-tests-g1" ],
+  "mysql_hostgroup_attributes-servers_defaults-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql_hostgroup_attributes_config_file-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql_query_logging_memory-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql_reconnect_libmariadb-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql_reconnect_libmysql-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql_resolution_unit-t" : [ "unit-tests-g1" ],
+  "mysql_stmt_send_long_data-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mysql_stmt_send_long_data_large-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "nl2sql_integration-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "nl2sql_internal-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "nl2sql_model_selection-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "nl2sql_prompt_builder-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "nl2sql_unit_base-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "ok_packet_mixed_queries-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "pgsql-admin_metacmds-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-admin_metacmds_describe_all_tables-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-admin_metacmds_describe_queries-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-basic_tests-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-connection_parameters_test-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-copy_from_stdin_session_parameter-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-copy_from_test-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-copy_to_test-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-extended_query_protocol_query_rules_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-extended_query_protocol_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-issue5384-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-monitor_ssl_connections_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-multiplex_status_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-notice_test-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-options_startup_params-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-parameterized_kill_queries_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-proxysql_cmd_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-query_cache_soft_ttl_pct-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-query_cache_test-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-query_cancel_session_termination_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-query_digests_stages_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-query_rules_routing-t" : [ "pgsql17-repl-g4" ],
+  "pgsql-reg_test_4707_threshold_resultset_size-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-reg_test_4716_single_semicolon-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-reg_test_4867_query_rules-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-reg_test_5140_bind_param_fmt_mix-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5273_bind_parameter_format-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5284_frontend_ssl_enforcement-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5300_threshold_resultset_deadlock-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5352_prepared_statement_refcount_race-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-reg_test_5415_copy_error_recovery-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-servers_ssl_params-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-set_parameter_validation_test-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-set_statement_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-ssl_keylog-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-test_malformed_packet-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-transaction_state_comprehensive-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-transaction_variable_state_tracking-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql-unsupported_feature_test-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql-watchdog_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
+  "pgsql_command_complete_unit-t" : [ "unit-tests-g1" ],
+  "pgsql_error_classifier_unit-t" : [ "unit-tests-g1" ],
+  "pgsql_error_helper_unit-t" : [ "unit-tests-g1" ],
+  "pgsql_monitor_unit-t" : [ "unit-tests-g1" ],
+  "pgsql_query_logging_autodump-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql_query_logging_memory-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
+  "pgsql_servers_ssl_params_unit-t" : [ "unit-tests-g1" ],
+  "pgsql_tokenizer_unit-t" : [ "unit-tests-g1" ],
+  "pgsql_txn_state_unit-t" : [ "unit-tests-g1" ],
+  "pgsql_variables_validator_unit-t" : [ "unit-tests-g1" ],
+  "prepare_statement_err3024-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "prepare_statement_err3024_async-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "prepare_statement_err3024_libmysql-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "protocol_unit-t" : [ "unit-tests-g1" ],
+  "proxy_protocol_unit-t" : [ "unit-tests-g1" ],
+  "proxysql_utils_unit-t" : [ "unit-tests-g1" ],
+  "query_cache_unit-t" : [ "unit-tests-g1" ],
+  "query_processor_firewall_unit-t" : [ "unit-tests-g1" ],
+  "query_processor_unit-t" : [ "unit-tests-g1" ],
+  "reg_test_1493-mixed_compression-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_1574-mariadb_read_stmt_execute_response-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_1574-stmt_metadata-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_2233_mirror_fast_routing-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_2793-compression-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3184-set_wait_timeout-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3223-restapi_return_codes-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3247-mycli_support-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3273_ssl_con-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3317-lock_hostgroup_special_queries-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3327-process_query_set_status_flags-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3371_prepared_statement_crash-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3427-stmt_first_comment1-param-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3427-stmt_first_comment1-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3427-stmt_first_comment2-param-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3427-stmt_first_comment2-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3434-text_stmt_mix-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3493-USE_with_comment-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3504-change_user-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3546-stmt_empty_params-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3549-autocommit_tracking-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3585-stmt_metadata-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3591-restapi_num_fds-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3603-stmt_metadata-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3606-mysql_warnings-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3625-sqlite3_session_client_error_limit-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3690-admin_large_pkts-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_3765_ssl_pollout-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql84-g4","mysql90-g2","mysql90-g4","mysql95-g2","mysql95-g4" ],
+  "reg_test_3838-restapi_eintr-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_3847_admin_lock-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_3992_fast_forward_malformed_packet-mysqlsh-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_3992_fast_forward_malformed_packet-pymysql-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_3992_fast_forward_malformed_packet-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4001-restapi_scripts_num_fds-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4055_restapi-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4072-show-warnings-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4158_change_user-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4264-commit_rollback-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4300-dollar_quote_check-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4399-stats_mysql_query_digest-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4402-mysql_fields-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4556-ssl_error_queue-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_4855_affected_rows_ddl-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_4935-caching_sha2-t" : [ "mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "reg_test_5212_tcp_keepalive_warnings-t" : [ "legacy-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_5233_set_warning-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_5306-show_warnings_with_comment-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_5389-flush_logs_no_drop-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "reg_test__ssl_client_busy_wait-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_com_change_user_malformed_packet-t" : [ "mysql84-g1","mysql95-g1" ],
+  "reg_test_compression_split_packets-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_fast_forward_split_packet-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_handshake_response_unterminated_username-t" : [ "mysql84-g1","mysql95-g1" ],
+  "reg_test_mariadb_metadata_check-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_mariadb_stmt_store_result-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_mariadb_stmt_store_result_async-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_mariadb_stmt_store_result_libmysql-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_proclist_use_after_free-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "reg_test_proxy_protocol_oversized_address-t" : [ "mysql84-g1","mysql95-g1" ],
+  "reg_test_sql_calc_found_rows-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_stmt_close_short_packet-t" : [ "mysql84-g1","mysql95-g1" ],
+  "reg_test_stmt_inv_param_offset-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_stmt_resultset_err_no_rows-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_stmt_resultset_err_no_rows_libmysql-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_stmt_resultset_err_no_rows_php-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_stmt_send_long_data_short_packet-t" : [ "mysql84-g1","mysql95-g1" ],
+  "reg_test_unexp_ping_pkt-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "rule_matching_unit-t" : [ "unit-tests-g1" ],
+  "savepoint-3749-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "savepoint-948-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "server_selection_unit-t" : [ "unit-tests-g1" ],
+  "set_character_set-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "set_testing-240-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "set_testing-multi-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "set_testing-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "setparser_test-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "setparser_test2-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "setparser_test3-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "smoke_test-t" : [ "unit-tests-g1" ],
+  "sqlite3-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "sqlite3db_unit-t" : [ "unit-tests-g1" ],
+  "sqlite_autocommit-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "statistics_unit-t" : [ "unit-tests-g1" ],
+  "stmt_explain-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "test_PROXY_Protocol-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_admin_stats-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "test_auth_methods-t" : [ "mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "test_auto_increment_delay_multiplex-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "test_backend_conn_ping-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "test_binlog_dump_multi_backend_crash-t" : [ "legacy-binlog-g1" ],
+  "test_binlog_fast_forward-t" : [ "legacy-binlog-g1","mysql84-binlog-g2","mysql90-binlog-g2","mysql95-binlog-g2" ],
+  "test_binlog_reader-t" : [ "legacy-binlog-g1","mysql84-binlog-g1","mysql90-binlog-g1","mysql95-binlog-g1" ],
+  "test_binlog_reader_uses_previous_hostgroup-t" : [ "legacy-binlog-g1","mysql84-g5","mysql90-g5","mysql95-g5" ],
+  "test_cacert_load_and_verify_duration-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_change_user-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_clickhouse_server-t" : [ "legacy-clickhouse-g1","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3" ],
+  "test_clickhouse_server_libmysql-t" : [ "legacy-clickhouse-g1","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3" ],
+  "test_client_limit_error-t" : [ "todo-g1" ],
+  "test_cluster1-t" : [ "legacy-g5","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g5","mysql90-g5","mysql95-g5" ],
+  "test_cluster_sync-t" : [ "legacy-g5","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g5","mysql90-g5","mysql95-g5" ],
+  "test_cluster_sync_mysql_servers-t" : [ "legacy-g5","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g5","mysql90-g5","mysql95-g5" ],
+  "test_cluster_sync_pgsql-t" : [ "legacy-g5","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3" ],
+  "test_com_binlog_dump_enables_fast_forward-t" : [ "legacy-binlog-g1","mysql84-binlog-g1","mysql90-binlog-g1","mysql95-binlog-g1" ],
+  "test_com_register_slave_enables_fast_forward-t" : [ "legacy-binlog-g1","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-binlog-g1","mysql90-binlog-g1","mysql95-binlog-g1" ],
+  "test_com_reset_connection_com_change_user-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_connection_annotation-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_csharp_connector_support-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_debug_filters-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_default_conn_collation-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_default_value_transaction_isolation_attr-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_digest_umap_aux-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_dns_cache-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_empty_query-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_enforce_autocommit_on_reads-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_ffto_bypass-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql_bypass_recovery-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql_concurrent-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql_errors-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql_large_queries-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql_large_resultsets-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql_mixed_protocol-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_mysql_transactions-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_command_types-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_concurrent-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_error_stats-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_errors-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_large_resultsets-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_mixed_protocol-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_pipeline-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_ffto_pgsql_stmt_portal-t" : [ "legacy-g4","@proxysql_min_version:3.1" ],
+  "test_filtered_set_statements-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_firewall-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_flagOUT_weight-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_flush_logs-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_format_utils-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_greeting_capabilities-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_gtid_forwarding-t" : [ "legacy-binlog-g1","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g5","mysql90-g5","mysql95-g5" ],
+  "test_hostgroup_attributes_online_servers-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_ignore_min_gtid-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_keep_multiplexing_variables-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_load_from_config_prefix_stripping-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_load_from_config_validation-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_load_restapi_from_config_startup-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_log_last_insert_id-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_match_eof_conn_cap_libmariadb-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_match_eof_conn_cap_libmysql-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_max_transaction_time-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_mcp_claude_headless_flow-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "test_mcp_llm_discovery_phaseb-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "test_mcp_rag_metrics-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "test_mcp_static_harvest-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "test_mysql_connect_retries-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_mysql_connect_retries_delay-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_mysql_hostgroup_attributes-1-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_mysql_query_digests_stages-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_mysql_query_rules_fast_routing-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_mysqlsh-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_noise_injection-t" : [ "legacy-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_pgsql_replication_lag-t" : [ "pgsql-repl" ],
+  "test_prepare_statement_memory_usage-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_prometheus_metrics-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_ps_async-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_ps_hg_routing-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_ps_large_result-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_ps_logging-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_ps_min_gtid-t" : [ "legacy-binlog-g1" ],
+  "test_ps_min_gtid_fc-t" : [ "legacy-binlog-g1" ],
+  "test_ps_no_store-t" : [ "legacy-g3","mysql-auto_increment_delay_multiplex=0-g3","mysql-multiplexing=false-g3","mysql-query_digests=0-g3","mysql-query_digests_keep_comment=1-g3","mysql84-g3","mysql90-g3","mysql95-g3" ],
+  "test_query_cache_soft_ttl_pct-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_query_rules_fast_routing_algorithm-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_query_rules_routing-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_query_timeout-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_read_only_actions_offline_hard_servers-t" : [ "legacy-g5","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql84-g5","mysql90-g4","mysql90-g5","mysql95-g4","mysql95-g5" ],
+  "test_rw_binary_data-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_server_sess_status-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_session_status_flags-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_set_character_results-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_set_collation-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_simple_embedded_HTTP_server-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_sqlite3_from_unixtime-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_sqlite3_pass_exts-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_sqlite3_server-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_sqlite3_server_and_fast_routing-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_sqlite3_special_queries_libmariadb-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_sqlite3_special_queries_libmysql-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_connect-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_fast_forward-1-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_fast_forward-2_libmariadb-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_fast_forward-2_libmysql-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_fast_forward-3_libmariadb-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_fast_forward-3_libmysql-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_large_query-1-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_ssl_large_query-2-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_stats_proxysql_message_metrics-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_thread_conn_dist-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_throttle_max_bytes_per_second_to_client-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_tls_stats-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_tsdb_api-t" : [ "ai-g1","@proxysql_min_version:3.1" ],
+  "test_tsdb_variables-t" : [ "ai-g1","@proxysql_min_version:3.1" ],
+  "test_unshun_algorithm-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_unsupported_queries-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_utf8mb4_as_ci-4841-t" : [ "mysql84-g1","mysql95-g1" ],
+  "test_warnings-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "test_wexecvp_syscall_failures-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "transaction_state_unit-t" : [ "unit-tests-g1" ],
+  "unit-strip_schema_from_query-t" : [ "unit-tests-g1" ],
+  "vector_db_performance-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
+  "vector_features-t" : [ "ai-g1","@proxysql_min_version:4.0" ]
 }

--- a/test/tap/groups/lint_groups_json.py
+++ b/test/tap/groups/lint_groups_json.py
@@ -9,25 +9,58 @@ Enforces the conventions documented in test/tap/groups/README.md:
   - Keys sorted alphabetically
   - File starts with '{' and ends with '}'
 
+Usage:
+    python3 lint_groups_json.py [--fix] [path/to/groups.json]
+
+    --fix   Auto-fix formatting issues (reformat in-place).
+
 Exit codes:
-    0 - Format is correct
-    1 - Format violations found
+    0 - Format is correct (or --fix applied successfully)
+    1 - Format violations found (and no --fix, or --fix failed)
 """
 
+import argparse
 import json
 import os
 import re
 import sys
 
 
-def main():
-    groups_path = os.path.join(os.path.dirname(__file__), "groups.json")
-    if len(sys.argv) > 1:
-        groups_path = sys.argv[1]
+def reformat_groups(groups_path):
+    """Read groups.json and rewrite it in the canonical one-line-per-entry format."""
+    with open(groups_path, "r") as f:
+        data = json.load(f)
 
+    if not isinstance(data, dict):
+        print(f"ERROR: Top-level value must be a JSON object", file=sys.stderr)
+        return False
+
+    sorted_keys = sorted(data.keys())
+    lines = ["{"]
+    for i, key in enumerate(sorted_keys):
+        groups = data[key]
+        # Sort groups for determinism, but keep special strings like @proxysql_min_version at end
+        regular = sorted(g for g in groups if not g.startswith("@"))
+        special = sorted(g for g in groups if g.startswith("@"))
+        sorted_groups = regular + special
+        groups_str = ",".join(f'"{g}"' for g in sorted_groups)
+        comma = "," if i < len(sorted_keys) - 1 else ""
+        lines.append(f'  "{key}" : [ {groups_str} ]{comma}')
+    lines.append("}")
+    lines.append("")  # trailing newline
+
+    with open(groups_path, "w") as f:
+        f.write("\n".join(lines))
+
+    print(f"Fixed: {groups_path} ({len(sorted_keys)} entries, sorted, compact)")
+    return True
+
+
+def lint_groups(groups_path):
+    """Lint groups.json and return (exit_code, error_count)."""
     if not os.path.isfile(groups_path):
         print(f"ERROR: {groups_path} not found", file=sys.stderr)
-        return 1
+        return 1, 0
 
     with open(groups_path, "r") as f:
         raw = f.read()
@@ -40,22 +73,20 @@ def main():
         data = json.loads(raw)
     except json.JSONDecodeError as e:
         errors.append(f"Invalid JSON: {e}")
-        # Can't do further checks
         for e in errors:
             print(f"ERROR: {e}", file=sys.stderr)
-        return 1
+        return 1, len(errors)
 
     if not isinstance(data, dict):
         errors.append("Top-level value must be a JSON object")
         for e in errors:
             print(f"ERROR: {e}", file=sys.stderr)
-        return 1
+        return 1, len(errors)
 
     # Check 2: first and last lines
     if not lines or lines[0].strip() != "{":
         errors.append("Line 1: must be '{'")
     if lines[-1].strip() == "":
-        # Allow trailing newline — check second-to-last
         if len(lines) < 2 or lines[-2].strip() != "}":
             errors.append(f"Last non-empty line: must be '}}'")
     elif lines[-1].strip() != "}":
@@ -66,7 +97,7 @@ def main():
         r'^  "([^"]+)" : \[ .+ \](,?)$'
     )
     keys_in_order = []
-    entry_lines = lines[1:]  # skip opening brace
+    entry_lines = lines[1:]
     for i, line in enumerate(entry_lines, start=2):
         stripped = line.strip()
         if stripped == "}" or stripped == "":
@@ -83,7 +114,6 @@ def main():
 
     # Check 4: keys are sorted
     if keys_in_order != sorted(keys_in_order):
-        # Find first out-of-order key
         for j in range(len(keys_in_order) - 1):
             if keys_in_order[j] > keys_in_order[j + 1]:
                 errors.append(
@@ -109,10 +139,29 @@ def main():
         print(f"groups.json format lint: {len(errors)} error(s) found:", file=sys.stderr)
         for e in errors:
             print(f"  {e}", file=sys.stderr)
-        return 1
+        print(f"\n  Hint: run 'python3 {os.path.abspath(__file__)} --fix' to auto-fix", file=sys.stderr)
+        return 1, len(errors)
 
     print(f"groups.json format lint: OK ({len(data)} entries, sorted, compact)")
-    return 0
+    return 0, 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Lint groups.json for format compliance.")
+    parser.add_argument("path", nargs="?", default=None, help="Path to groups.json")
+    parser.add_argument("--fix", action="store_true", help="Auto-fix formatting issues in-place")
+    args = parser.parse_args()
+
+    groups_path = args.path or os.path.join(os.path.dirname(__file__), "groups.json")
+
+    if args.fix:
+        ok = reformat_groups(groups_path)
+        if not ok:
+            return 1
+        # Re-lint after fixing to confirm
+        return lint_groups(groups_path)[0]
+
+    return lint_groups(groups_path)[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Recent merges (e.g., #5625) reformatted `groups.json` with multi-line arrays, breaking the one-line-per-test convention documented in `test/tap/groups/README.md`. This caused merge conflicts and CI lint failures on branches that added new entries in the correct format.

## Changes

- **`test/tap/groups/groups.json`**: Reformat to canonical format — one line per test, compact arrays, sorted keys, space before colon.
- **`test/tap/groups/lint_groups_json.py`**: Add `--fix` mode that auto-reformats the file in-place. Usage: `python3 test/tap/groups/lint_groups_json.py --fix`. The linter now also prints a hint suggesting `--fix` when it finds errors.

## Test plan

- [x] `python3 test/tap/groups/lint_groups_json.py` passes (385 entries, sorted, compact)
- [x] `python3 test/tap/groups/lint_groups_json.py --fix` is idempotent (no-op on already-correct file)
- [x] CI-lint-groups-json passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--fix` command-line flag to automatically reformat and fix configuration files to canonical format with proper key ordering and consistent formatting.
  * Improved error messages with helpful hints for resolving detected issues.

* **Bug Fixes**
  * Corrected exit code behavior to properly reflect successful auto-fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->