### PR TITLE
ci: add reusable workflow for mysql56-single-g1

### DIFF
--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -1,0 +1,137 @@
+name: CI-mysql56-single-g1
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+
+env:
+  SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # 'mysql56' here is cosmetic: it feeds the 'MATRIX' env below which is
+        # interpolated into the check-run display name so reviewers see
+        # 'CI-mysql56-single-g1 / tests (mysql56)' in the PR UI. The actual
+        # backend is selected by 'ensure-infras.bash' from the group's
+        # 'infras.lst' file (test/tap/groups/mysql56-single/infras.lst),
+        # which points to 'infra-dbdeployer-mysql56-single'.
+        infradb: [ 'mysql56' ]
+    env:
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
+      MATRIX: '(${{ matrix.infradb }})'
+
+    steps:
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ env.SHA }}
+        path: 'proxysql'
+        sparse-checkout: |
+          test/infra
+          test/tap/groups
+          test/scripts
+
+    - name: Cache restore src
+      id: cache-src
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ env.BLDCACHE }}
+        fail-on-cache-miss: true
+        path: |
+          proxysql/src/
+
+    - name: Cache restore test
+      id: cache-test
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        fail-on-cache-miss: true
+        path: |
+          proxysql/test/
+
+    - name: Verify binary
+      run: |
+        chmod +x proxysql/src/proxysql
+        file proxysql/src/proxysql
+
+    - name: Build CI base image
+      run: |
+        cd proxysql/test/infra/docker-base
+        docker build -t proxysql-ci-base:latest .
+
+    - name: Start infrastructure
+      run: |
+        cd proxysql
+        export INFRA_ID="ci-mysql56-single-g1"
+        export TAP_GROUP="mysql56-single-g1"
+        export SKIP_CLUSTER_START=1
+        test/infra/control/ensure-infras.bash
+
+    - name: Run mysql56-single-g1 tests
+      run: |
+        cd proxysql
+        export INFRA_ID="ci-mysql56-single-g1"
+        export TAP_GROUP="mysql56-single-g1"
+        export SKIP_CLUSTER_START=1
+        test/infra/control/run-tests-isolated.bash
+
+    - name: Cleanup
+      if: always()
+      run: |
+        set +e
+        cd proxysql
+        export INFRA_ID="ci-mysql56-single-g1"
+        export TAP_GROUP="mysql56-single-g1"
+        docker logs proxysql.ci-mysql56-single-g1 2>&1 | tail -50 || true
+        test/infra/control/stop-proxysql-isolated.bash
+        test/infra/control/destroy-infras.bash
+
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
+    - name: Archive artifacts logs
+      if: ${{ failure() && !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_*_logs/
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci-mysql56-single-g1.yml`, the reusable half of the caller/reusable pair for the new `mysql56-single-g1` TAP group introduced in #5166.
- Modelled verbatim on `ci-mysql84-g1.yml`; only the cosmetic `matrix.infradb` value and the `INFRA_ID` / `TAP_GROUP` strings differ.
- Real backend selection is handled by `ensure-infras.bash` via `test/tap/groups/mysql56-single/infras.lst` (points at `infra-dbdeployer-mysql56-single`); `matrix.infradb: [ mysql56 ]` here is display-only (feeds the check-run label).

## Landing order

Per `doc/GH-Actions/README.md` ("Adding a new test group end-to-end"), the reusable ships first on `GH-Actions`, then the caller ships on `v3.0`. The caller `CI-mysql56-single-g1.yml` is already committed on the `session-track-system-variable` branch of #5166 and becomes functional the moment this PR merges.

## Test plan

- [ ] Merge this PR to `GH-Actions`.
- [ ] Confirm `CI-mysql56-single-g1` appears in the Actions UI on the next push/PR to `v3.0` that carries the caller (via #5166 once rebased or on merge).
- [ ] Verify the check-run label reads `CI-mysql56-single-g1 / tests (mysql56)` in the PR UI.
- [ ] Confirm the job passes against the three tests registered for `mysql56-single-g1` in `groups.json`: `mysql-session_track_variables_enforced-t`, `mysql-session_track_variables_ff_mysql56-t`, `mysql-session_track_variables_optional-t`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing infrastructure for MySQL 5.6 compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->