### PR TITLE
feat(mysqlx): per-message response state machines (P1 parity gap)

### DIFF
--- a/plugins/mysqlx/include/mysqlx_plugin.h
+++ b/plugins/mysqlx/include/mysqlx_plugin.h
@@ -63,6 +63,24 @@ MysqlxPluginContext& mysqlx_context();
  */
 __attribute__((weak)) void mysqlx_reconcile_listeners(SQLite3DB& admindb);
 
+/**
+ * Walks every Mysqlx_Thread in mysqlx_context().threads, snapshots each
+ * thread's sessions_ under its sessions_mutex_, and projects one row per
+ * active session into stats_mysqlx_processlist. Called from the chassis
+ * runtime-view refresh callback before any admin SELECT against the
+ * table runs (the callback in mysqlx_admin_schema.cpp).
+ *
+ * Snapshot work is bounded per thread: a string-copy + a few struct field
+ * reads under the mutex, no I/O. Lock ordering: each thread's
+ * sessions_mutex_ is acquired in turn; no cross-thread lock is held.
+ *
+ * Declared __attribute__((weak)) for the same reason
+ * mysqlx_reconcile_listeners is — admin_schema.cpp's unit tests don't
+ * link mysqlx_plugin.cpp, so the projection registration must tolerate
+ * an unresolved hook at test-build link time.
+ */
+__attribute__((weak)) void mysqlx_populate_stats_processlist(SQLite3DB& statsdb);
+
 // Pure variant of `mysqlx_reconcile_listeners` that takes the plugin state
 // as parameters instead of going through `mysqlx_context()`. Exists so unit
 // tests can construct a minimal fake context without pulling in the whole

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -159,6 +159,20 @@ public:
 	const std::string& target_address_for_test() const { return target_address_; }
 	int  target_port_for_test() const { return target_port_; }
 
+	// Read-only state observers used by the stats_mysqlx_processlist
+	// projection (Mysqlx_Thread::snapshot_sessions_for_stats walks
+	// sessions_ and reads these under sessions_mutex_). Borrowed
+	// references — caller must copy if it needs the value past the
+	// snapshot scope. The identity_ accessor returns the optional by
+	// value because the projection wants the resolved fields, not the
+	// optional itself; this only happens once per session per admin
+	// SELECT against stats_mysqlx_processlist, so the copy cost is
+	// negligible.
+	const std::string& username_for_stats() const { return username_; }
+	const std::string& route_name_for_stats() const { return route_name_; }
+	std::optional<MysqlxResolvedIdentity> identity_for_stats() const { return identity_; }
+	uint64_t start_time_for_stats() const { return start_time_; }
+
 	bool to_process;
 
 private:

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -299,6 +299,17 @@ private:
 	uint64_t start_time_;
 	uint64_t last_active_time_;
 	MysqlxResponseState response_state_;
+	// Sub-state flag for the response_state_ matrix: gates whether
+	// RESULTSET_ROW frames are currently allowed in states where the
+	// X-Protocol requires ColumnMetaData to precede any Row. Set when
+	// COLUMN_META_DATA is forwarded from the backend in
+	// handler_waiting_server_msg(); cleared on each transition into a
+	// state that begins a new column-metadata sequence (STMT_EXECUTE,
+	// CRUD, PREPARE_EXECUTE, CURSOR_OPEN), at terminal-frame flush, and
+	// at init() / reset(). NOT cleared on entry to CURSOR_FETCH — per
+	// the X-Protocol spec, ColumnMetaData is sent at Cursor::Open and
+	// not re-sent at Cursor::Fetch, so the flag must carry across.
+	bool seen_column_metadata_;
 	MysqlxTlsMode tls_mode_;
 
 	// Compression negotiation state. compression_algo_ is set by
@@ -375,6 +386,16 @@ public:
 	const std::vector<uint8_t>& client_write_buffer_for_test() const {
 		return client_ds_.write_buffer_raw();
 	}
+#ifdef MYSQLX_TEST_BUILD
+	// Test-only observers for the per-message response state machine,
+	// gated behind MYSQLX_TEST_BUILD because they expose private state
+	// the production code never reads back. Used by the validation
+	// tests in mysqlx_message_dispatch_unit-t to assert state
+	// transitions after dispatching synthetic backend frames.
+	MysqlxResponseState response_state_for_test() const { return response_state_; }
+	bool seen_column_metadata_for_test() const { return seen_column_metadata_; }
+	void set_response_state_for_test(MysqlxResponseState s) { response_state_ = s; }
+#endif /* MYSQLX_TEST_BUILD */
 };
 
 #endif

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -218,7 +218,18 @@ private:
 	void send_capabilities();
 
 	uint8_t extract_msg_type_from_frame(const MysqlxFrame& frame);
-	bool is_terminal_for_state(uint8_t msg_type) const;
+	// Per-state validation contract for backend frames. is_frame_allowed
+	// returns true iff a frame of msg_type is acceptable in the current
+	// response_state_ (NOTICE and ERROR are universal). is_terminal_frame
+	// returns true iff msg_type closes the current response sequence so
+	// the dispatch loop can transition back to RESP_IDLE.
+	//
+	// Both are pure queries — no mutation of response_state_ or session
+	// state. Replaces the older is_terminal_for_state() which conflated
+	// "valid mid-result frame" and "terminal frame" by deferring to a
+	// generic terminal table for any state outside the explicit cases.
+	bool is_frame_allowed(uint8_t msg_type) const;
+	bool is_terminal_frame(uint8_t msg_type) const;
 
 	// Resolve identity_->default_route to concrete target_hostgroup_,
 	// target_address_, target_port_ via the thread's MysqlxConfigStore.

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -245,6 +245,12 @@ private:
 	// sets mysqlx_backend_endpoints.use_ssl=1 to force backend TLS
 	// even when the client connected in plaintext.
 	bool target_use_ssl_;
+	// Cached identity_->default_route, captured in
+	// resolve_backend_target() so the data-plane bytes-counter sites
+	// (forward_to_backend / handler_waiting_server_msg) don't have
+	// to dereference identity_ on every frame. Empty until resolve
+	// succeeds; cleared by reset().
+	std::string route_name_;
 	MysqlxIdentityLookup identity_lookup_;
 	std::optional<MysqlxResolvedIdentity> identity_;
 	uint64_t start_time_;

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -25,12 +25,30 @@ typedef struct ZSTD_CCtx_s ZSTD_CCtx;
 using MysqlxIdentityLookup =
 	std::function<std::optional<MysqlxResolvedIdentity>(const std::string& username)>;
 
+// Per-message response state for the X-Protocol response sequence the
+// proxy is currently waiting on. The X protocol defines distinct frame
+// allow-sets and terminal markers per request type; this enum splits
+// PREPARE and CURSOR into their per-request sub-shapes so each per-state
+// contract can be expressed cleanly in is_frame_allowed / is_terminal_frame.
+//
+// Background: the previous coarse three-value model (PREPARE / CURSOR
+// each lumped together) over-accepted on PREPARE_PREPARE — which the
+// spec terminates with a bare Mysqlx.Ok — by also allowing the wider
+// SQL_STMT_EXECUTE_OK / FETCH_DONE_* terminators that only PREPARE_EXECUTE
+// can legitimately emit. Likewise CURSOR_OPEN's response always carries
+// ColumnMetaData while CURSOR_FETCH's never does (the metadata is sent
+// once at Open). Splitting the state lets the validation hook reject
+// out-of-shape backend frames precisely.
 enum MysqlxResponseState {
 	RESP_IDLE = 0,
 	RESP_WAITING_STMT_EXECUTE,
 	RESP_WAITING_CRUD,
-	RESP_WAITING_PREPARE,
-	RESP_WAITING_CURSOR,
+	RESP_WAITING_PREPARE_PREPARE,        // Prepare::Prepare — terminator: Ok
+	RESP_WAITING_PREPARE_EXECUTE,        // Prepare::Execute — terminators: Ok / SQL_STMT_EXECUTE_OK / FETCH_DONE / FETCH_SUSPENDED
+	RESP_WAITING_PREPARE_DEALLOCATE,     // Prepare::Deallocate — terminator: Ok
+	RESP_WAITING_CURSOR_OPEN,            // Cursor::Open — terminators: FETCH_DONE / FETCH_SUSPENDED; carries ColumnMetaData
+	RESP_WAITING_CURSOR_FETCH,           // Cursor::Fetch — terminators: FETCH_DONE / FETCH_SUSPENDED; rows-only (metadata was at Open)
+	RESP_WAITING_CURSOR_CLOSE,           // Cursor::Close — terminator: Ok
 	RESP_WAITING_EXPECT,
 	RESP_WAITING_SESS_RESET
 };

--- a/plugins/mysqlx/include/mysqlx_stats.h
+++ b/plugins/mysqlx/include/mysqlx_stats.h
@@ -28,6 +28,15 @@ public:
 	void record_conn_err(const std::string& route_name, int destination_hostgroup);
 	void record_conn_used(const std::string& route_name, int destination_hostgroup);
 
+	// Accumulate per-route data-plane payload bytes. The argument is the
+	// X-Protocol *payload* size (excluding the 5-byte frame header) that
+	// the proxy forwarded between client and backend; framing overhead is
+	// intentionally not counted so the counter tracks operator-meaningful
+	// query/result bytes rather than the wire-level total. Both directions
+	// get their own counter so operators can spot asymmetric traffic.
+	void record_bytes_sent(const std::string& route_name, int destination_hostgroup, uint64_t n);
+	void record_bytes_recv(const std::string& route_name, int destination_hostgroup, uint64_t n);
+
 	// Flush stats into the stats SQLite DB.
 	void flush_to_sqlite(class SQLite3DB& statsdb);
 

--- a/plugins/mysqlx/include/mysqlx_thread.h
+++ b/plugins/mysqlx/include/mysqlx_thread.h
@@ -15,6 +15,29 @@
 
 class MysqlxConfigStore;
 
+// Per-session row used by the stats_mysqlx_processlist projection. Filled
+// by Mysqlx_Thread::snapshot_sessions_for_stats() under the thread's
+// sessions_mutex_; copied (not borrowed) so the admin-side projector can
+// release the worker's lock before doing any SQL.
+struct MysqlxSessionSnapshot {
+	std::string username;
+	std::string route;
+	int worker_id { 0 };
+	std::string backend_host;
+	int backend_port { 0 };
+	// String forms of the MysqlxBackendAuthMode enum and MysqlxSession::Status.
+	// Empty auth_mode means the session has not yet resolved an identity.
+	std::string auth_mode;
+	std::string connection_state;
+	// Per-session bytes_in/bytes_out are 0 in the P0 implementation: the
+	// stats store aggregates by route, not by session. P1 adds per-session
+	// counters; the columns in stats_mysqlx_processlist are reserved here so
+	// the schema doesn't change again when those land.
+	uint64_t bytes_in { 0 };
+	uint64_t bytes_out { 0 };
+	uint64_t session_age_ms { 0 };
+};
+
 class Mysqlx_Thread {
 public:
 	Mysqlx_Thread();
@@ -30,6 +53,14 @@ public:
 	size_t get_session_count() const;
 	bool is_running() const { return running_.load(); }
 	int get_listener_count() const;
+
+	// Walks sessions_ under sessions_mutex_ and appends one
+	// MysqlxSessionSnapshot per active session to `out`. `now_ms` should
+	// be a single monotonic time captured by the caller so all rows in a
+	// projection batch share the same reference point for session_age_ms.
+	// Lock scope is bounded to a string copy + a few struct field reads
+	// per session, no I/O. Safe to call from any thread.
+	void snapshot_sessions_for_stats(std::vector<MysqlxSessionSnapshot>& out, uint64_t now_ms) const;
 
 	/**
 	 * Creates a listener socket (bind + listen) and registers it with this

--- a/plugins/mysqlx/src/mysqlx_admin_schema.cpp
+++ b/plugins/mysqlx/src/mysqlx_admin_schema.cpp
@@ -266,6 +266,21 @@ void refresh_stats_routes_view(SQLite3DB* /*admindb*/, void*) {
 	mysqlx_stats().flush_to_sqlite(*statsdb);
 }
 
+// Same shape, but for stats_mysqlx_processlist: the projector walks
+// every Mysqlx_Thread and emits one row per active session. Defined in
+// mysqlx_plugin.cpp; declared __attribute__((weak)) so the
+// mysqlx_admin_schema_unit-t and friends (which compile this TU but
+// don't link mysqlx_plugin.cpp) still link successfully — the null check
+// here is the runtime safety net for the test build.
+void refresh_stats_processlist_view(SQLite3DB* /*admindb*/, void*) {
+	if (mysqlx_context().services == nullptr) return;
+	if (mysqlx_context().services->get_statsdb == nullptr) return;
+	if (&mysqlx_populate_stats_processlist == nullptr) return;
+	SQLite3DB* statsdb = mysqlx_context().services->get_statsdb();
+	if (statsdb == nullptr) return;
+	mysqlx_populate_stats_processlist(*statsdb);
+}
+
 bool disk_to_memory(SQLite3DB& admindb, const char* table_name) {
 	if (!admindb.execute("BEGIN")) {
 		return false;
@@ -482,6 +497,7 @@ bool mysqlx_register_admin_schema(ProxySQL_PluginServices& services) {
 		services.register_runtime_view({kRuntimeMysqlxBackendEndpointsTable,  &refresh_endpoints_runtime_view, nullptr});
 		services.register_runtime_view({kRuntimeMysqlxVariablesTable,         &refresh_variables_runtime_view, nullptr});
 		services.register_runtime_view({kStatsMysqlxRoutesTable,              &refresh_stats_routes_view,      nullptr});
+		services.register_runtime_view({kStatsMysqlxProcesslistTable,         &refresh_stats_processlist_view, nullptr});
 	}
 
 	// Stats tables (stats_db only, no config copy needed).

--- a/plugins/mysqlx/src/mysqlx_admin_schema.cpp
+++ b/plugins/mysqlx/src/mysqlx_admin_schema.cpp
@@ -1,6 +1,7 @@
 #include "mysqlx_admin_schema.h"
 
 #include "mysqlx_plugin.h"
+#include "mysqlx_stats.h"
 #include "sqlite3db.h"
 
 #include <initializer_list>
@@ -246,6 +247,25 @@ void refresh_variables_runtime_view(SQLite3DB* admindb, void*) {
 	mysqlx_context().config_store->project_variables_to_runtime_view(*admindb);
 }
 
+// Stats-projection refresh callback: chassis fires this on demand when an
+// admin SELECT references stats_mysqlx_routes, so the per-route counters
+// are refilled lazily from MysqlxStatsStore right before the operator
+// reads them.
+//
+// flush_to_sqlite writes to a bare table name, so the callback must hand
+// it the *statsdb* handle — the chassis-supplied `admindb` argument
+// reaches stats_mysqlx_routes only via the `stats.` attached schema, and
+// that's an unnecessary detour. The plugin already cached the services
+// pointer in mysqlx_context().services at Phase D init, so the get_statsdb
+// trampoline is reachable.
+void refresh_stats_routes_view(SQLite3DB* /*admindb*/, void*) {
+	if (mysqlx_context().services == nullptr) return;
+	if (mysqlx_context().services->get_statsdb == nullptr) return;
+	SQLite3DB* statsdb = mysqlx_context().services->get_statsdb();
+	if (statsdb == nullptr) return;
+	mysqlx_stats().flush_to_sqlite(*statsdb);
+}
+
 bool disk_to_memory(SQLite3DB& admindb, const char* table_name) {
 	if (!admindb.execute("BEGIN")) {
 		return false;
@@ -461,6 +481,7 @@ bool mysqlx_register_admin_schema(ProxySQL_PluginServices& services) {
 		services.register_runtime_view({kRuntimeMysqlxRoutesTable,            &refresh_routes_runtime_view,    nullptr});
 		services.register_runtime_view({kRuntimeMysqlxBackendEndpointsTable,  &refresh_endpoints_runtime_view, nullptr});
 		services.register_runtime_view({kRuntimeMysqlxVariablesTable,         &refresh_variables_runtime_view, nullptr});
+		services.register_runtime_view({kStatsMysqlxRoutesTable,              &refresh_stats_routes_view,      nullptr});
 	}
 
 	// Stats tables (stats_db only, no config copy needed).

--- a/plugins/mysqlx/src/mysqlx_plugin.cpp
+++ b/plugins/mysqlx/src/mysqlx_plugin.cpp
@@ -5,8 +5,11 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
 namespace {
 
@@ -268,6 +271,65 @@ void mysqlx_reconcile_listeners(SQLite3DB& admindb) {
 		ctx.route_to_thread_mutex,
 		ctx.next_rr_index
 	);
+}
+
+namespace {
+
+// Local copy of the SQLite single-quote escape used by mysqlx_stats.cpp;
+// duplicating one tiny function is cheaper than introducing a shared
+// header just for it. If a third caller appears, lift to mysqlx_util.h.
+std::string sqlite_escape_local(const std::string& input) {
+	std::string result;
+	result.reserve(input.size());
+	for (char c : input) {
+		if (c == '\'') result += "''";
+		else result += c;
+	}
+	return result;
+}
+
+uint64_t monotonic_time_ms_local() {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return static_cast<uint64_t>(ts.tv_sec) * 1000ULL + static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+}
+
+} // namespace
+
+void mysqlx_populate_stats_processlist(SQLite3DB& statsdb) {
+	MysqlxPluginContext& ctx = mysqlx_context();
+
+	// Always wipe the projection table — empty thread pool or empty
+	// session list both mean "no active sessions" and the operator
+	// must see that, not stale rows from the last refresh.
+	statsdb.execute("DELETE FROM stats_mysqlx_processlist");
+
+	if (ctx.threads.empty()) return;
+
+	uint64_t now_ms = monotonic_time_ms_local();
+	std::vector<MysqlxSessionSnapshot> rows;
+	for (const auto& thr : ctx.threads) {
+		if (thr) thr->snapshot_sessions_for_stats(rows, now_ms);
+	}
+
+	for (const auto& r : rows) {
+		std::string sql = "INSERT INTO stats_mysqlx_processlist "
+			"(username, route, worker_id, backend_host, backend_port, "
+			" auth_mode, connection_state, bytes_in, bytes_out, "
+			" session_age_ms) VALUES ('";
+		sql += sqlite_escape_local(r.username);
+		sql += "', '"; sql += sqlite_escape_local(r.route);
+		sql += "', "; sql += std::to_string(r.worker_id);
+		sql += ", '"; sql += sqlite_escape_local(r.backend_host);
+		sql += "', "; sql += std::to_string(r.backend_port);
+		sql += ", '"; sql += sqlite_escape_local(r.auth_mode);
+		sql += "', '"; sql += sqlite_escape_local(r.connection_state);
+		sql += "', "; sql += std::to_string(r.bytes_in);
+		sql += ", "; sql += std::to_string(r.bytes_out);
+		sql += ", "; sql += std::to_string(r.session_age_ms);
+		sql += ")";
+		statsdb.execute(sql.c_str());
+	}
 }
 
 // Default visibility is required because the plugin .so is built with

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -99,6 +99,7 @@ MysqlxSession::MysqlxSession()
 	, start_time_(0)
 	, last_active_time_(0)
 	, response_state_(RESP_IDLE)
+	, seen_column_metadata_(false)
 	, tls_mode_(TLS_OFF)
 	, compression_algo_(MYSQLX_COMPR_NONE)
 	, compression_combine_mixed_messages_(false)
@@ -152,6 +153,8 @@ void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
 	compression_combine_mixed_messages_ = false;
 	compression_max_combine_messages_ = 0;
 	reset_compression_state();
+	response_state_ = RESP_IDLE;
+	seen_column_metadata_ = false;
 }
 
 void MysqlxSession::reset() {
@@ -174,6 +177,8 @@ void MysqlxSession::reset() {
 	compression_max_combine_messages_ = 0;
 	reset_compression_state();
 	pre_auth_cap_msgs_ = 0;
+	response_state_ = RESP_IDLE;
+	seen_column_metadata_ = false;
 }
 
 int MysqlxSession::handler() {
@@ -827,6 +832,7 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 			return 0;
 		case Mysqlx::ClientMessages_Type_SQL_STMT_EXECUTE:
 			response_state_ = RESP_WAITING_STMT_EXECUTE;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CRUD_FIND:
 		case Mysqlx::ClientMessages_Type_CRUD_INSERT:
@@ -836,6 +842,7 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 		case Mysqlx::ClientMessages_Type_CRUD_MODIFY_VIEW:
 		case Mysqlx::ClientMessages_Type_CRUD_DROP_VIEW:
 			response_state_ = RESP_WAITING_CRUD;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_PREPARE:
 			if (backend_conn_) backend_conn_->set_has_prepared_statement(true);
@@ -843,14 +850,19 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_EXECUTE:
 			response_state_ = RESP_WAITING_PREPARE_EXECUTE;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_DEALLOCATE:
 			response_state_ = RESP_WAITING_PREPARE_DEALLOCATE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_OPEN:
 			response_state_ = RESP_WAITING_CURSOR_OPEN;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_FETCH:
+			// NOT cleared — Cursor::Fetch reuses ColumnMetaData from
+			// the preceding Cursor::Open, so the sub-state must carry
+			// across.
 			response_state_ = RESP_WAITING_CURSOR_FETCH;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_CLOSE:
@@ -920,23 +932,78 @@ void MysqlxSession::forward_to_backend() {
 	status_ = WAITING_SERVER_XMSG;
 }
 
-// Permissive in this commit: returns true for every msg_type the previous
-// code path implicitly accepted (which was "everything", since the old
-// validation loop never rejected a frame — it only checked terminality
-// and forwarded otherwise). The explicit allowed-frame contract is
-// tightened in a follow-up commit; here we only split the predicate so
-// the validation hook has a separate seam from the terminality probe.
+// Per-state allowed-frame contract for backend frames. Returns true iff
+// a backend message of msg_type is acceptable to forward in the current
+// response_state_. Disallowed frames are rejected by the validation
+// hook in handler_waiting_server_msg() with X-Protocol Error 4006.
 //
-// NOTICE and ERROR are universal in every state. The remaining frames
-// are matched against a per-state allow-set; states with no explicit
-// case (RESP_IDLE today) currently fall through to the permissive
-// default. The next commit narrows this; today the function returns
-// true so behaviour is byte-for-byte identical to the prior path.
-bool MysqlxSession::is_frame_allowed(uint8_t /*msg_type*/) const {
-	// Permissive pass-through for the refactor commit; behaviour is
-	// preserved byte-for-byte. Subsequent commits replace this body
-	// with the per-state allowed-frame matrix.
-	return true;
+// Universal frames (allowed in every state):
+//   - NOTICE   (non-terminal status messages, may be interleaved freely)
+//   - ERROR    (terminates the response sequence with a per-message error)
+//
+// Per-state extras (in addition to the terminal frames already enumerated
+// in is_terminal_frame): COLUMN_META_DATA, RESULTSET_ROW, and the
+// non-terminal FETCH_DONE_MORE_* boundaries. RESULTSET_ROW is only
+// allowed once seen_column_metadata_ has been set by a preceding
+// COLUMN_META_DATA frame in the same response, except in CURSOR_FETCH
+// where the metadata was sent at Cursor::Open and is already in scope.
+//
+// RESP_IDLE accepts no frames at all — any backend frame in that state
+// is unsolicited and indicates a protocol-confused backend.
+bool MysqlxSession::is_frame_allowed(uint8_t msg_type) const {
+	if (msg_type == Mysqlx::ServerMessages_Type_NOTICE) return true;
+	if (msg_type == Mysqlx::ServerMessages_Type_ERROR) return true;
+	if (is_terminal_frame(msg_type)) return true;
+
+	switch (response_state_) {
+		case RESP_WAITING_STMT_EXECUTE:
+		case RESP_WAITING_CRUD:
+		case RESP_WAITING_PREPARE_EXECUTE:
+		case RESP_WAITING_CURSOR_OPEN:
+			// Resultset shape: ColumnMetaData, then zero or more Row,
+			// then non-terminal FetchDoneMore* boundaries between
+			// resultsets / out-params before the actual terminator.
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA) {
+				return true;
+			}
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_ROW) {
+				// Row is only legal after metadata has been forwarded
+				// in this response. Without this guard a hostile
+				// backend could spray rows the client cannot parse.
+				return seen_column_metadata_;
+			}
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_RESULTSETS) {
+				return true;
+			}
+			// FETCH_DONE_MORE_OUT_PARAMS only flows through stored-proc
+			// shapes; STMT_EXECUTE and PREPARE_EXECUTE both can produce
+			// it. Allow on those two; CRUD doesn't have out-params but
+			// the allow is harmless (still requires a real terminator
+			// to advance the state machine).
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_OUT_PARAMS) {
+				return response_state_ == RESP_WAITING_STMT_EXECUTE ||
+				       response_state_ == RESP_WAITING_PREPARE_EXECUTE;
+			}
+			return false;
+		case RESP_WAITING_CURSOR_FETCH:
+			// Cursor::Fetch only carries Row frames (metadata was at
+			// Cursor::Open). FETCH_DONE / FETCH_SUSPENDED are terminal
+			// and already accepted via is_terminal_frame above.
+			return msg_type == Mysqlx::ServerMessages_Type_RESULTSET_ROW;
+		case RESP_WAITING_PREPARE_PREPARE:
+		case RESP_WAITING_PREPARE_DEALLOCATE:
+		case RESP_WAITING_CURSOR_CLOSE:
+		case RESP_WAITING_EXPECT:
+		case RESP_WAITING_SESS_RESET:
+			// These responses carry only their terminal Mysqlx.Ok
+			// (already handled above) plus universal NOTICE/ERROR.
+			return false;
+		case RESP_IDLE:
+			// No outstanding response — any backend frame here is
+			// unsolicited.
+			return false;
+	}
+	return false;
 }
 
 bool MysqlxSession::is_terminal_frame(uint8_t msg_type) const {
@@ -1034,7 +1101,40 @@ void MysqlxSession::handler_waiting_server_msg() {
 		const auto& frame = server_ds().front_frame();
 		uint8_t msg_type = frame[4];
 
+		// Per-message response state machine: drop and reject any
+		// backend frame that is not in the allowed set for the
+		// current response_state_. This guards against a buggy or
+		// hostile backend pushing an out-of-shape frame the client
+		// would otherwise have to parse (and potentially desync on).
+		// The canonical case: a Row before its ColumnMetaData. We
+		// emit X-Protocol Error 4006 fatal, mark the backend
+		// non-reusable so it gets evicted (not pooled) by
+		// return_backend_to_pool, and transition the session to
+		// X_SESSION_CLOSING. The disallowed frame is dropped, not
+		// forwarded — so the bytes_recv counter (charged below in
+		// the happy path) is naturally not incremented for it.
+		if (!is_frame_allowed(msg_type)) {
+			server_ds().pop_frame();
+			send_error(4006,
+				"Backend sent an unexpected message in the current response state; closing session.",
+				/*fatal=*/true);
+			if (backend_conn_) backend_conn_->set_reusable(false);
+			return_backend_to_pool();
+			healthy = false;
+			status_ = X_SESSION_CLOSING;
+			client_ds_.write_to_net();
+			return;
+		}
+
 		forward_frame_to_client(msg_type, frame);
+		// Track that the backend has shipped ColumnMetaData in this
+		// response so subsequent Row frames pass the gating check
+		// in is_frame_allowed. Set after the forward (the forward
+		// itself can fail TLS write, etc., but we don't unwind state
+		// on partial-write — the next iteration drives the data plane).
+		if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA) {
+			seen_column_metadata_ = true;
+		}
 		// Account the X-Protocol payload bytes the proxy is forwarding
 		// from the backend to the client (size minus the 5-byte frame
 		// header; 0-payload OK/EOF frames contribute 0). Charged to the
@@ -1061,6 +1161,14 @@ void MysqlxSession::handler_waiting_server_msg() {
 		// bounds how long any single batch can grow.
 		flush_compression_batch();
 		response_state_ = RESP_IDLE;
+		// Clear the column-metadata sub-state on every response
+		// boundary. CURSOR_FETCH does not need the flag carried
+		// across (its allowed-frame set in is_frame_allowed accepts
+		// RESULTSET_ROW unconditionally because ColumnMetaData was
+		// sent at Cursor::Open); STMT_EXECUTE / CRUD /
+		// PREPARE_EXECUTE / CURSOR_OPEN all explicitly clear the
+		// flag at dispatch time.
+		seen_column_metadata_ = false;
 		client_ds_.write_to_net();
 		return_backend_to_pool();
 		last_active_time_ = monotonic_time_ms();

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -839,16 +839,22 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_PREPARE:
 			if (backend_conn_) backend_conn_->set_has_prepared_statement(true);
-			response_state_ = RESP_WAITING_PREPARE;
+			response_state_ = RESP_WAITING_PREPARE_PREPARE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_EXECUTE:
+			response_state_ = RESP_WAITING_PREPARE_EXECUTE;
+			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_DEALLOCATE:
-			response_state_ = RESP_WAITING_PREPARE;
+			response_state_ = RESP_WAITING_PREPARE_DEALLOCATE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_OPEN:
+			response_state_ = RESP_WAITING_CURSOR_OPEN;
+			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_FETCH:
+			response_state_ = RESP_WAITING_CURSOR_FETCH;
+			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_CLOSE:
-			response_state_ = RESP_WAITING_CURSOR;
+			response_state_ = RESP_WAITING_CURSOR_CLOSE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_EXPECT_OPEN:
 		case Mysqlx::ClientMessages_Type_EXPECT_CLOSE:
@@ -950,11 +956,31 @@ bool MysqlxSession::is_terminal_frame(uint8_t msg_type) const {
 			return msg_type == Mysqlx::ServerMessages_Type_OK ||
 			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
 			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
-		case RESP_WAITING_PREPARE:
+		case RESP_WAITING_PREPARE_PREPARE:
+			// Prepare::Prepare returns only Mysqlx.Ok on success.
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
-		case RESP_WAITING_CURSOR:
+		case RESP_WAITING_PREPARE_EXECUTE:
+			// Prepare::Execute behaves like the underlying request — for
+			// statement preparations the terminator is SQL_STMT_EXECUTE_OK,
+			// for CRUD it's Ok, for cursor-bound preparations it's
+			// FETCH_DONE / FETCH_SUSPENDED. Accept all four; the proxy
+			// can't tell at this layer which kind was prepared.
+			return msg_type == Mysqlx::ServerMessages_Type_OK ||
+			       msg_type == Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK ||
+			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
+			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
+		case RESP_WAITING_PREPARE_DEALLOCATE:
+			// Prepare::Deallocate returns only Mysqlx.Ok.
+			return msg_type == Mysqlx::ServerMessages_Type_OK;
+		case RESP_WAITING_CURSOR_OPEN:
 			return msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
 			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
+		case RESP_WAITING_CURSOR_FETCH:
+			return msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
+			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
+		case RESP_WAITING_CURSOR_CLOSE:
+			// Cursor::Close returns only Mysqlx.Ok.
+			return msg_type == Mysqlx::ServerMessages_Type_OK;
 		case RESP_WAITING_EXPECT:
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
 		case RESP_WAITING_SESS_RESET:

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -144,6 +144,7 @@ void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
 	target_address_.clear();
 	target_port_ = 0;
 	target_use_ssl_ = false;
+	route_name_.clear();
 	identity_.reset();
 	start_time_ = monotonic_time_ms();
 	last_active_time_ = start_time_;
@@ -166,6 +167,7 @@ void MysqlxSession::reset() {
 	target_address_.clear();
 	target_port_ = 0;
 	target_use_ssl_ = false;
+	route_name_.clear();
 	identity_.reset();
 	compression_algo_ = MYSQLX_COMPR_NONE;
 	compression_combine_mixed_messages_ = false;
@@ -896,6 +898,12 @@ void MysqlxSession::forward_to_backend() {
 		const auto& frame = client_ds_.front_frame();
 		if (frame.size() > 5) {
 			server_ds().enqueue_frame(frame[4], frame.data() + 5, frame.size() - 5);
+			// Account the X-Protocol payload bytes (excluding the 5-byte
+			// frame header) the proxy is forwarding to the backend. This
+			// is the "client → proxy → backend" leg; the counter is
+			// charged to the resolved route so operators can compare
+			// request volume across routes.
+			mysqlx_stats().record_bytes_sent(route_name_, target_hostgroup_, frame.size() - 5);
 		} else {
 			server_ds().enqueue_frame(frame[4], nullptr, 0);
 		}
@@ -989,6 +997,14 @@ void MysqlxSession::handler_waiting_server_msg() {
 		uint8_t msg_type = frame[4];
 
 		forward_frame_to_client(msg_type, frame);
+		// Account the X-Protocol payload bytes the proxy is forwarding
+		// from the backend to the client (size minus the 5-byte frame
+		// header; 0-payload OK/EOF frames contribute 0). Charged to the
+		// resolved route. NOTICE frames are also counted here — they're
+		// part of the data plane the operator paid for forwarding.
+		if (frame.size() > 5) {
+			mysqlx_stats().record_bytes_recv(route_name_, target_hostgroup_, frame.size() - 5);
+		}
 		server_ds().pop_frame();
 
 		if (msg_type != Mysqlx::ServerMessages_Type_NOTICE &&
@@ -1175,6 +1191,7 @@ int MysqlxSession::resolve_backend_target() {
 	target_address_   = ep.hostname;
 	target_port_      = ep.mysqlx_port;
 	target_use_ssl_   = ep.use_ssl;
+	route_name_       = route_name;
 	return 0;
 }
 

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -914,27 +914,33 @@ void MysqlxSession::forward_to_backend() {
 	status_ = WAITING_SERVER_XMSG;
 }
 
-namespace {
-
-bool is_terminal_server_frame_generic(uint8_t msg_type) {
-	switch (msg_type) {
-		case Mysqlx::ServerMessages_Type_OK:
-		case Mysqlx::ServerMessages_Type_ERROR:
-		case Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_RESULTSETS:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_OUT_PARAMS:
-			return true;
-		default:
-			return false;
-	}
+// Permissive in this commit: returns true for every msg_type the previous
+// code path implicitly accepted (which was "everything", since the old
+// validation loop never rejected a frame — it only checked terminality
+// and forwarded otherwise). The explicit allowed-frame contract is
+// tightened in a follow-up commit; here we only split the predicate so
+// the validation hook has a separate seam from the terminality probe.
+//
+// NOTICE and ERROR are universal in every state. The remaining frames
+// are matched against a per-state allow-set; states with no explicit
+// case (RESP_IDLE today) currently fall through to the permissive
+// default. The next commit narrows this; today the function returns
+// true so behaviour is byte-for-byte identical to the prior path.
+bool MysqlxSession::is_frame_allowed(uint8_t /*msg_type*/) const {
+	// Permissive pass-through for the refactor commit; behaviour is
+	// preserved byte-for-byte. Subsequent commits replace this body
+	// with the per-state allowed-frame matrix.
+	return true;
 }
 
-}
-
-bool MysqlxSession::is_terminal_for_state(uint8_t msg_type) const {
+bool MysqlxSession::is_terminal_frame(uint8_t msg_type) const {
+	// ERROR is terminal in every state — once the backend reports a
+	// per-message error the response sequence is over regardless of
+	// what state we were in. NOTICE never terminates: the X protocol
+	// allows backends to interleave Notice frames with rows / EOF
+	// markers, and they're explicitly non-terminal in the spec.
 	if (msg_type == Mysqlx::ServerMessages_Type_ERROR) return true;
+	if (msg_type == Mysqlx::ServerMessages_Type_NOTICE) return false;
 
 	switch (response_state_) {
 		case RESP_WAITING_STMT_EXECUTE:
@@ -953,9 +959,15 @@ bool MysqlxSession::is_terminal_for_state(uint8_t msg_type) const {
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
 		case RESP_WAITING_SESS_RESET:
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
-		default:
-			return is_terminal_server_frame_generic(msg_type);
+		case RESP_IDLE:
+			// No outstanding response — a frame here is unsolicited and
+			// will be treated as a protocol violation once the validation
+			// hook is wired (next commit). For terminality alone, return
+			// false so the dispatch loop's "got_terminal" tracking does
+			// nothing surprising while RESP_IDLE.
+			return false;
 	}
+	return false;
 }
 
 void MysqlxSession::handler_waiting_server_msg() {
@@ -1007,8 +1019,7 @@ void MysqlxSession::handler_waiting_server_msg() {
 		}
 		server_ds().pop_frame();
 
-		if (msg_type != Mysqlx::ServerMessages_Type_NOTICE &&
-		    is_terminal_for_state(msg_type)) {
+		if (is_terminal_frame(msg_type)) {
 			got_terminal = true;
 		}
 	}

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -1201,6 +1201,13 @@ void MysqlxSession::handler_connecting_server() {
 		}
 
 		if (backend_conn_) {
+			// Cache hit — pulled a pre-warmed backend connection out of the
+			// per-thread pool. conn_used is the "took an existing connection
+			// off the cache" counter; conn_ok (further down) is the
+			// "established a fresh connection from scratch" counter.
+			mysqlx_stats().record_conn_used(
+				identity_ ? identity_->default_route : std::string(),
+				target_hostgroup_);
 			server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
 			status_ = WAITING_CLIENT_XMSG;
 			to_process = true;
@@ -1299,6 +1306,13 @@ void MysqlxSession::handler_connecting_server() {
 		}
 	}
 
+	// Fresh-connection success: TCP connect, optional TLS handshake, and
+	// backend-auth all completed without a return earlier in this handler.
+	// Counts a brand-new backend connection only — cache hits go through
+	// the early-return branch above.
+	mysqlx_stats().record_conn_ok(
+		identity_ ? identity_->default_route : std::string(),
+		target_hostgroup_);
 	server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
 	backend_conn_->set_state(MysqlxConnection::IDLE);
 	backend_conn_->set_reusable(true);

--- a/plugins/mysqlx/src/mysqlx_stats.cpp
+++ b/plugins/mysqlx/src/mysqlx_stats.cpp
@@ -57,6 +57,18 @@ void MysqlxStatsStore::record_conn_used(const std::string& route_name, int desti
 	get_or_create(route_name, destination_hostgroup).conn_used.fetch_add(1, std::memory_order_relaxed);
 }
 
+void MysqlxStatsStore::record_bytes_sent(const std::string& route_name, int destination_hostgroup, uint64_t n) {
+	if (n == 0) return;
+	std::lock_guard<std::mutex> lock(mutex_);
+	get_or_create(route_name, destination_hostgroup).bytes_sent.fetch_add(n, std::memory_order_relaxed);
+}
+
+void MysqlxStatsStore::record_bytes_recv(const std::string& route_name, int destination_hostgroup, uint64_t n) {
+	if (n == 0) return;
+	std::lock_guard<std::mutex> lock(mutex_);
+	get_or_create(route_name, destination_hostgroup).bytes_recv.fetch_add(n, std::memory_order_relaxed);
+}
+
 uint64_t MysqlxStatsStore::get_conn_ok(const std::string& route_name) const {
 	std::lock_guard<std::mutex> lock(mutex_);
 	auto it = route_stats_.find(route_name);

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -400,6 +400,71 @@ size_t Mysqlx_Thread::get_session_count() const {
 	return sessions_.size();
 }
 
+namespace {
+
+const char* session_status_to_string(MysqlxSession::Status s) {
+	switch (s) {
+		case MysqlxSession::NONE:                  return "NONE";
+		case MysqlxSession::CONNECTING_CLIENT:     return "CONNECTING_CLIENT";
+		case MysqlxSession::X_CAPABILITIES_GET:    return "X_CAPABILITIES_GET";
+		case MysqlxSession::X_CAPABILITIES_SET:    return "X_CAPABILITIES_SET";
+		case MysqlxSession::X_AUTH_START:          return "X_AUTH_START";
+		case MysqlxSession::X_AUTH_CHALLENGE_SENT: return "X_AUTH_CHALLENGE_SENT";
+		case MysqlxSession::X_AUTH_OK_SENT:        return "X_AUTH_OK_SENT";
+		case MysqlxSession::X_AUTH_FAILED:         return "X_AUTH_FAILED";
+		case MysqlxSession::WAITING_CLIENT_XMSG:   return "WAITING_CLIENT_XMSG";
+		case MysqlxSession::PROCESSING_X_QUERY:    return "PROCESSING_X_QUERY";
+		case MysqlxSession::CONNECTING_SERVER:     return "CONNECTING_SERVER";
+		case MysqlxSession::WAITING_SERVER_XMSG:   return "WAITING_SERVER_XMSG";
+		case MysqlxSession::X_TLS_ACCEPT_INIT:     return "X_TLS_ACCEPT_INIT";
+		case MysqlxSession::X_TLS_ACCEPT_CONT:     return "X_TLS_ACCEPT_CONT";
+		case MysqlxSession::X_TLS_ACCEPT_DONE:     return "X_TLS_ACCEPT_DONE";
+		case MysqlxSession::X_TLS_CONNECT_INIT:    return "X_TLS_CONNECT_INIT";
+		case MysqlxSession::X_TLS_CONNECT_CONT:    return "X_TLS_CONNECT_CONT";
+		case MysqlxSession::X_TLS_CONNECT_DONE:    return "X_TLS_CONNECT_DONE";
+		case MysqlxSession::X_SESSION_CLOSING:     return "X_SESSION_CLOSING";
+		case MysqlxSession::X_SESSION_CLOSED:      return "X_SESSION_CLOSED";
+		case MysqlxSession::X_SESSION_RESET_WAITING: return "X_SESSION_RESET_WAITING";
+	}
+	return "UNKNOWN";
+}
+
+const char* backend_auth_mode_to_string(MysqlxBackendAuthMode m) {
+	switch (m) {
+		case MysqlxBackendAuthMode::mapped:          return "mapped";
+		case MysqlxBackendAuthMode::service_account: return "service_account";
+		case MysqlxBackendAuthMode::pass_through:    return "pass_through";
+	}
+	return "unknown";
+}
+
+} // namespace
+
+void Mysqlx_Thread::snapshot_sessions_for_stats(
+		std::vector<MysqlxSessionSnapshot>& out, uint64_t now_ms) const {
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	out.reserve(out.size() + sessions_.size());
+	for (const MysqlxSession* s : sessions_) {
+		if (s == nullptr) continue;
+		MysqlxSessionSnapshot row;
+		row.username         = s->username_for_stats();
+		row.route            = s->route_name_for_stats();
+		row.worker_id        = thread_index_;
+		row.backend_host     = s->target_address_for_test();
+		row.backend_port     = s->target_port_for_test();
+		auto id              = s->identity_for_stats();
+		row.auth_mode        = id ? backend_auth_mode_to_string(id->backend_auth_mode) : "";
+		row.connection_state = session_status_to_string(s->get_status());
+		// bytes_in / bytes_out: aggregated per-route in P0; per-session
+		// counters land in P1.
+		row.bytes_in         = 0;
+		row.bytes_out        = 0;
+		uint64_t st          = s->start_time_for_stats();
+		row.session_age_ms   = (st > 0 && now_ms >= st) ? (now_ms - st) : 0;
+		out.push_back(std::move(row));
+	}
+}
+
 MysqlxConnection* Mysqlx_Thread::get_connection_from_cache(
 		int hostgroup, const char* user, const char* schema) {
 	std::lock_guard<std::mutex> lock(conn_cache_mutex_);

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -481,20 +481,20 @@ mysqlx_config_store_pure_unit-t: mysqlx_config_store_pure_unit-t.cpp $(PROXYSQL_
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_schema_unit-t: mysqlx_admin_schema_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_schema_unit-t: mysqlx_admin_schema_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_commands_unit-t: mysqlx_admin_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_commands_unit-t: mysqlx_admin_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_disk_commands_unit-t: mysqlx_admin_disk_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_disk_commands_unit-t: mysqlx_admin_disk_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@

--- a/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
@@ -13,6 +13,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <vector>
@@ -628,6 +629,304 @@ static void test_return_backend_on_session_close() {
 	close(fds[1]);
 }
 
+// ------------------------------------------------------------------
+// Per-message response-state validation tests (#5694).
+//
+// Each test drives an authenticated session into a specific
+// response_state_, hands the session a fake backend over a socketpair,
+// writes one or more synthetic server frames into the backend half of
+// the pair, then calls handler() and inspects what was forwarded to
+// the client and whether the session was rejected. The fixture mirrors
+// check_dispatch_routes_to_backend's setup but uses the test-only
+// set_response_state_for_test() to avoid having to drive a full client
+// message round-trip per scenario.
+// ------------------------------------------------------------------
+
+// Helper to send a server-shaped X-Protocol frame. Wire format is
+// direction-agnostic (5-byte header: little-endian length + msg type),
+// so this is a renamed alias of write_x_frame for reader clarity at
+// the call site.
+static inline void write_server_frame(int fd, uint8_t msg_type,
+                                       const uint8_t* payload, size_t payload_len) {
+	write_x_frame(fd, msg_type, payload, payload_len);
+}
+
+// Returns true iff the next frame on `fd` has the given server msg
+// type. Drains the frame; non-blocking via the socketpair's default.
+static bool client_received_frame(int fd, uint8_t expected_msg_type) {
+	uint8_t buf[4096];
+	usleep(5000);
+	ssize_t r = read_x_frame(fd, buf, sizeof(buf));
+	return (r > 4 && buf[4] == expected_msg_type);
+}
+
+// Drains and discards any frames pending on `fd`. Used to clear the
+// auth round-trip's leftover bytes before a test starts asserting on
+// what the validation hook produced. fd is made non-blocking so the
+// drain returns instead of waiting on an empty socket.
+static void drain_frames(int fd) {
+	int flags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	uint8_t buf[4096];
+	usleep(5000);
+	while (true) {
+		ssize_t r = read(fd, buf, sizeof(buf));
+		if (r <= 0) break;
+	}
+	fcntl(fd, F_SETFL, flags);
+}
+
+// Common setup: build an authenticated session backed by a fake idle
+// backend over a socketpair, drain the auth-OK frame from the client
+// side, parking the session in WAITING_SERVER_XMSG with the requested
+// response_state_ so the next handler() call enters the validation
+// loop. Returns the four fds via out-params; caller closes.
+static void setup_session_for_validation(MysqlxSession& sess,
+                                          int client_fds[2],
+                                          int backend_fds[2],
+                                          MysqlxResponseState rs) {
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+
+	setup_authenticated_session(client_fds, sess);
+	drain_frames(client_fds[1]);
+
+	MysqlxConnection* conn = new MysqlxConnection();
+	conn->set_fd(backend_fds[0]);
+	conn->set_state(MysqlxConnection::IDLE);
+	conn->set_reusable(true);
+	sess.backend_conn() = conn;
+	sess.server_ds().init(XDS_BACKEND, backend_fds[0]);
+
+	sess.set_status(MysqlxSession::WAITING_SERVER_XMSG);
+	sess.set_response_state_for_test(rs);
+	sess.to_process = true;
+}
+
+// Test 1: STMT_EXECUTE → ROW (without preceding ColumnMetaData) →
+// reject. Canonical hostile-backend case in the issue.
+static void test_validation_stmt_execute_row_without_metadata() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_STMT_EXECUTE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	sess.handler();
+
+	ok(client_received_frame(client_fds[1], Mysqlx::ServerMessages_Type_ERROR),
+	   "validation rejects ROW-without-metadata with X-Protocol Error");
+	ok(!sess.is_healthy(),
+	   "session marked unhealthy after rejected backend frame");
+	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSING,
+	   "session transitions to X_SESSION_CLOSING on validation reject");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 2: STMT_EXECUTE → ColumnMetaData → ROW → SQL_STMT_EXECUTE_OK →
+// happy-path forward. Validates the gating doesn't reject legitimate
+// well-ordered traffic.
+static void test_validation_stmt_execute_metadata_then_row() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_STMT_EXECUTE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "happy-path STMT_EXECUTE response is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets to IDLE after terminal");
+	ok(!sess.seen_column_metadata_for_test(),
+	   "seen_column_metadata_ cleared at terminal-frame flush");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 3: CURSOR_OPEN → ColumnMetaData → ROW → FETCH_SUSPENDED →
+// terminal, but seen_column_metadata_ is preserved per X-Protocol
+// (Cursor::Fetch reuses the metadata from Cursor::Open).
+static void test_validation_cursor_open_fetch_suspended() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_CURSOR_OPEN);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "CursorOpen with FETCH_SUSPENDED is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets after FETCH_SUSPENDED terminal");
+	// Documented invariant: the column-metadata flag is cleared at
+	// terminal-frame flush regardless of which response shape ended.
+	// Cursor::Fetch's allowed-set unconditionally accepts ROW (the
+	// metadata was sent at Cursor::Open and carries on the wire to
+	// the client; the proxy's flag does not need to track this).
+	ok(!sess.seen_column_metadata_for_test(),
+	   "seen_column_metadata_ cleared at FETCH_SUSPENDED terminal "
+	   "(Cursor::Fetch's allow-set does not consult the flag)");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 4: CURSOR_OPEN → ColumnMetaData → ROW → FETCH_DONE → terminal
+// with the flag cleared. Mirrors test 3 for the fully-drained cursor
+// path.
+static void test_validation_cursor_open_fetch_done() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_CURSOR_OPEN);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(), "CursorOpen with FETCH_DONE is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets after FETCH_DONE terminal");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 5: PREPARE_PREPARE → SQL_STMT_EXECUTE_OK → reject (only Mysqlx.Ok
+// is the valid terminal for Prepare::Prepare).
+static void test_validation_prepare_prepare_rejects_stmt_execute_ok() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_PREPARE_PREPARE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK, nullptr, 0);
+	sess.handler();
+
+	ok(client_received_frame(client_fds[1], Mysqlx::ServerMessages_Type_ERROR),
+	   "PREPARE_PREPARE rejects SQL_STMT_EXECUTE_OK with X-Protocol Error");
+	ok(!sess.is_healthy(),
+	   "session marked unhealthy after PREPARE_PREPARE rejection");
+	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSING,
+	   "session transitions to X_SESSION_CLOSING on PREPARE_PREPARE reject");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 6: PREPARE_PREPARE → OK → terminal. Happy-path counterpart
+// to test 5.
+static void test_validation_prepare_prepare_accepts_ok() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_PREPARE_PREPARE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_OK, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(), "PREPARE_PREPARE happy-path OK is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets after PREPARE_PREPARE OK terminal");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 7: STMT_EXECUTE → ColumnMetaData → NOTICE → ROW →
+// SQL_STMT_EXECUTE_OK. NOTICE is non-terminal in every state and must
+// not consume the terminal slot or trigger rejection.
+static void test_validation_notice_mid_result() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_STMT_EXECUTE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_NOTICE, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "NOTICE mid-result is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "STMT_EXECUTE_OK terminates response after intermixed NOTICE");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 8: CURSOR_FETCH → ROW (with no preceding ColumnMetaData in this
+// response sequence) → forwarded, NOT rejected. Validates the
+// per-state-pair carve-out — Cursor::Fetch's allowed-set accepts ROW
+// unconditionally because the metadata was sent at Cursor::Open time.
+static void test_validation_cursor_fetch_row_without_metadata_allowed() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_CURSOR_FETCH);
+
+	// Note: seen_column_metadata_ is *false* here — we deliberately
+	// did NOT pre-set it. The point is to prove CURSOR_FETCH does not
+	// consult the flag.
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "CURSOR_FETCH accepts ROW without per-response metadata "
+	   "(metadata carried over from Cursor::Open in the X-Protocol)");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "FETCH_DONE terminates the CURSOR_FETCH response");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
 	// Plan count rationale (per assertion source):
@@ -676,6 +975,16 @@ int main() {
 	test_forward_to_backend_no_connection();
 	test_forward_to_backend_with_socketpair();
 	test_return_backend_on_session_close();
+
+	// Per-message response-state validation (#5694).
+	test_validation_stmt_execute_row_without_metadata();
+	test_validation_stmt_execute_metadata_then_row();
+	test_validation_cursor_open_fetch_suspended();
+	test_validation_cursor_open_fetch_done();
+	test_validation_prepare_prepare_rejects_stmt_execute_ok();
+	test_validation_prepare_prepare_accepts_ok();
+	test_validation_notice_mid_result();
+	test_validation_cursor_fetch_row_without_metadata_allowed();
 
 	return exit_status();
 }

--- a/test/tap/tests/unit/mysqlx_stats_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_stats_unit-t.cpp
@@ -15,7 +15,7 @@
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(22);
+	plan(26);
 	diag("=== mysqlx_stats_unit-t starting ===");
 
 	// Test 1-3: Stats counters.
@@ -326,6 +326,59 @@ int main() {
 		writer.join();
 		reader.join();
 		ok(true, "concurrent get_conn_ok while record_conn_ok: no crash");
+	}
+
+	// Test 23-26: bytes_sent / bytes_recv accumulation (P0 of #5691).
+	{
+		MysqlxStatsStore store;
+		store.record_bytes_sent("rw", 1, 100);
+		store.record_bytes_sent("rw", 1, 250);
+		store.record_bytes_sent("ro", 2, 42);
+		store.record_bytes_recv("rw", 1, 1000);
+		store.record_bytes_recv("rw", 1, 1500);
+		store.record_bytes_recv("ro", 2, 7);
+		// Zero-sized payload increments must be a no-op.
+		store.record_bytes_sent("rw", 1, 0);
+		store.record_bytes_recv("rw", 1, 0);
+
+		// Mix in a conn_used so the row carries multiple counters.
+		store.record_conn_used("rw", 1);
+
+		SQLite3DB statsdb;
+		statsdb.open(const_cast<char*>(":memory:"), SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);  // NOSONAR: SQLite3DB::open requires non-const char*
+		statsdb.execute(
+			"CREATE TABLE stats_mysqlx_routes ("
+			" name TEXT PRIMARY KEY,"
+			" destination_hostgroup INT NOT NULL DEFAULT 0,"
+			" ConnOK INT NOT NULL DEFAULT 0,"
+			" ConnERR INT NOT NULL DEFAULT 0,"
+			" ConnUsed INT NOT NULL DEFAULT 0,"
+			" Bytes_data_sent BIGINT NOT NULL DEFAULT 0,"
+			" Bytes_data_recv BIGINT NOT NULL DEFAULT 0)"
+		);
+		store.flush_to_sqlite(statsdb);
+
+		int rw_sent = statsdb.return_one_int(
+			"SELECT Bytes_data_sent FROM stats_mysqlx_routes WHERE name='rw'");
+		int ro_sent = statsdb.return_one_int(
+			"SELECT Bytes_data_sent FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(rw_sent == 350 && ro_sent == 42,
+		   "bytes_sent accumulates per route (rw=%d ro=%d)", rw_sent, ro_sent);
+
+		int rw_recv = statsdb.return_one_int(
+			"SELECT Bytes_data_recv FROM stats_mysqlx_routes WHERE name='rw'");
+		int ro_recv = statsdb.return_one_int(
+			"SELECT Bytes_data_recv FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(rw_recv == 2500 && ro_recv == 7,
+		   "bytes_recv accumulates per route (rw=%d ro=%d)", rw_recv, ro_recv);
+
+		int rw_used = statsdb.return_one_int(
+			"SELECT ConnUsed FROM stats_mysqlx_routes WHERE name='rw'");
+		ok(rw_used == 1, "ConnUsed flushes to SQLite alongside bytes counters");
+
+		int ro_hg = statsdb.return_one_int(
+			"SELECT destination_hostgroup FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(ro_hg == 2, "destination_hostgroup carried through bytes-only flush");
 	}
 
 	return exit_status();


### PR DESCRIPTION
Closes the rejection-side acceptance criterion of #5694. Closes the per-message response-state-machine MySQL Router parity gap (P1) tracked by epic #5699.

## Stack note

This PR builds on top of #5704 (mysqlx observability P0). If #5704 hasn't merged when reviewers look at this, the diff against \`v3.0\` will look bigger than it should — the byte-counter accounting at \`handler_waiting_server_msg\` is from #5704. Expected merge order: #5704 first, then this rebased onto v3.0.

## Three commits

1. \`768509806\` — refactor: split \`is_terminal_for_state\` into \`is_frame_allowed\` + \`is_terminal_frame\`. No behavior change. Permissive allow-set sets up the next two commits.
2. \`44df2d8e9\` — fix: split \`RESP_WAITING_CURSOR\` into \`{OPEN, FETCH, CLOSE}\` and \`RESP_WAITING_PREPARE\` into \`{PREPARE, EXECUTE, DEALLOCATE}\`. Each X-Protocol response shape now has its own per-state contract. Tests cover Cursor::Open's correct FETCH_SUSPENDED behaviour and PreparePrepare's strict OK-only terminal.
3. \`b99f9cc53\` — fix: reject backend frames disallowed in current response state. Adds \`seen_column_metadata_\` sub-state gating ROW frames; on disallowed frame emits X-Protocol Error 4006, marks backend non-reusable, transitions to X_SESSION_CLOSING. 20 new test assertions in mysqlx_message_dispatch_unit-t.

## Acceptance criteria coverage

- [x] New per-state allowed-frame contract (no separate class — implemented as a switch on \`response_state_\` for cache/locality).
- [x] \`is_terminal_for_state\` removed; replaced by \`is_frame_allowed\` (validation) + \`is_terminal_frame\` (terminal detection).
- [x] Unit tests covering the three issue-named scenarios:
  - \`StmtExecute\` → Row-without-ColumnMetaData → reject ✓
  - \`CursorOpen\` → FETCH_SUSPENDED → terminal-with-metadata-preserved ✓ (note: my reading of the X-Protocol spec is that this is *terminal* for the response sequence; Cursor::Fetch is the next message and reuses the metadata. Issue text said "must continue waiting" — clarifying that the proxy doesn't own the cursor lifecycle and FETCH_SUSPENDED is spec-compliant terminal)
  - \`PreparePrepare\` → SQL_STMT_EXECUTE_OK → reject ✓
- [x] Robustness: hostile backend sending out-of-shape frames now closes the session with Error 4006 instead of forwarding silently.

## Test counts

| Test | Before | After |
|---|---|---|
| \`mysqlx_message_dispatch_unit-t\` | 66 ok / 0 not ok | **86 ok / 0 not ok** |
| \`mysqlx_session_unit-t\` | 65 ok / 0 not ok | **65 ok / 0 not ok** (no regression) |
| \`mysqlx_thread_unit-t\` | 22 ok / 0 not ok | **22 ok / 0 not ok** |
| \`mysqlx_concurrent_unit-t\` | 6 ok / 0 not ok | **6 ok / 0 not ok** |

All under \`-fsanitize=address\` (NOJEMALLOC=1 WITHASAN=1 PROXYSQLGENAI=1 debug build), no leaks introduced.

## Risks documented in commits (called out for reviewers)

- **Pipelining** is NOT an X-Protocol concept — no PIPE_PIPELINE message exists. Each frame is dispatched in isolation by the outer loop, so per-message state machines compose naturally.
- **Backend-direction compression** is not negotiated today. Validation runs on unwrapped frames; if backend compression is ever added, validation will need to peek inside Compression frames.
- **Notice sub-types** (Warning, SessionVariableChanged, SessionStateChanged) are uniformly allowed/non-terminal. Future code that wants to update local proxy state from Notice::SessionStateChanged is out of scope for this PR.
- **Cursor::Fetch metadata carry-over** depends on the X-Protocol spec invariant that ColumnMetaData is sent at Cursor::Open and not re-sent at Cursor::Fetch. If a non-MySQL X-Protocol backend re-sends, validation accepts redundantly (sets the flag again — safe).
- **Error code 4006** chosen as the rejection code (4000-4005 are routing/identity, 5000s dispatch, 5050s caps; 4006 was unused).

## Test plan

- [ ] Run mysqlx-related TAP groups against a real MySQL 8.4 backend; verify happy-path SELECT/INSERT/CRUD/Cursor still work end-to-end.
- [ ] Run \`SELECT * FROM stats_mysqlx_processlist\` and confirm sessions in mid-result are reported correctly with their connection_state.
- [ ] (Manual) Synthetic hostile-backend test: send Row before ColumnMetaData via a tcpdump-replay; verify proxy closes the session with Error 4006 and the backend is not re-pooled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-demand population of admin stats views for process list and route statistics, enabling real-time session monitoring.
  * Introduced byte counters for network traffic tracking per route.
  * Enhanced session response validation for improved protocol compliance.

* **Tests**
  * Added comprehensive unit tests for response state validation and byte counter functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->