### PR TITLE
ci: add 39 on-demand ARM64 package build workflows

### DIFF
--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux10-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux10
+      MATRIX: '(arm64,almalinux10-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux10-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux10-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux10
+      MATRIX: '(arm64,almalinux10-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux10-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux10
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux10
+      MATRIX: '(arm64,almalinux10)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux10
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux8-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux8
+      MATRIX: '(arm64,almalinux8-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux8-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux8-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux8
+      MATRIX: '(arm64,almalinux8-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux8-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux8
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux8
+      MATRIX: '(arm64,almalinux8)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux8
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux9-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux9
+      MATRIX: '(arm64,almalinux9-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux9-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux9-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux9
+      MATRIX: '(arm64,almalinux9-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux9-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-almalinux9
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: almalinux9
+      MATRIX: '(arm64,almalinux9)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-almalinux9
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-centos10-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: centos10
+      MATRIX: '(arm64,centos10-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-centos10-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-centos10-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: centos10
+      MATRIX: '(arm64,centos10-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-centos10-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-centos10
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: centos10
+      MATRIX: '(arm64,centos10)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-centos10
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-centos9-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: centos9
+      MATRIX: '(arm64,centos9-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-centos9-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-centos9-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: centos9
+      MATRIX: '(arm64,centos9-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-centos9-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-centos9
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: centos9
+      MATRIX: '(arm64,centos9)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-centos9
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-debian12-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: debian12
+      MATRIX: '(arm64,debian12-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-debian12-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-debian12-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: debian12
+      MATRIX: '(arm64,debian12-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-debian12-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-debian12
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: debian12
+      MATRIX: '(arm64,debian12)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-debian12
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-debian13-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: debian13
+      MATRIX: '(arm64,debian13-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-debian13-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-debian13-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: debian13
+      MATRIX: '(arm64,debian13-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-debian13-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-debian13
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: debian13
+      MATRIX: '(arm64,debian13)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-debian13
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-fedora42-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora42
+      MATRIX: '(arm64,fedora42-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-fedora42-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-fedora42-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora42
+      MATRIX: '(arm64,fedora42-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-fedora42-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-fedora42
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora42
+      MATRIX: '(arm64,fedora42)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-fedora42
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-fedora43-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora43
+      MATRIX: '(arm64,fedora43-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-fedora43-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-fedora43-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora43
+      MATRIX: '(arm64,fedora43-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-fedora43-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-fedora43
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora43
+      MATRIX: '(arm64,fedora43)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-fedora43
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-opensuse15-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: opensuse15
+      MATRIX: '(arm64,opensuse15-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-opensuse15-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-opensuse15-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: opensuse15
+      MATRIX: '(arm64,opensuse15-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-opensuse15-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-opensuse15
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: opensuse15
+      MATRIX: '(arm64,opensuse15)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-opensuse15
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-opensuse16-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: opensuse16
+      MATRIX: '(arm64,opensuse16-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-opensuse16-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-opensuse16-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: opensuse16
+      MATRIX: '(arm64,opensuse16-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-opensuse16-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-opensuse16
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: opensuse16
+      MATRIX: '(arm64,opensuse16)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-opensuse16
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-ubuntu22-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: ubuntu22
+      MATRIX: '(arm64,ubuntu22-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-ubuntu22-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-ubuntu22-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: ubuntu22
+      MATRIX: '(arm64,ubuntu22-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-ubuntu22-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-ubuntu22
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: ubuntu22
+      MATRIX: '(arm64,ubuntu22)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-ubuntu22
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQLGENAI=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-ubuntu24-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: ubuntu24
+      MATRIX: '(arm64,ubuntu24-genai)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-ubuntu24-genai
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         PROXYSQL31=1 make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-ubuntu24-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: ubuntu24
+      MATRIX: '(arm64,ubuntu24-v31)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-ubuntu24-v31
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -1,0 +1,60 @@
+name: CI-package-arm64-ubuntu24
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: ubuntu24
+      MATRIX: '(arm64,ubuntu24)'
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
+        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: proxysql-arm64-ubuntu24
+        path: binaries/
+        retention-days: 90
+        if-no-files-found: error
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -4,6 +4,10 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -38,8 +42,6 @@ jobs:
     - name: Build package
       run: |
         make ${{ env.DIST }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash 2>/dev/null || true)" >> $GITHUB_ENV
 
     - name: Upload package artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Adds 39 self-contained `workflow_dispatch`-only GitHub Actions workflows for building ARM64 packages on demand (no automatic triggers on push/PR).

### Structure

| Tier | Flag | Naming | Packages |
|------|------|--------|----------|
| Stable (v3.0.x) | — | `CI-package-arm64-<dist>.yml` | 13 |
| Innovative (v3.1.x) | `PROXYSQL31=1` | `CI-package-arm64-<dist>-v31.yml` | 13 |
| AI/MCP (v4.0.x) | `PROXYSQLGENAI=1` | `CI-package-arm64-<dist>-genai.yml` | 13 |

### Distros covered

centos9, centos10, debian12, debian13, ubuntu22, ubuntu24, fedora42, fedora43, opensuse15, opensuse16, almalinux8, almalinux9, almalinux10

### Per-workflow details

- **Runner:** `ubuntu-24.04-arm`
- **Artifact:** Built `.deb`/`.rpm` + hash, 90-day retention
- **Check runs:** via `LouisBrunner/checks-action@v2.0.0`
- **Concurrency:** One build per dist per branch, cancel-in-progress

### Usage

Trigger from GitHub Actions UI or CLI:
```bash
gh workflow run CI-package-arm64-ubuntu22.yml --ref v3.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added new manually‑triggered CI workflows to build ARM64 packages for AlmaLinux, CentOS, Debian, Fedora, OpenSUSE and Ubuntu (standard, v31 and GenAI variants).
  * CI now uploads built artifacts (binaries) with 90‑day retention and fails when no artifacts are produced.
  * Run status/check updates are published to show in‑progress and final results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->