### PR TITLE
ci: overwrite the expired key that mysql-apt-config.postinst installs

### DIFF
--- a/.github/workflows/ci-taptests-asan.yml
+++ b/.github/workflows/ci-taptests-asan.yml
@@ -117,10 +117,13 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
-        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
+        # mysql-apt-config.postinst writes an expired signing key into the
+        # keyring referenced by sources.list.d/mysql.list (signed-by=...).
+        # Overwrite with the renewed key (same fingerprint, valid through
+        # 2027-10-23) so apt-get update trusts the InRelease signature.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo gpg --dearmor --yes -o /usr/share/keyrings/mysql-apt-config.gpg
         sudo apt-get update -y
         sudo apt-cache policy mysql-shell
         sudo apt-get install -y mysql-shell

--- a/.github/workflows/ci-taptests-groups.yml
+++ b/.github/workflows/ci-taptests-groups.yml
@@ -132,10 +132,13 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
-        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
+        # mysql-apt-config.postinst writes an expired signing key into the
+        # keyring referenced by sources.list.d/mysql.list (signed-by=...).
+        # Overwrite with the renewed key (same fingerprint, valid through
+        # 2027-10-23) so apt-get update trusts the InRelease signature.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo gpg --dearmor --yes -o /usr/share/keyrings/mysql-apt-config.gpg
         sudo apt-get update -y
         sudo apt-cache policy mysql-shell
         sudo apt-get install -y mysql-shell

--- a/.github/workflows/ci-taptests-old.yml
+++ b/.github/workflows/ci-taptests-old.yml
@@ -29,10 +29,13 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
-        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
+        # mysql-apt-config.postinst writes an expired signing key into the
+        # keyring referenced by sources.list.d/mysql.list (signed-by=...).
+        # Overwrite with the renewed key (same fingerprint, valid through
+        # 2027-10-23) so apt-get update trusts the InRelease signature.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo gpg --dearmor --yes -o /usr/share/keyrings/mysql-apt-config.gpg
         sudo apt-get update -y
         sudo apt-cache policy mysql-shell
         sudo apt-get install -y mysql-shell

--- a/.github/workflows/ci-taptests-ssl.yml
+++ b/.github/workflows/ci-taptests-ssl.yml
@@ -95,10 +95,13 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
-        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
+        # mysql-apt-config.postinst writes an expired signing key into the
+        # keyring referenced by sources.list.d/mysql.list (signed-by=...).
+        # Overwrite with the renewed key (same fingerprint, valid through
+        # 2027-10-23) so apt-get update trusts the InRelease signature.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo gpg --dearmor --yes -o /usr/share/keyrings/mysql-apt-config.gpg
         sudo apt-get update -y
         sudo apt-cache policy mysql-shell
         sudo apt-get install -y mysql-shell

--- a/.github/workflows/ci-taptests.yml
+++ b/.github/workflows/ci-taptests.yml
@@ -114,10 +114,13 @@ jobs:
         sudo dpkg -i orchestrator-client_3.2.6_amd64.deb
         
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
-        # Ubuntu keyserver serves the expired B7B3B788A8D3785C; fetch renewed key from MySQL.
-        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo apt-key add -
         wget https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.29-1_all.deb
+        # mysql-apt-config.postinst writes an expired signing key into the
+        # keyring referenced by sources.list.d/mysql.list (signed-by=...).
+        # Overwrite with the renewed key (same fingerprint, valid through
+        # 2027-10-23) so apt-get update trusts the InRelease signature.
+        wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | sudo gpg --dearmor --yes -o /usr/share/keyrings/mysql-apt-config.gpg
         sudo apt-get update -y
         sudo apt-cache policy mysql-shell
         sudo apt-get install -y mysql-shell


### PR DESCRIPTION
## Summary

Follow-up to #5648. That PR fetched the renewed \`RPM-GPG-KEY-mysql-2025\` via \`apt-key add -\`, which writes to \`/etc/apt/trusted.gpg\`. But \`mysql-apt-config\`'s generated \`/etc/apt/sources.list.d/mysql.list\` uses \`[signed-by=/usr/share/keyrings/mysql-apt-config.gpg]\`, so apt ignored our renewed key. Build-time evidence on the v3.0 PR run (25c8fd16/deb1cbe9) showed the renewed key imported fine but apt still rejected the InRelease signature as expired.

## Root cause

\`mysql-apt-config_0.8.29-1_all.deb\` carries an embedded ASCII-armored key block inside its \`postinst\`. That \`postinst\` dearmors it into \`/usr/share/keyrings/mysql-apt-config.gpg\`, which is precisely the keyring \`mysql.list\` trusts via \`signed-by=\`. The embedded copy is \`2023-10-23 [expired: 2025-10-22]\` — same fingerprint \`BCA43417...A8D3785C\`, but the expired body, matching exactly what \`repo.mysql.com/RPM-GPG-KEY-mysql-2023\` publishes. The renewed body (valid through \`2027-10-23\`) is at \`repo.mysql.com/RPM-GPG-KEY-mysql-2025\`.

Verification on the build host:

\`\`\`
$ dpkg-deb -R mysql-apt-config_0.8.29-1_all.deb extracted
$ grep -n "mQINBGU2rNoB" extracted/DEBIAN/postinst
25:mQINBGU2rNoBEACSi5t0nL6/Hj3d0PwsbdnbY+SqLUIZ3uWZQm6tsNhvTnahvPPZ
$ curl -sS https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 | gpg --show-keys
pub   rsa4096 2023-10-23 [SC] [expired: 2025-10-22]
      BCA4 3417 C3B4 85DD 128E C6D4 B7B3 B788 A8D3 785C
$ curl -sS https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | gpg --show-keys
pub   rsa4096 2023-10-23 [SC] [expires: 2027-10-23]
      BCA4 3417 C3B4 85DD 128E C6D4 B7B3 B788 A8D3 785C
\`\`\`

## Fix

Run the renewed-key refresh **after** \`dpkg -i mysql-apt-config...\` and write directly to the keyring \`mysql.list\` trusts:

\`\`\`bash
wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 \\
  | sudo gpg --dearmor --yes -o /usr/share/keyrings/mysql-apt-config.gpg
\`\`\`

The \`apt-key add -\` step from #5648 is removed; the \`apt-key adv --recv-keys 467B942D3A79BD29\` line is untouched (unrelated key).

## Files changed (5)

Same workflows as #5648: \`ci-taptests.yml\`, \`ci-taptests-asan.yml\`, \`ci-taptests-groups.yml\`, \`ci-taptests-old.yml\` (only the jammy 0.8.29 block — 0.8.24 block kept as-is), \`ci-taptests-ssl.yml\`.

## Test plan
- [ ] Merge, then retrigger CI on PR #5647 and confirm \`CI-taptests-groups\` no longer fails at \`Install dependencies\`
- [ ] Check \`apt-cache policy mysql-shell\` shows candidates (repo trusted post-update)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configurations to modernize MySQL repository key installation procedures. Changes ensure consistent and secure handling of repository authentication across all continuous integration pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->