### PR TITLE
fix(test): test_mysqlx_plugin_load-t needs Phase B between load and init

### DIFF
--- a/test/tap/tests/test_mysqlx_plugin_load-t.cpp
+++ b/test/tap/tests/test_mysqlx_plugin_load-t.cpp
@@ -46,16 +46,25 @@ int main() {
 	// tables(kind) getters below return empty vectors regardless of
 	// init_all() succeeding. Plugins that opt out of Phase B (ABI 1)
 	// register everything in init_all(); for those the call below is a
-	// no-op (returns true with err empty).
-	ok(mgr.invoke_register_schemas_phase(err),
-	   "invoke_register_schemas_phase registers mysqlx schema");
-	if (!err.empty()) {
+	// no-op (returns true with err empty). BAIL_OUT on failure because
+	// every subsequent assertion asserts on tables(kind) state populated
+	// during Phase B — they would all spuriously fail and obscure the
+	// real cause.
+	//
+	// Capture return values explicitly rather than reading `err` to
+	// detect failure: both invoke_register_schemas_phase and init_all
+	// call err.clear() on entry, so a leftover err from a prior call
+	// can't be used as a success indicator.
+	const bool schemas_ok = mgr.invoke_register_schemas_phase(err);
+	ok(schemas_ok, "invoke_register_schemas_phase registers mysqlx schema");
+	if (!schemas_ok) {
 		diag("register_schemas error: %s", err.c_str());
-		err.clear();
+		BAIL_OUT("mysqlx schema registration must succeed before table assertions");
 	}
 
-	ok(mgr.init_all(err), "init_all completes after schema registration");
-	if (!err.empty()) {
+	const bool init_ok = mgr.init_all(err);
+	ok(init_ok, "init_all completes after schema registration");
+	if (!init_ok) {
 		diag("init error: %s", err.c_str());
 	}
 

--- a/test/tap/tests/test_mysqlx_plugin_load-t.cpp
+++ b/test/tap/tests/test_mysqlx_plugin_load-t.cpp
@@ -28,7 +28,7 @@ const ProxySQL_PluginTableDef* find_table(
 } // namespace
 
 int main() {
-	plan(6);
+	plan(7);
 
 	ProxySQL_PluginManager mgr;
 	std::string err {};
@@ -41,7 +41,20 @@ int main() {
 		BAIL_OUT("mysqlx plugin must load before schema assertions");
 	}
 
-	ok(mgr.init_all(err), "init_all registers mysqlx schema");
+	// Phase B: the mysqlx plugin (ABI 2+) registers its admin tables in
+	// register_schemas() rather than init(). Without this call the
+	// tables(kind) getters below return empty vectors regardless of
+	// init_all() succeeding. Plugins that opt out of Phase B (ABI 1)
+	// register everything in init_all(); for those the call below is a
+	// no-op (returns true with err empty).
+	ok(mgr.invoke_register_schemas_phase(err),
+	   "invoke_register_schemas_phase registers mysqlx schema");
+	if (!err.empty()) {
+		diag("register_schemas error: %s", err.c_str());
+		err.clear();
+	}
+
+	ok(mgr.init_all(err), "init_all completes after schema registration");
 	if (!err.empty()) {
 		diag("init error: %s", err.c_str());
 	}


### PR DESCRIPTION
Surfaced by CI-unit-tests-asan-coverage on plugin-chassis (run [25202654334](https://github.com/sysown/proxysql/actions/runs/25202654334), HEAD `bb199c6c`). Four of six assertions failed because the test calls `load()` + `init_all()` directly and skips Phase B (`invoke_register_schemas_phase`) — but the mysqlx plugin registers its admin tables in `register_schemas()`, not in `init()`.

## Failure log

```
1..6
ok 1 - load mysqlx plugin succeeds
ok 2 - init_all registers mysqlx schema
not ok 3 - mysqlx_users registered in admin_db
not ok 4 - mysqlx_users registered in config_db
not ok 5 - mysqlx_users admin schema includes allowed_auth_methods
not ok 6 - mysqlx_users config schema includes backend_auth_mode
```

## Why this only surfaces now

Pre-existing test bug. `test_mysqlx_plugin_load-t.cpp` was written before the four-phase lifecycle was finalised (commits go back to the mysqlx scaffolding). When `mysqlx_register_admin_schema` moved into `mysqlx_register_schemas` (Phase B), this test wasn't updated. Sibling tests (`test_mysqlx_admin_tables-t`, `plugin_manager_unit-t`) drive the full A→B→D lifecycle and stayed green; only this one took the short-cut and broke.

## Fix

```diff
+ // Phase B: the mysqlx plugin (ABI 2+) registers its admin tables in
+ // register_schemas() rather than init().  Without this call the
+ // tables(kind) getters below return empty vectors regardless of
+ // init_all() succeeding.
+ ok(mgr.invoke_register_schemas_phase(err),
+    "invoke_register_schemas_phase registers mysqlx schema");
```

Plan bumped from 6 to 7. ABI-1 plugins that don't declare `register_schemas` get a no-op (returns true with err empty), so the assertion is safe for any future plugin too.

## Verification

```
$ ./test_mysqlx_plugin_load-t
1..7
ok 1 - load mysqlx plugin succeeds
ok 2 - invoke_register_schemas_phase registers mysqlx schema
ok 3 - init_all completes after schema registration
ok 4 - mysqlx_users registered in admin_db
ok 5 - mysqlx_users registered in config_db
ok 6 - mysqlx_users admin schema includes allowed_auth_methods
ok 7 - mysqlx_users config schema includes backend_auth_mode
```

## Test plan

- [ ] CI-unit-tests-asan-coverage on this PR is green (specifically the `test_mysqlx_plugin_load-t` step).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Introduced an explicit two-step plugin setup in tests: schema-registration is validated before overall initialization.
  * Switched initialization checks to assert a boolean success result rather than relying on error text.
  * Updated TAP expectations from 6 to 7 assertions to reflect the added validation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->