### PR TITLE
ci: fix expired MySQL APT GPG key (B7B3B788A8D3785C)

### DIFF
--- a/.github/workflows/ci-taptests-asan.yml
+++ b/.github/workflows/ci-taptests-asan.yml
@@ -117,7 +117,8 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
+        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
         sudo apt-get update -y

--- a/.github/workflows/ci-taptests-groups.yml
+++ b/.github/workflows/ci-taptests-groups.yml
@@ -132,7 +132,8 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
+        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
         sudo apt-get update -y

--- a/.github/workflows/ci-taptests-old.yml
+++ b/.github/workflows/ci-taptests-old.yml
@@ -29,7 +29,8 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
+        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
         sudo apt-get update -y

--- a/.github/workflows/ci-taptests-ssl.yml
+++ b/.github/workflows/ci-taptests-ssl.yml
@@ -95,7 +95,8 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
+        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
         sudo apt-get update -y

--- a/.github/workflows/ci-taptests.yml
+++ b/.github/workflows/ci-taptests.yml
@@ -114,7 +114,8 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
+        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
         sudo apt-get update -y


### PR DESCRIPTION
## Summary

\`keyserver.ubuntu.com\` still returns the **expired** copy of MySQL's signing key \`BCA43417C3B485DD128EC6D4B7B3B788A8D3785C\`, so every CI job that installs from \`repo.mysql.com\` on jammy currently fails at \`apt-get update\` with:

\`\`\`
W: GPG error: http://repo.mysql.com/apt/ubuntu jammy InRelease: The following
   signatures were invalid: EXPKEYSIG B7B3B788A8D3785C
   MySQL Release Engineering <mysql-build@oss.oracle.com>
E: The repository 'http://repo.mysql.com/apt/ubuntu jammy InRelease' is not signed.
##[error]Process completed with exit code 100.
\`\`\`

MySQL re-signed the key with the same fingerprint and now publishes the renewed copy as \`RPM-GPG-KEY-mysql-2025\` (rsa4096, valid through **2027-10-23**). Fetch it directly from \`repo.mysql.com\` instead of the Ubuntu keyserver.

## Files changed (5)

All five reusable \`ci-taptests*\` workflows had the same broken line. Replaced:

\`\`\`bash
sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
\`\`\`

with:

\`\`\`bash
wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
\`\`\`

- \`.github/workflows/ci-taptests.yml\`
- \`.github/workflows/ci-taptests-asan.yml\`
- \`.github/workflows/ci-taptests-groups.yml\`
- \`.github/workflows/ci-taptests-old.yml\`
- \`.github/workflows/ci-taptests-ssl.yml\`

The \`467B942D3A79BD29\` line is untouched — that key is unrelated to the current failure.

## Why not \`apt-key\` → \`trusted.gpg.d\`?

\`apt-key\` is deprecated on Ubuntu 22+, but modernizing these workflows is a bigger scope change (needs \`gpg --dearmor\` + \`[signed-by=...]\` on the sources.list entry). This PR keeps the change surgical: swap the key source, nothing else.

## Test plan
- [ ] Merge and confirm \`CI-taptests-groups\`, \`CI-taptests-asan\`, \`CI-taptests-ssl\`, \`CI-taptests-old\`, and \`CI-taptests\` no longer fail at \`Install dependencies\`
- [ ] \`apt-cache policy mysql-shell\` surfaces candidates (verifies the repo is trusted post-update)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/build infrastructure to use refreshed security keys for MySQL repository verification across build pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->