### PR TITLE
ci: fix macOS package naming and release upload

### DIFF
--- a/.github/workflows/CI-build-macos-macos-13-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-13-genai.yml
@@ -13,12 +13,77 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: macos-13
     env:
       ARCH: x86_64
       MATRIX: '(macos-x86_64-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+      PROXYSQL31: "0"
+      PROXYSQLGENAI: "1"
       PKG_CONFIG_PATH: "/usr/local/opt/openssl@3/lib/pkgconfig"
       OPENSSL_ROOT_DIR: "/usr/local/opt/openssl@3"
 
@@ -52,16 +117,48 @@ jobs:
 
     - name: Package binary
       run: |
-        GIT_VERSION=$(git describe --long --abbrev=7 --tags 2>/dev/null || echo "unknown")
-        tar -C src -czf proxysql-${GIT_VERSION}-macos-x86_64.tar.gz proxysql
-        shasum -a 256 proxysql-${GIT_VERSION}-macos-x86_64.tar.gz > proxysql-${GIT_VERSION}-macos-x86_64.tar.gz.sha256
+        set -euo pipefail
+        # Mirror Makefile tier-version bump so tarball matches the built binary's version.
+        BASE=$(git describe --long --abbrev=7 --tags | sed 's/^v//')
+        if [ "${PROXYSQLGENAI:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%d.%s", $1+1, substr($0, length($1)+2)}')
+        elif [ "${PROXYSQL31:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%s.%d.%s", $1, $2+1, substr($0, length($1)+length($2)+3)}')
+        else
+          VERSION="$BASE"
+        fi
+        echo "Packaging as version: $VERSION"
+        tar -C src -czf proxysql-${VERSION}-macos-x86_64.tar.gz proxysql
+        shasum -a 256 proxysql-${VERSION}-macos-x86_64.tar.gz > proxysql-${VERSION}-macos-x86_64.tar.gz.sha256
 
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber proxysql-*-macos-x86_64.tar.gz proxysql-*-macos-x86_64.tar.gz.sha256
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in proxysql-*-macos-x86_64.tar.gz proxysql-*-macos-x86_64.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no macOS tarballs matched proxysql-*-macos-x86_64.tar.gz[.sha256]" >&2
+          ls -la || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-build-macos-macos-13-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-13-v31.yml
@@ -13,12 +13,77 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: macos-13
     env:
       ARCH: x86_64
       MATRIX: '(macos-x86_64-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+      PROXYSQL31: "1"
+      PROXYSQLGENAI: "0"
       PKG_CONFIG_PATH: "/usr/local/opt/openssl@3/lib/pkgconfig"
       OPENSSL_ROOT_DIR: "/usr/local/opt/openssl@3"
 
@@ -52,16 +117,48 @@ jobs:
 
     - name: Package binary
       run: |
-        GIT_VERSION=$(git describe --long --abbrev=7 --tags 2>/dev/null || echo "unknown")
-        tar -C src -czf proxysql-${GIT_VERSION}-macos-x86_64.tar.gz proxysql
-        shasum -a 256 proxysql-${GIT_VERSION}-macos-x86_64.tar.gz > proxysql-${GIT_VERSION}-macos-x86_64.tar.gz.sha256
+        set -euo pipefail
+        # Mirror Makefile tier-version bump so tarball matches the built binary's version.
+        BASE=$(git describe --long --abbrev=7 --tags | sed 's/^v//')
+        if [ "${PROXYSQLGENAI:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%d.%s", $1+1, substr($0, length($1)+2)}')
+        elif [ "${PROXYSQL31:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%s.%d.%s", $1, $2+1, substr($0, length($1)+length($2)+3)}')
+        else
+          VERSION="$BASE"
+        fi
+        echo "Packaging as version: $VERSION"
+        tar -C src -czf proxysql-${VERSION}-macos-x86_64.tar.gz proxysql
+        shasum -a 256 proxysql-${VERSION}-macos-x86_64.tar.gz > proxysql-${VERSION}-macos-x86_64.tar.gz.sha256
 
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber proxysql-*-macos-x86_64.tar.gz proxysql-*-macos-x86_64.tar.gz.sha256
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in proxysql-*-macos-x86_64.tar.gz proxysql-*-macos-x86_64.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no macOS tarballs matched proxysql-*-macos-x86_64.tar.gz[.sha256]" >&2
+          ls -la || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-build-macos-macos-13.yml
+++ b/.github/workflows/CI-build-macos-macos-13.yml
@@ -13,12 +13,77 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: macos-13
     env:
       ARCH: x86_64
       MATRIX: '(macos-x86_64)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+      PROXYSQL31: "0"
+      PROXYSQLGENAI: "0"
       PKG_CONFIG_PATH: "/usr/local/opt/openssl@3/lib/pkgconfig"
       OPENSSL_ROOT_DIR: "/usr/local/opt/openssl@3"
 
@@ -52,16 +117,48 @@ jobs:
 
     - name: Package binary
       run: |
-        GIT_VERSION=$(git describe --long --abbrev=7 --tags 2>/dev/null || echo "unknown")
-        tar -C src -czf proxysql-${GIT_VERSION}-macos-x86_64.tar.gz proxysql
-        shasum -a 256 proxysql-${GIT_VERSION}-macos-x86_64.tar.gz > proxysql-${GIT_VERSION}-macos-x86_64.tar.gz.sha256
+        set -euo pipefail
+        # Mirror Makefile tier-version bump so tarball matches the built binary's version.
+        BASE=$(git describe --long --abbrev=7 --tags | sed 's/^v//')
+        if [ "${PROXYSQLGENAI:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%d.%s", $1+1, substr($0, length($1)+2)}')
+        elif [ "${PROXYSQL31:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%s.%d.%s", $1, $2+1, substr($0, length($1)+length($2)+3)}')
+        else
+          VERSION="$BASE"
+        fi
+        echo "Packaging as version: $VERSION"
+        tar -C src -czf proxysql-${VERSION}-macos-x86_64.tar.gz proxysql
+        shasum -a 256 proxysql-${VERSION}-macos-x86_64.tar.gz > proxysql-${VERSION}-macos-x86_64.tar.gz.sha256
 
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber proxysql-*-macos-x86_64.tar.gz proxysql-*-macos-x86_64.tar.gz.sha256
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in proxysql-*-macos-x86_64.tar.gz proxysql-*-macos-x86_64.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no macOS tarballs matched proxysql-*-macos-x86_64.tar.gz[.sha256]" >&2
+          ls -la || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-build-macos-macos-14-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-14-genai.yml
@@ -13,12 +13,77 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: macos-14
     env:
       ARCH: arm64
       MATRIX: '(macos-arm64-genai)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+      PROXYSQL31: "0"
+      PROXYSQLGENAI: "1"
       PKG_CONFIG_PATH: "/opt/homebrew/opt/openssl@3/lib/pkgconfig"
       OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
 
@@ -52,16 +117,48 @@ jobs:
 
     - name: Package binary
       run: |
-        GIT_VERSION=$(git describe --long --abbrev=7 --tags 2>/dev/null || echo "unknown")
-        tar -C src -czf proxysql-${GIT_VERSION}-macos-arm64.tar.gz proxysql
-        shasum -a 256 proxysql-${GIT_VERSION}-macos-arm64.tar.gz > proxysql-${GIT_VERSION}-macos-arm64.tar.gz.sha256
+        set -euo pipefail
+        # Mirror Makefile tier-version bump so tarball matches the built binary's version.
+        BASE=$(git describe --long --abbrev=7 --tags | sed 's/^v//')
+        if [ "${PROXYSQLGENAI:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%d.%s", $1+1, substr($0, length($1)+2)}')
+        elif [ "${PROXYSQL31:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%s.%d.%s", $1, $2+1, substr($0, length($1)+length($2)+3)}')
+        else
+          VERSION="$BASE"
+        fi
+        echo "Packaging as version: $VERSION"
+        tar -C src -czf proxysql-${VERSION}-macos-arm64.tar.gz proxysql
+        shasum -a 256 proxysql-${VERSION}-macos-arm64.tar.gz > proxysql-${VERSION}-macos-arm64.tar.gz.sha256
 
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber proxysql-*-macos-arm64.tar.gz proxysql-*-macos-arm64.tar.gz.sha256
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in proxysql-*-macos-arm64.tar.gz proxysql-*-macos-arm64.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no macOS tarballs matched proxysql-*-macos-arm64.tar.gz[.sha256]" >&2
+          ls -la || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-build-macos-macos-14-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-14-v31.yml
@@ -13,12 +13,77 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: macos-14
     env:
       ARCH: arm64
       MATRIX: '(macos-arm64-v31)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+      PROXYSQL31: "1"
+      PROXYSQLGENAI: "0"
       PKG_CONFIG_PATH: "/opt/homebrew/opt/openssl@3/lib/pkgconfig"
       OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
 
@@ -52,16 +117,48 @@ jobs:
 
     - name: Package binary
       run: |
-        GIT_VERSION=$(git describe --long --abbrev=7 --tags 2>/dev/null || echo "unknown")
-        tar -C src -czf proxysql-${GIT_VERSION}-macos-arm64.tar.gz proxysql
-        shasum -a 256 proxysql-${GIT_VERSION}-macos-arm64.tar.gz > proxysql-${GIT_VERSION}-macos-arm64.tar.gz.sha256
+        set -euo pipefail
+        # Mirror Makefile tier-version bump so tarball matches the built binary's version.
+        BASE=$(git describe --long --abbrev=7 --tags | sed 's/^v//')
+        if [ "${PROXYSQLGENAI:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%d.%s", $1+1, substr($0, length($1)+2)}')
+        elif [ "${PROXYSQL31:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%s.%d.%s", $1, $2+1, substr($0, length($1)+length($2)+3)}')
+        else
+          VERSION="$BASE"
+        fi
+        echo "Packaging as version: $VERSION"
+        tar -C src -czf proxysql-${VERSION}-macos-arm64.tar.gz proxysql
+        shasum -a 256 proxysql-${VERSION}-macos-arm64.tar.gz > proxysql-${VERSION}-macos-arm64.tar.gz.sha256
 
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber proxysql-*-macos-arm64.tar.gz proxysql-*-macos-arm64.tar.gz.sha256
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in proxysql-*-macos-arm64.tar.gz proxysql-*-macos-arm64.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no macOS tarballs matched proxysql-*-macos-arm64.tar.gz[.sha256]" >&2
+          ls -la || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/CI-build-macos-macos-14.yml
+++ b/.github/workflows/CI-build-macos-macos-14.yml
@@ -13,12 +13,77 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: init_release
     runs-on: macos-14
     env:
       ARCH: arm64
       MATRIX: '(macos-arm64)'
       BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+      PROXYSQL31: "0"
+      PROXYSQLGENAI: "0"
       PKG_CONFIG_PATH: "/opt/homebrew/opt/openssl@3/lib/pkgconfig"
       OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
 
@@ -52,16 +117,48 @@ jobs:
 
     - name: Package binary
       run: |
-        GIT_VERSION=$(git describe --long --abbrev=7 --tags 2>/dev/null || echo "unknown")
-        tar -C src -czf proxysql-${GIT_VERSION}-macos-arm64.tar.gz proxysql
-        shasum -a 256 proxysql-${GIT_VERSION}-macos-arm64.tar.gz > proxysql-${GIT_VERSION}-macos-arm64.tar.gz.sha256
+        set -euo pipefail
+        # Mirror Makefile tier-version bump so tarball matches the built binary's version.
+        BASE=$(git describe --long --abbrev=7 --tags | sed 's/^v//')
+        if [ "${PROXYSQLGENAI:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%d.%s", $1+1, substr($0, length($1)+2)}')
+        elif [ "${PROXYSQL31:-0}" = "1" ]; then
+          VERSION=$(echo "$BASE" | awk -F. '{printf "%s.%d.%s", $1, $2+1, substr($0, length($1)+length($2)+3)}')
+        else
+          VERSION="$BASE"
+        fi
+        echo "Packaging as version: $VERSION"
+        tar -C src -czf proxysql-${VERSION}-macos-arm64.tar.gz proxysql
+        shasum -a 256 proxysql-${VERSION}-macos-arm64.tar.gz > proxysql-${VERSION}-macos-arm64.tar.gz.sha256
 
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create ${{ env.BRANCH }}-head --repo ${{ github.repository }} --title "${{ env.BRANCH }}-head" --target ${{ github.sha }} --draft --prerelease 2>/dev/null || true
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber proxysql-*-macos-arm64.tar.gz proxysql-*-macos-arm64.tar.gz.sha256
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in proxysql-*-macos-arm64.tar.gz proxysql-*-macos-arm64.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no macOS tarballs matched proxysql-*-macos-arm64.tar.gz[.sha256]" >&2
+          ls -la || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()


### PR DESCRIPTION
## Summary
The 6 macOS package-build workflows (`CI-build-macos-macos-1{3,4}{,-v31,-genai}`) had three interacting bugs that caused:
- artifacts named under the wrong version (e.g. a `PROXYSQLGENAI=1` build packaged as `proxysql-3.0.8-…` instead of `proxysql-4.0.8-…`),
- cross-tier clobber via `--clobber` on identical filenames, so only one tarball per arch survived across the three tier jobs,
- uploads landing in a non-deterministic draft release (often a stale SHA) rather than the canonical current-SHA draft used by the Linux `CI-package-*` workflows,
- several duplicate empty drafts spawned by `gh release create ... 2>/dev/null || true`.

This PR rewrites the 6 workflows to match the Linux pattern:

1. **`init_release` job** — race-tolerant find-or-create on `repos/{repo}/releases` filtering by `draft==true && target_commitish==SHA && tag_name==BRANCH-head`, deterministic lowest-id-wins, exports `RELEASE_ID` to the build job. Same logic as #5668.
2. **Tier-aware tarball version** — mirrors the Makefile tier bump directly in the `Package binary` step: `PROXYSQLGENAI=1` → major+1, `PROXYSQL31=1` → minor+1, else unchanged. Tarballs are then named `proxysql-3.0.8-<sha>-macos-<arch>.tar.gz`, `proxysql-3.1.8-<sha>-…`, `proxysql-4.0.8-<sha>-…` — matching the Linux RPM/DEB convention.
3. **Upload by release ID** — replaces `gh release upload ${BRANCH}-head --clobber` with per-asset delete-if-exists + POST to `uploads.github.com/.../releases/{RELEASE_ID}/assets`.

No code changes; only `.github/workflows/CI-build-macos-*.yml` (6 files) touched.

## Test plan
- [x] All 6 workflow files parse as valid YAML.
- [x] Version-bump logic verified locally against current `git describe` output: produces `3.0.8-…`, `3.1.8-…`, `4.0.8-…` as expected.
- [ ] After merge: dispatch all 6 `CI-build-macos-*` workflows on `v3.0` and confirm all 12 artifacts (6 tarballs + 6 sha256) land in the canonical draft release for the current SHA with the correct per-tier naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all macOS CI/CD build workflows to improve release creation reliability and consistency across build configurations.
  * Enhanced tarball artifact versioning to compute tier-specific versions, ensuring alignment between built binaries and published release assets.
  * Improved release asset management with deterministic duplicate file handling and automatic cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->