### PR TITLE
Add Contributor License Agreement (ICLA + CCLA)

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,262 @@
+# ProxySQL Contributor License Agreement
+
+This document sets out the Contributor License Agreement (CLA) that every
+contributor to the ProxySQL project must agree to before their pull request
+can be merged.
+
+It is published in two versions:
+
+- [Individual CLA](#individual-contributor-license-agreement) — for contributions made in your personal capacity.
+- [Corporate CLA](#corporate-contributor-license-agreement) — for contributions made on behalf of an employer or other legal entity.
+
+You only need to sign the variant that applies to you. If your employer owns
+the intellectual property in code you write, either you need your employer to
+sign the Corporate CLA, or you need a written waiver from them permitting you
+to sign the Individual CLA.
+
+## How to sign
+
+Signing is automated via [CLA assistant](https://cla-assistant.io/). When you
+open your first pull request against this repository the CLA assistant bot
+will comment with a link; click it, review the text, and confirm in the
+browser. Once you have signed, the bot records your signature and future pull
+requests do not require another click.
+
+You do not need to send a signed PDF, email anyone, or attach the CLA to your
+PR.
+
+## Background and acknowledgement
+
+The text below is adapted from the [Apache Software Foundation Individual
+Contributor License Agreement V2.2](https://www.apache.org/licenses/icla.pdf)
+and [Software Grant and Corporate Contributor License Agreement
+(r190612)](https://www.apache.org/licenses/cla-corporate.pdf). It has been
+modified in the following ways:
+
+- "The Apache Software Foundation" has been replaced throughout with
+  **ProxySQL LLC** (the legal entity that owns the ProxySQL project).
+- References to Apache-specific nonprofit/public-benefit obligations, Apache
+  IDs, Apache mailing lists, and the Apache privacy policy have been removed
+  or adapted.
+- The submission instructions (email a signed PDF to `secretary@apache.org`)
+  have been removed; signing is handled by the CLA assistant flow described
+  above.
+- Form fields for residence, telephone, etc. have been removed; identity and
+  contact information are captured by CLA assistant from your GitHub account.
+
+Outside of the above, the substance of the license grants, definitions, and
+representations is preserved from the Apache templates.
+
+---
+
+## Individual Contributor License Agreement
+
+Thank you for your interest in ProxySQL LLC (the "Company"). In order to
+clarify the intellectual property license granted with Contributions from any
+person or entity, the Company must have on file a signed Contributor License
+Agreement (the "Agreement") from each Contributor, indicating agreement with
+the license terms below. This Agreement is for your protection as a
+Contributor as well as the protection of the Company and its users. It does
+not change your rights to use your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your
+Contributions (present and future) that you submit to the Company. Except
+for the license granted herein to the Company and recipients of software
+distributed by the Company, You reserve all right, title, and interest in and
+to Your Contributions.
+
+### 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with the Company. For
+legal entities, the entity making a Contribution and all other entities that
+control, are controlled by, or are under common control with that entity are
+considered to be a single Contributor. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii)
+ownership of fifty percent (50%) or more of the outstanding shares, or (iii)
+beneficial ownership of such entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to the Company for inclusion in, or documentation of, any
+of the products owned or managed by the Company (the "Work"). For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Company or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed by,
+or on behalf of, the Company for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+the Company and to recipients of software distributed by the Company a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly
+display, publicly perform, sublicense, and distribute Your Contributions and
+such derivative works.
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+the Company and to recipients of software distributed by the Company a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of
+Your Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or any
+other entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that your Contribution, or the Work to which you have contributed,
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this Agreement for that Contribution
+or Work shall terminate as of the date such litigation is filed.
+
+### 4. Employer rights
+
+You represent that you are legally entitled to grant the above license. If
+your employer(s) has rights to intellectual property that you create that
+includes your Contributions, you represent that you have received permission
+to make Contributions on behalf of that employer, that your employer has
+waived such rights for your Contributions to the Company, or that your
+employer has executed a separate Corporate CLA with the Company.
+
+### 5. Original creation
+
+You represent that each of Your Contributions is Your original creation
+(see section 7 for submissions on behalf of others). You represent that
+Your Contribution submissions include complete details of any third-party
+license or other restriction (including, but not limited to, related patents
+and trademarks) of which you are personally aware and which are associated
+with any part of Your Contributions.
+
+### 6. Support and warranty disclaimer
+
+You are not expected to provide support for Your Contributions, except to
+the extent You desire to provide support. You may provide support for free,
+for a fee, or not at all. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### 7. Submissions on behalf of others
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Company separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking
+the work as "Submitted on behalf of a third-party: [named here]".
+
+### 8. Notification of changes
+
+You agree to notify the Company of any facts or circumstances of which you
+become aware that would make these representations inaccurate in any
+respect.
+
+---
+
+## Corporate Contributor License Agreement
+
+This version of the Agreement allows an entity (the "Corporation") to submit
+Contributions to ProxySQL LLC (the "Company"), to authorize Contributions
+submitted by its designated employees to the Company, and to grant copyright
+and patent licenses thereto.
+
+You accept and agree to the following terms and conditions for Your present
+and future Contributions submitted to the Company. Except for the license
+granted herein to the Company and recipients of software distributed by the
+Company, You reserve all right, title, and interest in and to Your
+Contributions.
+
+### 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with the Company. For
+legal entities, the entity making a Contribution and all other entities
+that control, are controlled by, or are under common control with that
+entity are considered to be a single Contributor. For the purposes of this
+definition, "control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or otherwise,
+or (ii) ownership of fifty percent (50%) or more of the outstanding shares,
+or (iii) beneficial ownership of such entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to the Company for inclusion in, or documentation of, any
+of the products owned or managed by the Company (the "Work"). For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Company or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed
+by, or on behalf of, the Company for the purpose of discussing and
+improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by You as "Not a Contribution."
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+the Company and to recipients of software distributed by the Company a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly
+display, publicly perform, sublicense, and distribute Your Contributions
+and such derivative works.
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+the Company and to recipients of software distributed by the Company a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of
+Your Contribution(s) with the Work to which such Contribution(s) were
+submitted. If any entity institutes patent litigation against You or any
+other entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that your Contribution, or the Work to which you have contributed,
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this Agreement for that Contribution
+or Work shall terminate as of the date such litigation is filed.
+
+### 4. Authority to grant and designate contributors
+
+You represent that You are legally entitled to grant the above license. You
+represent further that each employee of the Corporation authorized to
+submit Contributions on behalf of the Corporation has been identified to
+the Company (through the CLA assistant signing flow) as such, and is
+authorized to submit Contributions on behalf of the Corporation.
+
+### 5. Original creation
+
+You represent that each of Your Contributions is Your original creation
+(see section 7 for submissions on behalf of others).
+
+### 6. Support and warranty disclaimer
+
+You are not expected to provide support for Your Contributions, except to
+the extent You desire to provide support. You may provide support for free,
+for a fee, or not at all. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### 7. Submissions on behalf of others
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Company separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking
+the work as "Submitted on behalf of a third-party: [named here]".
+
+### 8. Notification of changes
+
+It is your responsibility to notify the Company when any change is required
+to the list of employees authorized to submit Contributions on behalf of
+the Corporation, or to the Corporation's Point of Contact with the Company.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,17 @@ Check existing issues: Someone might already be working on something similar.
 
 Reference issues: When fixing bugs or implementing requested features, mention the issue number in your PR.
 
+## Contributor License Agreement (CLA)
+
+Before we can merge your pull request you must agree to the [ProxySQL Contributor License Agreement](.github/CLA.md).
+
+Signing is automated: when you open your first PR, the [CLA assistant](https://cla-assistant.io/) bot comments with a link. Click it, review the agreement, and confirm — the signature is recorded and applies to all of your future contributions. No PDF, no email.
+
+Two variants exist in the same document:
+
+- **Individual CLA** — default, for contributions you make personally.
+- **Corporate CLA** — for contributions made on behalf of an employer. If your employer owns the IP in code you write, your employer must sign the Corporate CLA (or give you a written waiver so you can sign the Individual CLA).
+
 ## Development Setup
 
 ProxySQL provides Docker build images for development. The required packages for building are listed in the Dockerfiles at: https://github.com/ProxySQL/docker-images/tree/main/build-images


### PR DESCRIPTION
## Summary

Introduces `.github/CLA.md` (Individual + Corporate CLA) and extends `CONTRIBUTING.md` with a CLA section that describes the [CLA assistant](https://cla-assistant.io/) signing flow. This is the code/docs half of setting up CLA assistant on `sysown/proxysql`; see **Activation steps** below for the one-time browser work.

## What's in the CLA

Adapted from the Apache Software Foundation's templates:

- Individual CLA: Apache ICLA **V2.2** (https://www.apache.org/licenses/icla.pdf)
- Corporate CLA: Apache Software Grant and Corporate CLA **r190612** (https://www.apache.org/licenses/cla-corporate.pdf)

Modifications:

| Apache original | ProxySQL adaptation |
|---|---|
| "The Apache Software Foundation" / "the Foundation" | "ProxySQL LLC" / "the Company" |
| "Foundation shall not use Your Contributions ... contrary to the public benefit or inconsistent with its nonprofit status and bylaws" | Removed — ProxySQL LLC is a commercial entity. Reservation reduces to the simpler wording already present in the next sentence. |
| PDF form fields (full name, address, phone, etc.) | Removed — identity captured by CLA assistant from the contributor's GitHub account. |
| "email a pdf copy to secretary@apache.org" | Removed — signing is handled by the bot. |
| Apache IDs, Apache mailing list references, Apache privacy-policy link | Removed. |
| Schedule A/B (employee list, concurrent software grant) | Absorbed into prose — CCLA §4 references the CLA-assistant flow for designating employees. |

The substance of the **license grants**, **definitions**, and **representations** is preserved verbatim.

## Files changed

- `.github/CLA.md` — new file. ~270 lines. Contains both ICLA and CCLA in a single document.
- `CONTRIBUTING.md` — added a "Contributor License Agreement (CLA)" section right after "Before You Start", linking to `.github/CLA.md` and describing the bot flow.

## Activation steps (after merge)

These need to be done once by a `sysown` org admin in the browser — they can't be done in code:

1. Sign in to https://cla-assistant.io with your GitHub admin account.
2. Authorize CLA assistant for the `sysown` org (or at least `sysown/proxysql`).
3. Click "Configure CLA", select `sysown/proxysql`, and paste the raw URL:
   `https://github.com/sysown/proxysql/blob/v3.0/.github/CLA.md`
   (or a gist URL if you'd rather decouple the text from the repo).
4. Save. The bot will start commenting on new PRs immediately.

No workflow file or webhook setup is required — CLA assistant is a GitHub App and hooks its own PR events.

## Legal review recommended

I adapted the Apache templates mechanically but I'm not a lawyer. Before enforcing the CLA on real PRs, a ProxySQL-side reviewer should confirm:

- "ProxySQL LLC" is the correct legal entity name (US LLC? different jurisdiction? parent company?)
- Removing the nonprofit-reservation clause is acceptable, or substitute a commercial-equivalent protection.
- The GPLv3 outbound license is compatible with the permissive copyright grant being sought here (it is — this is the standard pattern — but worth double-checking).

## Test plan
- [ ] Legal review of CLA.md
- [ ] Merge this PR
- [ ] Complete the activation steps above
- [ ] Open a test PR from a separate account to verify the bot comments and the signing flow works end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Contributor License Agreement (CLA) requirements for all contributors. Contributors must sign the agreement before PR merge. Two CLA variants available: Individual (for personal contributions) and Corporate (for employer-represented contributions). Signing is automated via CLA assistant bot upon first PR submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->