### PR TITLE
feat(mysqlx): wire P0 observability — counters, byte accounting, runtime-view projections

### DIFF
--- a/plugins/mysqlx/include/mysqlx_plugin.h
+++ b/plugins/mysqlx/include/mysqlx_plugin.h
@@ -63,6 +63,24 @@ MysqlxPluginContext& mysqlx_context();
  */
 __attribute__((weak)) void mysqlx_reconcile_listeners(SQLite3DB& admindb);
 
+/**
+ * Walks every Mysqlx_Thread in mysqlx_context().threads, snapshots each
+ * thread's sessions_ under its sessions_mutex_, and projects one row per
+ * active session into stats_mysqlx_processlist. Called from the chassis
+ * runtime-view refresh callback before any admin SELECT against the
+ * table runs (the callback in mysqlx_admin_schema.cpp).
+ *
+ * Snapshot work is bounded per thread: a string-copy + a few struct field
+ * reads under the mutex, no I/O. Lock ordering: each thread's
+ * sessions_mutex_ is acquired in turn; no cross-thread lock is held.
+ *
+ * Declared __attribute__((weak)) for the same reason
+ * mysqlx_reconcile_listeners is — admin_schema.cpp's unit tests don't
+ * link mysqlx_plugin.cpp, so the projection registration must tolerate
+ * an unresolved hook at test-build link time.
+ */
+__attribute__((weak)) void mysqlx_populate_stats_processlist(SQLite3DB& statsdb);
+
 // Pure variant of `mysqlx_reconcile_listeners` that takes the plugin state
 // as parameters instead of going through `mysqlx_context()`. Exists so unit
 // tests can construct a minimal fake context without pulling in the whole

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -159,6 +159,20 @@ public:
 	const std::string& target_address_for_test() const { return target_address_; }
 	int  target_port_for_test() const { return target_port_; }
 
+	// Read-only state observers used by the stats_mysqlx_processlist
+	// projection (Mysqlx_Thread::snapshot_sessions_for_stats walks
+	// sessions_ and reads these under sessions_mutex_). Borrowed
+	// references — caller must copy if it needs the value past the
+	// snapshot scope. The identity_ accessor returns the optional by
+	// value because the projection wants the resolved fields, not the
+	// optional itself; this only happens once per session per admin
+	// SELECT against stats_mysqlx_processlist, so the copy cost is
+	// negligible.
+	const std::string& username_for_stats() const { return username_; }
+	const std::string& route_name_for_stats() const { return route_name_; }
+	std::optional<MysqlxResolvedIdentity> identity_for_stats() const { return identity_; }
+	uint64_t start_time_for_stats() const { return start_time_; }
+
 	bool to_process;
 
 private:

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -245,6 +245,12 @@ private:
 	// sets mysqlx_backend_endpoints.use_ssl=1 to force backend TLS
 	// even when the client connected in plaintext.
 	bool target_use_ssl_;
+	// Cached identity_->default_route, captured in
+	// resolve_backend_target() so the data-plane bytes-counter sites
+	// (forward_to_backend / handler_waiting_server_msg) don't have
+	// to dereference identity_ on every frame. Empty until resolve
+	// succeeds; cleared by reset().
+	std::string route_name_;
 	MysqlxIdentityLookup identity_lookup_;
 	std::optional<MysqlxResolvedIdentity> identity_;
 	uint64_t start_time_;

--- a/plugins/mysqlx/include/mysqlx_stats.h
+++ b/plugins/mysqlx/include/mysqlx_stats.h
@@ -28,6 +28,15 @@ public:
 	void record_conn_err(const std::string& route_name, int destination_hostgroup);
 	void record_conn_used(const std::string& route_name, int destination_hostgroup);
 
+	// Accumulate per-route data-plane payload bytes. The argument is the
+	// X-Protocol *payload* size (excluding the 5-byte frame header) that
+	// the proxy forwarded between client and backend; framing overhead is
+	// intentionally not counted so the counter tracks operator-meaningful
+	// query/result bytes rather than the wire-level total. Both directions
+	// get their own counter so operators can spot asymmetric traffic.
+	void record_bytes_sent(const std::string& route_name, int destination_hostgroup, uint64_t n);
+	void record_bytes_recv(const std::string& route_name, int destination_hostgroup, uint64_t n);
+
 	// Flush stats into the stats SQLite DB.
 	void flush_to_sqlite(class SQLite3DB& statsdb);
 

--- a/plugins/mysqlx/include/mysqlx_thread.h
+++ b/plugins/mysqlx/include/mysqlx_thread.h
@@ -15,6 +15,29 @@
 
 class MysqlxConfigStore;
 
+// Per-session row used by the stats_mysqlx_processlist projection. Filled
+// by Mysqlx_Thread::snapshot_sessions_for_stats() under the thread's
+// sessions_mutex_; copied (not borrowed) so the admin-side projector can
+// release the worker's lock before doing any SQL.
+struct MysqlxSessionSnapshot {
+	std::string username;
+	std::string route;
+	int worker_id { 0 };
+	std::string backend_host;
+	int backend_port { 0 };
+	// String forms of the MysqlxBackendAuthMode enum and MysqlxSession::Status.
+	// Empty auth_mode means the session has not yet resolved an identity.
+	std::string auth_mode;
+	std::string connection_state;
+	// Per-session bytes_in/bytes_out are 0 in the P0 implementation: the
+	// stats store aggregates by route, not by session. P1 adds per-session
+	// counters; the columns in stats_mysqlx_processlist are reserved here so
+	// the schema doesn't change again when those land.
+	uint64_t bytes_in { 0 };
+	uint64_t bytes_out { 0 };
+	uint64_t session_age_ms { 0 };
+};
+
 class Mysqlx_Thread {
 public:
 	Mysqlx_Thread();
@@ -30,6 +53,14 @@ public:
 	size_t get_session_count() const;
 	bool is_running() const { return running_.load(); }
 	int get_listener_count() const;
+
+	// Walks sessions_ under sessions_mutex_ and appends one
+	// MysqlxSessionSnapshot per active session to `out`. `now_ms` should
+	// be a single monotonic time captured by the caller so all rows in a
+	// projection batch share the same reference point for session_age_ms.
+	// Lock scope is bounded to a string copy + a few struct field reads
+	// per session, no I/O. Safe to call from any thread.
+	void snapshot_sessions_for_stats(std::vector<MysqlxSessionSnapshot>& out, uint64_t now_ms) const;
 
 	/**
 	 * Creates a listener socket (bind + listen) and registers it with this

--- a/plugins/mysqlx/src/mysqlx_admin_schema.cpp
+++ b/plugins/mysqlx/src/mysqlx_admin_schema.cpp
@@ -266,6 +266,21 @@ void refresh_stats_routes_view(SQLite3DB* /*admindb*/, void*) {
 	mysqlx_stats().flush_to_sqlite(*statsdb);
 }
 
+// Same shape, but for stats_mysqlx_processlist: the projector walks
+// every Mysqlx_Thread and emits one row per active session. Defined in
+// mysqlx_plugin.cpp; declared __attribute__((weak)) so the
+// mysqlx_admin_schema_unit-t and friends (which compile this TU but
+// don't link mysqlx_plugin.cpp) still link successfully — the null check
+// here is the runtime safety net for the test build.
+void refresh_stats_processlist_view(SQLite3DB* /*admindb*/, void*) {
+	if (mysqlx_context().services == nullptr) return;
+	if (mysqlx_context().services->get_statsdb == nullptr) return;
+	if (&mysqlx_populate_stats_processlist == nullptr) return;
+	SQLite3DB* statsdb = mysqlx_context().services->get_statsdb();
+	if (statsdb == nullptr) return;
+	mysqlx_populate_stats_processlist(*statsdb);
+}
+
 bool disk_to_memory(SQLite3DB& admindb, const char* table_name) {
 	if (!admindb.execute("BEGIN")) {
 		return false;
@@ -482,6 +497,7 @@ bool mysqlx_register_admin_schema(ProxySQL_PluginServices& services) {
 		services.register_runtime_view({kRuntimeMysqlxBackendEndpointsTable,  &refresh_endpoints_runtime_view, nullptr});
 		services.register_runtime_view({kRuntimeMysqlxVariablesTable,         &refresh_variables_runtime_view, nullptr});
 		services.register_runtime_view({kStatsMysqlxRoutesTable,              &refresh_stats_routes_view,      nullptr});
+		services.register_runtime_view({kStatsMysqlxProcesslistTable,         &refresh_stats_processlist_view, nullptr});
 	}
 
 	// Stats tables (stats_db only, no config copy needed).

--- a/plugins/mysqlx/src/mysqlx_admin_schema.cpp
+++ b/plugins/mysqlx/src/mysqlx_admin_schema.cpp
@@ -1,6 +1,7 @@
 #include "mysqlx_admin_schema.h"
 
 #include "mysqlx_plugin.h"
+#include "mysqlx_stats.h"
 #include "sqlite3db.h"
 
 #include <initializer_list>
@@ -246,6 +247,25 @@ void refresh_variables_runtime_view(SQLite3DB* admindb, void*) {
 	mysqlx_context().config_store->project_variables_to_runtime_view(*admindb);
 }
 
+// Stats-projection refresh callback: chassis fires this on demand when an
+// admin SELECT references stats_mysqlx_routes, so the per-route counters
+// are refilled lazily from MysqlxStatsStore right before the operator
+// reads them.
+//
+// flush_to_sqlite writes to a bare table name, so the callback must hand
+// it the *statsdb* handle — the chassis-supplied `admindb` argument
+// reaches stats_mysqlx_routes only via the `stats.` attached schema, and
+// that's an unnecessary detour. The plugin already cached the services
+// pointer in mysqlx_context().services at Phase D init, so the get_statsdb
+// trampoline is reachable.
+void refresh_stats_routes_view(SQLite3DB* /*admindb*/, void*) {
+	if (mysqlx_context().services == nullptr) return;
+	if (mysqlx_context().services->get_statsdb == nullptr) return;
+	SQLite3DB* statsdb = mysqlx_context().services->get_statsdb();
+	if (statsdb == nullptr) return;
+	mysqlx_stats().flush_to_sqlite(*statsdb);
+}
+
 bool disk_to_memory(SQLite3DB& admindb, const char* table_name) {
 	if (!admindb.execute("BEGIN")) {
 		return false;
@@ -461,6 +481,7 @@ bool mysqlx_register_admin_schema(ProxySQL_PluginServices& services) {
 		services.register_runtime_view({kRuntimeMysqlxRoutesTable,            &refresh_routes_runtime_view,    nullptr});
 		services.register_runtime_view({kRuntimeMysqlxBackendEndpointsTable,  &refresh_endpoints_runtime_view, nullptr});
 		services.register_runtime_view({kRuntimeMysqlxVariablesTable,         &refresh_variables_runtime_view, nullptr});
+		services.register_runtime_view({kStatsMysqlxRoutesTable,              &refresh_stats_routes_view,      nullptr});
 	}
 
 	// Stats tables (stats_db only, no config copy needed).

--- a/plugins/mysqlx/src/mysqlx_plugin.cpp
+++ b/plugins/mysqlx/src/mysqlx_plugin.cpp
@@ -5,8 +5,11 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
 namespace {
 
@@ -268,6 +271,65 @@ void mysqlx_reconcile_listeners(SQLite3DB& admindb) {
 		ctx.route_to_thread_mutex,
 		ctx.next_rr_index
 	);
+}
+
+namespace {
+
+// Local copy of the SQLite single-quote escape used by mysqlx_stats.cpp;
+// duplicating one tiny function is cheaper than introducing a shared
+// header just for it. If a third caller appears, lift to mysqlx_util.h.
+std::string sqlite_escape_local(const std::string& input) {
+	std::string result;
+	result.reserve(input.size());
+	for (char c : input) {
+		if (c == '\'') result += "''";
+		else result += c;
+	}
+	return result;
+}
+
+uint64_t monotonic_time_ms_local() {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return static_cast<uint64_t>(ts.tv_sec) * 1000ULL + static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+}
+
+} // namespace
+
+void mysqlx_populate_stats_processlist(SQLite3DB& statsdb) {
+	MysqlxPluginContext& ctx = mysqlx_context();
+
+	// Always wipe the projection table — empty thread pool or empty
+	// session list both mean "no active sessions" and the operator
+	// must see that, not stale rows from the last refresh.
+	statsdb.execute("DELETE FROM stats_mysqlx_processlist");
+
+	if (ctx.threads.empty()) return;
+
+	uint64_t now_ms = monotonic_time_ms_local();
+	std::vector<MysqlxSessionSnapshot> rows;
+	for (const auto& thr : ctx.threads) {
+		if (thr) thr->snapshot_sessions_for_stats(rows, now_ms);
+	}
+
+	for (const auto& r : rows) {
+		std::string sql = "INSERT INTO stats_mysqlx_processlist "
+			"(username, route, worker_id, backend_host, backend_port, "
+			" auth_mode, connection_state, bytes_in, bytes_out, "
+			" session_age_ms) VALUES ('";
+		sql += sqlite_escape_local(r.username);
+		sql += "', '"; sql += sqlite_escape_local(r.route);
+		sql += "', "; sql += std::to_string(r.worker_id);
+		sql += ", '"; sql += sqlite_escape_local(r.backend_host);
+		sql += "', "; sql += std::to_string(r.backend_port);
+		sql += ", '"; sql += sqlite_escape_local(r.auth_mode);
+		sql += "', '"; sql += sqlite_escape_local(r.connection_state);
+		sql += "', "; sql += std::to_string(r.bytes_in);
+		sql += ", "; sql += std::to_string(r.bytes_out);
+		sql += ", "; sql += std::to_string(r.session_age_ms);
+		sql += ")";
+		statsdb.execute(sql.c_str());
+	}
 }
 
 // Default visibility is required because the plugin .so is built with

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -144,6 +144,7 @@ void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
 	target_address_.clear();
 	target_port_ = 0;
 	target_use_ssl_ = false;
+	route_name_.clear();
 	identity_.reset();
 	start_time_ = monotonic_time_ms();
 	last_active_time_ = start_time_;
@@ -166,6 +167,7 @@ void MysqlxSession::reset() {
 	target_address_.clear();
 	target_port_ = 0;
 	target_use_ssl_ = false;
+	route_name_.clear();
 	identity_.reset();
 	compression_algo_ = MYSQLX_COMPR_NONE;
 	compression_combine_mixed_messages_ = false;
@@ -896,6 +898,12 @@ void MysqlxSession::forward_to_backend() {
 		const auto& frame = client_ds_.front_frame();
 		if (frame.size() > 5) {
 			server_ds().enqueue_frame(frame[4], frame.data() + 5, frame.size() - 5);
+			// Account the X-Protocol payload bytes (excluding the 5-byte
+			// frame header) the proxy is forwarding to the backend. This
+			// is the "client → proxy → backend" leg; the counter is
+			// charged to the resolved route so operators can compare
+			// request volume across routes.
+			mysqlx_stats().record_bytes_sent(route_name_, target_hostgroup_, frame.size() - 5);
 		} else {
 			server_ds().enqueue_frame(frame[4], nullptr, 0);
 		}
@@ -989,6 +997,14 @@ void MysqlxSession::handler_waiting_server_msg() {
 		uint8_t msg_type = frame[4];
 
 		forward_frame_to_client(msg_type, frame);
+		// Account the X-Protocol payload bytes the proxy is forwarding
+		// from the backend to the client (size minus the 5-byte frame
+		// header; 0-payload OK/EOF frames contribute 0). Charged to the
+		// resolved route. NOTICE frames are also counted here — they're
+		// part of the data plane the operator paid for forwarding.
+		if (frame.size() > 5) {
+			mysqlx_stats().record_bytes_recv(route_name_, target_hostgroup_, frame.size() - 5);
+		}
 		server_ds().pop_frame();
 
 		if (msg_type != Mysqlx::ServerMessages_Type_NOTICE &&
@@ -1175,6 +1191,7 @@ int MysqlxSession::resolve_backend_target() {
 	target_address_   = ep.hostname;
 	target_port_      = ep.mysqlx_port;
 	target_use_ssl_   = ep.use_ssl;
+	route_name_       = route_name;
 	return 0;
 }
 

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -1201,6 +1201,13 @@ void MysqlxSession::handler_connecting_server() {
 		}
 
 		if (backend_conn_) {
+			// Cache hit — pulled a pre-warmed backend connection out of the
+			// per-thread pool. conn_used is the "took an existing connection
+			// off the cache" counter; conn_ok (further down) is the
+			// "established a fresh connection from scratch" counter.
+			mysqlx_stats().record_conn_used(
+				identity_ ? identity_->default_route : std::string(),
+				target_hostgroup_);
 			server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
 			status_ = WAITING_CLIENT_XMSG;
 			to_process = true;
@@ -1299,6 +1306,13 @@ void MysqlxSession::handler_connecting_server() {
 		}
 	}
 
+	// Fresh-connection success: TCP connect, optional TLS handshake, and
+	// backend-auth all completed without a return earlier in this handler.
+	// Counts a brand-new backend connection only — cache hits go through
+	// the early-return branch above.
+	mysqlx_stats().record_conn_ok(
+		identity_ ? identity_->default_route : std::string(),
+		target_hostgroup_);
 	server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
 	backend_conn_->set_state(MysqlxConnection::IDLE);
 	backend_conn_->set_reusable(true);

--- a/plugins/mysqlx/src/mysqlx_stats.cpp
+++ b/plugins/mysqlx/src/mysqlx_stats.cpp
@@ -57,6 +57,18 @@ void MysqlxStatsStore::record_conn_used(const std::string& route_name, int desti
 	get_or_create(route_name, destination_hostgroup).conn_used.fetch_add(1, std::memory_order_relaxed);
 }
 
+void MysqlxStatsStore::record_bytes_sent(const std::string& route_name, int destination_hostgroup, uint64_t n) {
+	if (n == 0) return;
+	std::lock_guard<std::mutex> lock(mutex_);
+	get_or_create(route_name, destination_hostgroup).bytes_sent.fetch_add(n, std::memory_order_relaxed);
+}
+
+void MysqlxStatsStore::record_bytes_recv(const std::string& route_name, int destination_hostgroup, uint64_t n) {
+	if (n == 0) return;
+	std::lock_guard<std::mutex> lock(mutex_);
+	get_or_create(route_name, destination_hostgroup).bytes_recv.fetch_add(n, std::memory_order_relaxed);
+}
+
 uint64_t MysqlxStatsStore::get_conn_ok(const std::string& route_name) const {
 	std::lock_guard<std::mutex> lock(mutex_);
 	auto it = route_stats_.find(route_name);

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -400,6 +400,71 @@ size_t Mysqlx_Thread::get_session_count() const {
 	return sessions_.size();
 }
 
+namespace {
+
+const char* session_status_to_string(MysqlxSession::Status s) {
+	switch (s) {
+		case MysqlxSession::NONE:                  return "NONE";
+		case MysqlxSession::CONNECTING_CLIENT:     return "CONNECTING_CLIENT";
+		case MysqlxSession::X_CAPABILITIES_GET:    return "X_CAPABILITIES_GET";
+		case MysqlxSession::X_CAPABILITIES_SET:    return "X_CAPABILITIES_SET";
+		case MysqlxSession::X_AUTH_START:          return "X_AUTH_START";
+		case MysqlxSession::X_AUTH_CHALLENGE_SENT: return "X_AUTH_CHALLENGE_SENT";
+		case MysqlxSession::X_AUTH_OK_SENT:        return "X_AUTH_OK_SENT";
+		case MysqlxSession::X_AUTH_FAILED:         return "X_AUTH_FAILED";
+		case MysqlxSession::WAITING_CLIENT_XMSG:   return "WAITING_CLIENT_XMSG";
+		case MysqlxSession::PROCESSING_X_QUERY:    return "PROCESSING_X_QUERY";
+		case MysqlxSession::CONNECTING_SERVER:     return "CONNECTING_SERVER";
+		case MysqlxSession::WAITING_SERVER_XMSG:   return "WAITING_SERVER_XMSG";
+		case MysqlxSession::X_TLS_ACCEPT_INIT:     return "X_TLS_ACCEPT_INIT";
+		case MysqlxSession::X_TLS_ACCEPT_CONT:     return "X_TLS_ACCEPT_CONT";
+		case MysqlxSession::X_TLS_ACCEPT_DONE:     return "X_TLS_ACCEPT_DONE";
+		case MysqlxSession::X_TLS_CONNECT_INIT:    return "X_TLS_CONNECT_INIT";
+		case MysqlxSession::X_TLS_CONNECT_CONT:    return "X_TLS_CONNECT_CONT";
+		case MysqlxSession::X_TLS_CONNECT_DONE:    return "X_TLS_CONNECT_DONE";
+		case MysqlxSession::X_SESSION_CLOSING:     return "X_SESSION_CLOSING";
+		case MysqlxSession::X_SESSION_CLOSED:      return "X_SESSION_CLOSED";
+		case MysqlxSession::X_SESSION_RESET_WAITING: return "X_SESSION_RESET_WAITING";
+	}
+	return "UNKNOWN";
+}
+
+const char* backend_auth_mode_to_string(MysqlxBackendAuthMode m) {
+	switch (m) {
+		case MysqlxBackendAuthMode::mapped:          return "mapped";
+		case MysqlxBackendAuthMode::service_account: return "service_account";
+		case MysqlxBackendAuthMode::pass_through:    return "pass_through";
+	}
+	return "unknown";
+}
+
+} // namespace
+
+void Mysqlx_Thread::snapshot_sessions_for_stats(
+		std::vector<MysqlxSessionSnapshot>& out, uint64_t now_ms) const {
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	out.reserve(out.size() + sessions_.size());
+	for (const MysqlxSession* s : sessions_) {
+		if (s == nullptr) continue;
+		MysqlxSessionSnapshot row;
+		row.username         = s->username_for_stats();
+		row.route            = s->route_name_for_stats();
+		row.worker_id        = thread_index_;
+		row.backend_host     = s->target_address_for_test();
+		row.backend_port     = s->target_port_for_test();
+		auto id              = s->identity_for_stats();
+		row.auth_mode        = id ? backend_auth_mode_to_string(id->backend_auth_mode) : "";
+		row.connection_state = session_status_to_string(s->get_status());
+		// bytes_in / bytes_out: aggregated per-route in P0; per-session
+		// counters land in P1.
+		row.bytes_in         = 0;
+		row.bytes_out        = 0;
+		uint64_t st          = s->start_time_for_stats();
+		row.session_age_ms   = (st > 0 && now_ms >= st) ? (now_ms - st) : 0;
+		out.push_back(std::move(row));
+	}
+}
+
 MysqlxConnection* Mysqlx_Thread::get_connection_from_cache(
 		int hostgroup, const char* user, const char* schema) {
 	std::lock_guard<std::mutex> lock(conn_cache_mutex_);

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -481,20 +481,20 @@ mysqlx_config_store_pure_unit-t: mysqlx_config_store_pure_unit-t.cpp $(PROXYSQL_
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_schema_unit-t: mysqlx_admin_schema_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_schema_unit-t: mysqlx_admin_schema_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_commands_unit-t: mysqlx_admin_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_commands_unit-t: mysqlx_admin_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_disk_commands_unit-t: mysqlx_admin_disk_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_disk_commands_unit-t: mysqlx_admin_disk_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@

--- a/test/tap/tests/unit/mysqlx_stats_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_stats_unit-t.cpp
@@ -15,7 +15,7 @@
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(22);
+	plan(26);
 	diag("=== mysqlx_stats_unit-t starting ===");
 
 	// Test 1-3: Stats counters.
@@ -326,6 +326,59 @@ int main() {
 		writer.join();
 		reader.join();
 		ok(true, "concurrent get_conn_ok while record_conn_ok: no crash");
+	}
+
+	// Test 23-26: bytes_sent / bytes_recv accumulation (P0 of #5691).
+	{
+		MysqlxStatsStore store;
+		store.record_bytes_sent("rw", 1, 100);
+		store.record_bytes_sent("rw", 1, 250);
+		store.record_bytes_sent("ro", 2, 42);
+		store.record_bytes_recv("rw", 1, 1000);
+		store.record_bytes_recv("rw", 1, 1500);
+		store.record_bytes_recv("ro", 2, 7);
+		// Zero-sized payload increments must be a no-op.
+		store.record_bytes_sent("rw", 1, 0);
+		store.record_bytes_recv("rw", 1, 0);
+
+		// Mix in a conn_used so the row carries multiple counters.
+		store.record_conn_used("rw", 1);
+
+		SQLite3DB statsdb;
+		statsdb.open(const_cast<char*>(":memory:"), SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);  // NOSONAR: SQLite3DB::open requires non-const char*
+		statsdb.execute(
+			"CREATE TABLE stats_mysqlx_routes ("
+			" name TEXT PRIMARY KEY,"
+			" destination_hostgroup INT NOT NULL DEFAULT 0,"
+			" ConnOK INT NOT NULL DEFAULT 0,"
+			" ConnERR INT NOT NULL DEFAULT 0,"
+			" ConnUsed INT NOT NULL DEFAULT 0,"
+			" Bytes_data_sent BIGINT NOT NULL DEFAULT 0,"
+			" Bytes_data_recv BIGINT NOT NULL DEFAULT 0)"
+		);
+		store.flush_to_sqlite(statsdb);
+
+		int rw_sent = statsdb.return_one_int(
+			"SELECT Bytes_data_sent FROM stats_mysqlx_routes WHERE name='rw'");
+		int ro_sent = statsdb.return_one_int(
+			"SELECT Bytes_data_sent FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(rw_sent == 350 && ro_sent == 42,
+		   "bytes_sent accumulates per route (rw=%d ro=%d)", rw_sent, ro_sent);
+
+		int rw_recv = statsdb.return_one_int(
+			"SELECT Bytes_data_recv FROM stats_mysqlx_routes WHERE name='rw'");
+		int ro_recv = statsdb.return_one_int(
+			"SELECT Bytes_data_recv FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(rw_recv == 2500 && ro_recv == 7,
+		   "bytes_recv accumulates per route (rw=%d ro=%d)", rw_recv, ro_recv);
+
+		int rw_used = statsdb.return_one_int(
+			"SELECT ConnUsed FROM stats_mysqlx_routes WHERE name='rw'");
+		ok(rw_used == 1, "ConnUsed flushes to SQLite alongside bytes counters");
+
+		int ro_hg = statsdb.return_one_int(
+			"SELECT destination_hostgroup FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(ro_hg == 2, "destination_hostgroup carried through bytes-only flush");
 	}
 
 	return exit_status();


### PR DESCRIPTION
Closes the **P0 scope** of issue #5691. The mysqlx plugin shipped a stats *skeleton* — `MysqlxStatsStore` with five declared per-route counters, `flush_to_sqlite()`, two registered tables — but only `conn_err` was wired and no projection writer ever ran. Operators got an empty `stats_mysqlx_routes` and an empty `stats_mysqlx_processlist`. P0 fixes the four bullets the issue body called out as v4.0 GA blockers.

## Commits (one per acceptance bullet, each builds and tests clean)

1. `64dadd199` — record conn_ok and conn_used in handler_connecting_server
2. `3dd402e53` — account per-route bytes_sent / bytes_recv on the data plane
3. `d78a2da62` — expose stats_mysqlx_routes via runtime-view refresh
4. `9c13d1d5a` — project per-session state into stats_mysqlx_processlist

## Acceptance criteria coverage

- [x] Wire `record_conn_ok` and `record_conn_used` from MysqlxSession::handler_connecting_server (cache-hit branch and fresh-connection success tail). Both already had `target_hostgroup_` and `identity_` in scope; the route name comes from `identity_->default_route` with a defensive `identity_ ? ... : \"\"` ternary.
- [x] Wire `bytes_sent` / `bytes_recv` per route from `forward_to_backend` and `handler_waiting_server_msg`. Convention: payload bytes only (`frame.size() - 5`) — strips the 5-byte X-Protocol frame header so the counter tracks operator-meaningful query/CRUD bytes rather than wire-level total. Per-session `route_name_` cached at `resolve_backend_target` time so the I/O sites don't deref `identity_` per frame.
- [x] Register `stats_mysqlx_routes` as an ABI 3 runtime view via `services.register_runtime_view`. Refresh callback fetches `services->get_statsdb()` and calls `MysqlxStatsStore::flush_to_sqlite()` on demand — flush_to_sqlite writes bare table names so the statsdb handle (not the chassis-supplied admindb argument) is the right target.
- [x] Add `mysqlx_populate_stats_processlist(SQLite3DB&)` that walks every `Mysqlx_Thread::sessions_` under each thread's `sessions_mutex_`, snapshots one row per active session into a `MysqlxSessionSnapshot` vector, then DELETEs + re-INSERTs `stats_mysqlx_processlist`. Registered as a runtime view too.

## Tests

- `test/tap/tests/unit/mysqlx_stats_unit-t.cpp` — extended to plan(26), adding 4 assertions covering bytes_sent/bytes_recv accumulation through `flush_to_sqlite`, the 0-arg no-op invariant, ConnUsed alongside bytes counters, and `destination_hostgroup` carrying through.
- All 9 affected mysqlx unit suites stay green under ASAN (255 assertions): mysqlx_thread, mysqlx_session, mysqlx_stats, mysqlx_admin_schema, mysqlx_admin_commands, mysqlx_admin_disk_commands, mysqlx_concurrent, test_mysqlx_admin_tables, test_mysqlx_plugin_load.

## Known limitation flagged for follow-up (not in P0 scope)

The chassis dispatcher only fires plugin runtime views on **admin-session** SELECTs (`lib/ProxySQL_Admin.cpp:1654` is gated on `if (admin)`). SELECTs against the **stats port** (port 6032 with stats credentials, `Admin_Handler.cpp:5520`) bypass the dispatcher entirely → return whatever's in the projected table since the last admin-session refresh. The fix is in admin-side query handling, not in mysqlx; will file as a separate chassis-side issue.

## Out of scope (intentionally left for P1/P2/P3 of #5691)

- Per-protobuf-message-type counters and per-route latency histograms (P1)
- Auth-failure split counter (P1)
- Prometheus exporter via `services.get_prometheus_registry()` (P2)
- Per-thread metrics (busy time, poll iterations, signal-pipe wakeups) (P2)
- Connection-pool hit/miss/eviction counters (P2)
- Lifecycle hygiene: move the function-static `mysqlx_stats()` singleton into `MysqlxPluginContext` (P3)
- Per-session bytes_in/bytes_out — the `MysqlxStatsStore` aggregates by route; per-session counters land in P1, with the schema columns reserved at 0 in this PR

## Test plan

- [ ] Verify `SELECT * FROM stats_mysqlx_routes` from the admin port returns one row per active route after at least one session has connected (admin-port refresh triggers).
- [ ] Verify `SELECT * FROM stats_mysqlx_processlist` from the admin port returns one row per currently-connected mysqlx session.
- [ ] Verify the `Bytes_data_sent` and `Bytes_data_recv` columns increment after running queries through a mysqlx session.
- [ ] Verify `ConnOK` increments on a fresh backend connection and `ConnUsed` increments when the per-thread cache returns a pre-warmed connection.
- [ ] Verify `connection_state` in stats_mysqlx_processlist reflects the live session state machine (e.g. `WAITING_CLIENT_XMSG` for an idle authenticated session).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New processlist statistics table available in admin schema, providing per-session visibility including connection details and state tracking
  * Byte-level traffic metrics now tracked per route and destination hostgroup for data-plane monitoring in both directions

* **Tests**
  * Added unit test coverage to validate byte metrics recording, route tracking, and stats table updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->