### PR TITLE
fix: macOS build - sqlite3 link and missing libtool

### DIFF
--- a/.github/workflows/CI-build-macos-macos-13-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-13-genai.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install automake bzip2 cmake gpatch gnutls openssl@3 icu4c pkg-config libiconv zlib
+        brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/CI-build-macos-macos-13-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-13-v31.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install automake bzip2 cmake gpatch gnutls openssl@3 icu4c pkg-config libiconv zlib
+        brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/CI-build-macos-macos-13.yml
+++ b/.github/workflows/CI-build-macos-macos-13.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install automake bzip2 cmake gpatch gnutls openssl@3 icu4c pkg-config libiconv zlib
+        brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/CI-build-macos-macos-14-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-14-genai.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install automake bzip2 cmake gpatch gnutls openssl@3 icu4c pkg-config libiconv zlib
+        brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/CI-build-macos-macos-14-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-14-v31.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install automake bzip2 cmake gpatch gnutls openssl@3 icu4c pkg-config libiconv zlib
+        brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/CI-build-macos-macos-14.yml
+++ b/.github/workflows/CI-build-macos-macos-14.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install automake bzip2 cmake gpatch gnutls openssl@3 icu4c pkg-config libiconv zlib
+        brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -272,7 +272,7 @@ sqlite3/sqlite3/sqlite3.o:
 	cd sqlite3/sqlite3 && patch -p0 < ../throw.patch
 	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o sqlite3.o sqlite3.c -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DSQLITE_DLL=1 -DSQLITE_ENABLE_MATH_FUNCTIONS
 ifeq ($(UNAME_S),Darwin)
-	cd sqlite3/sqlite3 && ${CC} -dynamiclib -undefined dynamic_lookup -install_name @rpath/libsqlite3.so -o libsqlite3.so sqlite3.o $(LIB_SSL_PATH) $(LIB_CRYPTO_PATH)
+	cd sqlite3/sqlite3 && ${CC} -dynamiclib -undefined dynamic_lookup -install_name @rpath/libsqlite3.so -o libsqlite3.so sqlite3.o
 else
 	cd sqlite3/sqlite3 && ${CC} -shared -o libsqlite3.so sqlite3.o
 endif

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -271,7 +271,11 @@ sqlite3/sqlite3/sqlite3.o:
 	cd sqlite3/sqlite3 && patch -p0 < ../sqlite3_pass_exts.patch
 	cd sqlite3/sqlite3 && patch -p0 < ../throw.patch
 	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o sqlite3.o sqlite3.c -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DSQLITE_DLL=1 -DSQLITE_ENABLE_MATH_FUNCTIONS
+ifeq ($(UNAME_S),Darwin)
+	cd sqlite3/sqlite3 && ${CC} -dynamiclib -undefined dynamic_lookup -install_name @rpath/libsqlite3.so -o libsqlite3.so sqlite3.o $(LIB_SSL_PATH) $(LIB_CRYPTO_PATH)
+else
 	cd sqlite3/sqlite3 && ${CC} -shared -o libsqlite3.so sqlite3.o
+endif
 
 sqlite3/sqlite3/vec.o: sqlite3/sqlite3/sqlite3.o
 	cd sqlite3/sqlite3 && cp ../sqlite-vec-source/sqlite-vec.c . && cp ../sqlite-vec-source/sqlite-vec.h .

--- a/include/proxysql_gtid.h
+++ b/include/proxysql_gtid.h
@@ -28,9 +28,9 @@ class TrxId_Interval {
 		const bool merge(const TrxId_Interval& other);
 
 		const int cmp(const TrxId_Interval& other);
-		const bool operator<(const TrxId_Interval& other);
-		const bool operator==(const TrxId_Interval& other);
-		const bool operator!=(const TrxId_Interval& other);
+bool operator<(const TrxId_Interval& other) const;
+bool operator==(const TrxId_Interval& other) const;
+bool operator!=(const TrxId_Interval& other) const;
 };
 
 // Encapsulates a map of UUID -> trxid intervals.

--- a/include/proxysql_gtid.h
+++ b/include/proxysql_gtid.h
@@ -27,7 +27,7 @@ class TrxId_Interval {
 		const bool append(const TrxId_Interval& other);
 		const bool merge(const TrxId_Interval& other);
 
-		const int cmp(const TrxId_Interval& other);
+		int cmp(const TrxId_Interval& other) const;
 bool operator<(const TrxId_Interval& other) const;
 bool operator==(const TrxId_Interval& other) const;
 bool operator!=(const TrxId_Interval& other) const;

--- a/lib/proxysql_gtid.cpp
+++ b/lib/proxysql_gtid.cpp
@@ -142,7 +142,7 @@ const bool TrxId_Interval::merge(const TrxId_Interval& other) {
 }
 
 // Compares two trxid intervals, by strict weak ordering.
-const int TrxId_Interval::cmp(const TrxId_Interval& other) {
+int TrxId_Interval::cmp(const TrxId_Interval& other) const {
 	if (start < other.start) {
 		return -1;
 	}

--- a/lib/proxysql_gtid.cpp
+++ b/lib/proxysql_gtid.cpp
@@ -158,15 +158,15 @@ const int TrxId_Interval::cmp(const TrxId_Interval& other) {
 	return 0;
 }
 
-const bool TrxId_Interval::operator<(const TrxId_Interval& other) {
+bool TrxId_Interval::operator<(const TrxId_Interval& other) const {
 	return cmp(other) == -1;
 }
 
-const bool TrxId_Interval::operator==(const TrxId_Interval& other) {
+bool TrxId_Interval::operator==(const TrxId_Interval& other) const {
 	return cmp(other) == 0;
 }
 
-const bool TrxId_Interval::operator!=(const TrxId_Interval& other) {
+bool TrxId_Interval::operator!=(const TrxId_Interval& other) const {
 	return cmp(other) != 0;
 }
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -135,7 +135,7 @@ endif
 endif
 
 ifeq ($(UNAME_S),Darwin)
-	MYLIBS :=-lre2 -lmariadbclient -lssl -lcrypto -lpthread -lm -lz -liconv -lgnutls -lprometheus-cpp-pull -lprometheus-cpp-core -luuid
+	MYLIBS :=-lre2 -lmariadbclient -lssl -lcrypto -lpthread -lm -lz -liconv -lgnutls -lprometheus-cpp-pull -lprometheus-cpp-core
 else
 	CURL_DIR := $(DEPS_PATH)/curl/curl
 	IDIRS += -L$(CURL_DIR)/include


### PR DESCRIPTION
## Summary

Fixes two issues preventing ProxySQL from building on macOS (GitHub Actions runners):

1. **sqlite3 shared lib link** — `cc -shared` on macOS requires all symbols resolved at link time, unlike Linux. Added `-dynamiclib -undefined dynamic_lookup` with OpenSSL link flags for Darwin.

2. **Missing libtool** — `autoreconf` (called by curl build) requires `glibtoolize`, provided by Homebrew's `libtool` package. Added to brew install list.

These are real bugs that also affect local macOS builds in clean environments — the sqlite3 issue was masked on machines where OpenSSL was already in the linker search path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * macOS CI pipelines updated to include libtool for a more consistent macOS toolchain.
  * macOS build/linking adjusted (SQLite linking and macOS library flags) to improve macOS build reliability and compatibility.
* **Refactor**
  * Internal comparison code made const-correct to improve code robustness (no user-facing behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->