### PR TITLE
ci: drop concurrency group on init_release, use race-tolerant find-or-create

### DIFF
--- a/.github/workflows/CI-package-amd64-almalinux10-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux10.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux8.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-almalinux9.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos10.yml
+++ b/.github/workflows/CI-package-amd64-centos10.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-centos9.yml
+++ b/.github/workflows/CI-package-amd64-centos9.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian12.yml
+++ b/.github/workflows/CI-package-amd64-debian12.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-debian13.yml
+++ b/.github/workflows/CI-package-amd64-debian13.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora42.yml
+++ b/.github/workflows/CI-package-amd64-fedora42.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-fedora43.yml
+++ b/.github/workflows/CI-package-amd64-fedora43.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse15.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-opensuse16.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu22.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-amd64-ubuntu24.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -15,9 +15,11 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
-    concurrency:
-      group: release-init-${{ github.sha }}
-      cancel-in-progress: false
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -38,22 +40,36 @@ jobs:
         GIT_DESC=$(git describe --long --abbrev=7 --tags)
         TAG_NAME="${{ github.ref_name }}-head"
         RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
-        echo "Target: $RELEASE_NAME (sha ${{ github.sha }})"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
 
-        RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-          --jq ".[] | select(.draft==true and .name==\"${RELEASE_NAME}\") | .id" | head -1)
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
 
-        if [ -z "$RELEASE_ID" ]; then
-          echo "No matching draft; creating."
-          RELEASE_ID=$(gh api -X POST "repos/${{ github.repository }}/releases" \
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
             -f tag_name="${TAG_NAME}" \
             -f name="${RELEASE_NAME}" \
-            -f target_commitish="${{ github.sha }}" \
-            -F draft=true -F prerelease=true \
-            --jq '.id')
-          echo "Created release id=${RELEASE_ID}"
-        else
-          echo "Reusing existing draft id=${RELEASE_ID}"
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
         fi
 
         echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes a mass-cancellation bug in #5666 that only surfaces when many package workflows are dispatched at once.

## Problem observed

After merging #5666 and dispatching all 156 package workflows at the same commit:

| Status | Count |
|---|---|
| completed / cancelled | **142** |
| in_progress | 9 |
| completed / success | 6 (and growing) |

Only ~15 workflows ever ran to completion. The other 141 were cancelled before their `init_release` step even started.

## Root cause

The init_release job was serialized via:

```yaml
concurrency:
  group: release-init-${{ github.sha }}
  cancel-in-progress: false
```

Per GitHub's docs on [concurrency groups](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-concurrency):

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. **Any previously pending job or workflow in the concurrency group will be canceled.**

So the group holds at most **1 running + 1 pending**. Triggering 156 workflows simultaneously caused a rolling cancellation: each new arrival displaced the previously-pending one, cancelling it. Net result: only the first-arrived and last-arrived ever progressed past init.

The Option A design from #5666 was validated with just 2 parallel workflows — at N=2, the `1 running + 1 pending` cap fits exactly, so the bug didn't show. At N=156 it's catastrophic.

## Fix

Drop the concurrency group entirely. All 156 init_release jobs run in parallel and converge via a race-tolerant find-or-create loop:

```bash
sleep $(( RANDOM % 10 ))   # stagger start to soften thundering-herd
for attempt in 1..6:
  IDS=$(find drafts where target_commitish==$SHA AND tag_name==$TAG | sort -n)
  if [ -n "$IDS" ]:
    RELEASE_ID=$(head -1)  # deterministic winner: lowest id
    break
  gh api -X POST releases   # create; races tolerated
  sleep 2-5s
```

Key properties:

- **Deterministic winner.** All workers pick the *oldest* draft (lowest release id) matching SHA+tag. No matter who queries when, they all agree on the same draft.
- **No deletion during race.** A worker doesn't delete "duplicate" drafts it sees, because another worker might just have resolved to upload there. Orphan drafts from the race are left in place and can be swept separately if the list grows (most races produce 0–5 duplicates per burst, not 156).
- **Stagger + retry.** Random 0–9s initial sleep and 2–5s inter-attempt sleep spread the load over ~30s, so most workers find an already-created draft on their first query.

## Validation

- Lint: all 156 generated workflows pass structural YAML checks; `concurrency` key is absent from the `init_release` job.
- Full end-to-end can only be done post-merge: dispatch all 156 on the same SHA and confirm (a) all succeed (no cancellations), (b) exactly one canonical draft accumulates every distro × variant × tier asset.

## Out of scope

- Orphan-draft cleanup. If the find-or-create race leaves small numbers of empty drafts behind, they accumulate harmlessly. A future scheduled workflow (e.g. "sweep drafts with 0 assets older than 1d") can mop up.

## Test plan

- [ ] Merge to v3.0.
- [ ] Dispatch all 156 `CI-package-*` workflows on the new HEAD SHA.
- [ ] Confirm: 0 cancellations, 156 init_releases all complete, all uploads land in the same draft release (one name, one target_commitish).
- [ ] Check `gh api repos/sysown/proxysql/releases` after completion — ideally ≤ 5 duplicate empty drafts (from race), to be cleaned up manually if so.