### PR TITLE
build: add WITHTSAN=1 plumbing for ThreadSanitizer builds

### DIFF
--- a/include/makefiles_vars.mk
+++ b/include/makefiles_vars.mk
@@ -50,6 +50,22 @@ ifeq ($(TEST_WITHASAN),1)
 	WASAN += -DTEST_WITHASAN
 endif
 
+# ThreadSanitizer support. Mutually exclusive with WITHASAN — both
+# sanitizers reroute the same memory-management hooks and the linker
+# rejects the combination outright. Like ASAN, TSAN is incompatible
+# with jemalloc, so NOJEMALLOC is forced. The flag is added to both
+# CXX_FLAGS and LD_FLAGS via $(WASAN) — TSAN piggybacks on the same
+# variable name to keep the propagation paths unchanged across deps/
+# lib/ src/ test/ Makefiles. Reuse means a build is *either* ASAN
+# *or* TSAN, never both.
+ifeq ($(WITHTSAN),1)
+ifeq ($(WITHASAN),1)
+    $(error WITHASAN=1 and WITHTSAN=1 are mutually exclusive — pick one)
+endif
+	WASAN := -fsanitize=thread
+	export NOJEMALLOC=1
+endif
+
 NOJEM :=
 ifeq ($(NOJEMALLOC),1)
 	NOJEM := -DNOJEM


### PR DESCRIPTION
Small Makefile addition for #5675 phase 2 (TSAN coverage of the plugin chassis + mysqlx). The repo already had WITHASAN plumbing in \`include/makefiles_vars.mk\`; this mirrors it for WITHTSAN.

## What changes

- New \`WITHTSAN=1\` guard in \`include/makefiles_vars.mk\` that sets \`-fsanitize=thread\` (reusing the \`WASAN\` propagation variable so deps/, lib/, src/, plugins/, test/ Makefiles don't need touching).
- WITHASAN=1 + WITHTSAN=1 produces a make-time \`\$(error)\` rather than a confusing linker error.
- Auto-forces \`NOJEMALLOC=1\` for TSAN, same as ASAN.

## Usage

Mirrors the documented ASAN flow:

    NOJEMALLOC=1 WITHTSAN=1 PROXYSQLGENAI=1 \
        make build_deps_debug -j\$(nproc) && \
        make debug -j\$(nproc) && \
        make build_tap_test_debug -j\$(nproc)

## Verified locally

- Plumbing builds cleanly (deps + lib + tests all link with \`-fsanitize=thread\`).
- TSAN-instrumented \`mysqlx_concurrent_unit-t\` and \`mysqlx_session_unit-t\` ran clean — **0 race conditions detected** in the focused mysqlx concurrency tests.
- 7 of the 9 targeted tests bailed pre-init on \`FATAL: ThreadSanitizer: unexpected memory mapping\` — this is an ASLR width issue (Ubuntu 22.04 / kernel ≥5.18 defaults vm.mmap_rnd_bits=32; TSAN expects ≤28). Workaround:

      sudo sysctl vm.mmap_rnd_bits=28

ASAN has the same constraint and the existing WITHASAN block warns about it. Not adding a second warning to keep the Makefile uncluttered.

Refs #5675.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to support ThreadSanitizer with compatibility validation and memory allocator integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->