### PR TITLE
ci: add libprotobuf-dev to unit-tests-asan-coverage workflow

### DIFF
--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -87,13 +87,19 @@ jobs:
     - name: Install build dependencies
       # Mirrors the Ubuntu list in INSTALL.md. libmysqlclient-dev is
       # needed by some internal build-time helpers used by the vendored
-      # deps.
+      # deps. libprotobuf-dev is required for the mysqlx plugin: with
+      # PROXYSQLGENAI=1 the top-level Makefile recurses into
+      # plugins/mysqlx (PROXYSQL40 is implied), and that Makefile's
+      # protobuf 3.x ABI guard fires at parse time without it. The
+      # docker-compose entrypoints (deb/rhel/suse-compliant) install
+      # this on demand for container-based builds; this workflow runs
+      # directly on the runner host so it has to be installed here.
       run: |
         sudo apt-get -y install \
           libssl-dev libgnutls28-dev libmysqlclient-dev \
           libboost-all-dev libunwind8 libunwind-dev uuid-dev \
           libncurses-dev libicu-dev libevent-dev libtirpc-dev \
-          ca-certificates
+          ca-certificates libprotobuf-dev
 
     - name: Install coverage tooling
       run: |


### PR DESCRIPTION
## Summary

CI-unit-tests-asan-coverage runs directly on the GitHub runner host
(not inside the `deb`/`rhel`/`suse-compliant` docker containers whose
entrypoints install `libprotobuf-dev` on demand), so the dependency
must be installed in the workflow itself.

Without it, any PR whose source builds with `PROXYSQLGENAI=1` and
recurses into `plugins/mysqlx` fails at Makefile parse time:

```
Makefile:47: *** libprotobuf not found via pkg-config. Install
libprotobuf-dev (3.x). ... Stop.
```

This is what is currently blocking CI-unit-tests-asan-coverage on the
plugin-chassis PR (#5651): `workflow_run` reads the workflow YAML from
the **default branch** (v3.0), not from the PR branch, so the fix has
to live on v3.0 to take effect.

The change is purely the apt install list — no source code touched.
Adding `libprotobuf-dev` is a no-op on v3.0's own commits today (no
mysqlx plugin yet), but lines this workflow up with `INSTALL.md` and
unblocks the chassis PR's CI.

## Test plan

- [ ] CI-unit-tests-asan-coverage on this PR is green (verifies the
      install step succeeds and the build path on v3.0 still works).
- [ ] Re-run CI-unit-tests-asan-coverage on plugin-chassis (PR #5651)
      after merge — should now find protobuf and reach the unit test
      step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies to support enhanced build verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->