### PR TITLE
ci: add amd64 package workflows, fix upload glob, dedupe release drafts

### DIFF
--- a/.github/workflows/CI-package-amd64-almalinux10-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux10-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MAKE_TARGET: almalinux10-clang
+      MATRIX: '(amd64,almalinux10-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux10-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MAKE_TARGET: almalinux10-dbg
+      MATRIX: '(amd64,almalinux10-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux10-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MAKE_TARGET: almalinux10-clang
+      MATRIX: '(amd64,almalinux10-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux10-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MAKE_TARGET: almalinux10-dbg
+      MATRIX: '(amd64,almalinux10-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux10
+      MAKE_TARGET: almalinux10
       MATRIX: '(amd64,almalinux10-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux10-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MATRIX: '(amd64,almalinux10-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux10-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MAKE_TARGET: almalinux10-clang
+      MATRIX: '(amd64,almalinux10-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux10-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MAKE_TARGET: almalinux10-dbg
+      MATRIX: '(amd64,almalinux10-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux10-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MATRIX: '(amd64,almalinux10-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux10
+      MAKE_TARGET: almalinux10
       MATRIX: '(amd64,almalinux10-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux10.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux10
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux10
+      MATRIX: '(amd64,almalinux10)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux10.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux10
+      MAKE_TARGET: almalinux10
       MATRIX: '(amd64,almalinux10)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux8-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux8-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MAKE_TARGET: almalinux8-clang
+      MATRIX: '(amd64,almalinux8-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux8-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MAKE_TARGET: almalinux8-dbg
+      MATRIX: '(amd64,almalinux8-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux8-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MAKE_TARGET: almalinux8-clang
+      MATRIX: '(amd64,almalinux8-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux8-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MAKE_TARGET: almalinux8-dbg
+      MATRIX: '(amd64,almalinux8-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux8
+      MAKE_TARGET: almalinux8
       MATRIX: '(amd64,almalinux8-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux8-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MATRIX: '(amd64,almalinux8-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux8-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MAKE_TARGET: almalinux8-clang
+      MATRIX: '(amd64,almalinux8-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux8-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MAKE_TARGET: almalinux8-dbg
+      MATRIX: '(amd64,almalinux8-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux8
+      MAKE_TARGET: almalinux8
       MATRIX: '(amd64,almalinux8-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux8-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MATRIX: '(amd64,almalinux8-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux8
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux8
+      MATRIX: '(amd64,almalinux8)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux8.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux8
+      MAKE_TARGET: almalinux8
       MATRIX: '(amd64,almalinux8)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux9-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux9-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MAKE_TARGET: almalinux9-clang
+      MATRIX: '(amd64,almalinux9-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux9-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MAKE_TARGET: almalinux9-dbg
+      MATRIX: '(amd64,almalinux9-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux9-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MAKE_TARGET: almalinux9-clang
+      MATRIX: '(amd64,almalinux9-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux9-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MAKE_TARGET: almalinux9-dbg
+      MATRIX: '(amd64,almalinux9-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux9
+      MAKE_TARGET: almalinux9
       MATRIX: '(amd64,almalinux9-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux9-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MATRIX: '(amd64,almalinux9-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux9-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MAKE_TARGET: almalinux9-clang
+      MATRIX: '(amd64,almalinux9-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-almalinux9-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MAKE_TARGET: almalinux9-dbg
+      MATRIX: '(amd64,almalinux9-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux9-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MATRIX: '(amd64,almalinux9-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux9
+      MAKE_TARGET: almalinux9
       MATRIX: '(amd64,almalinux9-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-almalinux9.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-almalinux9
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: almalinux9
+      MATRIX: '(amd64,almalinux9)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-almalinux9.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: almalinux9
+      MAKE_TARGET: almalinux9
       MATRIX: '(amd64,almalinux9)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-centos10-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos10-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MAKE_TARGET: centos10-clang
+      MATRIX: '(amd64,centos10-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos10-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MAKE_TARGET: centos10-dbg
+      MATRIX: '(amd64,centos10-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos10-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MAKE_TARGET: centos10-clang
+      MATRIX: '(amd64,centos10-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos10-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MAKE_TARGET: centos10-dbg
+      MATRIX: '(amd64,centos10-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-centos10-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MATRIX: '(amd64,centos10-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: centos10
+      MAKE_TARGET: centos10
       MATRIX: '(amd64,centos10-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos10-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MAKE_TARGET: centos10-clang
+      MATRIX: '(amd64,centos10-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos10-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MAKE_TARGET: centos10-dbg
+      MATRIX: '(amd64,centos10-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-centos10-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MATRIX: '(amd64,centos10-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: centos10
+      MAKE_TARGET: centos10
       MATRIX: '(amd64,centos10-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-centos10.yml
+++ b/.github/workflows/CI-package-amd64-centos10.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-centos10
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos10
+      MATRIX: '(amd64,centos10)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos10.yml
+++ b/.github/workflows/CI-package-amd64-centos10.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: centos10
+      MAKE_TARGET: centos10
       MATRIX: '(amd64,centos10)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-centos9-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos9-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MAKE_TARGET: centos9-clang
+      MATRIX: '(amd64,centos9-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos9-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MAKE_TARGET: centos9-dbg
+      MATRIX: '(amd64,centos9-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos9-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MAKE_TARGET: centos9-clang
+      MATRIX: '(amd64,centos9-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos9-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MAKE_TARGET: centos9-dbg
+      MATRIX: '(amd64,centos9-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: centos9
+      MAKE_TARGET: centos9
       MATRIX: '(amd64,centos9-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-centos9-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-centos9-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MATRIX: '(amd64,centos9-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos9-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MAKE_TARGET: centos9-clang
+      MATRIX: '(amd64,centos9-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-centos9-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MAKE_TARGET: centos9-dbg
+      MATRIX: '(amd64,centos9-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-centos9-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MATRIX: '(amd64,centos9-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: centos9
+      MAKE_TARGET: centos9
       MATRIX: '(amd64,centos9-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-centos9.yml
+++ b/.github/workflows/CI-package-amd64-centos9.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-centos9
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: centos9
+      MATRIX: '(amd64,centos9)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-centos9.yml
+++ b/.github/workflows/CI-package-amd64-centos9.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: centos9
+      MAKE_TARGET: centos9
       MATRIX: '(amd64,centos9)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-debian12-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian12-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MAKE_TARGET: debian12-clang
+      MATRIX: '(amd64,debian12-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian12-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MAKE_TARGET: debian12-dbg
+      MATRIX: '(amd64,debian12-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian12-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MAKE_TARGET: debian12-clang
+      MATRIX: '(amd64,debian12-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian12-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MAKE_TARGET: debian12-dbg
+      MATRIX: '(amd64,debian12-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-debian12-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MATRIX: '(amd64,debian12-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: debian12
+      MAKE_TARGET: debian12
       MATRIX: '(amd64,debian12-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian12-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MAKE_TARGET: debian12-clang
+      MATRIX: '(amd64,debian12-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian12-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MAKE_TARGET: debian12-dbg
+      MATRIX: '(amd64,debian12-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: debian12
+      MAKE_TARGET: debian12
       MATRIX: '(amd64,debian12-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-debian12-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-debian12-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MATRIX: '(amd64,debian12-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12.yml
+++ b/.github/workflows/CI-package-amd64-debian12.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-debian12
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian12
+      MATRIX: '(amd64,debian12)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian12.yml
+++ b/.github/workflows/CI-package-amd64-debian12.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: debian12
+      MAKE_TARGET: debian12
       MATRIX: '(amd64,debian12)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-debian13-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian13-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MAKE_TARGET: debian13-clang
+      MATRIX: '(amd64,debian13-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian13-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MAKE_TARGET: debian13-dbg
+      MATRIX: '(amd64,debian13-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian13-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MAKE_TARGET: debian13-clang
+      MATRIX: '(amd64,debian13-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian13-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MAKE_TARGET: debian13-dbg
+      MATRIX: '(amd64,debian13-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: debian13
+      MAKE_TARGET: debian13
       MATRIX: '(amd64,debian13-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-debian13-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-debian13-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MATRIX: '(amd64,debian13-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian13-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MAKE_TARGET: debian13-clang
+      MATRIX: '(amd64,debian13-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-debian13-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MAKE_TARGET: debian13-dbg
+      MATRIX: '(amd64,debian13-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-debian13-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MATRIX: '(amd64,debian13-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-debian13-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: debian13
+      MAKE_TARGET: debian13
       MATRIX: '(amd64,debian13-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-debian13.yml
+++ b/.github/workflows/CI-package-amd64-debian13.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: debian13
+      MAKE_TARGET: debian13
       MATRIX: '(amd64,debian13)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-debian13.yml
+++ b/.github/workflows/CI-package-amd64-debian13.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-debian13
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: debian13
+      MATRIX: '(amd64,debian13)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora42-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MAKE_TARGET: fedora42-clang
+      MATRIX: '(amd64,fedora42-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora42-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MAKE_TARGET: fedora42-dbg
+      MATRIX: '(amd64,fedora42-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora42-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MAKE_TARGET: fedora42-clang
+      MATRIX: '(amd64,fedora42-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora42-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MAKE_TARGET: fedora42-dbg
+      MATRIX: '(amd64,fedora42-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: fedora42
+      MAKE_TARGET: fedora42
       MATRIX: '(amd64,fedora42-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-fedora42-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MATRIX: '(amd64,fedora42-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora42-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MAKE_TARGET: fedora42-clang
+      MATRIX: '(amd64,fedora42-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora42-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MAKE_TARGET: fedora42-dbg
+      MATRIX: '(amd64,fedora42-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: fedora42
+      MAKE_TARGET: fedora42
       MATRIX: '(amd64,fedora42-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-fedora42-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MATRIX: '(amd64,fedora42-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42.yml
+++ b/.github/workflows/CI-package-amd64-fedora42.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-fedora42
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora42
+      MATRIX: '(amd64,fedora42)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora42.yml
+++ b/.github/workflows/CI-package-amd64-fedora42.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: fedora42
+      MAKE_TARGET: fedora42
       MATRIX: '(amd64,fedora42)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-fedora43-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora43-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MAKE_TARGET: fedora43-clang
+      MATRIX: '(amd64,fedora43-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora43-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MAKE_TARGET: fedora43-dbg
+      MATRIX: '(amd64,fedora43-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora43-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MAKE_TARGET: fedora43-clang
+      MATRIX: '(amd64,fedora43-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora43-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MAKE_TARGET: fedora43-dbg
+      MATRIX: '(amd64,fedora43-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: fedora43
+      MAKE_TARGET: fedora43
       MATRIX: '(amd64,fedora43-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-fedora43-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MATRIX: '(amd64,fedora43-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora43-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MAKE_TARGET: fedora43-clang
+      MATRIX: '(amd64,fedora43-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-fedora43-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MAKE_TARGET: fedora43-dbg
+      MATRIX: '(amd64,fedora43-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-fedora43-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MATRIX: '(amd64,fedora43-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: fedora43
+      MAKE_TARGET: fedora43
       MATRIX: '(amd64,fedora43-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-fedora43.yml
+++ b/.github/workflows/CI-package-amd64-fedora43.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: fedora43
+      MAKE_TARGET: fedora43
       MATRIX: '(amd64,fedora43)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-fedora43.yml
+++ b/.github/workflows/CI-package-amd64-fedora43.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-fedora43
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora43
+      MATRIX: '(amd64,fedora43)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse15-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MAKE_TARGET: opensuse15-clang
+      MATRIX: '(amd64,opensuse15-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse15-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MAKE_TARGET: opensuse15-dbg
+      MATRIX: '(amd64,opensuse15-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse15-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MAKE_TARGET: opensuse15-clang
+      MATRIX: '(amd64,opensuse15-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse15-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MAKE_TARGET: opensuse15-dbg
+      MATRIX: '(amd64,opensuse15-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-opensuse15-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MATRIX: '(amd64,opensuse15-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: opensuse15
+      MAKE_TARGET: opensuse15
       MATRIX: '(amd64,opensuse15-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse15-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MAKE_TARGET: opensuse15-clang
+      MATRIX: '(amd64,opensuse15-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse15-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MAKE_TARGET: opensuse15-dbg
+      MATRIX: '(amd64,opensuse15-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-opensuse15-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MATRIX: '(amd64,opensuse15-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: opensuse15
+      MAKE_TARGET: opensuse15
       MATRIX: '(amd64,opensuse15-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-opensuse15.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: opensuse15
+      MAKE_TARGET: opensuse15
       MATRIX: '(amd64,opensuse15)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-opensuse15.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-opensuse15
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse15
+      MATRIX: '(amd64,opensuse15)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse16-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MAKE_TARGET: opensuse16-clang
+      MATRIX: '(amd64,opensuse16-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse16-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MAKE_TARGET: opensuse16-dbg
+      MATRIX: '(amd64,opensuse16-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse16-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MAKE_TARGET: opensuse16-clang
+      MATRIX: '(amd64,opensuse16-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse16-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MAKE_TARGET: opensuse16-dbg
+      MATRIX: '(amd64,opensuse16-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-opensuse16-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MATRIX: '(amd64,opensuse16-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: opensuse16
+      MAKE_TARGET: opensuse16
       MATRIX: '(amd64,opensuse16-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse16-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MAKE_TARGET: opensuse16-clang
+      MATRIX: '(amd64,opensuse16-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-opensuse16-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MAKE_TARGET: opensuse16-dbg
+      MATRIX: '(amd64,opensuse16-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: opensuse16
+      MAKE_TARGET: opensuse16
       MATRIX: '(amd64,opensuse16-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-opensuse16-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MATRIX: '(amd64,opensuse16-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-opensuse16.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: opensuse16
+      MAKE_TARGET: opensuse16
       MATRIX: '(amd64,opensuse16)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-opensuse16.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-opensuse16
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: opensuse16
+      MATRIX: '(amd64,opensuse16)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu22-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MAKE_TARGET: ubuntu22-clang
+      MATRIX: '(amd64,ubuntu22-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu22-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MAKE_TARGET: ubuntu22-dbg
+      MATRIX: '(amd64,ubuntu22-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu22-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MAKE_TARGET: ubuntu22-clang
+      MATRIX: '(amd64,ubuntu22-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu22-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MAKE_TARGET: ubuntu22-dbg
+      MATRIX: '(amd64,ubuntu22-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: ubuntu22
+      MAKE_TARGET: ubuntu22
       MATRIX: '(amd64,ubuntu22-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-ubuntu22-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MATRIX: '(amd64,ubuntu22-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu22-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MAKE_TARGET: ubuntu22-clang
+      MATRIX: '(amd64,ubuntu22-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu22-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MAKE_TARGET: ubuntu22-dbg
+      MATRIX: '(amd64,ubuntu22-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: ubuntu22
+      MAKE_TARGET: ubuntu22
       MATRIX: '(amd64,ubuntu22-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-ubuntu22-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MATRIX: '(amd64,ubuntu22-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu22.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: ubuntu22
+      MAKE_TARGET: ubuntu22
       MATRIX: '(amd64,ubuntu22)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-ubuntu22.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-ubuntu22
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu22
+      MATRIX: '(amd64,ubuntu22)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu24-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MAKE_TARGET: ubuntu24-clang
+      MATRIX: '(amd64,ubuntu24-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu24-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MAKE_TARGET: ubuntu24-dbg
+      MATRIX: '(amd64,ubuntu24-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu24-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MAKE_TARGET: ubuntu24-clang
+      MATRIX: '(amd64,ubuntu24-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu24-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MAKE_TARGET: ubuntu24-dbg
+      MATRIX: '(amd64,ubuntu24-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: ubuntu24
+      MAKE_TARGET: ubuntu24
       MATRIX: '(amd64,ubuntu24-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-ubuntu24-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MATRIX: '(amd64,ubuntu24-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQLGENAI=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu24-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MAKE_TARGET: ubuntu24-clang
+      MATRIX: '(amd64,ubuntu24-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
@@ -1,0 +1,133 @@
+name: CI-package-amd64-ubuntu24-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MAKE_TARGET: ubuntu24-dbg
+      MATRIX: '(amd64,ubuntu24-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-ubuntu24-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MATRIX: '(amd64,ubuntu24-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: ubuntu24
+      MAKE_TARGET: ubuntu24
       MATRIX: '(amd64,ubuntu24-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-ubuntu24.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: amd64
       DIST: ubuntu24
+      MAKE_TARGET: ubuntu24
       MATRIX: '(amd64,ubuntu24)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-amd64-ubuntu24.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24.yml
@@ -1,0 +1,132 @@
+name: CI-package-amd64-ubuntu24
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: ubuntu24
+      MATRIX: '(amd64,ubuntu24)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.DIST }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux10
       MATRIX: '(arm64,almalinux10-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux10
+      MAKE_TARGET: almalinux10
       MATRIX: '(arm64,almalinux10-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux10
       MATRIX: '(arm64,almalinux10-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux10
+      MAKE_TARGET: almalinux10
       MATRIX: '(arm64,almalinux10-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux10
       MATRIX: '(arm64,almalinux10)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux10
+      MAKE_TARGET: almalinux10
       MATRIX: '(arm64,almalinux10)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux8
       MATRIX: '(arm64,almalinux8-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux8
+      MAKE_TARGET: almalinux8
       MATRIX: '(arm64,almalinux8-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux8
       MATRIX: '(arm64,almalinux8-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux8
+      MAKE_TARGET: almalinux8
       MATRIX: '(arm64,almalinux8-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux8
+      MAKE_TARGET: almalinux8
       MATRIX: '(arm64,almalinux8)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux8
       MATRIX: '(arm64,almalinux8)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux9
       MATRIX: '(arm64,almalinux9-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux9
+      MAKE_TARGET: almalinux9
       MATRIX: '(arm64,almalinux9-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux9
+      MAKE_TARGET: almalinux9
       MATRIX: '(arm64,almalinux9-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux9
       MATRIX: '(arm64,almalinux9-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: almalinux9
+      MAKE_TARGET: almalinux9
       MATRIX: '(arm64,almalinux9)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: almalinux9
       MATRIX: '(arm64,almalinux9)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: centos10
       MATRIX: '(arm64,centos10-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: centos10
+      MAKE_TARGET: centos10
       MATRIX: '(arm64,centos10-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: centos10
       MATRIX: '(arm64,centos10-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: centos10
+      MAKE_TARGET: centos10
       MATRIX: '(arm64,centos10-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: centos10
+      MAKE_TARGET: centos10
       MATRIX: '(arm64,centos10)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: centos10
       MATRIX: '(arm64,centos10)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: centos9
       MATRIX: '(arm64,centos9-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: centos9
+      MAKE_TARGET: centos9
       MATRIX: '(arm64,centos9-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: centos9
       MATRIX: '(arm64,centos9-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: centos9
+      MAKE_TARGET: centos9
       MATRIX: '(arm64,centos9-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: centos9
       MATRIX: '(arm64,centos9)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: centos9
+      MAKE_TARGET: centos9
       MATRIX: '(arm64,centos9)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: debian12
       MATRIX: '(arm64,debian12-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: debian12
+      MAKE_TARGET: debian12
       MATRIX: '(arm64,debian12-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: debian12
+      MAKE_TARGET: debian12
       MATRIX: '(arm64,debian12-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: debian12
       MATRIX: '(arm64,debian12-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: debian12
+      MAKE_TARGET: debian12
       MATRIX: '(arm64,debian12)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: debian12
       MATRIX: '(arm64,debian12)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: debian13
+      MAKE_TARGET: debian13
       MATRIX: '(arm64,debian13-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: debian13
       MATRIX: '(arm64,debian13-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: debian13
+      MAKE_TARGET: debian13
       MATRIX: '(arm64,debian13-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: debian13
       MATRIX: '(arm64,debian13-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: debian13
       MATRIX: '(arm64,debian13)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: debian13
+      MAKE_TARGET: debian13
       MATRIX: '(arm64,debian13)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: fedora42
+      MAKE_TARGET: fedora42
       MATRIX: '(arm64,fedora42-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: fedora42
       MATRIX: '(arm64,fedora42-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: fedora42
       MATRIX: '(arm64,fedora42-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: fedora42
+      MAKE_TARGET: fedora42
       MATRIX: '(arm64,fedora42-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: fedora42
+      MAKE_TARGET: fedora42
       MATRIX: '(arm64,fedora42)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: fedora42
       MATRIX: '(arm64,fedora42)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: fedora43
       MATRIX: '(arm64,fedora43-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: fedora43
+      MAKE_TARGET: fedora43
       MATRIX: '(arm64,fedora43-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: fedora43
+      MAKE_TARGET: fedora43
       MATRIX: '(arm64,fedora43-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: fedora43
       MATRIX: '(arm64,fedora43-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: fedora43
       MATRIX: '(arm64,fedora43)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: fedora43
+      MAKE_TARGET: fedora43
       MATRIX: '(arm64,fedora43)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: opensuse15
+      MAKE_TARGET: opensuse15
       MATRIX: '(arm64,opensuse15-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: opensuse15
       MATRIX: '(arm64,opensuse15-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: opensuse15
+      MAKE_TARGET: opensuse15
       MATRIX: '(arm64,opensuse15-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: opensuse15
       MATRIX: '(arm64,opensuse15-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: opensuse15
+      MAKE_TARGET: opensuse15
       MATRIX: '(arm64,opensuse15)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: opensuse15
       MATRIX: '(arm64,opensuse15)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: opensuse16
       MATRIX: '(arm64,opensuse16-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: opensuse16
+      MAKE_TARGET: opensuse16
       MATRIX: '(arm64,opensuse16-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: opensuse16
+      MAKE_TARGET: opensuse16
       MATRIX: '(arm64,opensuse16-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: opensuse16
       MATRIX: '(arm64,opensuse16-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: opensuse16
       MATRIX: '(arm64,opensuse16)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: opensuse16
+      MAKE_TARGET: opensuse16
       MATRIX: '(arm64,opensuse16)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: ubuntu22
       MATRIX: '(arm64,ubuntu22-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: ubuntu22
+      MAKE_TARGET: ubuntu22
       MATRIX: '(arm64,ubuntu22-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: ubuntu22
+      MAKE_TARGET: ubuntu22
       MATRIX: '(arm64,ubuntu22-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: ubuntu22
       MATRIX: '(arm64,ubuntu22-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: ubuntu22
       MATRIX: '(arm64,ubuntu22)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: ubuntu22
+      MAKE_TARGET: ubuntu22
       MATRIX: '(arm64,ubuntu22)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: ubuntu24
       MATRIX: '(arm64,ubuntu24-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: ubuntu24
+      MAKE_TARGET: ubuntu24
       MATRIX: '(arm64,ubuntu24-genai)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQLGENAI=1 make ${{ env.DIST }}
+        PROXYSQLGENAI=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: ubuntu24
       MATRIX: '(arm64,ubuntu24-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: ubuntu24
+      MAKE_TARGET: ubuntu24
       MATRIX: '(arm64,ubuntu24-v31)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        PROXYSQL31=1 make ${{ env.DIST }}
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -13,13 +13,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-init-${{ github.sha }}
+      cancel-in-progress: false
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+
+        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "No matching draft; creating."
+          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${{ github.sha }}" \
+            -F draft=true -F prerelease=true \
+            --jq '.id')
+          echo "Created release id=${RELEASE_ID}"
+        else
+          echo "Reusing existing draft id=${RELEASE_ID}"
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: ubuntu-24.04-arm
     env:
       ARCH: arm64
       DIST: ubuntu24
       MATRIX: '(arm64,ubuntu24)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
     - uses: LouisBrunner/checks-action@v2.0.0
@@ -48,8 +96,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber binaries/*.[mb] binaries/*.id-hash 2>/dev/null || true
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       ARCH: arm64
       DIST: ubuntu24
+      MAKE_TARGET: ubuntu24
       MATRIX: '(arm64,ubuntu24)'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
@@ -90,7 +91,7 @@ jobs:
 
     - name: Build package
       run: |
-        make ${{ env.DIST }}
+        make ${{ env.MAKE_TARGET }}
 
     - name: Upload to release
       env:


### PR DESCRIPTION
## Summary

Three linked CI fixes/additions for the on-demand package build workflows:

1. **Fix broken upload glob.** The existing 39 `CI-package-arm64-*` workflows had `binaries/*.[mb]` — matches only single-char extensions (`.m`, `.b`), never `.rpm` or `.deb`. Combined with `2>/dev/null || true`, failures were silently swallowed and draft releases stayed empty. Corrected to `binaries/*[mb]` (matches any filename ending in `m` → `.rpm`, or `b` → `.deb`).

2. **Add 117 amd64 package workflows** mirroring the ARM matrix, plus amd64's additional `-clang` and `-dbg` build variants:
   - ARM64: 13 distros × 1 variant × 3 tiers = **39 workflows** (plain gcc only)
   - amd64: 13 distros × 3 variants (plain gcc, clang, dbg) × 3 tiers = **117 workflows**
   - Naming: `CI-package-<arch>-<distro>[-<tier>][-<variant>]` (tier first, then compiler variant).
   - Each workflow exposes both `DIST` (distro) and `MAKE_TARGET` (distro + variant) env vars; the build step invokes `make $MAKE_TARGET`.

3. **Fix draft-release proliferation (Option A: shared concurrency group).** Each previous workflow run called `gh release create --draft` independently, and GitHub's REST API does not dedupe drafts by tag name — so 39 parallel workflows each got their own fresh draft. The Releases tab accumulated 84 drafts at peak. Each workflow is now split into two jobs:

   ```yaml
   init_release:           # serialized across ALL workflows on this SHA
     concurrency:
       group: release-init-${{ github.sha }}
       cancel-in-progress: false
     # finds or creates a single draft named "<branch>-head - <git describe>"
     # outputs release_id
   build:
     needs: init_release
     # uploads by release ID to the shared draft
   ```

   `cancel-in-progress: false` queues the init jobs, so the first creates the draft and the rest reuse it. Draft stays hidden; name is unique per commit.

## Validation

- All 156 generated YAML files pass a structural lint (jobs.init_release + jobs.build with correct `needs` and concurrency group).
- End-to-end tested on this branch by dispatching 2 ARM workflows in parallel:
  - `CI-package-arm64-debian13` (stable tier, .deb, run 24880067393)
  - `CI-package-arm64-almalinux10-v31` (v31 tier, .rpm, run 24880068429)
- Result: both succeeded, exactly **one** draft release created (id 313109286, name `"v3.0-ci-pkg-workflows-head - 3.0.8-475-g5bd72d1"`, `draft: true`), containing 4 assets:
  - `proxysql_3.0.8-debian13_arm64.deb` (34.3 MB) + `.id-hash`
  - `proxysql-3.1.8-1-almalinux10.aarch64.rpm` (39.2 MB) + `.id-hash`
- The v31 tier correctly produces v3.1.8 per the feature-tier versioning in `CLAUDE.md`.

amd64 workflows could not be dispatched pre-merge — GitHub's `workflow_dispatch` requires the workflow file to exist on the default branch before it can be triggered on any ref. They'll become dispatchable once this PR merges.

## Cleanup (done out-of-band)

74 leftover draft releases named exactly `v3.0-head` were deleted prior to this PR. Legitimate long-name drafts (e.g. `v3.0-head - 3.0.8-474-g0f2b3e6`) from the main CI-package-build pipeline and 3 drafts from `fix/macos-build-deps-head` were kept untouched.

## Test plan

- [ ] After merge, dispatch a handful of amd64 workflows (e.g. `CI-package-amd64-debian13`, `CI-package-amd64-almalinux10-v31-clang`, `CI-package-amd64-ubuntu24-dbg`) and verify:
  - [ ] They find and reuse the single draft release for this SHA (no duplicate drafts created).
  - [ ] `.rpm`/`.deb`/`.id-hash` assets appear in the draft under the expected filenames (clang & dbg variant filenames should differ from plain).
- [ ] Verify existing ARM workflows (`CI-package-arm64-*`) still succeed end-to-end after merge.
- [ ] Sanity check: re-run an already-completed workflow for the same SHA and confirm that existing assets are replaced (idempotent) rather than duplicated or failed.