### PR TITLE
fix(mysqlx): address 6 findings from external code review

### DIFF
--- a/include/ProxySQL_Plugin.h
+++ b/include/ProxySQL_Plugin.h
@@ -102,6 +102,19 @@ using proxysql_plugin_log_message_cb =
 #ifdef PROXYSQL40
 // Pre-execution query hook (Step 2 ABI extension).
 //
+// STATUS (chassis ABI 2 — initial baseline): the registration and
+// dispatch path are wired through ProxySQL_PluginManager and the
+// chassis fast-path probe (proxysql_has_configured_plugin_query_hook),
+// and unit tests exercise the dispatch surface end-to-end. However,
+// the production data plane (MySQL_Session::handler___status_WAITING_
+// CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo and the matching
+// PgSQL_Session COM_QUERY entry) does NOT yet call the dispatch
+// helper. Plugins that register a query hook today will see the
+// callback invoked from unit tests but not from real client traffic.
+// Wiring the production fast-path is a deliberate follow-up — search
+// for "TODO(plugin-query-hook)" in lib/MySQL_Session.cpp and
+// lib/PgSQL_Session.cpp for the precise injection points.
+//
 // Wire protocol the hook is being invoked for.  A plugin can register
 // independently for each protocol; one hook per protocol per plugin.
 enum class ProxySQL_PluginProtocol : uint8_t {

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -3383,6 +3383,16 @@ void MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_C
 				(begint.tv_sec*1000000000+begint.tv_nsec);
 		}
 		assert(qpo);	// GloMyQPro->process_mysql_query() should always return a qpo
+		// TODO(plugin-query-hook): inject pre-execution hook dispatch
+		// here, after CurrentQuery is populated and before the query
+		// is committed for backend execution. The chassis ABI surface
+		// (proxysql_has_configured_plugin_query_hook +
+		// proxysql_dispatch_configured_plugin_query_hook in
+		// include/ProxySQL_PluginManager.h) is in place; this is the
+		// missing data-plane integration. See ProxySQL_Plugin.h's
+		// "STATUS (chassis ABI 2 — initial baseline)" comment for
+		// the full scope. Same injection pattern needed at line ~5398
+		// (this same source file) and the PgSQL COM_QUERY entry.
 		// setting 'prepared' to prevent fetching results from the cache if the digest matches
 		rc_break=handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo(&pkt, &lock_hostgroup, ps_type_prepare_stmt);
 		if (rc_break==true) {
@@ -5402,6 +5412,11 @@ __get_pkts_from_client:
 											(endt.tv_sec*1000000000+endt.tv_nsec) -
 											(begint.tv_sec*1000000000+begint.tv_nsec);
 									}
+									// TODO(plugin-query-hook): inject pre-execution
+									// hook dispatch here for the COM_QUERY codepath,
+									// after CurrentQuery is populated. See
+									// ProxySQL_Plugin.h "STATUS (chassis ABI 2 —
+									// initial baseline)".
 									assert(qpo);	// GloMyQPro->process_mysql_query() should always return a qpo
 
 									{

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -2385,6 +2385,15 @@ __implicit_sync:
 										(endt.tv_sec * 1000000000 + endt.tv_nsec) -
 										(begint.tv_sec * 1000000000 + begint.tv_nsec);
 								}
+								// TODO(plugin-query-hook): inject pre-execution
+								// hook dispatch here for the PgSQL COM_QUERY
+								// codepath, after CurrentQuery is populated.
+								// Use proxysql_dispatch_configured_plugin_
+								// query_hook with ProxySQL_PluginProtocol::pgsql.
+								// See ProxySQL_Plugin.h "STATUS (chassis ABI 2 —
+								// initial baseline)" — the dispatch ABI is
+								// already in place; this is the data-plane
+								// integration that needs to land.
 								assert(qpo);	// GloPgQPro->process_mysql_query() should always return a qpo
 								// ===================================================
 								if (qpo->max_lag_ms >= 0) {

--- a/plugins/mysqlx/Makefile
+++ b/plugins/mysqlx/Makefile
@@ -64,8 +64,25 @@ OPTZ ?= -O2 -ggdb
 # the flags libproxysql.a was built with; a mismatch silently changes the
 # ProxySQL_PluginDescriptor / ProxySQL_PluginServices layout the core and
 # the plugin each see, and the loader then reads past the end of the
-# plugin's static descriptor.  (If this Makefile is run standalone, the
-# caller is expected to export PROXYSQL40/31/etc. to match the lib.)
+# plugin's static descriptor.
+#
+# Tier cascade (mirrors the top-level Makefile):
+#   PROXYSQLGENAI=1 ⇒ PROXYSQL40=1 ⇒ PROXYSQL31=1 ⇒ PROXYSQLFFTO=1 + PROXYSQLTSDB=1
+# A standalone `make -C plugins/mysqlx PROXYSQLGENAI=1` previously set only
+# -DPROXYSQLGENAI and quietly produced a layout-mismatched .so. The cascade
+# below forces the implied flags so the standalone path matches the
+# top-level build.
+ifeq ($(PROXYSQLGENAI),1)
+	PROXYSQL40 := 1
+endif
+ifeq ($(PROXYSQL40),1)
+	PROXYSQL31 := 1
+endif
+ifeq ($(PROXYSQL31),1)
+	PROXYSQLFFTO := 1
+	PROXYSQLTSDB := 1
+endif
+
 PSQL40 :=
 ifeq ($(PROXYSQL40),1)
 	PSQL40 := -DPROXYSQL40

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -177,6 +177,20 @@ private:
 
 	void handle_auth_mysql41(const std::string& auth_data);
 	void handle_auth_plain(const std::string& auth_data);
+
+	// After identity_ is resolved, validate that the user is allowed to
+	// authenticate with the negotiated mechanism over the current
+	// transport. Sends the appropriate X-Protocol error frame and
+	// returns false if any per-identity policy is violated:
+	//   - identity_->require_tls=1 and the frontend connection is
+	//     not encrypted
+	//   - identity_->allowed_auth_methods is set and does not contain
+	//     auth_method_ (a comma-separated list; empty means
+	//     "any wired method allowed", matching the historical default)
+	// Caller is expected to set `healthy = false` and return on a
+	// false return value (the helper itself does not change session
+	// state beyond emitting the error frame).
+	bool enforce_identity_policy();
 	void forward_frame_to_client(uint8_t msg_type, const MysqlxFrame& frame);
 
 	int dispatch_client_message(uint8_t msg_type);

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -225,6 +225,12 @@ private:
 	int target_hostgroup_;
 	std::string target_address_;
 	int target_port_;
+	// Per-endpoint TLS posture, copied from the resolved
+	// MysqlxBackendEndpoint at resolve_backend_target time. Drives
+	// backend TLS independently of frontend TLS state — operator
+	// sets mysqlx_backend_endpoints.use_ssl=1 to force backend TLS
+	// even when the client connected in plaintext.
+	bool target_use_ssl_;
 	MysqlxIdentityLookup identity_lookup_;
 	std::optional<MysqlxResolvedIdentity> identity_;
 	uint64_t start_time_;

--- a/plugins/mysqlx/src/mysqlx_connection.cpp
+++ b/plugins/mysqlx/src/mysqlx_connection.cpp
@@ -31,6 +31,15 @@ MysqlxConnection::~MysqlxConnection() {
 }
 
 bool MysqlxConnection::is_reusable() const {
+	// State-machine disqualifiers: connection has reached a terminal /
+	// error state from which reuse is unsafe regardless of the
+	// reusable_ flag. These catch failure paths that callers might
+	// have forgotten to translate into set_reusable(false).
+	if (state_ == ERROR_STATE || state_ == CLOSED) return false;
+	if (auth_state_ == BACKEND_AUTH_ERROR) return false;
+	// Caller-marked: in_transaction_ or has_prepared_stmt_ being true
+	// means the next session picking up this connection from the pool
+	// would inherit session-scoped state.
 	if (in_transaction_) return false;
 	if (has_prepared_stmt_) return false;
 	return reusable_;

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -479,6 +479,24 @@ bool MysqlxSession::enforce_identity_policy() {
 		return true;  // nothing to enforce
 	}
 
+	// backend_auth_mode='pass_through' is parsed and round-trips through
+	// the config store but the backend-auth state machine does not
+	// actually forward AuthStart unmodified to the backend (the existing
+	// code maps the user's frontend creds to backend creds either via
+	// the mapped or service_account paths). Per the design spec
+	// (docs/superpowers/specs/2026-04-07-mysqlx-plugin-design.md §
+	// "Backend authentication", around the pass_through bullet:
+	// "configuration validation should reject pass_through rather than
+	// silently downgrading it"), refuse the auth attempt instead of
+	// approximating it. The accepted modes today are 'mapped' (default)
+	// and 'service_account'; pass_through is reserved for a future
+	// implementation that forwards the client's AuthStart frame
+	// verbatim to the backend.
+	if (identity_->backend_auth_mode == MysqlxBackendAuthMode::pass_through) {
+		send_error(1045, "backend_auth_mode 'pass_through' is not yet implemented; refusing rather than silently downgrading");
+		return false;
+	}
+
 	// require_tls: per-user "MYSQL41 / PLAIN must run over TLS".
 	// PLAIN already has a hardcoded TLS gate at handle_auth_plain entry;
 	// this is the per-user knob that also covers MYSQL41 — operators set

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -875,6 +875,11 @@ bool MysqlxSession::is_terminal_for_state(uint8_t msg_type) const {
 
 void MysqlxSession::handler_waiting_server_msg() {
 	if (server_ds().get_fd() < 0) {
+		// server_ds fd is -1 means we lost the backend out-of-band
+		// (close, error, premature stream reset). Don't put it in the
+		// pool as if it were healthy; is_reusable() will refuse it
+		// even if we did, but be explicit at the call site too.
+		if (backend_conn_) backend_conn_->set_reusable(false);
 		return_backend_to_pool();
 		status_ = WAITING_CLIENT_XMSG;
 		to_process = true;
@@ -884,12 +889,18 @@ void MysqlxSession::handler_waiting_server_msg() {
 	ssize_t r = server_ds().read_from_net();
 	if (r == 0) {
 		send_error(2013, "Lost connection to backend during query");
+		// Mark non-reusable so return_backend_to_pool deletes the
+		// connection instead of caching a dead socket. Without this,
+		// the next session that pulls from the pool gets a backend
+		// whose fd is closed / EOF.
+		if (backend_conn_) backend_conn_->set_reusable(false);
 		return_backend_to_pool();
 		healthy = false;
 		return;
 	}
 	if (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 		send_error(2013, "Backend read error during query");
+		if (backend_conn_) backend_conn_->set_reusable(false);
 		return_backend_to_pool();
 		healthy = false;
 		return;
@@ -930,6 +941,7 @@ void MysqlxSession::handler_waiting_server_msg() {
 
 void MysqlxSession::handler_session_reset_waiting() {
 	if (server_ds().get_fd() < 0) {
+		if (backend_conn_) backend_conn_->set_reusable(false);
 		return_backend_to_pool();
 		status_ = WAITING_CLIENT_XMSG;
 		to_process = true;
@@ -938,6 +950,9 @@ void MysqlxSession::handler_session_reset_waiting() {
 
 	ssize_t r = server_ds().read_from_net();
 	if (r == 0 || (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+		// Backend died while waiting for the SESS_RESET response — treat
+		// the connection as dead, don't recycle it.
+		if (backend_conn_) backend_conn_->set_reusable(false);
 		return_backend_to_pool();
 		status_ = WAITING_CLIENT_XMSG;
 		to_process = true;

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -95,6 +95,7 @@ MysqlxSession::MysqlxSession()
 	, healthy(true)
 	, target_hostgroup_(0)
 	, target_port_(0)
+	, target_use_ssl_(false)
 	, start_time_(0)
 	, last_active_time_(0)
 	, response_state_(RESP_IDLE)
@@ -142,6 +143,7 @@ void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
 	target_hostgroup_ = 0;
 	target_address_.clear();
 	target_port_ = 0;
+	target_use_ssl_ = false;
 	identity_.reset();
 	start_time_ = monotonic_time_ms();
 	last_active_time_ = start_time_;
@@ -163,6 +165,7 @@ void MysqlxSession::reset() {
 	target_hostgroup_ = 0;
 	target_address_.clear();
 	target_port_ = 0;
+	target_use_ssl_ = false;
 	identity_.reset();
 	compression_algo_ = MYSQLX_COMPR_NONE;
 	compression_combine_mixed_messages_ = false;
@@ -1097,6 +1100,7 @@ int MysqlxSession::resolve_backend_target() {
 	target_hostgroup_ = hg;
 	target_address_   = ep.hostname;
 	target_port_      = ep.mysqlx_port;
+	target_use_ssl_   = ep.use_ssl;
 	return 0;
 }
 
@@ -1179,7 +1183,18 @@ void MysqlxSession::handler_connecting_server() {
 		backend_conn_->set_backend_user(backend_user.c_str());
 		backend_conn_->set_backend_schema(schema_.c_str());
 
-		if (client_ds_.is_encrypted()) {
+		// Backend TLS is enabled when EITHER the operator forced it via
+		// the endpoint's use_ssl=1 flag (mysqlx_backend_endpoints.
+		// use_ssl, captured into target_use_ssl_ at
+		// resolve_backend_target time) OR the client connected to the
+		// proxy over TLS. The endpoint-flag path lets operators mandate
+		// proxy↔backend encryption even for plaintext clients on a
+		// trusted private network — previously the flag was loaded into
+		// MysqlxBackendEndpoint but silently dropped here, so plaintext
+		// clients always produced plaintext backend traffic regardless
+		// of the operator's setting.
+		const bool require_backend_tls = target_use_ssl_ || client_ds_.is_encrypted();
+		if (require_backend_tls) {
 			if (thread_ptr_ && thread_ptr_->get_ssl_ctx()) {
 				backend_conn_->set_backend_tls_required(true);
 				backend_conn_->set_ssl_ctx(thread_ptr_->get_ssl_ctx());

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -474,6 +474,51 @@ void MysqlxSession::handler_capabilities_set() {
 	status_ = CONNECTING_CLIENT;
 }
 
+bool MysqlxSession::enforce_identity_policy() {
+	if (!identity_) {
+		return true;  // nothing to enforce
+	}
+
+	// require_tls: per-user "MYSQL41 / PLAIN must run over TLS".
+	// PLAIN already has a hardcoded TLS gate at handle_auth_plain entry;
+	// this is the per-user knob that also covers MYSQL41 — operators set
+	// require_tls=1 on a row to forbid the (otherwise legal) "MYSQL41
+	// over plaintext" path.
+	if (identity_->require_tls && !client_ds_.is_encrypted()) {
+		send_error(1045, "User requires a TLS connection");
+		return false;
+	}
+
+	// allowed_auth_methods: per-user whitelist of mechanism names.
+	// Empty string preserves the historical "any wired method" default
+	// so existing rows don't require a backfill. Non-empty: comma-
+	// separated, case-insensitive match against auth_method_.
+	if (!identity_->allowed_auth_methods.empty()) {
+		const std::string& list = identity_->allowed_auth_methods;
+		bool matched = false;
+		size_t pos = 0;
+		while (pos < list.size()) {
+			size_t comma = list.find(',', pos);
+			if (comma == std::string::npos) comma = list.size();
+			std::string token = list.substr(pos, comma - pos);
+			// Trim leading/trailing whitespace.
+			while (!token.empty() && (token.front() == ' ' || token.front() == '\t')) token.erase(token.begin());
+			while (!token.empty() && (token.back()  == ' ' || token.back()  == '\t')) token.pop_back();
+			if (!token.empty() && strcasecmp(token.c_str(), auth_method_.c_str()) == 0) {
+				matched = true;
+				break;
+			}
+			pos = comma + 1;
+		}
+		if (!matched) {
+			send_error(1045, "Authentication mechanism not allowed for user");
+			return false;
+		}
+	}
+
+	return true;
+}
+
 void MysqlxSession::handle_auth_mysql41(const std::string& auth_data) {
 	size_t first_nul = auth_data.find('\0');
 	if (first_nul != std::string::npos) {
@@ -531,6 +576,11 @@ void MysqlxSession::handle_auth_plain(const std::string& auth_data) {
 	identity_ = identity_lookup_(username_);
 	if (!identity_ || !identity_->x_enabled) {
 		send_error(1045, "Access denied for user");
+		healthy = false;
+		return;
+	}
+
+	if (!enforce_identity_policy()) {
 		healthy = false;
 		return;
 	}
@@ -659,6 +709,11 @@ void MysqlxSession::handler_auth_challenge_response() {
 		identity_ = identity_lookup_(username_);
 		if (!identity_ || !identity_->x_enabled) {
 			send_error(1045, "Access denied for user");
+			healthy = false;
+			return;
+		}
+
+		if (!enforce_identity_policy()) {
 			healthy = false;
 			return;
 		}

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -418,6 +418,22 @@ MysqlxConnection* Mysqlx_Thread::get_connection_from_cache(
 }
 
 void Mysqlx_Thread::return_connection_to_cache(MysqlxConnection* conn) {
+	// Decide reuse BEFORE reset(). reset() unconditionally clears
+	// in_transaction_ / has_prepared_stmt_ / sets reusable_=true
+	// (mysqlx_connection.cpp::reset). If we called reset first and
+	// THEN consulted is_reusable(), every connection — including ones
+	// in mid-transaction, ones holding prepared statements, ones the
+	// session explicitly marked non-reusable on a backend EOF or read
+	// error — would come back as "reusable" and re-enter the cache.
+	//
+	// is_reusable() also fails if the underlying socket is dead (EOF
+	// or read error path in mysqlx_session.cpp::~884 sets reusable_=
+	// false before calling return_backend_to_pool); preserving that
+	// signal here keeps dead fds out of the cache.
+	if (!conn->is_reusable()) {
+		delete conn;
+		return;
+	}
 	conn->reset();
 	std::lock_guard<std::mutex> lock(conn_cache_mutex_);
 	if (conn_cache_.size() >= max_cached_) {

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -260,6 +260,14 @@ void Mysqlx_Thread::process_all_sessions() {
 		// on either data stream, the session asked to be re-run, or there are
 		// already-buffered frames to dispatch. Forcing to_process=true on every
 		// tick burned the CPU at large session counts.
+		//
+		// Clear the per-stream revents bitmask AFTER handler() consumes it.
+		// process_ready_fds() above writes set_revents(revents) on whichever
+		// streams poll() flagged this iteration, but nothing else clears the
+		// field — without the post-handler reset here, a session that received
+		// one POLLIN event would re-enter handler() every poll cycle (each
+		// time hitting EAGAIN) until the stream is closed, defeating the
+		// "real work only" gating this whole block was added to provide.
 		short c_rev = sess->client_ds().get_revents();
 		short s_rev = sess->server_ds().get_revents();
 		bool fd_ready = (c_rev != 0) || (s_rev != 0);
@@ -268,6 +276,10 @@ void Mysqlx_Thread::process_all_sessions() {
 		if (fd_ready || buffered || sess->to_process) {
 			sess->to_process = true;
 			rc = sess->handler();
+			// Consume the readiness flags so the next iteration only fires
+			// on a fresh poll event (or buffered work / explicit to_process).
+			sess->client_ds().set_revents(0);
+			sess->server_ds().set_revents(0);
 		}
 
 		bool timeout = false;

--- a/test/tap/tests/unit/mysqlx_session_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_session_unit-t.cpp
@@ -451,6 +451,98 @@ static void test_mysql41_auth_wrong_password() {
 	close(fds[1]);
 }
 
+// Regression test for the design-spec rule that backend_auth_mode
+// 'pass_through' must be rejected at auth time rather than silently
+// downgraded to mapped/service_account. See docs/superpowers/specs/
+// 2026-04-07-mysqlx-plugin-design.md:298-299 ("configuration validation
+// should reject pass_through rather than silently downgrading it") and
+// the MysqlxSession::enforce_identity_policy() rejection landed in
+// commit 2bfc88661.
+static void test_pass_through_rejected() {
+	diag(">>> %s", __func__);
+	int fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+
+	MysqlxSession sess;
+	sess.init(fds[0], nullptr);
+
+	// Identity opts into pass_through. Otherwise this is a perfectly
+	// valid MYSQL41-capable user — password matches, x_enabled=1,
+	// allowed_auth_methods permits MYSQL41 — so any rejection on this
+	// path can only come from the backend_auth_mode policy check.
+	sess.set_identity_lookup([](const std::string& user) -> std::optional<MysqlxResolvedIdentity> {
+		if (user == "ptuser") {
+			MysqlxResolvedIdentity id{};
+			id.username = user;
+			id.x_enabled = true;
+			id.password = "testpass";
+			id.allowed_auth_methods = "MYSQL41";
+			id.backend_auth_mode = MysqlxBackendAuthMode::pass_through;
+			return id;
+		}
+		return std::nullopt;
+	});
+
+	sess.to_process = true;
+
+	Mysqlx::Session::AuthenticateStart auth_start;
+	auth_start.set_mech_name("MYSQL41");
+	auth_start.set_auth_data(std::string("\0testdb\0ptuser", 14));
+	std::string serialized;
+	auth_start.SerializeToString(&serialized);
+
+	write_x_frame(fds[1], Mysqlx::ClientMessages_Type_SESS_AUTHENTICATE_START,
+		reinterpret_cast<const uint8_t*>(serialized.data()), serialized.size());
+
+	sess.handler();
+
+	uint8_t buf[4096];
+	usleep(10000);
+	ssize_t r = read_x_frame(fds[1], buf, sizeof(buf));
+
+	Mysqlx::Session::AuthenticateContinue cont_msg;
+	cont_msg.ParseFromArray(buf + 5, r - 5);
+	std::vector<uint8_t> challenge(cont_msg.auth_data().begin(), cont_msg.auth_data().end());
+
+	// Send the *correct* scramble. If the rejection path didn't fire
+	// we'd see SESS_AUTHENTICATE_OK; the test asserts the contrary.
+	std::vector<uint8_t> scramble = mysqlx_mysql41_scramble(challenge, "testpass");
+	std::string hex_scramble = mysqlx_hex_encode(scramble);
+	std::string response_str = std::string("*") + hex_scramble;
+
+	cont_msg.Clear();
+	cont_msg.set_auth_data(response_str);
+	cont_msg.SerializeToString(&serialized);
+
+	write_x_frame(fds[1], Mysqlx::ClientMessages_Type_SESS_AUTHENTICATE_CONTINUE,
+		reinterpret_cast<const uint8_t*>(serialized.data()), serialized.size());
+
+	sess.to_process = true;
+	sess.handler();
+
+	usleep(10000);
+	r = read_x_frame(fds[1], buf, sizeof(buf));
+	ok(r > 0, "got response for pass_through user");
+	if (r > 0) {
+		ok(buf[4] == Mysqlx::ServerMessages_Type_ERROR,
+		   "pass_through auth rejected (Error frame, not AUTHENTICATE_OK)");
+
+		// The error message must mention pass_through so an operator
+		// looking at the client-side error knows exactly which knob is
+		// the culprit.
+		Mysqlx::Error err;
+		if (err.ParseFromArray(buf + 5, static_cast<int>(r - 5))) {
+			ok(err.code() == 1045, "pass_through rejection uses code 1045");
+			ok(err.msg().find("pass_through") != std::string::npos,
+			   "error message mentions 'pass_through' (got: %s)", err.msg().c_str());
+		}
+	}
+	ok(!sess.is_healthy(), "session unhealthy after pass_through rejection");
+
+	close(fds[0]);
+	close(fds[1]);
+}
+
 static void test_error_severity_non_fatal() {
 	diag(">>> %s", __func__);
 	int fds[2];
@@ -688,7 +780,7 @@ static void test_session_timestamps() {
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(60);
+	plan(65);
 	diag("=== mysqlx_session_unit-t starting ===");
 
 	test_session_init();
@@ -701,6 +793,7 @@ int main() {
 	test_plain_rejected_without_tls();
 	test_mysql41_auth_with_credentials();
 	test_mysql41_auth_wrong_password();
+	test_pass_through_rejected();
 	test_error_severity_non_fatal();
 	test_compression_error_non_fatal();
 	test_post_auth_capabilities_get();


### PR DESCRIPTION
External review surfaced 6 findings on the mysqlx plugin / chassis surface. All 6 verified against the actual code; all 6 addressed in this PR (5 production fixes + 1 deferred-with-TODO-markers for the largest-scope one).

## Findings + commits

| # | Finding | Severity | Commit |
|---|---|---|---|
| 1 | Pool returns dead/stateful connections — `return_connection_to_cache` calls `conn->reset()` *before* deciding reuse, wiping `has_prepared_stmt_` / `in_transaction_` / `reusable_=false` set by callers | High | `bd49725a6` |
| 2 | `require_tls` and `allowed_auth_methods` per-user policy fields loaded but never enforced at auth time | High | `e535a66ee` |
| 3 | `mysqlx_backend_endpoints.use_ssl` documented as forcing backend TLS but silently dropped — backend TLS gated only on frontend TLS state | High | `4e32f4419` |
| 4 | `MysqlxDataStream::revents_` never cleared after `handler()` runs — once a session got POLLIN, every poll cycle re-entered handler hitting EAGAIN, defeating the "real work only" CPU-saving gate | Medium | `9c84ae455` |
| 5 | Chassis query-hook ABI never invoked from production data plane (MySQL_Session / PgSQL_Session) — plugins can register hooks that never fire on real client traffic | Medium | `6d8dff293` (deferred + TODO markers, see below) |
| 6 | Standalone `make -C plugins/mysqlx PROXYSQLGENAI=1` produces a layout-mismatched .so because the plugin Makefile doesn't mirror the top-level feature-tier cascade | Medium (footgun) | `f08206a2f` |

## #5: deferred with explicit scaffold-state acknowledgement

Wiring the query-hook dispatch into `MySQL_Session::handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo` (and the COM_STMT_PREPARE / COM_STMT_EXECUTE entries that share the `qpo` machinery, plus the equivalent in `PgSQL_Session`) is mechanical but touches a 95k-LOC hot-path file. A bug there ships as a query-blocking regression. The integration deserves its own focused PR with TAP coverage exercising ALLOW and DENY paths against a fake plugin — not a side-quest in this PR.

What this commit ships:

- Explicit scaffold-state callout in `include/ProxySQL_Plugin.h`'s query-hook section so plugin authors don't assume the hook fires in production today.
- `TODO(plugin-query-hook)` markers at the precise injection sites — two in `lib/MySQL_Session.cpp`, one in `lib/PgSQL_Session.cpp` — each immediately following the `process_query` call where `CurrentQuery` is populated.

The next person picking this up has an unambiguous starting point.

## Verification

- All 22 mysqlx-related unit tests green (21 mysqlx_*_unit-t + plugin_runtime_views_unit-t).
- libproxysql.a + plugins/mysqlx/ProxySQL_MySQLX_Plugin.so build clean with the full PROXYSQLGENAI tier.
- Standalone plugin build with just `PROXYSQLGENAI=1` now produces all 5 tier flags (verified via `make -n` after the Makefile cascade fix).

## Test plan

- [ ] CI-unit-tests-asan-coverage on plugin-chassis stays green (specifically `mysqlx_thread_unit-t` for the revents fix and `mysqlx_connection_unit-t` for the pool-reuse fix).
- [ ] CI-mysqlx soak test goes green (or at minimum doesn't regress) — Findings 1 and 4 both improve runtime correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user authentication policy enforcement (TLS requirement, auth-method whitelist).
  * Independent backend TLS selection driven by endpoint configuration.

* **Bug Fixes**
  * Prevent reusing connections after terminal/error or failed-auth states.
  * Improve backend I/O loss detection and pool cleanup; avoid recycling dead sockets.
  * Correct poll readiness handling to prevent repeated handler re-entry.

* **Documentation**
  * Added TODO notes clarifying intended pre-execution query-hook integration points.

* **Tests**
  * Added unit test asserting rejection of pass_through backend auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->