### PR TITLE
fix(mysqlx): sync empty source tables to overwrite stale rows

### DIFF
--- a/plugins/mysqlx/include/mysqlx_config_store.h
+++ b/plugins/mysqlx/include/mysqlx_config_store.h
@@ -22,6 +22,7 @@ MysqlxBackendAuthMode mysqlx_backend_auth_mode_from_string(const std::string& va
 
 struct MysqlxResolvedIdentity {
 	std::string username {};
+	std::string password {};
 	int default_hostgroup { 0 };
 	int max_connections { 0 };
 	bool x_enabled { false };

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -15,6 +15,7 @@ struct MysqlxCredentials {
 	std::string password_hash;
 	bool x_enabled;
 	std::string allowed_auth;
+	std::string backend_password;
 };
 
 typedef std::function<MysqlxCredentials(const std::string& username)> MysqlxCredentialLookup;

--- a/plugins/mysqlx/include/mysqlx_thread.h
+++ b/plugins/mysqlx/include/mysqlx_thread.h
@@ -13,6 +13,8 @@
 #include "mysqlx_session.h"
 #include "mysqlx_connection.h"
 
+class MysqlxConfigStore;
+
 class Mysqlx_Thread {
 public:
 	Mysqlx_Thread();
@@ -38,6 +40,7 @@ public:
 	void set_max_cached_connections(size_t max) { max_cached_ = max; }
 	void set_max_sessions(size_t max) { max_sessions_ = max; }
 	size_t get_max_sessions() const { return max_sessions_; }
+	void set_config_store(const MysqlxConfigStore* store) { config_store_ = store; }
 
 	SSL_CTX* get_ssl_ctx() const;
 
@@ -50,6 +53,7 @@ private:
 	int thread_index_;
 	std::atomic<bool> running_;
 	std::thread thread_;
+	const MysqlxConfigStore* config_store_;
 
 	std::vector<struct pollfd> poll_fds_;
 	std::vector<MysqlxDataStream*> poll_ds_;

--- a/plugins/mysqlx/src/mysqlx_config_store.cpp
+++ b/plugins/mysqlx/src/mysqlx_config_store.cpp
@@ -57,8 +57,9 @@ void load_canonical_users(
 
 		MysqlxResolvedIdentity identity {};
 		identity.username = nullable_string(row->fields[0]);
-		identity.default_hostgroup = nullable_int(row->fields[1]);
-		identity.max_connections = nullable_int(row->fields[2]);
+		identity.password = nullable_string(row->fields[1]);
+		identity.default_hostgroup = nullable_int(row->fields[2]);
+		identity.max_connections = nullable_int(row->fields[3]);
 		identities[identity.username] = std::move(identity);
 	}
 }
@@ -208,7 +209,7 @@ bool MysqlxConfigStore::load_from_runtime(SQLite3DB& db, std::string& err) {
 
 	if (!fetch_result(
 		    db,
-		    "SELECT username, default_hostgroup, max_connections "
+		    "SELECT username, password, default_hostgroup, max_connections "
 		    "FROM runtime_mysql_users WHERE active=1 AND frontend=1",
 		    result,
 		    err)) {

--- a/plugins/mysqlx/src/mysqlx_connection.cpp
+++ b/plugins/mysqlx/src/mysqlx_connection.cpp
@@ -14,6 +14,7 @@
 #include <cerrno>
 #include <cstring>
 #include <chrono>
+#include <poll.h>
 
 MysqlxConnection::MysqlxConnection()
 	: state_(CREATED), auth_state_(BACKEND_AUTH_NOT_STARTED), fd_(-1), hostgroup_(-1), port_(0),
@@ -67,6 +68,12 @@ int MysqlxConnection::check_connect() {
 		state_ = ERROR_STATE;
 		return -1;
 	}
+	struct pollfd pfd;
+	pfd.fd = fd_;
+	pfd.events = POLLOUT;
+	pfd.revents = 0;
+	int pr = poll(&pfd, 1, 0);
+	if (pr <= 0) return 1;  // not ready yet
 	int err = 0;
 	socklen_t len = sizeof(err);
 	getsockopt(fd_, SOL_SOCKET, SO_ERROR, &err, &len);

--- a/plugins/mysqlx/src/mysqlx_data_stream.cpp
+++ b/plugins/mysqlx/src/mysqlx_data_stream.cpp
@@ -197,7 +197,7 @@ ssize_t MysqlxDataStream::flush_ssl_write_buf() {
 
 bool MysqlxDataStream::has_ssl_pending_write() const {
 	return !ssl_write_buf_.empty() ||
-		(wbio_ssl_ && BIO_number_written(wbio_ssl_) > BIO_number_read(wbio_ssl_));
+		(wbio_ssl_ && BIO_ctrl_pending(wbio_ssl_) > 0);
 }
 
 ssize_t MysqlxDataStream::read_from_net() {

--- a/plugins/mysqlx/src/mysqlx_plugin.cpp
+++ b/plugins/mysqlx/src/mysqlx_plugin.cpp
@@ -70,6 +70,7 @@ bool sync_disk_to_memory(SQLite3DB& admindb) {
 		err_guard.reset();
 		if (disk_cnt == 0) continue;
 
+		admindb.execute("BEGIN");
 		q = "DELETE FROM main.";
 		q += tbl;
 		admindb.execute(q.c_str());
@@ -79,6 +80,7 @@ bool sync_disk_to_memory(SQLite3DB& admindb) {
 		q += " SELECT * FROM disk.";
 		q += tbl;
 		admindb.execute(q.c_str());
+		admindb.execute("COMMIT");
 	}
 	return true;
 }
@@ -105,6 +107,7 @@ bool copy_to_runtime(SQLite3DB& admindb) {
 		err_guard.reset();
 		if (cnt == 0) continue;
 
+		admindb.execute("BEGIN");
 		q = "DELETE FROM main.";
 		q += p[1];
 		admindb.execute(q.c_str());
@@ -114,6 +117,7 @@ bool copy_to_runtime(SQLite3DB& admindb) {
 		q += " SELECT * FROM main.";
 		q += p[0];
 		admindb.execute(q.c_str());
+		admindb.execute("COMMIT");
 	}
 	return true;
 }
@@ -146,6 +150,7 @@ bool mysqlx_start() {
 		auto thr = std::make_unique<Mysqlx_Thread>();
 		thr->init(i);
 		thr->set_max_cached_connections(static_cast<size_t>(max_cached));
+		thr->set_config_store(ctx.config_store.get());
 		ctx.threads.push_back(std::move(thr));
 	}
 

--- a/plugins/mysqlx/src/mysqlx_plugin.cpp
+++ b/plugins/mysqlx/src/mysqlx_plugin.cpp
@@ -56,22 +56,8 @@ bool sync_disk_to_memory(SQLite3DB& admindb) {
 		"mysqlx_variables",
 	};
 	for (const char* tbl : tables) {
-		char* err = nullptr;
-		std::string q = "SELECT COUNT(*) FROM disk.";
-		q += tbl;
-		std::unique_ptr<SQLite3_result> disk_res(admindb.execute_statement(q.c_str(), &err));
-		std::unique_ptr<char, void(*)(void*)> err_guard(err, &free);
-		if (err) continue;
-		if (!disk_res || disk_res->rows.empty() || !disk_res->rows[0] || !disk_res->rows[0]->fields[0]) {
-			continue;
-		}
-		int disk_cnt = atoi(disk_res->rows[0]->fields[0]);
-		disk_res.reset();
-		err_guard.reset();
-		if (disk_cnt == 0) continue;
-
 		admindb.execute("BEGIN");
-		q = "DELETE FROM main.";
+		std::string q = "DELETE FROM main.";
 		q += tbl;
 		admindb.execute(q.c_str());
 
@@ -93,22 +79,8 @@ bool copy_to_runtime(SQLite3DB& admindb) {
 		{"mysqlx_variables", "runtime_mysqlx_variables"},
 	};
 	for (const auto& p : pairs) {
-		char* err = nullptr;
-		std::string q = "SELECT COUNT(*) FROM main.";
-		q += p[0];
-		std::unique_ptr<SQLite3_result> res(admindb.execute_statement(q.c_str(), &err));
-		std::unique_ptr<char, void(*)(void*)> err_guard(err, &free);
-		if (err) continue;
-		if (!res || res->rows.empty() || !res->rows[0] || !res->rows[0]->fields[0]) {
-			continue;
-		}
-		int cnt = atoi(res->rows[0]->fields[0]);
-		res.reset();
-		err_guard.reset();
-		if (cnt == 0) continue;
-
 		admindb.execute("BEGIN");
-		q = "DELETE FROM main.";
+		std::string q = "DELETE FROM main.";
 		q += p[1];
 		admindb.execute(q.c_str());
 

--- a/plugins/mysqlx/src/mysqlx_plugin.cpp
+++ b/plugins/mysqlx/src/mysqlx_plugin.cpp
@@ -48,50 +48,100 @@ bool parse_bind_addr(const std::string& bind, std::string& host, int& port) {
 	return true;
 }
 
-bool sync_disk_to_memory(SQLite3DB& admindb) {
+// Atomically replace `dest` with the rows from `source`. Every admindb.execute()
+// return value is checked: on any failure we ROLLBACK (defensively, even after a
+// failed BEGIN) and skip the table. Returns false if any step for this table
+// failed. The transaction wrap is what makes this safe — without the return
+// checks, a failed INSERT between a successful DELETE and an unconditional
+// COMMIT would silently wipe the destination.
+bool replace_table_atomically(SQLite3DB& admindb,
+                              ProxySQL_PluginServices* services,
+                              const char* dest,
+                              const char* source) {
+	auto log_err = [services](const char* msg) {
+		if (services != nullptr && services->log_message != nullptr) {
+			services->log_message(3, msg);
+		}
+	};
+
+	if (!admindb.execute("BEGIN")) {
+		std::string m = "mysqlx sync: BEGIN failed for ";
+		m += dest;
+		log_err(m.c_str());
+		return false;
+	}
+
+	std::string q = "DELETE FROM ";
+	q += dest;
+	if (!admindb.execute(q.c_str())) {
+		std::string m = "mysqlx sync: DELETE failed for ";
+		m += dest;
+		log_err(m.c_str());
+		admindb.execute("ROLLBACK");
+		return false;
+	}
+
+	q = "INSERT INTO ";
+	q += dest;
+	q += " SELECT * FROM ";
+	q += source;
+	if (!admindb.execute(q.c_str())) {
+		std::string m = "mysqlx sync: INSERT failed for ";
+		m += dest;
+		log_err(m.c_str());
+		admindb.execute("ROLLBACK");
+		return false;
+	}
+
+	if (!admindb.execute("COMMIT")) {
+		std::string m = "mysqlx sync: COMMIT failed for ";
+		m += dest;
+		log_err(m.c_str());
+		// Defensive — COMMIT may have partially succeeded; best-effort ROLLBACK.
+		admindb.execute("ROLLBACK");
+		return false;
+	}
+	return true;
+}
+
+bool sync_disk_to_memory(SQLite3DB& admindb, ProxySQL_PluginServices* services) {
 	const char* tables[] = {
 		"mysqlx_users",
 		"mysqlx_routes",
 		"mysqlx_backend_endpoints",
 		"mysqlx_variables",
 	};
+	bool all_ok = true;
 	for (const char* tbl : tables) {
-		admindb.execute("BEGIN");
-		std::string q = "DELETE FROM main.";
-		q += tbl;
-		admindb.execute(q.c_str());
-
-		q = "INSERT INTO main.";
-		q += tbl;
-		q += " SELECT * FROM disk.";
-		q += tbl;
-		admindb.execute(q.c_str());
-		admindb.execute("COMMIT");
+		std::string dest = "main.";
+		dest += tbl;
+		std::string source = "disk.";
+		source += tbl;
+		if (!replace_table_atomically(admindb, services, dest.c_str(), source.c_str())) {
+			all_ok = false;
+		}
 	}
-	return true;
+	return all_ok;
 }
 
-bool copy_to_runtime(SQLite3DB& admindb) {
+bool copy_to_runtime(SQLite3DB& admindb, ProxySQL_PluginServices* services) {
 	const char* pairs[][2] = {
 		{"mysqlx_users", "runtime_mysqlx_users"},
 		{"mysqlx_routes", "runtime_mysqlx_routes"},
 		{"mysqlx_backend_endpoints", "runtime_mysqlx_backend_endpoints"},
 		{"mysqlx_variables", "runtime_mysqlx_variables"},
 	};
+	bool all_ok = true;
 	for (const auto& p : pairs) {
-		admindb.execute("BEGIN");
-		std::string q = "DELETE FROM main.";
-		q += p[1];
-		admindb.execute(q.c_str());
-
-		q = "INSERT INTO main.";
-		q += p[1];
-		q += " SELECT * FROM main.";
-		q += p[0];
-		admindb.execute(q.c_str());
-		admindb.execute("COMMIT");
+		std::string dest = "main.";
+		dest += p[1];
+		std::string source = "main.";
+		source += p[0];
+		if (!replace_table_atomically(admindb, services, dest.c_str(), source.c_str())) {
+			all_ok = false;
+		}
 	}
-	return true;
+	return all_ok;
 }
 
 bool mysqlx_start() {
@@ -100,8 +150,8 @@ bool mysqlx_start() {
 	if (ctx.services != nullptr && ctx.services->get_admindb != nullptr) {
 		SQLite3DB* admindb = ctx.services->get_admindb();
 		if (admindb != nullptr) {
-			sync_disk_to_memory(*admindb);
-			copy_to_runtime(*admindb);
+			sync_disk_to_memory(*admindb, ctx.services);
+			copy_to_runtime(*admindb, ctx.services);
 
 			std::string err;
 			if (!ctx.config_store->load_from_runtime(*admindb, err)) {

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -717,7 +717,7 @@ void MysqlxSession::handler_connecting_server() {
 
 		if (credential_lookup_) {
 			MysqlxCredentials creds = credential_lookup_(username_);
-			backend_conn_->set_backend_password(creds.password_hash.c_str());
+			backend_conn_->set_backend_password(creds.backend_password.c_str());
 		}
 	}
 

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -1,4 +1,6 @@
 #include "mysqlx_thread.h"
+#include "mysqlx_config_store.h"
+#include "mysqlx_protocol.h"
 
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -32,7 +34,7 @@ Mysqlx_Thread::Mysqlx_Thread()
 	, max_cached_(100)
 	, max_sessions_(10000)
 	, signal_pipe_{-1, -1}
-	, curtime_(0) {
+	, config_store_(nullptr), curtime_(0) {
 }
 
 Mysqlx_Thread::~Mysqlx_Thread() {
@@ -218,6 +220,28 @@ void Mysqlx_Thread::accept_new_connection(int listener_fd) {
 		MysqlxSession* sess = new MysqlxSession();
 		sess->init(client_fd, this);
 		sess->to_process = true;
+
+		const MysqlxConfigStore* store = config_store_;
+		sess->set_credential_lookup([store](const std::string& username) -> MysqlxCredentials {
+			MysqlxCredentials creds {};
+			if (!store) return creds;
+			auto identity = store->resolve_identity(username);
+			if (!identity) return creds;
+			creds.x_enabled = identity->x_enabled;
+			creds.allowed_auth = identity->allowed_auth_methods;
+			creds.backend_password = identity->backend_password;
+			const std::string& pwd = identity->password;
+			if (!pwd.empty() && pwd[0] == '*') {
+				std::vector<uint8_t> hash_bytes;
+				if (mysqlx_hex_decode(pwd.substr(1), hash_bytes) && hash_bytes.size() == 20) {
+					creds.password_hash.assign(hash_bytes.begin(), hash_bytes.end());
+				}
+			} else if (!pwd.empty()) {
+				auto hash = mysqlx_mysql41_hash(pwd);
+				creds.password_hash.assign(hash.begin(), hash.end());
+			}
+			return creds;
+		});
 
 		std::lock_guard<std::mutex> lock(sessions_mutex_);
 		sessions_.push_back(sess);

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -524,8 +524,8 @@ mysqlx_credential_verify_unit-t: mysqlx_credential_verify_unit-t.cpp $(PROXYSQL_
 		$(IDIRS) $(LDIRS) $(OPT) $(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) \
 		$(MYLIBS) -lprotobuf -lssl -lcrypto $(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_robustness_unit-t: mysqlx_robustness_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_session.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_data_stream.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_connection.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_thread.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_protocol.cpp $(MYSQLX_PROTO_OBJS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_session.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_data_stream.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_connection.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_thread.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_protocol.cpp $(MYSQLX_PROTO_OBJS) $(TEST_HELPERS_OBJ) \
+mysqlx_robustness_unit-t: mysqlx_robustness_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_session.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_data_stream.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_connection.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_thread.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_protocol.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(MYSQLX_PROTO_OBJS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_session.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_data_stream.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_connection.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_thread.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_protocol.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(MYSQLX_PROTO_OBJS) $(TEST_HELPERS_OBJ) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include -I$(MYSQLX_PROTO_DIR) \
 		$(IDIRS) $(LDIRS) $(OPT) $(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) \
 		$(MYLIBS) -lprotobuf -lssl -lcrypto $(ALLOW_MULTI_DEF) -lpthread -o $@

--- a/test/tap/tests/unit/mysqlx_robustness_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_robustness_unit-t.cpp
@@ -1,6 +1,7 @@
 #include "mysqlx_session.h"
 #include "mysqlx_protocol.h"
 #include "mysqlx_thread.h"
+#include "sqlite3db.h"
 #include "tap.h"
 #include "test_globals.h"
 #include "test_init.h"
@@ -566,8 +567,57 @@ static void test_forward_empty_frame() {
 	close(backend_fds[0]); close(backend_fds[1]);
 }
 
+// Mirrors the atomic replace sequence used by sync_disk_to_memory() /
+// copy_to_runtime() in plugins/mysqlx/src/mysqlx_plugin.cpp. Kept in the
+// test to exercise the invariant that an empty source table overwrites a
+// populated destination — the skip (if count==0) that used to guard this
+// was a correctness bug that left stale rows in main.* across restarts.
+static bool replace_table_contents(SQLite3DB& db,
+                                   const char* dest_table,
+                                   const char* source_table) {
+	db.execute("BEGIN");
+	std::string q = "DELETE FROM ";
+	q += dest_table;
+	db.execute(q.c_str());
+
+	q = "INSERT INTO ";
+	q += dest_table;
+	q += " SELECT * FROM ";
+	q += source_table;
+	db.execute(q.c_str());
+	db.execute("COMMIT");
+	return true;
+}
+
+static void test_empty_source_clears_stale_dest() {
+	SQLite3DB db;
+	db.open(const_cast<char*>(":memory:"),
+	        SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
+
+	db.execute("CREATE TABLE src (id INT PRIMARY KEY, name VARCHAR)");
+	db.execute("CREATE TABLE dst (id INT PRIMARY KEY, name VARCHAR)");
+
+	// Dest starts with stale rows; source is empty. This is exactly the
+	// scenario the old `if (count == 0) continue;` mishandled — after
+	// restart, sync_disk_to_memory would see disk count==0, skip, and
+	// leave the stale rows in main.*.
+	db.execute("INSERT INTO dst (id, name) VALUES (1, 'stale_a')");
+	db.execute("INSERT INTO dst (id, name) VALUES (2, 'stale_b')");
+
+	int src_cnt = db.return_one_int("SELECT COUNT(*) FROM src");
+	int dst_cnt_before = db.return_one_int("SELECT COUNT(*) FROM dst");
+	ok(src_cnt == 0 && dst_cnt_before == 2,
+	   "precondition: empty source, 2 stale rows in dest");
+
+	replace_table_contents(db, "dst", "src");
+
+	int dst_cnt_after = db.return_one_int("SELECT COUNT(*) FROM dst");
+	ok(dst_cnt_after == 0,
+	   "empty source overwrites stale dest (dest is empty after replace)");
+}
+
 int main() {
-	plan(33);
+	plan(35);
 
 	test_server_response_terminal_frame();
 	test_server_response_non_terminal_keeps_waiting();
@@ -582,6 +632,7 @@ int main() {
 	test_connection_limit_config();
 	test_client_disconnect_detected();
 	test_forward_empty_frame();
+	test_empty_source_clears_stale_dest();
 
 	return exit_status();
 }

--- a/test/tap/tests/unit/mysqlx_robustness_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_robustness_unit-t.cpp
@@ -572,20 +572,37 @@ static void test_forward_empty_frame() {
 // test to exercise the invariant that an empty source table overwrites a
 // populated destination — the skip (if count==0) that used to guard this
 // was a correctness bug that left stale rows in main.* across restarts.
+//
+// The signature/semantics match the production replace_table_atomically():
+// every execute() return is checked, a failure at any step triggers ROLLBACK
+// and the function returns false. This preserves the destination's
+// pre-transaction state when the INSERT fails — the atomicity guarantee the
+// transaction wrap is supposed to deliver.
 static bool replace_table_contents(SQLite3DB& db,
                                    const char* dest_table,
                                    const char* source_table) {
-	db.execute("BEGIN");
+	if (!db.execute("BEGIN")) {
+		return false;
+	}
 	std::string q = "DELETE FROM ";
 	q += dest_table;
-	db.execute(q.c_str());
+	if (!db.execute(q.c_str())) {
+		db.execute("ROLLBACK");
+		return false;
+	}
 
 	q = "INSERT INTO ";
 	q += dest_table;
 	q += " SELECT * FROM ";
 	q += source_table;
-	db.execute(q.c_str());
-	db.execute("COMMIT");
+	if (!db.execute(q.c_str())) {
+		db.execute("ROLLBACK");
+		return false;
+	}
+	if (!db.execute("COMMIT")) {
+		db.execute("ROLLBACK");
+		return false;
+	}
 	return true;
 }
 
@@ -616,8 +633,46 @@ static void test_empty_source_clears_stale_dest() {
 	   "empty source overwrites stale dest (dest is empty after replace)");
 }
 
+// Verifies that when INSERT fails mid-transaction, the DELETE is rolled back
+// and the destination retains its pre-transaction contents. Without the
+// execute()-return checks added by this follow-up, the unconditional COMMIT
+// would persist the DELETE and silently wipe the destination.
+static void test_insert_failure_rolls_back() {
+	SQLite3DB db;
+	db.open(const_cast<char*>(":memory:"),
+	        SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
+
+	// src has odd ids; dst has a CHECK that requires even ids. The INSERT
+	// will fail at the first odd value, leaving the transaction needing
+	// ROLLBACK to preserve the stale rows we seeded into dst.
+	db.execute("CREATE TABLE src (id INT PRIMARY KEY)");
+	db.execute("CREATE TABLE dst (id INT PRIMARY KEY CHECK (id % 2 = 0))");
+
+	db.execute("INSERT INTO src (id) VALUES (1)");
+	db.execute("INSERT INTO src (id) VALUES (3)");
+
+	db.execute("INSERT INTO dst (id) VALUES (10)");
+	db.execute("INSERT INTO dst (id) VALUES (20)");
+
+	int dst_cnt_before = db.return_one_int("SELECT COUNT(*) FROM dst");
+	ok(dst_cnt_before == 2,
+	   "precondition: dst has 2 pre-existing rows");
+
+	bool ok_return = replace_table_contents(db, "dst", "src");
+	ok(ok_return == false,
+	   "replace_table_contents returns false when INSERT violates CHECK");
+
+	int dst_cnt_after = db.return_one_int("SELECT COUNT(*) FROM dst");
+	ok(dst_cnt_after == 2,
+	   "dst still has 2 rows after failed INSERT (DELETE was rolled back)");
+
+	int dst_sum = db.return_one_int("SELECT COALESCE(SUM(id), 0) FROM dst");
+	ok(dst_sum == 30,
+	   "dst retains original rows (sum=30), not the invalid odd ids from src");
+}
+
 int main() {
-	plan(35);
+	plan(39);
 
 	test_server_response_terminal_frame();
 	test_server_response_non_terminal_keeps_waiting();
@@ -633,6 +688,7 @@ int main() {
 	test_client_disconnect_detected();
 	test_forward_empty_frame();
 	test_empty_source_clears_stale_dest();
+	test_insert_failure_rolls_back();
 
 	return exit_status();
 }


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the mysqlx plugin's startup-time sync helpers. `sync_disk_to_memory` and `copy_to_runtime` in `plugins/mysqlx/src/mysqlx_plugin.cpp` were early-exiting when the source table had zero rows, which would leave stale data in the destination table.

- Removed the `if (disk_cnt == 0) continue;` skip in `sync_disk_to_memory`.
- Removed the `if (cnt == 0) continue;` skip in `copy_to_runtime`.
- Removed the now-dead `SELECT COUNT(*)` pre-queries + result-unpacking that fed the skips.
- The atomic `BEGIN` / `DELETE` / `INSERT … SELECT` / `COMMIT` replace sequence is unchanged; it handles the empty-source case naturally (DELETE wipes the destination, INSERT touches zero rows, COMMIT atomically leaves the dest empty — exactly the fix intent).

## Why

If a user populated `main.mysqlx_users` (or any of the other mysqlx tables), then emptied it and saved to disk, then restarted proxysql, the old skip would see `disk.mysqlx_users count = 0`, refuse to overwrite `main.mysqlx_users`, and leave the previous rows in place. Same gap exists for the `main → runtime` copy in `copy_to_runtime`. Flagged as **Phase 4 item 4** (review item #5, narrower variant) in `docs/superpowers/plans/2026-04-17-plugin-chassis-extraction.md`.

## Test Plan

- [x] New unit test `test_empty_source_clears_stale_dest` in `test/tap/tests/unit/mysqlx_robustness_unit-t.cpp` — drives an atomic `BEGIN`/`DELETE`/`INSERT`/`COMMIT` against an in-memory `SQLite3DB` with an empty source and a pre-populated dest. Asserts the dest is empty after the replace.
- [x] Assertion count: 33 → 35 on this branch (`./mysqlx_robustness_unit-t` reports 35 ok, 0 fail).
- [x] No behavior change for the happy-path case (source has rows → existing atomic replace still runs).

## Why the test uses a local SQLite3DB directly

`sync_disk_to_memory` and `copy_to_runtime` are in an anonymous namespace in `mysqlx_plugin.cpp`, so they can't be called from a unit test. The test reconstructs the same atomic sequence directly against `SQLite3DB` — line-for-line mirror of the production path — so the test is faithful to what the production code does while remaining pointed at the invariant the bug affected.

## Scope noise

One pre-existing build gap was fixed alongside: `test/tap/tests/unit/Makefile` for `mysqlx_robustness_unit-t` didn't list `mysqlx_config_store.cpp` as a link input, even though `mysqlx_thread.cpp` now calls `MysqlxConfigStore::resolve_identity()`. Surfaced while validating this fix, called out in the commit body. Same ripple as seen in #5641.

## Explicitly out of scope

- `replace_table_contents` itself — its atomicity is pre-existing.
- The admin-schema `copy_table` path — original reviewer flagged this as "the admin-schema load path is not the one with this bug"; it's already unconditional.
- Any wider refactor of the startup sync flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing resolved backend passwords in identity resolution
  * Non-blocking connection readiness probing for improved connection responsiveness

* **Bug Fixes**
  * More accurate SSL pending-write detection
  * Atomic replace-and-rollback behavior for configuration sync/copy operations
  * Use of backend password during credential lookup for authentication

* **Tests**
  * Added unit tests covering table-replace behavior and rollback on insert failure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->