### PR TITLE
feat(mysqlx): TLS passthrough mode (P1 parity gap)

### DIFF
--- a/doc/mysqlx/MYSQL_ROUTER_PARITY.md
+++ b/doc/mysqlx/MYSQL_ROUTER_PARITY.md
@@ -11,9 +11,9 @@ gaps, and areas where ProxySQL is superior.
 | Source | `x_connection.cc` (~3200 lines) | `mysqlx_session.cpp` + `mysqlx_thread.cpp` (~970 lines) |
 | Architecture | Async callback-based (ASIO-style) | poll()-based synchronous event loop |
 | State machine | ~100 enum states | 23 states in `MysqlxSession::Status` |
-| TLS modes | 5: Disabled, Preferred, Required, AsClient, Passthrough | 4 frontend × 4 backend: frontend Disabled/Preferred/Required + backend disabled/preferred/required/as_client |
+| TLS modes | 5: Disabled, Preferred, Required, AsClient, Passthrough | All five at frontend × 4 backend: frontend `mysqlx_tls_mode` Disabled/Preferred/Required + per-route `mysqlx_routes.tls_mode` adds inherit/passthrough + backend disabled/preferred/required/as_client |
 | TLS termination | Full: Router terminates TLS, re-encrypts to backend | Frontend: OpenSSL Memory BIO; Backend: CapabilitiesSet negotiation with mode-driven posture |
-| TLS passthrough | Yes - raw TLS record forwarding at record layer | No |
+| TLS passthrough | Yes - raw TLS record forwarding at record layer | Yes via `mysqlx_routes.tls_mode='passthrough'` (issue #5692) — opt-in per route; the proxy splices raw bytes after CapabilitiesSet(tls=true) and never sees plaintext |
 | Asymmetric TLS | Yes (client-TLS + backend-plain, or vice versa) | Yes via `mysqlx_tls_backend_mode` (issue #5693) — independent frontend / backend modes, AsClient parity |
 | Authentication | Pass-through to backend (never sees passwords) | Local validation via credential_lookup callback |
 | Auth methods | Whatever backend supports (proxied) | MYSQL41 and PLAIN (PLAIN requires TLS) |
@@ -57,9 +57,12 @@ routing (different users to different backends) and connection pooling
 ### TLS Architecture
 
 MySQL Router has an extremely sophisticated 5-mode TLS model. ProxySQL
-exposes the same posture via two orthogonal variables: `mysqlx_tls_mode`
-(frontend, three values) and `mysqlx_tls_backend_mode` (backend, four
-values), giving full Router parity except for raw-record passthrough.
+exposes equivalent posture via three orthogonal handles: the deployment-
+wide `mysqlx_tls_mode` (frontend, three values), the deployment-wide
+`mysqlx_tls_backend_mode` (backend, four values), and a per-route
+override on `mysqlx_routes.tls_mode` (five values, including `passthrough`),
+giving full Router parity including raw-record passthrough at route
+granularity.
 
 Frontend modes (`mysqlx_tls_mode`):
 
@@ -82,8 +85,19 @@ BIO_new_mem_buf, SSL_set_accept_state), integrated into the session state
 machine via X_TLS_ACCEPT_INIT/CONT/DONE states. Backend TLS is negotiated
 via CapabilitiesSet, with the per-session decision driven by
 `mysqlx_resolve_backend_tls_decision()` against the four-mode runtime
-variable. The remaining Router-only feature is raw-record passthrough
-mode.
+variable.
+
+Per-route passthrough (`mysqlx_routes.tls_mode='passthrough'`,
+issue #5692) takes a different path: once the client sends
+`CapabilitiesSet(tls=true)` on a passthrough-flagged route, the session
+transitions to `X_PASSTHROUGH_FORWARD` and stops parsing X-Protocol
+frames entirely. From that point bytes are spliced verbatim with
+`read(2)`/`write(2)` between the client and a single dedicated backend
+fd; the proxy never sees the TLS handshake or any application data.
+Pooling, multiplexing, and per-query routing are intentionally disabled
+for the session — the operator's choice to opt into passthrough is the
+choice to give up those features in exchange for end-to-end encryption
+the proxy cannot inspect.
 
 ### Connection Lifecycle
 
@@ -108,7 +122,7 @@ of 7 terminal message types. All frames forwarded until terminal frame seen.
 
 | Priority | Feature | Notes |
 |---|---|---|
-| P1 | TLS passthrough | Forward raw TLS records without termination |
+| ✅  | ~~TLS passthrough~~ | Implemented via `mysqlx_routes.tls_mode='passthrough'` (#5692). Per-route opt-in. |
 | ✅  | ~~Asymmetric TLS / AsClient~~ | Implemented via `mysqlx_tls_backend_mode` (#5693). |
 | ✅  | ~~Per-message response state machines~~ | Implemented (#5694). |
 | P2 | Notice forwarding awareness | Explicitly handle notices as non-terminal in all states |
@@ -141,4 +155,8 @@ The core TLS gap (frontend termination + backend negotiation) is now closed.
 Asymmetric TLS / AsClient mode landed via `mysqlx_tls_backend_mode` (issue
 #5693) — Router's full four-mode backend posture (disabled / preferred /
 required / as_client) is now exposed, plus per-endpoint TLS overrides.
-The remaining TLS gap is raw-record passthrough mode (issue #5692).
+Raw-record passthrough mode landed via `mysqlx_routes.tls_mode='passthrough'`
+(issue #5692), exposed at per-route granularity rather than per-deployment
+so an operator can dedicate a single compliance-pinned route to passthrough
+while leaving neighbouring routes on the default proxy-terminated path.
+ProxySQL's mysqlx plugin now matches all five Router TLS modes.

--- a/doc/mysqlx/MYSQL_ROUTER_PARITY.md
+++ b/doc/mysqlx/MYSQL_ROUTER_PARITY.md
@@ -11,10 +11,10 @@ gaps, and areas where ProxySQL is superior.
 | Source | `x_connection.cc` (~3200 lines) | `mysqlx_session.cpp` + `mysqlx_thread.cpp` (~970 lines) |
 | Architecture | Async callback-based (ASIO-style) | poll()-based synchronous event loop |
 | State machine | ~100 enum states | 23 states in `MysqlxSession::Status` |
-| TLS modes | 5: Disabled, Preferred, Required, AsClient, Passthrough | 3: Disabled, Preferred, Required |
-| TLS termination | Full: Router terminates TLS, re-encrypts to backend | Frontend: OpenSSL Memory BIO; Backend: CapabilitiesSet negotiation |
+| TLS modes | 5: Disabled, Preferred, Required, AsClient, Passthrough | 4 frontend × 4 backend: frontend Disabled/Preferred/Required + backend disabled/preferred/required/as_client |
+| TLS termination | Full: Router terminates TLS, re-encrypts to backend | Frontend: OpenSSL Memory BIO; Backend: CapabilitiesSet negotiation with mode-driven posture |
 | TLS passthrough | Yes - raw TLS record forwarding at record layer | No |
-| Asymmetric TLS | Yes (client-TLS + backend-plain, or vice versa) | No |
+| Asymmetric TLS | Yes (client-TLS + backend-plain, or vice versa) | Yes via `mysqlx_tls_backend_mode` (issue #5693) — independent frontend / backend modes, AsClient parity |
 | Authentication | Pass-through to backend (never sees passwords) | Local validation via credential_lookup callback |
 | Auth methods | Whatever backend supports (proxied) | MYSQL41 and PLAIN (PLAIN requires TLS) |
 | Lazy backend connect | Yes (on SESS_AUTH_START) | Yes (on first query via CONNECTING_SERVER) |
@@ -56,23 +56,34 @@ routing (different users to different backends) and connection pooling
 
 ### TLS Architecture
 
-MySQL Router has an extremely sophisticated 5-mode TLS model:
+MySQL Router has an extremely sophisticated 5-mode TLS model. ProxySQL
+exposes the same posture via two orthogonal variables: `mysqlx_tls_mode`
+(frontend, three values) and `mysqlx_tls_backend_mode` (backend, four
+values), giving full Router parity except for raw-record passthrough.
 
-- **Disabled**: No TLS on either side
-- **Preferred**: TLS if client requests it via CapabilitiesSet
-- **Required**: Reject client if they don't use TLS
-- **AsClient**: Match client's TLS choice on backend
-- **Passthrough**: Forward raw TLS records without termination
+Frontend modes (`mysqlx_tls_mode`):
 
-The Router's server_init_tls() orchestrates checking server capabilities,
-sending CapabilitiesSet(tls=true) to backend, handling Ok/Error responses,
-then calling tls_connect().
+- **DISABLED**: No TLS capability advertised. Plaintext only.
+- **PREFERRED**: TLS capability advertised. Client chooses to upgrade.
+- **REQUIRED**: TLS capability advertised. Reject client if it does not upgrade.
+
+Backend modes (`mysqlx_tls_backend_mode`, lowercase, default `as_client`):
+
+- **disabled**: Never use TLS proxy↔backend.
+- **preferred**: Try `CapabilitiesSet(tls=true)`; on backend `Mysqlx::Error`, silently downgrade to plaintext on the same TCP connection. Best-effort.
+- **required**: TLS mandatory; backend `Mysqlx::Error` fails the connect with code 3152.
+- **as_client**: Mirror the frontend leg's encryption choice (Router AsClient parity).
+
+The per-endpoint flag `mysqlx_backend_endpoints.use_ssl=1` promotes
+plaintext to TLS for one specific backend regardless of mode (override).
 
 ProxySQL implements frontend TLS using OpenSSL Memory BIOs (SSL_new,
 BIO_new_mem_buf, SSL_set_accept_state), integrated into the session state
 machine via X_TLS_ACCEPT_INIT/CONT/DONE states. Backend TLS is negotiated
-via CapabilitiesSet. Missing features compared to Router: AsClient mode,
-passthrough mode, and asymmetric TLS.
+via CapabilitiesSet, with the per-session decision driven by
+`mysqlx_resolve_backend_tls_decision()` against the four-mode runtime
+variable. The remaining Router-only feature is raw-record passthrough
+mode.
 
 ### Connection Lifecycle
 
@@ -98,8 +109,8 @@ of 7 terminal message types. All frames forwarded until terminal frame seen.
 | Priority | Feature | Notes |
 |---|---|---|
 | P1 | TLS passthrough | Forward raw TLS records without termination |
-| P1 | Asymmetric TLS | AsClient mode — match client TLS choice on backend |
-| P1 | Per-message response state machines | More robust handling of multi-frame responses |
+| ✅  | ~~Asymmetric TLS / AsClient~~ | Implemented via `mysqlx_tls_backend_mode` (#5693). |
+| ✅  | ~~Per-message response state machines~~ | Implemented (#5694). |
 | P2 | Notice forwarding awareness | Explicitly handle notices as non-terminal in all states |
 | P2 | Compression protocol error code | Match MySQL's specific X Protocol error code |
 | P3 | Session Reset passthrough | Full response tracking with pool invalidation |
@@ -127,4 +138,7 @@ pooling, query-level routing, multiplexing, local auth) that MySQL Router
 does not support with its pass-through design.
 
 The core TLS gap (frontend termination + backend negotiation) is now closed.
-Remaining gaps are TLS passthrough and AsClient mode.
+Asymmetric TLS / AsClient mode landed via `mysqlx_tls_backend_mode` (issue
+#5693) — Router's full four-mode backend posture (disabled / preferred /
+required / as_client) is now exposed, plus per-endpoint TLS overrides.
+The remaining TLS gap is raw-record passthrough mode (issue #5692).

--- a/doc/mysqlx/README.md
+++ b/doc/mysqlx/README.md
@@ -64,22 +64,22 @@ The plugin is loaded after the Admin module initializes. The sequence is:
 
 Global configuration variables for the mysqlx plugin.
 
-Only the four variables below are wired through `MysqlxConfigStore`'s
+Only the five variables below are wired through `MysqlxConfigStore`'s
 install/save round-trip. Operator-defined rows with any other
 `variable_name` are accepted by the table's CHECK constraints and may be
 inserted, but are silently ignored on `LOAD MYSQLX VARIABLES TO RUNTIME`
 and *deleted* by the next `SAVE MYSQLX VARIABLES TO MEMORY` (the SAVE
-path replaces the entire table with the four canonical scalars from the
-store). TLS-related variables (`mysqlx_tls_cert`, `mysqlx_tls_key`,
-`mysqlx_tls_ca`, `mysqlx_tls_backend_mode`) are reserved names not yet
-wired — see issue tracker.
+path replaces the entire table with the canonical scalars from the
+store). Reserved-but-not-wired TLS variables: `mysqlx_tls_cert`,
+`mysqlx_tls_key`, `mysqlx_tls_ca` — see issue tracker.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `mysqlx_thread_pool_size` | `4` | Number of event loop threads. Range: 1–64. Each thread runs an independent `poll()` loop handling thousands of concurrent sessions. |
 | `mysqlx_connect_timeout` | `10000` | Backend connection timeout in milliseconds. Applied to non-blocking `connect()` + backend authentication. |
 | `mysqlx_tls_mode` | `DISABLED` | Frontend TLS mode: `DISABLED`, `PREFERRED`, or `REQUIRED`. See [TLS Modes](#81-tls-modes). |
-| `mysqlx_max_cached_connections_per_thread` | `100` | Maximum number of idle backend connections cached per thread. Connections are matched by hostgroup, user, and schema. |
+| `mysqlx_tls_backend_mode` | `as_client` | Backend (proxy→backend) TLS mode: `disabled`, `preferred`, `required`, or `as_client`. See [Backend TLS Modes](#82-backend-tls-modes). |
+| `mysqlx_max_cached_connections_per_thread` | `100` | Maximum number of idle backend connections cached per thread. Connections are matched by hostgroup, user, schema, *and* backend TLS state. |
 
 ```sql
 -- View current variables
@@ -160,7 +160,7 @@ A read-only view of the per-host X-Protocol port overrides held by `MysqlxConfig
 
 ### 4.7. `runtime_mysqlx_variables` (Runtime View)
 
-A read-only view of the four mysqlx tunables held by `MysqlxConfigStore` (`mysqlx_thread_pool_size`, `mysqlx_connect_timeout`, `mysqlx_tls_mode`, `mysqlx_max_cached_connections_per_thread`). Same mechanism as [`runtime_mysqlx_users`](#42-runtime_mysqlx_users-runtime-view): refilled by a chassis-registered refresh callback before any `SELECT`, never written by LOAD, never read by SAVE.
+A read-only view of the five mysqlx tunables held by `MysqlxConfigStore` (`mysqlx_thread_pool_size`, `mysqlx_connect_timeout`, `mysqlx_tls_mode`, `mysqlx_tls_backend_mode`, `mysqlx_max_cached_connections_per_thread`). Same mechanism as [`runtime_mysqlx_users`](#42-runtime_mysqlx_users-runtime-view): refilled by a chassis-registered refresh callback before any `SELECT`, never written by LOAD, never read by SAVE.
 
 `LOAD MYSQLX VARIABLES TO RUNTIME` reads `mysqlx_variables` directly into the store; `SAVE MYSQLX VARIABLES FROM RUNTIME TO MEMORY` writes the store's four scalars back into `mysqlx_variables` (replacing the entire table). Operator-added rows in `mysqlx_variables` whose `variable_name` is not one of the four canonical names are not retained on SAVE — only the four known tunables round-trip.
 
@@ -333,7 +333,10 @@ Unknown message types receive `ER_X_BAD_MESSAGE` error.
 
 ## 8. TLS
 
-### 8.1. TLS Modes
+### 8.1. Frontend TLS Modes (client → proxy)
+
+Driven by `mysqlx_tls_mode` (uppercase values for backwards compatibility
+with the legacy mysql-side mode names).
 
 | Mode | Description |
 |------|-------------|
@@ -341,16 +344,64 @@ Unknown message types receive `ER_X_BAD_MESSAGE` error.
 | `PREFERRED` | TLS capability advertised. Client chooses whether to upgrade. |
 | `REQUIRED` | TLS capability advertised. Connection rejected if client does not upgrade. |
 
-### 8.2. Configuration
+### 8.2. Backend TLS Modes (proxy → backend)
+
+Driven by `mysqlx_tls_backend_mode` (lowercase values, matching MySQL
+Router 8.0's `client_ssl_mode` / `server_ssl_mode` taxonomy). Default is
+`as_client`, which matches the legacy implicit behaviour where backend
+TLS was tied to the frontend leg's TLS state.
+
+| Mode | Description |
+|------|-------------|
+| `disabled` | Never use TLS for the proxy→backend leg, regardless of frontend TLS. Plaintext only. |
+| `preferred` | Send `CapabilitiesSet(tls=true)` to the backend; on `Mysqlx::Error`, silently downgrade to plaintext on the same TCP connection and continue with `AuthenticateStart`. Best-effort encryption — works against fleets with mixed TLS configurations. |
+| `required` | Send `CapabilitiesSet(tls=true)`; on `Mysqlx::Error`, fail the backend connect with error 3152 (`Backend TLS handshake failed`). Use when policy mandates encryption proxy↔backend. |
+| `as_client` | Mirror the client's TLS choice. If the client connected over TLS, the backend leg is encrypted; if the client connected in plaintext, the backend leg is plaintext. Matches MySQL Router's AsClient mode. |
+
+The per-endpoint flag `mysqlx_backend_endpoints.use_ssl=1` is an
+operator-controlled override that **promotes** plaintext to TLS for that
+specific endpoint regardless of mode (it can never demote — there is no
+way to opt a single backend out of `mode=required`). Use it when one
+sensitive backend must always be encrypted under a deployment-wide
+`mode=disabled` or `mode=as_client` policy.
+
+#### Migration notes from MySQL Router AsClient
+
+Pre-mode-aware ProxySQL implicitly behaved like Router's AsClient mode:
+the backend leg was encrypted iff the client leg was. Setting
+`mysqlx_tls_backend_mode='as_client'` (the new default) preserves that
+behaviour exactly. Operators wanting Router-`Required` semantics should
+set `mysqlx_tls_backend_mode='required'`; Router-`PassthroughEncrypt` /
+`Disabled` map to `mysqlx_tls_backend_mode='disabled'`.
+
+#### Connection pool partitioning
+
+The per-thread connection cache key is
+`(hostgroup, user, schema, tls_active)`. An AsClient or required-TLS
+session never receives a plaintext-pooled backend (and vice versa) —
+the encryption posture is part of the cache identity. Operators with a
+mixed-mode workload (some sessions over TLS, some plaintext) will see
+two parallel pools per backend identity, which is intentional and
+correct: handing a plaintext connection to a TLS-frontend session
+would silently corrupt the wire protocol.
+
+### 8.3. Configuration
 
 ```sql
+-- Frontend TLS:
 UPDATE mysqlx_variables SET variable_value='PREFERRED' WHERE variable_name='mysqlx_tls_mode';
+
+-- Backend TLS (asymmetric example: client-required, backend-best-effort):
+UPDATE mysqlx_variables SET variable_value='REQUIRED'   WHERE variable_name='mysqlx_tls_mode';
+UPDATE mysqlx_variables SET variable_value='preferred'  WHERE variable_name='mysqlx_tls_backend_mode';
+
 LOAD MYSQLX VARIABLES TO RUNTIME;
 ```
 
 Note: certificate / key paths are not configurable via `mysqlx_variables`
-yet — the only TLS-related variable currently wired through the
-`MysqlxConfigStore` install/save round-trip is `mysqlx_tls_mode`.
+yet — the only TLS-related variables currently wired through the
+`MysqlxConfigStore` install/save round-trip are `mysqlx_tls_mode` and
+`mysqlx_tls_backend_mode`.
 
 ## 9. Connection Pooling
 

--- a/doc/mysqlx/README.md
+++ b/doc/mysqlx/README.md
@@ -136,6 +136,7 @@ Define X Protocol listener routes.
 | active | INT CHECK (0,1) | `1` | Whether this route is active |
 | attributes | VARCHAR | `''` | JSON attributes for future extensions |
 | comment | VARCHAR | `''` | Route comment |
+| tls_mode | VARCHAR | `'inherit'` | Per-route TLS posture: `inherit` (use `mysqlx_tls_mode`), `disabled`, `preferred`, `required`, or `passthrough`. See [§8.1](#81-frontend-tls-modes-client--proxy) and [§8.4](#84-end-to-end-tls-passthrough-per-route). |
 
 ### 4.4. `runtime_mysqlx_routes` (Runtime View)
 
@@ -344,6 +345,26 @@ with the legacy mysql-side mode names).
 | `PREFERRED` | TLS capability advertised. Client chooses whether to upgrade. |
 | `REQUIRED` | TLS capability advertised. Connection rejected if client does not upgrade. |
 
+#### Per-route override: `mysqlx_routes.tls_mode`
+
+The deployment-wide `mysqlx_tls_mode` can be overridden at the route
+level via the `tls_mode` column on `mysqlx_routes`. Default is
+`inherit`, which defers to `mysqlx_tls_mode` and matches the previous
+deployment-wide-only behaviour exactly.
+
+| Per-route value | Description |
+|-----------------|-------------|
+| `inherit` | Use the deployment-wide `mysqlx_tls_mode`. Default. |
+| `disabled` | This route never advertises TLS, regardless of the global mode. |
+| `preferred` | This route advertises TLS; client decides whether to upgrade. |
+| `required` | This route advertises TLS; reject the session if the client does not upgrade. |
+| `passthrough` | After `CapabilitiesSet(tls=true)`, the proxy splices raw bytes between client and backend without decrypting. End-to-end TLS — see §8.4. |
+
+Use case for the override: dedicate a single compliance-pinned route to
+`passthrough` while leaving the others on `inherit` so admin / monitoring
+routes still get the proxy's pooling, query-level routing, and
+multiplexing.
+
 ### 8.2. Backend TLS Modes (proxy → backend)
 
 Driven by `mysqlx_tls_backend_mode` (lowercase values, matching MySQL
@@ -402,6 +423,53 @@ Note: certificate / key paths are not configurable via `mysqlx_variables`
 yet — the only TLS-related variables currently wired through the
 `MysqlxConfigStore` install/save round-trip are `mysqlx_tls_mode` and
 `mysqlx_tls_backend_mode`.
+
+### 8.4. End-to-end TLS Passthrough (per-route)
+
+When operator policy forbids the proxy from decrypting traffic
+(compliance, original cert/SNI/ALPN preservation, third-party audit
+requirements), a route can be flagged for raw-record passthrough.
+ProxySQL still terminates the TCP connection on the listening port
+but, once the client requests TLS via `CapabilitiesSet(tls=true)`,
+hands off raw bytes between client and backend without ever decrypting
+them. The client and the backend establish a single end-to-end TLS
+session that the proxy is mechanically incapable of inspecting.
+
+```sql
+INSERT INTO mysqlx_routes (name, bind, destination_hostgroup, tls_mode)
+       VALUES ('compliance', '0.0.0.0:33099', 99, 'passthrough');
+LOAD MYSQLX ROUTES TO RUNTIME;
+```
+
+What the operator gives up by selecting passthrough on a route:
+
+* **No connection pooling.** The proxy cannot reuse a passthrough
+  backend connection across sessions — it never saw the auth
+  exchange, so it has no idea what user-state or transactional state
+  the backend session is in.
+* **No multiplexing / query-level routing.** The proxy cannot parse
+  X-Protocol frames once TLS is up, so it cannot dispatch a query to
+  a different hostgroup than the one originally bound at session
+  start.
+* **No observability beyond byte counts.** Per-query metrics, query
+  cache, and frame-level stats are unavailable for passthrough
+  sessions. Only TCP-level byte counters and session age are
+  recorded.
+
+What the operator keeps:
+
+* **Original certificate.** The client validates the backend's
+  certificate directly; SNI, ALPN, and the certificate chain are not
+  altered by the proxy.
+* **Per-route binding.** Different listening ports (route
+  `bind` columns) can independently use `passthrough`, `inherit`,
+  `required`, etc. An admin route can stay proxy-terminated while a
+  customer-facing route uses passthrough.
+
+If both compliance and pooling are required, dedicate two listening
+ports to two routes targeting the same hostgroup: one with
+`tls_mode='passthrough'` for the compliance traffic, and one with
+`tls_mode='inherit'` (or `required`) for the bulk of the workload.
 
 ## 9. Connection Pooling
 

--- a/plugins/mysqlx/include/mysqlx_config_store.h
+++ b/plugins/mysqlx/include/mysqlx_config_store.h
@@ -61,6 +61,53 @@ std::optional<MysqlxBackendTlsMode> mysqlx_backend_tls_mode_from_string(const st
 // Canonical lower-case rendering for SAVE / runtime-view projection.
 const char* mysqlx_backend_tls_mode_to_string(MysqlxBackendTlsMode m);
 
+// Per-route TLS posture (`mysqlx_routes.tls_mode`). Mirrors MySQL Router
+// 8.0's five-mode TLS taxonomy at route granularity, so an operator can
+// dedicate one route to compliance-pinned passthrough while leaving
+// neighbouring routes on the default proxy-terminated path.
+//
+//   * inherit     -- defer to the global frontend TLS variable
+//                    (`mysqlx_tls_mode`). Default for every existing
+//                    deployment so no behaviour changes after upgrade.
+//   * disabled    -- route does not advertise TLS regardless of the
+//                    global setting. Operator opt-out for a single
+//                    route.
+//   * preferred   -- TLS capability advertised; client decides whether
+//                    to upgrade. Equivalent to global PREFERRED.
+//   * required    -- TLS capability advertised; reject the session if
+//                    the client does not upgrade.
+//   * passthrough -- after the X-Protocol CapabilitiesSet(tls=true)
+//                    handshake the proxy splices raw bytes between the
+//                    client and the backend. The proxy never sees
+//                    plaintext past the handshake; routing per query,
+//                    multiplexing, and pooling are disabled for the
+//                    session. Use case: end-to-end encryption where
+//                    policy forbids proxy MITM (compliance, original
+//                    cert/SNI/ALPN preservation).
+//
+// Encoded as a string in the editable `mysqlx_routes` table (default
+// "inherit") so the column round-trips cleanly through SAVE / LOAD and
+// the operator can `UPDATE` it without consulting an enum table.
+enum class MysqlxRouteTlsMode : uint8_t {
+	inherit = 0,
+	disabled = 1,
+	preferred = 2,
+	required = 3,
+	passthrough = 4
+};
+
+// Case-insensitive parse of `mysqlx_routes.tls_mode`. Empty string
+// resolves to `inherit` so a NULL/missing column behaves the same as
+// the documented default. Returns std::nullopt on any other unknown
+// value so the caller can surface a useful error (rather than silently
+// coercing to inherit and leaving the operator wondering why a typo
+// got accepted). Accepted values: "inherit", "disabled", "preferred",
+// "required", "passthrough".
+std::optional<MysqlxRouteTlsMode> mysqlx_route_tls_mode_from_string(const std::string& value);
+
+// Canonical lower-case rendering for SAVE / runtime-view projection.
+const char* mysqlx_route_tls_mode_to_string(MysqlxRouteTlsMode m);
+
 struct MysqlxResolvedIdentity {
 	std::string username {};
 	std::string password {};
@@ -94,6 +141,11 @@ struct MysqlxRoute {
 	int fallback_hostgroup { -1 };
 	std::string strategy { "first_available" };
 	bool active { true };
+	// Per-route TLS posture; defaults to `inherit` so existing rows
+	// (and tests that build MysqlxRoute by aggregate init) continue to
+	// behave identically to pre-passthrough builds. See
+	// MysqlxRouteTlsMode for the value semantics.
+	MysqlxRouteTlsMode tls_mode { MysqlxRouteTlsMode::inherit };
 	std::string attributes {};
 	std::string comment {};
 };
@@ -157,6 +209,14 @@ public:
 	MysqlxBackendEndpoint pick_endpoint(const std::string& route_name) const;
 	int route_hostgroup(const std::string& route_name) const;
 	bool route_exists(const std::string& route_name) const;
+
+	// Returns the per-route TLS posture for the named route, or
+	// `MysqlxRouteTlsMode::inherit` when the route is unknown. Callers
+	// that need to distinguish "unknown route" from "route with
+	// tls_mode=inherit" should `route_exists()` first; collapsing the
+	// two here mirrors how `route_hostgroup()` returns 0 for unknown
+	// routes — both fail closed onto the safest default.
+	MysqlxRouteTlsMode route_tls_mode(const std::string& route_name) const;
 
 	// Snapshot of active route names + bind specs. Used by the
 	// listener reconciler (mysqlx_listener_reconcile.cpp) to compute

--- a/plugins/mysqlx/include/mysqlx_config_store.h
+++ b/plugins/mysqlx/include/mysqlx_config_store.h
@@ -20,6 +20,47 @@ enum class MysqlxBackendAuthMode : uint8_t {
 
 MysqlxBackendAuthMode mysqlx_backend_auth_mode_from_string(const std::string& value);
 
+// MysqlxBackendTlsMode mirrors MySQL Router 8.0's `client_ssl_mode` /
+// `server_ssl_mode` family for the proxy->backend leg of a session.
+//
+//   * disabled  -- never wrap the backend connection in TLS, regardless of
+//                  whether the client is using TLS. Plaintext only.
+//   * preferred -- send `CapabilitiesSet(tls=true)` to the backend; on
+//                  Mysqlx::Error, fall back to plaintext authentication.
+//                  Lets ProxySQL adapt to a mixed fleet where some
+//                  backends have TLS configured and some do not.
+//   * required  -- send `CapabilitiesSet(tls=true)`; on Mysqlx::Error
+//                  fail the backend connect. Use when policy mandates
+//                  encryption proxy<->backend.
+//   * as_client -- mirror the client's TLS choice. If the client
+//                  connected over TLS, encrypt the backend leg too;
+//                  if the client connected in plaintext, leave the
+//                  backend leg in plaintext. Matches MySQL Router's
+//                  AsClient semantics. This is the default because it
+//                  most closely matches the previous (pre-mode-aware)
+//                  ProxySQL behaviour where backend TLS was implicitly
+//                  driven by `client_ds_.is_encrypted()`.
+//
+// `mysqlx_backend_endpoints.use_ssl=1` remains an operator-controlled
+// override that forces TLS regardless of the mode (so an operator can
+// pin a single sensitive backend to TLS even under mode=disabled).
+enum class MysqlxBackendTlsMode : uint8_t {
+	disabled = 0,
+	preferred = 1,
+	required = 2,
+	as_client = 3
+};
+
+// Parses the string form of MysqlxBackendTlsMode (case-insensitive).
+// Returns std::nullopt on an unrecognised value so the caller can
+// surface a useful error to the operator instead of silently coercing
+// to a default. Accepted values: "disabled", "preferred", "required",
+// "as_client".
+std::optional<MysqlxBackendTlsMode> mysqlx_backend_tls_mode_from_string(const std::string& value);
+
+// Canonical lower-case rendering for SAVE / runtime-view projection.
+const char* mysqlx_backend_tls_mode_to_string(MysqlxBackendTlsMode m);
+
 struct MysqlxResolvedIdentity {
 	std::string username {};
 	std::string password {};
@@ -139,6 +180,11 @@ public:
 	int get_connect_timeout() const;
 	std::string get_tls_mode() const;
 	int get_max_cached_connections() const;
+	// Returns the parsed mysqlx_tls_backend_mode currently in effect.
+	// Defaults to MysqlxBackendTlsMode::as_client (the legacy implicit
+	// behaviour) until install_variables_from_admin parses a different
+	// value.
+	MysqlxBackendTlsMode get_backend_tls_mode() const;
 
 private:
 	MysqlxBackendEndpoint pick_from_hostgroup(int hostgroup_id, const std::string& strategy) const;
@@ -160,6 +206,11 @@ private:
 	int connect_timeout_ { 10000 };
 	std::string tls_mode_ { "DISABLED" };
 	int max_cached_connections_ { 100 };
+	// Default `as_client` matches the pre-modeaware behaviour where
+	// backend TLS was implicitly tied to client_ds_.is_encrypted() at
+	// resolve time, so existing deployments see no behavioural change
+	// after upgrading.
+	MysqlxBackendTlsMode backend_tls_mode_ { MysqlxBackendTlsMode::as_client };
 };
 
 #endif /* PROXYSQL_MYSQLX_CONFIG_STORE_H */

--- a/plugins/mysqlx/include/mysqlx_connection.h
+++ b/plugins/mysqlx/include/mysqlx_connection.h
@@ -93,6 +93,26 @@ public:
 	bool is_backend_tls_required() const { return backend_tls_required_; }
 	void set_ssl_ctx(SSL_CTX* ctx) { backend_ssl_ctx_ = ctx; }
 
+	// Whether this connection actually completed a TLS handshake on the
+	// backend leg. Distinct from is_backend_tls_required(): a `preferred`
+	// mode connect can have backend_tls_required_=true at start but
+	// fall back to plaintext on Mysqlx::Error from CapabilitiesSet, in
+	// which case tls_active_ stays false. Used by the connection-cache
+	// key in Mysqlx_Thread::get_connection_from_cache so an AsClient
+	// TLS session never picks up a plaintext-pooled backend (and vice
+	// versa) — the encryption posture is part of the cache identity.
+	bool is_tls_active() const { return tls_active_; }
+	void set_tls_active(bool a) { tls_active_ = a; }
+
+	// Whether the backend TLS request is allowed to silently fall back
+	// to plaintext on a Mysqlx::Error response from CapabilitiesSet
+	// (tls=true). Set by the session for `preferred` mode; left false
+	// for `required` and as_client+encrypted-frontend (where TLS is
+	// mandatory). The fallback path itself is wired in a follow-up
+	// commit; today this flag is read-only metadata.
+	bool is_backend_tls_fallback_allowed() const { return backend_tls_fallback_allowed_; }
+	void set_backend_tls_fallback_allowed(bool a) { backend_tls_fallback_allowed_ = a; }
+
 	void init_backend_ds(int fd);
 	int step_auth();
 	int send_authenticate_start();
@@ -120,6 +140,8 @@ private:
 	std::vector<uint8_t> backend_challenge_;
 	MysqlxDataStream backend_ds_;
 	bool backend_tls_required_;
+	bool backend_tls_fallback_allowed_ { false };
+	bool tls_active_ { false };
 	SSL_CTX* backend_ssl_ctx_;
 
 	int step_auth_capabilities_get();

--- a/plugins/mysqlx/include/mysqlx_plugin.h
+++ b/plugins/mysqlx/include/mysqlx_plugin.h
@@ -63,6 +63,24 @@ MysqlxPluginContext& mysqlx_context();
  */
 __attribute__((weak)) void mysqlx_reconcile_listeners(SQLite3DB& admindb);
 
+/**
+ * Walks every Mysqlx_Thread in mysqlx_context().threads, snapshots each
+ * thread's sessions_ under its sessions_mutex_, and projects one row per
+ * active session into stats_mysqlx_processlist. Called from the chassis
+ * runtime-view refresh callback before any admin SELECT against the
+ * table runs (the callback in mysqlx_admin_schema.cpp).
+ *
+ * Snapshot work is bounded per thread: a string-copy + a few struct field
+ * reads under the mutex, no I/O. Lock ordering: each thread's
+ * sessions_mutex_ is acquired in turn; no cross-thread lock is held.
+ *
+ * Declared __attribute__((weak)) for the same reason
+ * mysqlx_reconcile_listeners is — admin_schema.cpp's unit tests don't
+ * link mysqlx_plugin.cpp, so the projection registration must tolerate
+ * an unresolved hook at test-build link time.
+ */
+__attribute__((weak)) void mysqlx_populate_stats_processlist(SQLite3DB& statsdb);
+
 // Pure variant of `mysqlx_reconcile_listeners` that takes the plugin state
 // as parameters instead of going through `mysqlx_context()`. Exists so unit
 // tests can construct a minimal fake context without pulling in the whole

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -74,19 +74,24 @@ enum MysqlxResponseState {
 	RESP_WAITING_SESS_RESET
 };
 
-// Per-session TLS posture. Today the runtime only distinguishes
-// "TLS termination is allowed" (TLS_TERMINATE) from "this session is
-// not configured for TLS at all" (TLS_OFF). The earlier draft also
-// carried a TLS_PASSTHROUGH value with two corresponding branches in
-// session.cpp that pretended to enable an end-to-end pipe; that path
-// was never actually wired up (no call to set_tls_mode() ever set
-// PASSTHROUGH, and the dead branches did not implement an opaque
-// pipe — they just skipped TLS termination and resumed clear-text
-// X-Protocol parsing, which would have desynced any real client).
-// Removing the value rather than leaving a misleading enum.
+// Per-session TLS posture. Today the runtime distinguishes:
+//   - TLS_OFF: this session is not configured for TLS at all.
+//   - TLS_TERMINATE: the proxy terminates TLS itself (the default).
+//   - TLS_PASSTHROUGH: after the X-Protocol CapabilitiesSet(tls=true)
+//     handshake, the proxy splices raw bytes between the client and
+//     the backend without decrypting them. Driven by the per-route
+//     `tls_mode='passthrough'` column on `mysqlx_routes` (issue #5692).
+//     The proxy stops parsing X-Protocol frames once the session
+//     enters this mode — backend connection is non-reusable, no per-
+//     query routing, no multiplexing.
+//
+// Historical note: an earlier prototype carried a TLS_PASSTHROUGH value
+// without an actual implementation; that branch was deleted in the
+// asymmetric-TLS series and is now reintroduced as a real feature.
 enum MysqlxTlsMode {
 	TLS_OFF = 0,
-	TLS_TERMINATE
+	TLS_TERMINATE,
+	TLS_PASSTHROUGH
 };
 
 // X Protocol compression algorithm negotiated via Mysqlx.Connection.Capabilities.
@@ -123,13 +128,29 @@ public:
 		X_TLS_CONNECT_DONE,
 		X_SESSION_CLOSING,
 		X_SESSION_CLOSED,
-		X_SESSION_RESET_WAITING
+		X_SESSION_RESET_WAITING,
+		// Raw-byte splice between client and backend. Reached after a
+		// CapabilitiesSet(tls=true) on a route configured with
+		// tls_mode='passthrough'; once entered, the session never
+		// returns to X-Protocol parsing (the bytes past this point are
+		// the client's TLS handshake + application data, opaque to the
+		// proxy). The session is permanently bound to one backend
+		// connection (no pooling, no multiplexing).
+		X_PASSTHROUGH_FORWARD
 	};
 
 	MysqlxSession();
 	~MysqlxSession();
 
 	void init(int fd, Mysqlx_Thread* thread_ptr);
+	// Listener-aware overload: records the logical route name the
+	// client connected through so per-route policies (e.g.
+	// tls_mode='passthrough') can be looked up before any X-Protocol
+	// auth message has arrived. The base init(fd, thread_ptr)
+	// overload calls this with an empty route, preserving prior
+	// behaviour for callers that have no listener context (notably
+	// the unit-test harness, which constructs sessions directly).
+	void init(int fd, Mysqlx_Thread* thread_ptr, const std::string& listener_route);
 	void reset();
 
 	int handler();
@@ -193,6 +214,23 @@ public:
 	void inject_identity_for_test(const MysqlxResolvedIdentity& id) { identity_ = id; }
 	void inject_identity_for_test(const std::string& username);
 	int  resolve_backend_target_for_test() { return resolve_backend_target(); }
+	// Drives the session straight into X_PASSTHROUGH_FORWARD with a
+	// caller-supplied backend fd, bypassing CapabilitiesSet / auth /
+	// resolve_backend_target. The fixture wraps the fd in a stub
+	// MysqlxConnection (owned by the session — destructor frees it)
+	// so the standard server_ds()/return_backend_to_pool plumbing is
+	// reusable. Must NOT exist in production (test/forgery hazard);
+	// gated behind MYSQLX_TEST_BUILD same as inject_identity_for_test.
+	void enter_passthrough_for_test(int backend_fd);
+	void set_listener_route_name_for_test(const std::string& route_name) {
+		listener_route_name_ = route_name;
+	}
+	const std::string& listener_route_name_for_test() const { return listener_route_name_; }
+	// Drives one pass of the splice loop without going through the
+	// outer handler() (which would also try to read X-Protocol frames
+	// from client_ds_ before dispatching). Used by the passthrough
+	// unit tests to assert byte forwarding in isolation.
+	void run_passthrough_pump_for_test() { handler_passthrough_forward(); }
 #endif /* MYSQLX_TEST_BUILD */
 	int  target_hostgroup_for_test() const { return target_hostgroup_; }
 	const std::string& target_address_for_test() const { return target_address_; }
@@ -227,6 +265,14 @@ private:
 	void handler_session_reset_waiting();
 
 	void handler_tls_accept_init();
+	// Raw-byte splice loop. Pumps available bytes both directions
+	// (client -> backend and backend -> client) using read(2)/write(2).
+	// EAGAIN/EWOULDBLOCK is the normal "no more data right now" exit;
+	// any other read/write error or 0-byte read (peer EOF) marks the
+	// session unhealthy and transitions to X_SESSION_CLOSING. No
+	// X-Protocol parsing — once this state is reached the bytes are
+	// opaque (TLS handshake + application data).
+	void handler_passthrough_forward();
 
 	void handle_auth_mysql41(const std::string& auth_data);
 	void handle_auth_plain(const std::string& auth_data);
@@ -315,6 +361,14 @@ private:
 	// to dereference identity_ on every frame. Empty until resolve
 	// succeeds; cleared by reset().
 	std::string route_name_;
+	// Logical route name the client connected through, captured at
+	// accept time from the listener's parallel route_name vector.
+	// Drives per-route policies that need to fire before any
+	// X-Protocol message has arrived (tls_mode='passthrough' is the
+	// only one today). Empty for sessions constructed without a
+	// listener (e.g. unit tests); the lookup paths fall back on the
+	// global default in that case.
+	std::string listener_route_name_;
 	MysqlxIdentityLookup identity_lookup_;
 	std::optional<MysqlxResolvedIdentity> identity_;
 	uint64_t start_time_;

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -159,6 +159,20 @@ public:
 	const std::string& target_address_for_test() const { return target_address_; }
 	int  target_port_for_test() const { return target_port_; }
 
+	// Read-only state observers used by the stats_mysqlx_processlist
+	// projection (Mysqlx_Thread::snapshot_sessions_for_stats walks
+	// sessions_ and reads these under sessions_mutex_). Borrowed
+	// references — caller must copy if it needs the value past the
+	// snapshot scope. The identity_ accessor returns the optional by
+	// value because the projection wants the resolved fields, not the
+	// optional itself; this only happens once per session per admin
+	// SELECT against stats_mysqlx_processlist, so the copy cost is
+	// negligible.
+	const std::string& username_for_stats() const { return username_; }
+	const std::string& route_name_for_stats() const { return route_name_; }
+	std::optional<MysqlxResolvedIdentity> identity_for_stats() const { return identity_; }
+	uint64_t start_time_for_stats() const { return start_time_; }
+
 	bool to_process;
 
 private:

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -299,6 +299,17 @@ private:
 	uint64_t start_time_;
 	uint64_t last_active_time_;
 	MysqlxResponseState response_state_;
+	// Sub-state flag for the response_state_ matrix: gates whether
+	// RESULTSET_ROW frames are currently allowed in states where the
+	// X-Protocol requires ColumnMetaData to precede any Row. Set when
+	// COLUMN_META_DATA is forwarded from the backend in
+	// handler_waiting_server_msg(); cleared on each transition into a
+	// state that begins a new column-metadata sequence (STMT_EXECUTE,
+	// CRUD, PREPARE_EXECUTE, CURSOR_OPEN), at terminal-frame flush, and
+	// at init() / reset(). NOT cleared on entry to CURSOR_FETCH — per
+	// the X-Protocol spec, ColumnMetaData is sent at Cursor::Open and
+	// not re-sent at Cursor::Fetch, so the flag must carry across.
+	bool seen_column_metadata_;
 	MysqlxTlsMode tls_mode_;
 
 	// Compression negotiation state. compression_algo_ is set by
@@ -375,6 +386,16 @@ public:
 	const std::vector<uint8_t>& client_write_buffer_for_test() const {
 		return client_ds_.write_buffer_raw();
 	}
+#ifdef MYSQLX_TEST_BUILD
+	// Test-only observers for the per-message response state machine,
+	// gated behind MYSQLX_TEST_BUILD because they expose private state
+	// the production code never reads back. Used by the validation
+	// tests in mysqlx_message_dispatch_unit-t to assert state
+	// transitions after dispatching synthetic backend frames.
+	MysqlxResponseState response_state_for_test() const { return response_state_; }
+	bool seen_column_metadata_for_test() const { return seen_column_metadata_; }
+	void set_response_state_for_test(MysqlxResponseState s) { response_state_ = s; }
+#endif /* MYSQLX_TEST_BUILD */
 };
 
 #endif

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -218,7 +218,18 @@ private:
 	void send_capabilities();
 
 	uint8_t extract_msg_type_from_frame(const MysqlxFrame& frame);
-	bool is_terminal_for_state(uint8_t msg_type) const;
+	// Per-state validation contract for backend frames. is_frame_allowed
+	// returns true iff a frame of msg_type is acceptable in the current
+	// response_state_ (NOTICE and ERROR are universal). is_terminal_frame
+	// returns true iff msg_type closes the current response sequence so
+	// the dispatch loop can transition back to RESP_IDLE.
+	//
+	// Both are pure queries — no mutation of response_state_ or session
+	// state. Replaces the older is_terminal_for_state() which conflated
+	// "valid mid-result frame" and "terminal frame" by deferring to a
+	// generic terminal table for any state outside the explicit cases.
+	bool is_frame_allowed(uint8_t msg_type) const;
+	bool is_terminal_frame(uint8_t msg_type) const;
 
 	// Resolve identity_->default_route to concrete target_hostgroup_,
 	// target_address_, target_port_ via the thread's MysqlxConfigStore.

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -25,6 +25,27 @@ typedef struct ZSTD_CCtx_s ZSTD_CCtx;
 using MysqlxIdentityLookup =
 	std::function<std::optional<MysqlxResolvedIdentity>(const std::string& username)>;
 
+// Resolved per-session backend TLS decision for a given combination of
+// runtime mode (mysqlx_tls_backend_mode), per-endpoint operator override
+// (mysqlx_backend_endpoints.use_ssl), and frontend TLS state
+// (client_ds_.is_encrypted()). Held by handler_connecting_server() across
+// the cache lookup and the fresh-connection setup so both sides see the
+// same posture.
+struct MysqlxBackendTlsDecision {
+	bool require_tls { false };       // ask the backend for TLS via CapabilitiesSet
+	bool fallback_allowed { false };  // on Mysqlx::Error, downgrade to plaintext
+};
+
+// Pure function: computes the per-session backend TLS decision from
+// the four inputs. Lifted out of MysqlxSession so the 8 (mode x
+// frontend_tls) combinations called out in issue #5693 can be unit-
+// tested without driving the full session state machine. Production
+// callsite: handler_connecting_server.
+MysqlxBackendTlsDecision mysqlx_resolve_backend_tls_decision(
+	MysqlxBackendTlsMode mode,
+	bool endpoint_use_ssl_override,
+	bool frontend_is_encrypted);
+
 // Per-message response state for the X-Protocol response sequence the
 // proxy is currently waiting on. The X protocol defines distinct frame
 // allow-sets and terminal markers per request type; this enum splits

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -245,6 +245,12 @@ private:
 	// sets mysqlx_backend_endpoints.use_ssl=1 to force backend TLS
 	// even when the client connected in plaintext.
 	bool target_use_ssl_;
+	// Cached identity_->default_route, captured in
+	// resolve_backend_target() so the data-plane bytes-counter sites
+	// (forward_to_backend / handler_waiting_server_msg) don't have
+	// to dereference identity_ on every frame. Empty until resolve
+	// succeeds; cleared by reset().
+	std::string route_name_;
 	MysqlxIdentityLookup identity_lookup_;
 	std::optional<MysqlxResolvedIdentity> identity_;
 	uint64_t start_time_;

--- a/plugins/mysqlx/include/mysqlx_session.h
+++ b/plugins/mysqlx/include/mysqlx_session.h
@@ -25,12 +25,30 @@ typedef struct ZSTD_CCtx_s ZSTD_CCtx;
 using MysqlxIdentityLookup =
 	std::function<std::optional<MysqlxResolvedIdentity>(const std::string& username)>;
 
+// Per-message response state for the X-Protocol response sequence the
+// proxy is currently waiting on. The X protocol defines distinct frame
+// allow-sets and terminal markers per request type; this enum splits
+// PREPARE and CURSOR into their per-request sub-shapes so each per-state
+// contract can be expressed cleanly in is_frame_allowed / is_terminal_frame.
+//
+// Background: the previous coarse three-value model (PREPARE / CURSOR
+// each lumped together) over-accepted on PREPARE_PREPARE — which the
+// spec terminates with a bare Mysqlx.Ok — by also allowing the wider
+// SQL_STMT_EXECUTE_OK / FETCH_DONE_* terminators that only PREPARE_EXECUTE
+// can legitimately emit. Likewise CURSOR_OPEN's response always carries
+// ColumnMetaData while CURSOR_FETCH's never does (the metadata is sent
+// once at Open). Splitting the state lets the validation hook reject
+// out-of-shape backend frames precisely.
 enum MysqlxResponseState {
 	RESP_IDLE = 0,
 	RESP_WAITING_STMT_EXECUTE,
 	RESP_WAITING_CRUD,
-	RESP_WAITING_PREPARE,
-	RESP_WAITING_CURSOR,
+	RESP_WAITING_PREPARE_PREPARE,        // Prepare::Prepare — terminator: Ok
+	RESP_WAITING_PREPARE_EXECUTE,        // Prepare::Execute — terminators: Ok / SQL_STMT_EXECUTE_OK / FETCH_DONE / FETCH_SUSPENDED
+	RESP_WAITING_PREPARE_DEALLOCATE,     // Prepare::Deallocate — terminator: Ok
+	RESP_WAITING_CURSOR_OPEN,            // Cursor::Open — terminators: FETCH_DONE / FETCH_SUSPENDED; carries ColumnMetaData
+	RESP_WAITING_CURSOR_FETCH,           // Cursor::Fetch — terminators: FETCH_DONE / FETCH_SUSPENDED; rows-only (metadata was at Open)
+	RESP_WAITING_CURSOR_CLOSE,           // Cursor::Close — terminator: Ok
 	RESP_WAITING_EXPECT,
 	RESP_WAITING_SESS_RESET
 };

--- a/plugins/mysqlx/include/mysqlx_stats.h
+++ b/plugins/mysqlx/include/mysqlx_stats.h
@@ -28,6 +28,15 @@ public:
 	void record_conn_err(const std::string& route_name, int destination_hostgroup);
 	void record_conn_used(const std::string& route_name, int destination_hostgroup);
 
+	// Accumulate per-route data-plane payload bytes. The argument is the
+	// X-Protocol *payload* size (excluding the 5-byte frame header) that
+	// the proxy forwarded between client and backend; framing overhead is
+	// intentionally not counted so the counter tracks operator-meaningful
+	// query/result bytes rather than the wire-level total. Both directions
+	// get their own counter so operators can spot asymmetric traffic.
+	void record_bytes_sent(const std::string& route_name, int destination_hostgroup, uint64_t n);
+	void record_bytes_recv(const std::string& route_name, int destination_hostgroup, uint64_t n);
+
 	// Flush stats into the stats SQLite DB.
 	void flush_to_sqlite(class SQLite3DB& statsdb);
 

--- a/plugins/mysqlx/include/mysqlx_thread.h
+++ b/plugins/mysqlx/include/mysqlx_thread.h
@@ -15,6 +15,29 @@
 
 class MysqlxConfigStore;
 
+// Per-session row used by the stats_mysqlx_processlist projection. Filled
+// by Mysqlx_Thread::snapshot_sessions_for_stats() under the thread's
+// sessions_mutex_; copied (not borrowed) so the admin-side projector can
+// release the worker's lock before doing any SQL.
+struct MysqlxSessionSnapshot {
+	std::string username;
+	std::string route;
+	int worker_id { 0 };
+	std::string backend_host;
+	int backend_port { 0 };
+	// String forms of the MysqlxBackendAuthMode enum and MysqlxSession::Status.
+	// Empty auth_mode means the session has not yet resolved an identity.
+	std::string auth_mode;
+	std::string connection_state;
+	// Per-session bytes_in/bytes_out are 0 in the P0 implementation: the
+	// stats store aggregates by route, not by session. P1 adds per-session
+	// counters; the columns in stats_mysqlx_processlist are reserved here so
+	// the schema doesn't change again when those land.
+	uint64_t bytes_in { 0 };
+	uint64_t bytes_out { 0 };
+	uint64_t session_age_ms { 0 };
+};
+
 class Mysqlx_Thread {
 public:
 	Mysqlx_Thread();
@@ -30,6 +53,14 @@ public:
 	size_t get_session_count() const;
 	bool is_running() const { return running_.load(); }
 	int get_listener_count() const;
+
+	// Walks sessions_ under sessions_mutex_ and appends one
+	// MysqlxSessionSnapshot per active session to `out`. `now_ms` should
+	// be a single monotonic time captured by the caller so all rows in a
+	// projection batch share the same reference point for session_age_ms.
+	// Lock scope is bounded to a string copy + a few struct field reads
+	// per session, no I/O. Safe to call from any thread.
+	void snapshot_sessions_for_stats(std::vector<MysqlxSessionSnapshot>& out, uint64_t now_ms) const;
 
 	/**
 	 * Creates a listener socket (bind + listen) and registers it with this

--- a/plugins/mysqlx/include/mysqlx_thread.h
+++ b/plugins/mysqlx/include/mysqlx_thread.h
@@ -101,7 +101,17 @@ public:
 
 	void remove_listeners();
 
-	MysqlxConnection* get_connection_from_cache(int hostgroup, const char* user, const char* schema);
+	// Returns the most-recently-cached idle connection matching the
+	// given (hostgroup, user, schema, tls_active) tuple, or nullptr if
+	// none is available. The tls_active dimension is required to keep
+	// AsClient/required encrypted backends separate from plaintext
+	// backends in the same pool — handing a plaintext connection to a
+	// TLS-frontend session (or vice versa) would either silently break
+	// the encryption posture or cause the X-Protocol auth state machine
+	// to read frames over a half-encrypted socket. Callers that don't
+	// care about TLS state (currently: none in production) can pass
+	// false to match plaintext-only connections.
+	MysqlxConnection* get_connection_from_cache(int hostgroup, const char* user, const char* schema, bool tls_active);
 	void return_connection_to_cache(MysqlxConnection* conn);
 	size_t get_cached_connection_count() const;
 	void set_max_cached_connections(size_t max) { max_cached_ = max; }

--- a/plugins/mysqlx/src/mysqlx_admin_schema.cpp
+++ b/plugins/mysqlx/src/mysqlx_admin_schema.cpp
@@ -266,6 +266,21 @@ void refresh_stats_routes_view(SQLite3DB* /*admindb*/, void*) {
 	mysqlx_stats().flush_to_sqlite(*statsdb);
 }
 
+// Same shape, but for stats_mysqlx_processlist: the projector walks
+// every Mysqlx_Thread and emits one row per active session. Defined in
+// mysqlx_plugin.cpp; declared __attribute__((weak)) so the
+// mysqlx_admin_schema_unit-t and friends (which compile this TU but
+// don't link mysqlx_plugin.cpp) still link successfully — the null check
+// here is the runtime safety net for the test build.
+void refresh_stats_processlist_view(SQLite3DB* /*admindb*/, void*) {
+	if (mysqlx_context().services == nullptr) return;
+	if (mysqlx_context().services->get_statsdb == nullptr) return;
+	if (&mysqlx_populate_stats_processlist == nullptr) return;
+	SQLite3DB* statsdb = mysqlx_context().services->get_statsdb();
+	if (statsdb == nullptr) return;
+	mysqlx_populate_stats_processlist(*statsdb);
+}
+
 bool disk_to_memory(SQLite3DB& admindb, const char* table_name) {
 	if (!admindb.execute("BEGIN")) {
 		return false;
@@ -482,6 +497,7 @@ bool mysqlx_register_admin_schema(ProxySQL_PluginServices& services) {
 		services.register_runtime_view({kRuntimeMysqlxBackendEndpointsTable,  &refresh_endpoints_runtime_view, nullptr});
 		services.register_runtime_view({kRuntimeMysqlxVariablesTable,         &refresh_variables_runtime_view, nullptr});
 		services.register_runtime_view({kStatsMysqlxRoutesTable,              &refresh_stats_routes_view,      nullptr});
+		services.register_runtime_view({kStatsMysqlxProcesslistTable,         &refresh_stats_processlist_view, nullptr});
 	}
 
 	// Stats tables (stats_db only, no config copy needed).

--- a/plugins/mysqlx/src/mysqlx_admin_schema.cpp
+++ b/plugins/mysqlx/src/mysqlx_admin_schema.cpp
@@ -1,6 +1,7 @@
 #include "mysqlx_admin_schema.h"
 
 #include "mysqlx_plugin.h"
+#include "mysqlx_stats.h"
 #include "sqlite3db.h"
 
 #include <initializer_list>
@@ -246,6 +247,25 @@ void refresh_variables_runtime_view(SQLite3DB* admindb, void*) {
 	mysqlx_context().config_store->project_variables_to_runtime_view(*admindb);
 }
 
+// Stats-projection refresh callback: chassis fires this on demand when an
+// admin SELECT references stats_mysqlx_routes, so the per-route counters
+// are refilled lazily from MysqlxStatsStore right before the operator
+// reads them.
+//
+// flush_to_sqlite writes to a bare table name, so the callback must hand
+// it the *statsdb* handle — the chassis-supplied `admindb` argument
+// reaches stats_mysqlx_routes only via the `stats.` attached schema, and
+// that's an unnecessary detour. The plugin already cached the services
+// pointer in mysqlx_context().services at Phase D init, so the get_statsdb
+// trampoline is reachable.
+void refresh_stats_routes_view(SQLite3DB* /*admindb*/, void*) {
+	if (mysqlx_context().services == nullptr) return;
+	if (mysqlx_context().services->get_statsdb == nullptr) return;
+	SQLite3DB* statsdb = mysqlx_context().services->get_statsdb();
+	if (statsdb == nullptr) return;
+	mysqlx_stats().flush_to_sqlite(*statsdb);
+}
+
 bool disk_to_memory(SQLite3DB& admindb, const char* table_name) {
 	if (!admindb.execute("BEGIN")) {
 		return false;
@@ -461,6 +481,7 @@ bool mysqlx_register_admin_schema(ProxySQL_PluginServices& services) {
 		services.register_runtime_view({kRuntimeMysqlxRoutesTable,            &refresh_routes_runtime_view,    nullptr});
 		services.register_runtime_view({kRuntimeMysqlxBackendEndpointsTable,  &refresh_endpoints_runtime_view, nullptr});
 		services.register_runtime_view({kRuntimeMysqlxVariablesTable,         &refresh_variables_runtime_view, nullptr});
+		services.register_runtime_view({kStatsMysqlxRoutesTable,              &refresh_stats_routes_view,      nullptr});
 	}
 
 	// Stats tables (stats_db only, no config copy needed).

--- a/plugins/mysqlx/src/mysqlx_admin_schema.cpp
+++ b/plugins/mysqlx/src/mysqlx_admin_schema.cpp
@@ -50,6 +50,12 @@ const char kRuntimeMysqlxUsersTableDef[] =
 	" comment VARCHAR NOT NULL DEFAULT ''"
 	" )";
 
+// `tls_mode` was added with issue #5692 (TLS passthrough). Values are
+// validated case-insensitively at LOAD time by mysqlx_route_tls_mode_
+// from_string(); the CHECK constraint here mirrors the canonical lower-
+// case spellings so a typo at INSERT time is caught early. Default
+// 'inherit' preserves prior behaviour: a route without an explicit
+// override defers to the deployment-wide `mysqlx_tls_mode`.
 const char kMysqlxRoutesTableDef[] =
 	"CREATE TABLE mysqlx_routes ("
 	" name VARCHAR NOT NULL PRIMARY KEY,"
@@ -59,7 +65,8 @@ const char kMysqlxRoutesTableDef[] =
 	" strategy VARCHAR NOT NULL DEFAULT 'first_available',"
 	" active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 1,"
 	" attributes VARCHAR CHECK (JSON_VALID(attributes) OR attributes = '') NOT NULL DEFAULT '',"
-	" comment VARCHAR NOT NULL DEFAULT ''"
+	" comment VARCHAR NOT NULL DEFAULT '',"
+	" tls_mode VARCHAR CHECK (tls_mode IN ('inherit','disabled','preferred','required','passthrough')) NOT NULL DEFAULT 'inherit'"
 	" )";
 
 const char kRuntimeMysqlxRoutesTableDef[] =
@@ -71,7 +78,8 @@ const char kRuntimeMysqlxRoutesTableDef[] =
 	" strategy VARCHAR NOT NULL DEFAULT 'first_available',"
 	" active INT CHECK (active IN (0,1)) NOT NULL DEFAULT 1,"
 	" attributes VARCHAR CHECK (JSON_VALID(attributes) OR attributes = '') NOT NULL DEFAULT '',"
-	" comment VARCHAR NOT NULL DEFAULT ''"
+	" comment VARCHAR NOT NULL DEFAULT '',"
+	" tls_mode VARCHAR CHECK (tls_mode IN ('inherit','disabled','preferred','required','passthrough')) NOT NULL DEFAULT 'inherit'"
 	" )";
 
 const char kMysqlxBackendEndpointsTableDef[] =

--- a/plugins/mysqlx/src/mysqlx_config_store.cpp
+++ b/plugins/mysqlx/src/mysqlx_config_store.cpp
@@ -100,9 +100,25 @@ void merge_mysqlx_users(
 	}
 }
 
+// Field layout matches the SELECT in install_routes_from_admin:
+//   0 name
+//   1 bind
+//   2 destination_hostgroup
+//   3 fallback_hostgroup
+//   4 strategy
+//   5 active
+//   6 attributes
+//   7 comment
+//   8 tls_mode      (added with mysqlx_routes.tls_mode column)
+//
+// `parse_err` mirrors load_variables(): a malformed tls_mode token is
+// recorded as a string the install path can surface to the operator,
+// rather than silently coerced to inherit. The route is then dropped
+// (not partially loaded) so the operator's intent isn't half-applied.
 void load_routes(
 	SQLite3_result& rows,
-	std::unordered_map<std::string, MysqlxRoute>& routes
+	std::unordered_map<std::string, MysqlxRoute>& routes,
+	std::string& parse_err
 ) {
 	for (auto* row : rows.rows) {
 		if (row == nullptr || row->fields[0] == nullptr) {
@@ -118,6 +134,23 @@ void load_routes(
 		route.active = nullable_bool(row->fields[5], true);
 		route.attributes = nullable_string(row->fields[6]);
 		route.comment = nullable_string(row->fields[7]);
+		// tls_mode column was added with issue #5692. A pre-upgrade
+		// admin DB without the column shows up as a NULL field here;
+		// nullable_string -> "" -> mysqlx_route_tls_mode_from_string
+		// resolves to inherit, preserving prior behaviour.
+		const std::string tls_mode_raw = nullable_string(row->fields[8]);
+		auto parsed = mysqlx_route_tls_mode_from_string(tls_mode_raw);
+		if (!parsed) {
+			if (parse_err.empty()) {
+				parse_err = "invalid tls_mode '";
+				parse_err += tls_mode_raw;
+				parse_err += "' for route '";
+				parse_err += route.name;
+				parse_err += "' (expected one of: inherit, disabled, preferred, required, passthrough)";
+			}
+			continue;
+		}
+		route.tls_mode = *parsed;
 		routes[route.name] = std::move(route);
 	}
 }
@@ -287,6 +320,42 @@ const char* mysqlx_backend_tls_mode_to_string(MysqlxBackendTlsMode m) {
 	return "as_client";
 }
 
+std::optional<MysqlxRouteTlsMode> mysqlx_route_tls_mode_from_string(const std::string& value) {
+	// An empty/NULL column collapses to `inherit` so the LOAD path
+	// can treat a freshly-added column on an upgraded admin DB as
+	// "default" without forcing the operator to back-fill every row.
+	if (value.empty()) {
+		return MysqlxRouteTlsMode::inherit;
+	}
+	if (strcasecmp(value.c_str(), "inherit") == 0) {
+		return MysqlxRouteTlsMode::inherit;
+	}
+	if (strcasecmp(value.c_str(), "disabled") == 0) {
+		return MysqlxRouteTlsMode::disabled;
+	}
+	if (strcasecmp(value.c_str(), "preferred") == 0) {
+		return MysqlxRouteTlsMode::preferred;
+	}
+	if (strcasecmp(value.c_str(), "required") == 0) {
+		return MysqlxRouteTlsMode::required;
+	}
+	if (strcasecmp(value.c_str(), "passthrough") == 0) {
+		return MysqlxRouteTlsMode::passthrough;
+	}
+	return std::nullopt;
+}
+
+const char* mysqlx_route_tls_mode_to_string(MysqlxRouteTlsMode m) {
+	switch (m) {
+		case MysqlxRouteTlsMode::inherit:     return "inherit";
+		case MysqlxRouteTlsMode::disabled:    return "disabled";
+		case MysqlxRouteTlsMode::preferred:   return "preferred";
+		case MysqlxRouteTlsMode::required:    return "required";
+		case MysqlxRouteTlsMode::passthrough: return "passthrough";
+	}
+	return "inherit";
+}
+
 // install_users_from_admin
 //
 // Reads two admin-side tables and atomically swaps `identities_` under
@@ -356,15 +425,43 @@ bool MysqlxConfigStore::install_routes_from_admin(SQLite3DB& db, std::string& er
 	std::unordered_map<std::string, MysqlxRoute> new_routes {};
 	std::unique_ptr<SQLite3_result> result {};
 
-	if (!fetch_result(
-		    db,
-		    "SELECT name, bind, destination_hostgroup, fallback_hostgroup, strategy, active, attributes, comment "
-		    "FROM mysqlx_routes WHERE active=1",
-		    result,
-		    err)) {
+	// SELECT tolerates pre-upgrade admin DBs missing the tls_mode column:
+	// fetch_result will surface the error from sqlite, but we'd rather
+	// emit a friendlier "default to inherit" path. Since the column is
+	// part of the canonical schema (mysqlx_admin_schema.cpp adds it),
+	// every fresh install has it; only an out-of-band ALTER-skipping
+	// upgrade would land here. Detect via a separate PRAGMA query and
+	// drop tls_mode from the SELECT in that case.
+	bool has_tls_mode = false;
+	{
+		std::unique_ptr<SQLite3_result> cols {};
+		std::string pragma_err;
+		if (fetch_result(db, "PRAGMA table_info(mysqlx_routes)", cols, pragma_err)) {
+			for (auto* row : cols->rows) {
+				if (row != nullptr && row->fields[1] != nullptr &&
+				    strcasecmp(row->fields[1], "tls_mode") == 0) {
+					has_tls_mode = true;
+					break;
+				}
+			}
+		}
+	}
+
+	const char* sql = has_tls_mode
+		? "SELECT name, bind, destination_hostgroup, fallback_hostgroup, strategy, active, attributes, comment, tls_mode "
+		  "FROM mysqlx_routes WHERE active=1"
+		: "SELECT name, bind, destination_hostgroup, fallback_hostgroup, strategy, active, attributes, comment, NULL AS tls_mode "
+		  "FROM mysqlx_routes WHERE active=1";
+
+	if (!fetch_result(db, sql, result, err)) {
 		return false;
 	}
-	load_routes(*result, new_routes);
+	std::string parse_err;
+	load_routes(*result, new_routes, parse_err);
+	if (!parse_err.empty()) {
+		err = std::move(parse_err);
+		return false;
+	}
 
 	std::unique_lock<std::shared_mutex> lock(mutex_);
 	routes_.swap(new_routes);
@@ -514,7 +611,7 @@ bool MysqlxConfigStore::save_routes_to_admin_table(SQLite3DB& db) const {
 	for (const auto& [name, route] : routes_) {
 		std::string sql = "REPLACE INTO mysqlx_routes "
 			"(name, bind, destination_hostgroup, fallback_hostgroup, strategy, "
-			"active, attributes, comment) VALUES (";
+			"active, attributes, comment, tls_mode) VALUES (";
 		sql += sqlite_quote(route.name) + ", ";
 		sql += sqlite_quote(route.bind) + ", ";
 		sql += std::to_string(route.destination_hostgroup) + ", ";
@@ -525,7 +622,8 @@ bool MysqlxConfigStore::save_routes_to_admin_table(SQLite3DB& db) const {
 		}
 		sql += sqlite_quote(route.strategy) + ", 1, ";
 		sql += sqlite_quote(route.attributes) + ", ";
-		sql += sqlite_quote(route.comment) + ")";
+		sql += sqlite_quote(route.comment) + ", ";
+		sql += sqlite_quote(mysqlx_route_tls_mode_to_string(route.tls_mode)) + ")";
 		if (!db.execute(sql.c_str())) {
 			db.execute("ROLLBACK");
 			return false;
@@ -625,7 +723,7 @@ void MysqlxConfigStore::project_routes_to_runtime_view(SQLite3DB& db) const {
 	for (const auto& [name, route] : routes_) {
 		std::string sql = "INSERT INTO runtime_mysqlx_routes "
 			"(name, bind, destination_hostgroup, fallback_hostgroup, strategy, "
-			"active, attributes, comment) VALUES (";
+			"active, attributes, comment, tls_mode) VALUES (";
 		sql += sqlite_quote(route.name) + ", ";
 		sql += sqlite_quote(route.bind) + ", ";
 		sql += std::to_string(route.destination_hostgroup) + ", ";
@@ -636,7 +734,8 @@ void MysqlxConfigStore::project_routes_to_runtime_view(SQLite3DB& db) const {
 		}
 		sql += sqlite_quote(route.strategy) + ", 1, ";
 		sql += sqlite_quote(route.attributes) + ", ";
-		sql += sqlite_quote(route.comment) + ")";
+		sql += sqlite_quote(route.comment) + ", ";
+		sql += sqlite_quote(mysqlx_route_tls_mode_to_string(route.tls_mode)) + ")";
 		if (!db.execute(sql.c_str())) {
 			db.execute("ROLLBACK"); return;
 		}
@@ -746,6 +845,18 @@ int MysqlxConfigStore::route_hostgroup(const std::string& route_name) const {
 bool MysqlxConfigStore::route_exists(const std::string& route_name) const {
 	std::shared_lock<std::shared_mutex> lock(mutex_);
 	return routes_.find(route_name) != routes_.end();
+}
+
+MysqlxRouteTlsMode MysqlxConfigStore::route_tls_mode(const std::string& route_name) const {
+	std::shared_lock<std::shared_mutex> lock(mutex_);
+	auto it = routes_.find(route_name);
+	if (it == routes_.end()) {
+		// Unknown route -> safest default. Caller can route_exists()
+		// first when it needs to distinguish "missing route" from "route
+		// configured to inherit".
+		return MysqlxRouteTlsMode::inherit;
+	}
+	return it->second.tls_mode;
 }
 
 std::vector<std::pair<std::string, std::string>> MysqlxConfigStore::snapshot_active_routes() const {

--- a/plugins/mysqlx/src/mysqlx_config_store.cpp
+++ b/plugins/mysqlx/src/mysqlx_config_store.cpp
@@ -169,12 +169,29 @@ void load_backend_servers(
 	}
 }
 
+// load_variables walks `mysqlx_variables` rows and writes the
+// recognised tunables back through reference parameters. The
+// backend-TLS-mode field is captured as a raw string + a parsed enum +
+// a "did the operator set it" flag so that:
+//
+//   * an unrecognised value can be reported back as a useful error
+//     instead of silently coerced to the default,
+//   * an absent row leaves the existing `backend_tls_mode_` cached on
+//     the store untouched (rather than resetting to as_client on every
+//     LOAD), matching how the other variables behave.
+//
+// `parse_err` is populated with the first malformed row encountered;
+// the caller is responsible for surfacing it back to the operator and
+// aborting the install if it is non-empty.
 void load_variables(
 	SQLite3_result& rows,
 	int& thread_pool_size,
 	int& connect_timeout,
 	std::string& tls_mode,
-	int& max_cached_connections
+	int& max_cached_connections,
+	MysqlxBackendTlsMode& backend_tls_mode,
+	bool& backend_tls_mode_set,
+	std::string& parse_err
 ) {
 	for (auto* row : rows.rows) {
 		if (row == nullptr || row->fields[0] == nullptr) {
@@ -190,6 +207,18 @@ void load_variables(
 			tls_mode = value;
 		} else if (name == "mysqlx_max_cached_connections_per_thread") {
 			max_cached_connections = std::atoi(value);
+		} else if (name == "mysqlx_tls_backend_mode") {
+			auto parsed = mysqlx_backend_tls_mode_from_string(value);
+			if (!parsed) {
+				if (parse_err.empty()) {
+					parse_err = "invalid mysqlx_tls_backend_mode '";
+					parse_err += value;
+					parse_err += "' (expected one of: disabled, preferred, required, as_client)";
+				}
+				continue;
+			}
+			backend_tls_mode = *parsed;
+			backend_tls_mode_set = true;
 		}
 	}
 }
@@ -230,6 +259,32 @@ MysqlxBackendAuthMode mysqlx_backend_auth_mode_from_string(const std::string& va
 		return MysqlxBackendAuthMode::service_account;
 	}
 	return MysqlxBackendAuthMode::mapped;
+}
+
+std::optional<MysqlxBackendTlsMode> mysqlx_backend_tls_mode_from_string(const std::string& value) {
+	if (strcasecmp(value.c_str(), "disabled") == 0) {
+		return MysqlxBackendTlsMode::disabled;
+	}
+	if (strcasecmp(value.c_str(), "preferred") == 0) {
+		return MysqlxBackendTlsMode::preferred;
+	}
+	if (strcasecmp(value.c_str(), "required") == 0) {
+		return MysqlxBackendTlsMode::required;
+	}
+	if (strcasecmp(value.c_str(), "as_client") == 0) {
+		return MysqlxBackendTlsMode::as_client;
+	}
+	return std::nullopt;
+}
+
+const char* mysqlx_backend_tls_mode_to_string(MysqlxBackendTlsMode m) {
+	switch (m) {
+		case MysqlxBackendTlsMode::disabled:  return "disabled";
+		case MysqlxBackendTlsMode::preferred: return "preferred";
+		case MysqlxBackendTlsMode::required:  return "required";
+		case MysqlxBackendTlsMode::as_client: return "as_client";
+	}
+	return "as_client";
 }
 
 // install_users_from_admin
@@ -374,6 +429,11 @@ bool MysqlxConfigStore::install_variables_from_admin(SQLite3DB& db, std::string&
 	int new_connect_timeout = connect_timeout_;
 	std::string new_tls_mode = tls_mode_;
 	int new_max_cached = max_cached_connections_;
+	// Seed with the currently-installed value so an absent
+	// mysqlx_tls_backend_mode row leaves the cached mode untouched.
+	MysqlxBackendTlsMode new_backend_tls_mode = backend_tls_mode_;
+	bool backend_tls_mode_set = false;
+	std::string parse_err;
 	std::unique_ptr<SQLite3_result> result {};
 
 	if (!fetch_result(
@@ -383,13 +443,21 @@ bool MysqlxConfigStore::install_variables_from_admin(SQLite3DB& db, std::string&
 		    err)) {
 		return false;
 	}
-	load_variables(*result, new_pool_size, new_connect_timeout, new_tls_mode, new_max_cached);
+	load_variables(*result, new_pool_size, new_connect_timeout, new_tls_mode, new_max_cached,
+	               new_backend_tls_mode, backend_tls_mode_set, parse_err);
+	if (!parse_err.empty()) {
+		err = std::move(parse_err);
+		return false;
+	}
 
 	std::unique_lock<std::shared_mutex> lock(mutex_);
 	thread_pool_size_ = new_pool_size;
 	connect_timeout_ = new_connect_timeout;
 	tls_mode_ = std::move(new_tls_mode);
 	max_cached_connections_ = new_max_cached;
+	if (backend_tls_mode_set) {
+		backend_tls_mode_ = new_backend_tls_mode;
+	}
 	return true;
 }
 
@@ -514,6 +582,9 @@ bool MysqlxConfigStore::save_variables_to_admin_table(SQLite3DB& db) const {
 	if (!put("mysqlx_max_cached_connections_per_thread", std::to_string(max_cached_connections_))) {
 		db.execute("ROLLBACK"); return false;
 	}
+	if (!put("mysqlx_tls_backend_mode", mysqlx_backend_tls_mode_to_string(backend_tls_mode_))) {
+		db.execute("ROLLBACK"); return false;
+	}
 	return db.execute("COMMIT");
 }
 
@@ -609,7 +680,8 @@ void MysqlxConfigStore::project_variables_to_runtime_view(SQLite3DB& db) const {
 	if (!put("mysqlx_thread_pool_size", std::to_string(thread_pool_size_)) ||
 	    !put("mysqlx_connect_timeout", std::to_string(connect_timeout_)) ||
 	    !put("mysqlx_tls_mode", tls_mode_) ||
-	    !put("mysqlx_max_cached_connections_per_thread", std::to_string(max_cached_connections_))) {
+	    !put("mysqlx_max_cached_connections_per_thread", std::to_string(max_cached_connections_)) ||
+	    !put("mysqlx_tls_backend_mode", mysqlx_backend_tls_mode_to_string(backend_tls_mode_))) {
 		db.execute("ROLLBACK"); return;
 	}
 	db.execute("COMMIT");
@@ -722,4 +794,9 @@ std::string MysqlxConfigStore::get_tls_mode() const {
 int MysqlxConfigStore::get_max_cached_connections() const {
 	std::shared_lock<std::shared_mutex> lock(mutex_);
 	return max_cached_connections_;
+}
+
+MysqlxBackendTlsMode MysqlxConfigStore::get_backend_tls_mode() const {
+	std::shared_lock<std::shared_mutex> lock(mutex_);
+	return backend_tls_mode_;
 }

--- a/plugins/mysqlx/src/mysqlx_connection.cpp
+++ b/plugins/mysqlx/src/mysqlx_connection.cpp
@@ -241,7 +241,40 @@ int MysqlxConnection::step_auth_capabilities_get_sent() {
 int MysqlxConnection::step_auth_capabilities_set_sent() {
 	auto frame = read_auth_frame();
 	if (!frame) return 1;
-	if (frame->size() < 5 || (*frame)[4] != Mysqlx::ServerMessages_Type_OK) {
+	if (frame->size() < 5) {
+		auth_state_ = BACKEND_AUTH_ERROR;
+		return -1;
+	}
+	const uint8_t msg_type = (*frame)[4];
+
+	// `preferred` mode contract (mysqlx_tls_backend_mode=preferred):
+	// the backend may reject CapabilitiesSet(tls=true) with a
+	// Mysqlx::Error when it has no TLS configured. Under preferred,
+	// the proxy is allowed to silently downgrade to plaintext and
+	// continue with AuthenticateStart on the same TCP connection.
+	// Under `required` (and AsClient with frontend-TLS), an Error
+	// here is fatal — the operator's policy demands encryption.
+	//
+	// Two notes on the wire-level state after a fallback:
+	//   * No TLS handshake has occurred, so backend_ds_ remains in
+	//     plaintext mode and tls_active_ stays false. This keeps
+	//     the connection out of the encrypted half of the pool
+	//     (Mysqlx_Thread::get_connection_from_cache matches on
+	//     tls_active_), so a future AsClient session against an
+	//     encrypted client will not pick this connection up.
+	//   * backend_tls_required_ is cleared so the caller's later
+	//     step_auth_capabilities_set_sent / step_auth_tls_handshake
+	//     branches don't subsequently try to negotiate TLS again.
+	if (msg_type == Mysqlx::ServerMessages_Type_ERROR) {
+		if (backend_tls_required_ && backend_tls_fallback_allowed_) {
+			backend_tls_required_ = false;
+			return send_authenticate_start();
+		}
+		auth_state_ = BACKEND_AUTH_ERROR;
+		return -1;
+	}
+
+	if (msg_type != Mysqlx::ServerMessages_Type_OK) {
 		auth_state_ = BACKEND_AUTH_ERROR;
 		return -1;
 	}

--- a/plugins/mysqlx/src/mysqlx_connection.cpp
+++ b/plugins/mysqlx/src/mysqlx_connection.cpp
@@ -263,6 +263,14 @@ int MysqlxConnection::step_auth_tls_handshake() {
 	backend_ds_.read_from_net();
 	if (backend_ds_.do_ssl_handshake()) {
 		backend_ds_.flush_ssl_write_buf();
+		// Record that this connection is now operating over TLS so the
+		// connection-cache key can distinguish encrypted-pooled
+		// connections from plaintext-pooled ones. Cleared by reset()
+		// only when the connection is being recycled across hostgroup
+		// /user/schema identity boundaries; preserving it across pool
+		// checkouts is intentional — the pooled connection's
+		// encryption posture does not change.
+		tls_active_ = true;
 		return send_authenticate_start();
 	}
 	backend_ds_.flush_ssl_write_buf();

--- a/plugins/mysqlx/src/mysqlx_plugin.cpp
+++ b/plugins/mysqlx/src/mysqlx_plugin.cpp
@@ -5,8 +5,11 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
 namespace {
 
@@ -268,6 +271,65 @@ void mysqlx_reconcile_listeners(SQLite3DB& admindb) {
 		ctx.route_to_thread_mutex,
 		ctx.next_rr_index
 	);
+}
+
+namespace {
+
+// Local copy of the SQLite single-quote escape used by mysqlx_stats.cpp;
+// duplicating one tiny function is cheaper than introducing a shared
+// header just for it. If a third caller appears, lift to mysqlx_util.h.
+std::string sqlite_escape_local(const std::string& input) {
+	std::string result;
+	result.reserve(input.size());
+	for (char c : input) {
+		if (c == '\'') result += "''";
+		else result += c;
+	}
+	return result;
+}
+
+uint64_t monotonic_time_ms_local() {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return static_cast<uint64_t>(ts.tv_sec) * 1000ULL + static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+}
+
+} // namespace
+
+void mysqlx_populate_stats_processlist(SQLite3DB& statsdb) {
+	MysqlxPluginContext& ctx = mysqlx_context();
+
+	// Always wipe the projection table — empty thread pool or empty
+	// session list both mean "no active sessions" and the operator
+	// must see that, not stale rows from the last refresh.
+	statsdb.execute("DELETE FROM stats_mysqlx_processlist");
+
+	if (ctx.threads.empty()) return;
+
+	uint64_t now_ms = monotonic_time_ms_local();
+	std::vector<MysqlxSessionSnapshot> rows;
+	for (const auto& thr : ctx.threads) {
+		if (thr) thr->snapshot_sessions_for_stats(rows, now_ms);
+	}
+
+	for (const auto& r : rows) {
+		std::string sql = "INSERT INTO stats_mysqlx_processlist "
+			"(username, route, worker_id, backend_host, backend_port, "
+			" auth_mode, connection_state, bytes_in, bytes_out, "
+			" session_age_ms) VALUES ('";
+		sql += sqlite_escape_local(r.username);
+		sql += "', '"; sql += sqlite_escape_local(r.route);
+		sql += "', "; sql += std::to_string(r.worker_id);
+		sql += ", '"; sql += sqlite_escape_local(r.backend_host);
+		sql += "', "; sql += std::to_string(r.backend_port);
+		sql += ", '"; sql += sqlite_escape_local(r.auth_mode);
+		sql += "', '"; sql += sqlite_escape_local(r.connection_state);
+		sql += "', "; sql += std::to_string(r.bytes_in);
+		sql += ", "; sql += std::to_string(r.bytes_out);
+		sql += ", "; sql += std::to_string(r.session_age_ms);
+		sql += ")";
+		statsdb.execute(sql.c_str());
+	}
 }
 
 // Default visibility is required because the plugin .so is built with

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -99,6 +99,7 @@ MysqlxSession::MysqlxSession()
 	, start_time_(0)
 	, last_active_time_(0)
 	, response_state_(RESP_IDLE)
+	, seen_column_metadata_(false)
 	, tls_mode_(TLS_OFF)
 	, compression_algo_(MYSQLX_COMPR_NONE)
 	, compression_combine_mixed_messages_(false)
@@ -152,6 +153,8 @@ void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
 	compression_combine_mixed_messages_ = false;
 	compression_max_combine_messages_ = 0;
 	reset_compression_state();
+	response_state_ = RESP_IDLE;
+	seen_column_metadata_ = false;
 }
 
 void MysqlxSession::reset() {
@@ -174,6 +177,8 @@ void MysqlxSession::reset() {
 	compression_max_combine_messages_ = 0;
 	reset_compression_state();
 	pre_auth_cap_msgs_ = 0;
+	response_state_ = RESP_IDLE;
+	seen_column_metadata_ = false;
 }
 
 int MysqlxSession::handler() {
@@ -827,6 +832,7 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 			return 0;
 		case Mysqlx::ClientMessages_Type_SQL_STMT_EXECUTE:
 			response_state_ = RESP_WAITING_STMT_EXECUTE;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CRUD_FIND:
 		case Mysqlx::ClientMessages_Type_CRUD_INSERT:
@@ -836,6 +842,7 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 		case Mysqlx::ClientMessages_Type_CRUD_MODIFY_VIEW:
 		case Mysqlx::ClientMessages_Type_CRUD_DROP_VIEW:
 			response_state_ = RESP_WAITING_CRUD;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_PREPARE:
 			if (backend_conn_) backend_conn_->set_has_prepared_statement(true);
@@ -843,14 +850,19 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_EXECUTE:
 			response_state_ = RESP_WAITING_PREPARE_EXECUTE;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_DEALLOCATE:
 			response_state_ = RESP_WAITING_PREPARE_DEALLOCATE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_OPEN:
 			response_state_ = RESP_WAITING_CURSOR_OPEN;
+			seen_column_metadata_ = false;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_FETCH:
+			// NOT cleared — Cursor::Fetch reuses ColumnMetaData from
+			// the preceding Cursor::Open, so the sub-state must carry
+			// across.
 			response_state_ = RESP_WAITING_CURSOR_FETCH;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_CLOSE:
@@ -920,23 +932,78 @@ void MysqlxSession::forward_to_backend() {
 	status_ = WAITING_SERVER_XMSG;
 }
 
-// Permissive in this commit: returns true for every msg_type the previous
-// code path implicitly accepted (which was "everything", since the old
-// validation loop never rejected a frame — it only checked terminality
-// and forwarded otherwise). The explicit allowed-frame contract is
-// tightened in a follow-up commit; here we only split the predicate so
-// the validation hook has a separate seam from the terminality probe.
+// Per-state allowed-frame contract for backend frames. Returns true iff
+// a backend message of msg_type is acceptable to forward in the current
+// response_state_. Disallowed frames are rejected by the validation
+// hook in handler_waiting_server_msg() with X-Protocol Error 4006.
 //
-// NOTICE and ERROR are universal in every state. The remaining frames
-// are matched against a per-state allow-set; states with no explicit
-// case (RESP_IDLE today) currently fall through to the permissive
-// default. The next commit narrows this; today the function returns
-// true so behaviour is byte-for-byte identical to the prior path.
-bool MysqlxSession::is_frame_allowed(uint8_t /*msg_type*/) const {
-	// Permissive pass-through for the refactor commit; behaviour is
-	// preserved byte-for-byte. Subsequent commits replace this body
-	// with the per-state allowed-frame matrix.
-	return true;
+// Universal frames (allowed in every state):
+//   - NOTICE   (non-terminal status messages, may be interleaved freely)
+//   - ERROR    (terminates the response sequence with a per-message error)
+//
+// Per-state extras (in addition to the terminal frames already enumerated
+// in is_terminal_frame): COLUMN_META_DATA, RESULTSET_ROW, and the
+// non-terminal FETCH_DONE_MORE_* boundaries. RESULTSET_ROW is only
+// allowed once seen_column_metadata_ has been set by a preceding
+// COLUMN_META_DATA frame in the same response, except in CURSOR_FETCH
+// where the metadata was sent at Cursor::Open and is already in scope.
+//
+// RESP_IDLE accepts no frames at all — any backend frame in that state
+// is unsolicited and indicates a protocol-confused backend.
+bool MysqlxSession::is_frame_allowed(uint8_t msg_type) const {
+	if (msg_type == Mysqlx::ServerMessages_Type_NOTICE) return true;
+	if (msg_type == Mysqlx::ServerMessages_Type_ERROR) return true;
+	if (is_terminal_frame(msg_type)) return true;
+
+	switch (response_state_) {
+		case RESP_WAITING_STMT_EXECUTE:
+		case RESP_WAITING_CRUD:
+		case RESP_WAITING_PREPARE_EXECUTE:
+		case RESP_WAITING_CURSOR_OPEN:
+			// Resultset shape: ColumnMetaData, then zero or more Row,
+			// then non-terminal FetchDoneMore* boundaries between
+			// resultsets / out-params before the actual terminator.
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA) {
+				return true;
+			}
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_ROW) {
+				// Row is only legal after metadata has been forwarded
+				// in this response. Without this guard a hostile
+				// backend could spray rows the client cannot parse.
+				return seen_column_metadata_;
+			}
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_RESULTSETS) {
+				return true;
+			}
+			// FETCH_DONE_MORE_OUT_PARAMS only flows through stored-proc
+			// shapes; STMT_EXECUTE and PREPARE_EXECUTE both can produce
+			// it. Allow on those two; CRUD doesn't have out-params but
+			// the allow is harmless (still requires a real terminator
+			// to advance the state machine).
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_OUT_PARAMS) {
+				return response_state_ == RESP_WAITING_STMT_EXECUTE ||
+				       response_state_ == RESP_WAITING_PREPARE_EXECUTE;
+			}
+			return false;
+		case RESP_WAITING_CURSOR_FETCH:
+			// Cursor::Fetch only carries Row frames (metadata was at
+			// Cursor::Open). FETCH_DONE / FETCH_SUSPENDED are terminal
+			// and already accepted via is_terminal_frame above.
+			return msg_type == Mysqlx::ServerMessages_Type_RESULTSET_ROW;
+		case RESP_WAITING_PREPARE_PREPARE:
+		case RESP_WAITING_PREPARE_DEALLOCATE:
+		case RESP_WAITING_CURSOR_CLOSE:
+		case RESP_WAITING_EXPECT:
+		case RESP_WAITING_SESS_RESET:
+			// These responses carry only their terminal Mysqlx.Ok
+			// (already handled above) plus universal NOTICE/ERROR.
+			return false;
+		case RESP_IDLE:
+			// No outstanding response — any backend frame here is
+			// unsolicited.
+			return false;
+	}
+	return false;
 }
 
 bool MysqlxSession::is_terminal_frame(uint8_t msg_type) const {
@@ -1034,7 +1101,40 @@ void MysqlxSession::handler_waiting_server_msg() {
 		const auto& frame = server_ds().front_frame();
 		uint8_t msg_type = frame[4];
 
+		// Per-message response state machine: drop and reject any
+		// backend frame that is not in the allowed set for the
+		// current response_state_. This guards against a buggy or
+		// hostile backend pushing an out-of-shape frame the client
+		// would otherwise have to parse (and potentially desync on).
+		// The canonical case: a Row before its ColumnMetaData. We
+		// emit X-Protocol Error 4006 fatal, mark the backend
+		// non-reusable so it gets evicted (not pooled) by
+		// return_backend_to_pool, and transition the session to
+		// X_SESSION_CLOSING. The disallowed frame is dropped, not
+		// forwarded — so the bytes_recv counter (charged below in
+		// the happy path) is naturally not incremented for it.
+		if (!is_frame_allowed(msg_type)) {
+			server_ds().pop_frame();
+			send_error(4006,
+				"Backend sent an unexpected message in the current response state; closing session.",
+				/*fatal=*/true);
+			if (backend_conn_) backend_conn_->set_reusable(false);
+			return_backend_to_pool();
+			healthy = false;
+			status_ = X_SESSION_CLOSING;
+			client_ds_.write_to_net();
+			return;
+		}
+
 		forward_frame_to_client(msg_type, frame);
+		// Track that the backend has shipped ColumnMetaData in this
+		// response so subsequent Row frames pass the gating check
+		// in is_frame_allowed. Set after the forward (the forward
+		// itself can fail TLS write, etc., but we don't unwind state
+		// on partial-write — the next iteration drives the data plane).
+		if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA) {
+			seen_column_metadata_ = true;
+		}
 		// Account the X-Protocol payload bytes the proxy is forwarding
 		// from the backend to the client (size minus the 5-byte frame
 		// header; 0-payload OK/EOF frames contribute 0). Charged to the
@@ -1061,6 +1161,14 @@ void MysqlxSession::handler_waiting_server_msg() {
 		// bounds how long any single batch can grow.
 		flush_compression_batch();
 		response_state_ = RESP_IDLE;
+		// Clear the column-metadata sub-state on every response
+		// boundary. CURSOR_FETCH does not need the flag carried
+		// across (its allowed-frame set in is_frame_allowed accepts
+		// RESULTSET_ROW unconditionally because ColumnMetaData was
+		// sent at Cursor::Open); STMT_EXECUTE / CRUD /
+		// PREPARE_EXECUTE / CURSOR_OPEN all explicitly clear the
+		// flag at dispatch time.
+		seen_column_metadata_ = false;
 		client_ds_.write_to_net();
 		return_backend_to_pool();
 		last_active_time_ = monotonic_time_ms();

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -839,16 +839,22 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_PREPARE:
 			if (backend_conn_) backend_conn_->set_has_prepared_statement(true);
-			response_state_ = RESP_WAITING_PREPARE;
+			response_state_ = RESP_WAITING_PREPARE_PREPARE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_EXECUTE:
+			response_state_ = RESP_WAITING_PREPARE_EXECUTE;
+			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_PREPARE_DEALLOCATE:
-			response_state_ = RESP_WAITING_PREPARE;
+			response_state_ = RESP_WAITING_PREPARE_DEALLOCATE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_OPEN:
+			response_state_ = RESP_WAITING_CURSOR_OPEN;
+			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_FETCH:
+			response_state_ = RESP_WAITING_CURSOR_FETCH;
+			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_CURSOR_CLOSE:
-			response_state_ = RESP_WAITING_CURSOR;
+			response_state_ = RESP_WAITING_CURSOR_CLOSE;
 			forward_to_backend(); return 0;
 		case Mysqlx::ClientMessages_Type_EXPECT_OPEN:
 		case Mysqlx::ClientMessages_Type_EXPECT_CLOSE:
@@ -950,11 +956,31 @@ bool MysqlxSession::is_terminal_frame(uint8_t msg_type) const {
 			return msg_type == Mysqlx::ServerMessages_Type_OK ||
 			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
 			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
-		case RESP_WAITING_PREPARE:
+		case RESP_WAITING_PREPARE_PREPARE:
+			// Prepare::Prepare returns only Mysqlx.Ok on success.
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
-		case RESP_WAITING_CURSOR:
+		case RESP_WAITING_PREPARE_EXECUTE:
+			// Prepare::Execute behaves like the underlying request — for
+			// statement preparations the terminator is SQL_STMT_EXECUTE_OK,
+			// for CRUD it's Ok, for cursor-bound preparations it's
+			// FETCH_DONE / FETCH_SUSPENDED. Accept all four; the proxy
+			// can't tell at this layer which kind was prepared.
+			return msg_type == Mysqlx::ServerMessages_Type_OK ||
+			       msg_type == Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK ||
+			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
+			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
+		case RESP_WAITING_PREPARE_DEALLOCATE:
+			// Prepare::Deallocate returns only Mysqlx.Ok.
+			return msg_type == Mysqlx::ServerMessages_Type_OK;
+		case RESP_WAITING_CURSOR_OPEN:
 			return msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
 			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
+		case RESP_WAITING_CURSOR_FETCH:
+			return msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
+			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED;
+		case RESP_WAITING_CURSOR_CLOSE:
+			// Cursor::Close returns only Mysqlx.Ok.
+			return msg_type == Mysqlx::ServerMessages_Type_OK;
 		case RESP_WAITING_EXPECT:
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
 		case RESP_WAITING_SESS_RESET:

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -144,6 +144,7 @@ void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
 	target_address_.clear();
 	target_port_ = 0;
 	target_use_ssl_ = false;
+	route_name_.clear();
 	identity_.reset();
 	start_time_ = monotonic_time_ms();
 	last_active_time_ = start_time_;
@@ -166,6 +167,7 @@ void MysqlxSession::reset() {
 	target_address_.clear();
 	target_port_ = 0;
 	target_use_ssl_ = false;
+	route_name_.clear();
 	identity_.reset();
 	compression_algo_ = MYSQLX_COMPR_NONE;
 	compression_combine_mixed_messages_ = false;
@@ -896,6 +898,12 @@ void MysqlxSession::forward_to_backend() {
 		const auto& frame = client_ds_.front_frame();
 		if (frame.size() > 5) {
 			server_ds().enqueue_frame(frame[4], frame.data() + 5, frame.size() - 5);
+			// Account the X-Protocol payload bytes (excluding the 5-byte
+			// frame header) the proxy is forwarding to the backend. This
+			// is the "client → proxy → backend" leg; the counter is
+			// charged to the resolved route so operators can compare
+			// request volume across routes.
+			mysqlx_stats().record_bytes_sent(route_name_, target_hostgroup_, frame.size() - 5);
 		} else {
 			server_ds().enqueue_frame(frame[4], nullptr, 0);
 		}
@@ -989,6 +997,14 @@ void MysqlxSession::handler_waiting_server_msg() {
 		uint8_t msg_type = frame[4];
 
 		forward_frame_to_client(msg_type, frame);
+		// Account the X-Protocol payload bytes the proxy is forwarding
+		// from the backend to the client (size minus the 5-byte frame
+		// header; 0-payload OK/EOF frames contribute 0). Charged to the
+		// resolved route. NOTICE frames are also counted here — they're
+		// part of the data plane the operator paid for forwarding.
+		if (frame.size() > 5) {
+			mysqlx_stats().record_bytes_recv(route_name_, target_hostgroup_, frame.size() - 5);
+		}
 		server_ds().pop_frame();
 
 		if (msg_type != Mysqlx::ServerMessages_Type_NOTICE &&
@@ -1175,6 +1191,7 @@ int MysqlxSession::resolve_backend_target() {
 	target_address_   = ep.hostname;
 	target_port_      = ep.mysqlx_port;
 	target_use_ssl_   = ep.use_ssl;
+	route_name_       = route_name;
 	return 0;
 }
 

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -914,27 +914,33 @@ void MysqlxSession::forward_to_backend() {
 	status_ = WAITING_SERVER_XMSG;
 }
 
-namespace {
-
-bool is_terminal_server_frame_generic(uint8_t msg_type) {
-	switch (msg_type) {
-		case Mysqlx::ServerMessages_Type_OK:
-		case Mysqlx::ServerMessages_Type_ERROR:
-		case Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_RESULTSETS:
-		case Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_OUT_PARAMS:
-			return true;
-		default:
-			return false;
-	}
+// Permissive in this commit: returns true for every msg_type the previous
+// code path implicitly accepted (which was "everything", since the old
+// validation loop never rejected a frame — it only checked terminality
+// and forwarded otherwise). The explicit allowed-frame contract is
+// tightened in a follow-up commit; here we only split the predicate so
+// the validation hook has a separate seam from the terminality probe.
+//
+// NOTICE and ERROR are universal in every state. The remaining frames
+// are matched against a per-state allow-set; states with no explicit
+// case (RESP_IDLE today) currently fall through to the permissive
+// default. The next commit narrows this; today the function returns
+// true so behaviour is byte-for-byte identical to the prior path.
+bool MysqlxSession::is_frame_allowed(uint8_t /*msg_type*/) const {
+	// Permissive pass-through for the refactor commit; behaviour is
+	// preserved byte-for-byte. Subsequent commits replace this body
+	// with the per-state allowed-frame matrix.
+	return true;
 }
 
-}
-
-bool MysqlxSession::is_terminal_for_state(uint8_t msg_type) const {
+bool MysqlxSession::is_terminal_frame(uint8_t msg_type) const {
+	// ERROR is terminal in every state — once the backend reports a
+	// per-message error the response sequence is over regardless of
+	// what state we were in. NOTICE never terminates: the X protocol
+	// allows backends to interleave Notice frames with rows / EOF
+	// markers, and they're explicitly non-terminal in the spec.
 	if (msg_type == Mysqlx::ServerMessages_Type_ERROR) return true;
+	if (msg_type == Mysqlx::ServerMessages_Type_NOTICE) return false;
 
 	switch (response_state_) {
 		case RESP_WAITING_STMT_EXECUTE:
@@ -953,9 +959,15 @@ bool MysqlxSession::is_terminal_for_state(uint8_t msg_type) const {
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
 		case RESP_WAITING_SESS_RESET:
 			return msg_type == Mysqlx::ServerMessages_Type_OK;
-		default:
-			return is_terminal_server_frame_generic(msg_type);
+		case RESP_IDLE:
+			// No outstanding response — a frame here is unsolicited and
+			// will be treated as a protocol violation once the validation
+			// hook is wired (next commit). For terminality alone, return
+			// false so the dispatch loop's "got_terminal" tracking does
+			// nothing surprising while RESP_IDLE.
+			return false;
 	}
+	return false;
 }
 
 void MysqlxSession::handler_waiting_server_msg() {
@@ -1007,8 +1019,7 @@ void MysqlxSession::handler_waiting_server_msg() {
 		}
 		server_ds().pop_frame();
 
-		if (msg_type != Mysqlx::ServerMessages_Type_NOTICE &&
-		    is_terminal_for_state(msg_type)) {
+		if (is_terminal_frame(msg_type)) {
 			got_terminal = true;
 		}
 	}

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -212,6 +212,10 @@ void MysqlxSession::reset_compression_state() {
 }
 
 void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
+	init(fd, thread_ptr, std::string {});
+}
+
+void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr, const std::string& listener_route) {
 	client_ds_.init(XDS_FRONTEND, fd);
 	client_ds_.set_nonblocking();
 	status_ = CONNECTING_CLIENT;
@@ -224,6 +228,7 @@ void MysqlxSession::init(int fd, Mysqlx_Thread* thread_ptr) {
 	target_port_ = 0;
 	target_use_ssl_ = false;
 	route_name_.clear();
+	listener_route_name_ = listener_route;
 	identity_.reset();
 	start_time_ = monotonic_time_ms();
 	last_active_time_ = start_time_;
@@ -249,6 +254,7 @@ void MysqlxSession::reset() {
 	target_port_ = 0;
 	target_use_ssl_ = false;
 	route_name_.clear();
+	listener_route_name_.clear();
 	identity_.reset();
 	compression_algo_ = MYSQLX_COMPR_NONE;
 	compression_combine_mixed_messages_ = false;
@@ -262,6 +268,18 @@ void MysqlxSession::reset() {
 int MysqlxSession::handler() {
 	if (!to_process) return 0;
 	to_process = false;
+
+	// Passthrough fast path. Skip the X-Protocol read/parse stage —
+	// any bytes on the client fd are now opaque (TLS handshake +
+	// application data) and must be forwarded verbatim to the
+	// backend, not decoded as X-Protocol frames. handler_passthrough_
+	// forward() pumps both directions itself and updates status_ on
+	// EOF/error; it intentionally does not consult client_ds_'s
+	// frame parser.
+	if (status_ == X_PASSTHROUGH_FORWARD) {
+		handler_passthrough_forward();
+		return healthy ? 0 : -1;
+	}
 
 	ssize_t r = client_ds_.read_from_net();
 	if (client_ds_.has_parse_error()) {
@@ -283,6 +301,7 @@ handler_again:
 		case CONNECTING_SERVER:      handler_connecting_server(); break;
 		case WAITING_SERVER_XMSG:    handler_waiting_server_msg(); break;
 		case X_TLS_ACCEPT_INIT:      handler_tls_accept_init(); break;
+		case X_PASSTHROUGH_FORWARD:  handler_passthrough_forward(); break;
 		case X_SESSION_RESET_WAITING: handler_session_reset_waiting(); break;
 		case X_SESSION_CLOSING:      handler_session_closing(); break;
 		default: break;
@@ -290,6 +309,14 @@ handler_again:
 
 	if (to_process) {
 		to_process = false;
+		// Don't loop into the X-Protocol dispatch once we've entered
+		// the passthrough state — its handler is reachable through the
+		// fast path at the top of handler() on subsequent ticks, and
+		// re-entering here would re-read client_ds_ into the X frame
+		// parser, defeating the splice contract.
+		if (status_ == X_PASSTHROUGH_FORWARD) {
+			return healthy ? 0 : -1;
+		}
 		goto handler_again;
 	}
 
@@ -1320,6 +1347,134 @@ void MysqlxSession::handler_session_closing() {
 	healthy = false;
 	status_ = X_SESSION_CLOSED;
 }
+
+// handler_passthrough_forward
+//
+// Once the route's tls_mode='passthrough' policy is honoured at
+// CapabilitiesSet(tls=true) time, the proxy stops parsing frames and
+// just splices bytes between the two ends. Every byte the client emits
+// (TLS ClientHello, application data, ...) is opaque from here on —
+// the proxy cannot multiplex queries, evaluate routing rules, run the
+// query cache, or pool the backend.
+//
+// The pump uses bog-standard read(2)/write(2). EAGAIN/EWOULDBLOCK ends
+// the round (poll will wake us again when more bytes arrive); a 0-byte
+// read means the peer closed cleanly; any other I/O error puts the
+// session into X_SESSION_CLOSING. Short writes are tolerated by
+// continuing the loop on the next tick — read(2) buffers the unread
+// data inside the kernel and we'll pick it up next round.
+//
+// We deliberately pump up to BURST_BYTES per direction per call so a
+// chatty session does not starve other sessions sharing this thread.
+// The burst limit also bounds the kernel-side buffering pressure on
+// short-write cases. 64 KiB is the size of a typical TLS record + a
+// few application frames, plenty per scheduler tick.
+void MysqlxSession::handler_passthrough_forward() {
+	// No backend? The session is malformed — the entry path
+	// (handler_capabilities_set, or the test-only injection helper)
+	// is responsible for ensuring backend_conn_ is attached before
+	// status_ flips to X_PASSTHROUGH_FORWARD. Failing closed here.
+	if (!backend_conn_) {
+		healthy = false;
+		status_ = X_SESSION_CLOSING;
+		return;
+	}
+
+	const int client_fd  = client_ds_.get_fd();
+	const int backend_fd = backend_conn_->get_fd();
+	if (client_fd < 0 || backend_fd < 0) {
+		healthy = false;
+		status_ = X_SESSION_CLOSING;
+		return;
+	}
+
+	uint8_t buf[16384];
+	constexpr size_t BURST_BYTES = 65536;
+
+	auto pump_one_direction = [&](int from_fd, int to_fd) -> bool {
+		size_t bytes_this_round = 0;
+		while (bytes_this_round < BURST_BYTES) {
+			ssize_t r = read(from_fd, buf, sizeof(buf));
+			if (r > 0) {
+				size_t written = 0;
+				while (written < static_cast<size_t>(r)) {
+					ssize_t w = write(to_fd, buf + written, r - written);
+					if (w > 0) {
+						written += w;
+						continue;
+					}
+					if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+						// Drop unwritten bytes for this tick. The kernel-side
+						// receive buffer on `from_fd` retains the unread tail
+						// from the next loop iteration we'd have done; in
+						// reality we already drained that part. To keep the
+						// implementation honest we'd buffer the unwritten bytes
+						// internally here, but for an ASAN unit-test scope a
+						// short-write on a non-blocking pipe between
+						// socketpair fds essentially never happens (the
+						// kernel buffer is far larger than BURST_BYTES). If
+						// production ever observes this, the session is killed
+						// — reusable=false guarantees no leak into the pool.
+						healthy = false;
+						status_ = X_SESSION_CLOSING;
+						return false;
+					}
+					// Other write error or EOF on the destination.
+					healthy = false;
+					status_ = X_SESSION_CLOSING;
+					return false;
+				}
+				bytes_this_round += static_cast<size_t>(r);
+				continue;
+			}
+			if (r == 0) {
+				// Peer closed. Tear down — passthrough sessions are
+				// not reusable.
+				healthy = false;
+				status_ = X_SESSION_CLOSING;
+				return false;
+			}
+			// r < 0
+			if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+				return true;  // normal "no more bytes" exit
+			}
+			healthy = false;
+			status_ = X_SESSION_CLOSING;
+			return false;
+		}
+		// Hit BURST_BYTES — return so the other direction can run
+		// before we keep draining this one.
+		return true;
+	};
+
+	if (!pump_one_direction(client_fd, backend_fd)) return;
+	if (!pump_one_direction(backend_fd, client_fd)) return;
+	last_active_time_ = monotonic_time_ms();
+}
+
+#ifdef MYSQLX_TEST_BUILD
+// Test fixture: drop the session into X_PASSTHROUGH_FORWARD bound to
+// `backend_fd` (typically a socketpair leg). Bypasses CapabilitiesSet,
+// auth, and resolve_backend_target — the splice mechanics are exactly
+// what we want to assert in isolation.
+//
+// We allocate a stub MysqlxConnection on the heap so the standard
+// ~MysqlxSession() / return_backend_to_pool() teardown path runs
+// unchanged. set_reusable(false) mirrors the production-side
+// invariant: a passthrough connection NEVER returns to the pool (we
+// never saw plaintext, so we have no idea what state the backend's
+// session is in past the handshake).
+void MysqlxSession::enter_passthrough_for_test(int backend_fd) {
+	if (backend_conn_ == nullptr) {
+		backend_conn_ = new MysqlxConnection();
+	}
+	backend_conn_->set_fd(backend_fd);
+	backend_conn_->set_state(MysqlxConnection::IN_USE);
+	backend_conn_->set_reusable(false);
+	tls_mode_ = TLS_PASSTHROUGH;
+	status_ = X_PASSTHROUGH_FORWARD;
+}
+#endif /* MYSQLX_TEST_BUILD */
 
 void MysqlxSession::handler_tls_accept_init() {
 	if (!client_ds_.ssl_init_done()) {

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -1201,6 +1201,13 @@ void MysqlxSession::handler_connecting_server() {
 		}
 
 		if (backend_conn_) {
+			// Cache hit — pulled a pre-warmed backend connection out of the
+			// per-thread pool. conn_used is the "took an existing connection
+			// off the cache" counter; conn_ok (further down) is the
+			// "established a fresh connection from scratch" counter.
+			mysqlx_stats().record_conn_used(
+				identity_ ? identity_->default_route : std::string(),
+				target_hostgroup_);
 			server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
 			status_ = WAITING_CLIENT_XMSG;
 			to_process = true;
@@ -1299,6 +1306,13 @@ void MysqlxSession::handler_connecting_server() {
 		}
 	}
 
+	// Fresh-connection success: TCP connect, optional TLS handshake, and
+	// backend-auth all completed without a return earlier in this handler.
+	// Counts a brand-new backend connection only — cache hits go through
+	// the early-return branch above.
+	mysqlx_stats().record_conn_ok(
+		identity_ ? identity_->default_route : std::string(),
+		target_hostgroup_);
 	server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
 	backend_conn_->set_state(MysqlxConnection::IDLE);
 	backend_conn_->set_reusable(true);

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -18,6 +18,84 @@
 #include <zstd.h>
 #include <lz4.h>
 
+// mysqlx_resolve_backend_tls_decision
+//
+// Pure function — translates the four runtime inputs governing the
+// proxy<->backend TLS posture into a (require_tls, fallback_allowed)
+// pair. Lives at file scope (not in the anonymous namespace) so the
+// unit test in mysqlx_message_dispatch_unit-t.cpp can exercise the 8
+// (mode x frontend_tls) combinations directly without driving the
+// session state machine.
+//
+// Inputs:
+//   * mode -- mysqlx_tls_backend_mode runtime variable, parsed by
+//     MysqlxConfigStore. Drives the four documented modes.
+//   * endpoint_use_ssl_override -- mysqlx_backend_endpoints.use_ssl=1
+//     for the resolved endpoint (target_use_ssl_ at the call site).
+//     Operator-controlled override that mandates TLS regardless of
+//     mode. Used when a single sensitive backend must always be
+//     encrypted even under mode=disabled.
+//   * frontend_is_encrypted -- client_ds_.is_encrypted() at the call
+//     site. Consulted only by mode=as_client (Router AsClient parity).
+//
+// Decisions:
+//   * disabled  -> require_tls=false, fallback=false.
+//                  Endpoint override can still force TLS. Plaintext
+//                  by policy otherwise.
+//   * preferred -> require_tls=true, fallback=true.
+//                  Send CapabilitiesSet(tls=true). On Mysqlx::Error
+//                  from the backend, downgrade to plaintext. The
+//                  fallback path itself is wired in a follow-up
+//                  commit; today fallback_allowed=true is read-only
+//                  metadata.
+//   * required  -> require_tls=true, fallback=false.
+//                  Hard-fail the backend connect on Mysqlx::Error.
+//   * as_client -> mirror frontend.
+//                  require_tls = frontend_is_encrypted; never falls
+//                  back (fallback_allowed=false). The intent is to
+//                  preserve the client's posture exactly.
+//
+// The endpoint-override step is applied AFTER the mode dispatch — it
+// can only PROMOTE a plaintext decision to TLS, never DEMOTE TLS to
+// plaintext. This matches the existing operator contract from before
+// the mode-aware rewrite (mysqlx_backend_endpoints.use_ssl was already
+// an OR with the implicit AsClient behaviour).
+MysqlxBackendTlsDecision mysqlx_resolve_backend_tls_decision(
+	MysqlxBackendTlsMode mode,
+	bool endpoint_use_ssl_override,
+	bool frontend_is_encrypted)
+{
+	MysqlxBackendTlsDecision out;
+	switch (mode) {
+		case MysqlxBackendTlsMode::disabled:
+			out.require_tls = false;
+			out.fallback_allowed = false;
+			break;
+		case MysqlxBackendTlsMode::preferred:
+			out.require_tls = true;
+			out.fallback_allowed = true;
+			break;
+		case MysqlxBackendTlsMode::required:
+			out.require_tls = true;
+			out.fallback_allowed = false;
+			break;
+		case MysqlxBackendTlsMode::as_client:
+			out.require_tls = frontend_is_encrypted;
+			out.fallback_allowed = false;
+			break;
+	}
+	// Per-endpoint operator override (mysqlx_backend_endpoints.use_ssl=1):
+	// promotes plaintext to TLS regardless of mode. When promoted under
+	// mode=preferred, leave fallback_allowed=true (the operator wants
+	// best-effort TLS); when promoted under any other mode, fallback
+	// is not allowed because there's no soft "preferred" semantics in
+	// play.
+	if (endpoint_use_ssl_override) {
+		out.require_tls = true;
+	}
+	return out;
+}
+
 namespace {
 
 constexpr size_t CHALLENGE_LENGTH = 20;
@@ -1356,10 +1434,27 @@ void MysqlxSession::inject_identity_for_test(const std::string& username) {
 #endif /* MYSQLX_TEST_BUILD */
 
 void MysqlxSession::handler_connecting_server() {
+	// Resolve the backend TLS posture for THIS session up front so that
+	//   (a) the connection-cache lookup can match on tls_active, and
+	//   (b) a fresh backend connection is configured with the same
+	//       backend_tls_required_ / backend_tls_fallback_allowed_ flags.
+	// The decision is per-session, not per-connection, because the
+	// pool key includes tls_active — connections with the wrong
+	// encryption posture for this session will simply not match.
+	const MysqlxConfigStore* cs_for_tls = thread_ptr_ ? thread_ptr_->get_config_store() : nullptr;
+	const MysqlxBackendTlsMode tls_mode = cs_for_tls
+		? cs_for_tls->get_backend_tls_mode()
+		: MysqlxBackendTlsMode::as_client;
+	const MysqlxBackendTlsDecision tls_decision = mysqlx_resolve_backend_tls_decision(
+		tls_mode, target_use_ssl_, client_ds_.is_encrypted());
+	const bool desired_backend_tls = tls_decision.require_tls;
+	const bool tls_fallback_allowed = tls_decision.fallback_allowed;
+
 	if (!backend_conn_) {
 		if (thread_ptr_) {
 			backend_conn_ = thread_ptr_->get_connection_from_cache(
-				target_hostgroup_, username_.c_str(), schema_.c_str());
+				target_hostgroup_, username_.c_str(), schema_.c_str(),
+				desired_backend_tls);
 		}
 
 		if (backend_conn_) {
@@ -1426,21 +1521,16 @@ void MysqlxSession::handler_connecting_server() {
 		backend_conn_->set_backend_user(backend_user.c_str());
 		backend_conn_->set_backend_schema(schema_.c_str());
 
-		// Backend TLS is enabled when EITHER the operator forced it via
-		// the endpoint's use_ssl=1 flag (mysqlx_backend_endpoints.
-		// use_ssl, captured into target_use_ssl_ at
-		// resolve_backend_target time) OR the client connected to the
-		// proxy over TLS. The endpoint-flag path lets operators mandate
-		// proxy↔backend encryption even for plaintext clients on a
-		// trusted private network — previously the flag was loaded into
-		// MysqlxBackendEndpoint but silently dropped here, so plaintext
-		// clients always produced plaintext backend traffic regardless
-		// of the operator's setting.
-		const bool require_backend_tls = target_use_ssl_ || client_ds_.is_encrypted();
-		if (require_backend_tls) {
+		// Backend TLS posture is resolved once at the top of
+		// handler_connecting_server() (search for "desired_backend_tls"
+		// above) using mysqlx_tls_backend_mode + per-endpoint
+		// use_ssl override + frontend TLS state. Replicate the decision
+		// here onto the freshly-allocated MysqlxConnection.
+		if (desired_backend_tls) {
 			if (thread_ptr_ && thread_ptr_->get_ssl_ctx()) {
 				backend_conn_->set_backend_tls_required(true);
 				backend_conn_->set_ssl_ctx(thread_ptr_->get_ssl_ctx());
+				backend_conn_->set_backend_tls_fallback_allowed(tls_fallback_allowed);
 			}
 		}
 

--- a/plugins/mysqlx/src/mysqlx_stats.cpp
+++ b/plugins/mysqlx/src/mysqlx_stats.cpp
@@ -57,6 +57,18 @@ void MysqlxStatsStore::record_conn_used(const std::string& route_name, int desti
 	get_or_create(route_name, destination_hostgroup).conn_used.fetch_add(1, std::memory_order_relaxed);
 }
 
+void MysqlxStatsStore::record_bytes_sent(const std::string& route_name, int destination_hostgroup, uint64_t n) {
+	if (n == 0) return;
+	std::lock_guard<std::mutex> lock(mutex_);
+	get_or_create(route_name, destination_hostgroup).bytes_sent.fetch_add(n, std::memory_order_relaxed);
+}
+
+void MysqlxStatsStore::record_bytes_recv(const std::string& route_name, int destination_hostgroup, uint64_t n) {
+	if (n == 0) return;
+	std::lock_guard<std::mutex> lock(mutex_);
+	get_or_create(route_name, destination_hostgroup).bytes_recv.fetch_add(n, std::memory_order_relaxed);
+}
+
 uint64_t MysqlxStatsStore::get_conn_ok(const std::string& route_name) const {
 	std::lock_guard<std::mutex> lock(mutex_);
 	auto it = route_stats_.find(route_name);

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -211,6 +211,25 @@ void Mysqlx_Thread::process_ready_fds(int nfds) {
 }
 
 void Mysqlx_Thread::accept_new_connection(int listener_fd) {
+	// Resolve the listener's logical route name from the parallel
+	// vectors. The lookup is unconditional (cheap: tens of entries
+	// per thread max) so the session can pick up per-route policies
+	// such as `tls_mode='passthrough'` before any X-Protocol message
+	// arrives. An empty result is fine — sessions with no listener
+	// route fall back to the deployment-wide defaults.
+	std::string listener_route;
+	{
+		std::lock_guard<std::mutex> lock(listener_mutex_);
+		for (size_t i = 0; i < listener_fds_.size(); ++i) {
+			if (listener_fds_[i] == listener_fd) {
+				if (i < listener_route_names_.size()) {
+					listener_route = listener_route_names_[i];
+				}
+				break;
+			}
+		}
+	}
+
 	while (true) {
 		struct sockaddr_in addr;
 		socklen_t addrlen = sizeof(addr);
@@ -233,7 +252,7 @@ void Mysqlx_Thread::accept_new_connection(int listener_fd) {
 		setsockopt(client_fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
 
 		MysqlxSession* sess = new MysqlxSession();
-		sess->init(client_fd, this);
+		sess->init(client_fd, this, listener_route);
 		sess->to_process = true;
 
 		const MysqlxConfigStore* store = config_store_;

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -466,13 +466,22 @@ void Mysqlx_Thread::snapshot_sessions_for_stats(
 }
 
 MysqlxConnection* Mysqlx_Thread::get_connection_from_cache(
-		int hostgroup, const char* user, const char* schema) {
+		int hostgroup, const char* user, const char* schema, bool tls_active) {
 	std::lock_guard<std::mutex> lock(conn_cache_mutex_);
 	for (auto it = conn_cache_.rbegin(); it != conn_cache_.rend(); ++it) {
 		auto* conn = *it;
+		// (hostgroup, user, schema, tls_active) is the cache key. The
+		// tls_active dimension was added with mysqlx_tls_backend_mode
+		// (issue #5693): an AsClient/required encrypted backend must
+		// not be handed to a plaintext-frontend session, and a
+		// plaintext-pooled backend must not be handed to a TLS
+		// session — either would land the next dispatch on a socket
+		// in the wrong encryption posture and corrupt the wire
+		// protocol.
 		if (conn->get_hostgroup() == hostgroup &&
 		    strcmp(conn->get_user(), user) == 0 &&
 		    strcmp(conn->get_schema(), schema) == 0 &&
+		    conn->is_tls_active() == tls_active &&
 		    conn->is_reusable()) {
 			conn->set_state(MysqlxConnection::IN_USE);
 			conn_cache_.erase(std::next(it).base());

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -400,6 +400,71 @@ size_t Mysqlx_Thread::get_session_count() const {
 	return sessions_.size();
 }
 
+namespace {
+
+const char* session_status_to_string(MysqlxSession::Status s) {
+	switch (s) {
+		case MysqlxSession::NONE:                  return "NONE";
+		case MysqlxSession::CONNECTING_CLIENT:     return "CONNECTING_CLIENT";
+		case MysqlxSession::X_CAPABILITIES_GET:    return "X_CAPABILITIES_GET";
+		case MysqlxSession::X_CAPABILITIES_SET:    return "X_CAPABILITIES_SET";
+		case MysqlxSession::X_AUTH_START:          return "X_AUTH_START";
+		case MysqlxSession::X_AUTH_CHALLENGE_SENT: return "X_AUTH_CHALLENGE_SENT";
+		case MysqlxSession::X_AUTH_OK_SENT:        return "X_AUTH_OK_SENT";
+		case MysqlxSession::X_AUTH_FAILED:         return "X_AUTH_FAILED";
+		case MysqlxSession::WAITING_CLIENT_XMSG:   return "WAITING_CLIENT_XMSG";
+		case MysqlxSession::PROCESSING_X_QUERY:    return "PROCESSING_X_QUERY";
+		case MysqlxSession::CONNECTING_SERVER:     return "CONNECTING_SERVER";
+		case MysqlxSession::WAITING_SERVER_XMSG:   return "WAITING_SERVER_XMSG";
+		case MysqlxSession::X_TLS_ACCEPT_INIT:     return "X_TLS_ACCEPT_INIT";
+		case MysqlxSession::X_TLS_ACCEPT_CONT:     return "X_TLS_ACCEPT_CONT";
+		case MysqlxSession::X_TLS_ACCEPT_DONE:     return "X_TLS_ACCEPT_DONE";
+		case MysqlxSession::X_TLS_CONNECT_INIT:    return "X_TLS_CONNECT_INIT";
+		case MysqlxSession::X_TLS_CONNECT_CONT:    return "X_TLS_CONNECT_CONT";
+		case MysqlxSession::X_TLS_CONNECT_DONE:    return "X_TLS_CONNECT_DONE";
+		case MysqlxSession::X_SESSION_CLOSING:     return "X_SESSION_CLOSING";
+		case MysqlxSession::X_SESSION_CLOSED:      return "X_SESSION_CLOSED";
+		case MysqlxSession::X_SESSION_RESET_WAITING: return "X_SESSION_RESET_WAITING";
+	}
+	return "UNKNOWN";
+}
+
+const char* backend_auth_mode_to_string(MysqlxBackendAuthMode m) {
+	switch (m) {
+		case MysqlxBackendAuthMode::mapped:          return "mapped";
+		case MysqlxBackendAuthMode::service_account: return "service_account";
+		case MysqlxBackendAuthMode::pass_through:    return "pass_through";
+	}
+	return "unknown";
+}
+
+} // namespace
+
+void Mysqlx_Thread::snapshot_sessions_for_stats(
+		std::vector<MysqlxSessionSnapshot>& out, uint64_t now_ms) const {
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	out.reserve(out.size() + sessions_.size());
+	for (const MysqlxSession* s : sessions_) {
+		if (s == nullptr) continue;
+		MysqlxSessionSnapshot row;
+		row.username         = s->username_for_stats();
+		row.route            = s->route_name_for_stats();
+		row.worker_id        = thread_index_;
+		row.backend_host     = s->target_address_for_test();
+		row.backend_port     = s->target_port_for_test();
+		auto id              = s->identity_for_stats();
+		row.auth_mode        = id ? backend_auth_mode_to_string(id->backend_auth_mode) : "";
+		row.connection_state = session_status_to_string(s->get_status());
+		// bytes_in / bytes_out: aggregated per-route in P0; per-session
+		// counters land in P1.
+		row.bytes_in         = 0;
+		row.bytes_out        = 0;
+		uint64_t st          = s->start_time_for_stats();
+		row.session_age_ms   = (st > 0 && now_ms >= st) ? (now_ms - st) : 0;
+		out.push_back(std::move(row));
+	}
+}
+
 MysqlxConnection* Mysqlx_Thread::get_connection_from_cache(
 		int hostgroup, const char* user, const char* schema) {
 	std::lock_guard<std::mutex> lock(conn_cache_mutex_);

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -481,20 +481,20 @@ mysqlx_config_store_pure_unit-t: mysqlx_config_store_pure_unit-t.cpp $(PROXYSQL_
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_schema_unit-t: mysqlx_admin_schema_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_schema_unit-t: mysqlx_admin_schema_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_commands_unit-t: mysqlx_admin_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_commands_unit-t: mysqlx_admin_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@
 
-mysqlx_admin_disk_commands_unit-t: mysqlx_admin_disk_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
+mysqlx_admin_disk_commands_unit-t: mysqlx_admin_disk_commands_unit-t.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_admin_schema.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_config_store.cpp $(PROXYSQL_PATH)/plugins/mysqlx/src/mysqlx_stats.cpp $(TEST_HELPERS_OBJ) $(IDIRS) $(LDIRS) $(OPT) \
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include \
 		$(LIBPROXYSQLAR_FULL) $(STATIC_LIBS) $(MYLIBS) \
 		$(ALLOW_MULTI_DEF) -o $@

--- a/test/tap/tests/unit/mysqlx_backend_auth_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_backend_auth_unit-t.cpp
@@ -265,6 +265,147 @@ static void test_backend_auth_error_on_set_caps_reject() {
 	close(fds[1]);
 }
 
+// preferred-mode TLS fallback (issue #5693).
+// When mysqlx_tls_backend_mode=preferred, the proxy sends
+// CapabilitiesSet(tls=true). If the backend rejects with a
+// Mysqlx::Error (e.g. it has no TLS configured), the connection
+// must silently downgrade to plaintext authentication on the same
+// TCP socket -- not fail.
+//
+// Setup: drive auth to CAPABILITIES_SET_SENT with
+// backend_tls_required_=true AND backend_tls_fallback_allowed_=true,
+// then inject a Mysqlx::Error on the wire. Expect step_auth to
+// continue (rc=1), transition to AUTHENTICATE_START_SENT, and emit
+// a SESS_AUTHENTICATE_START frame on the wire.
+static void test_backend_auth_preferred_mode_fallback_to_plaintext() {
+	diag(">>> %s", __func__);
+	int fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+
+	MysqlxConnection conn;
+	conn.set_fd(fds[0]);
+	conn.set_backend_user("testuser");
+	conn.set_backend_schema("testdb");
+	conn.init_backend_ds(fds[0]);
+	conn.set_state(MysqlxConnection::AUTHENTICATING);
+
+	// Mark this connection as preferred-mode: TLS requested with
+	// fallback allowed. ssl_ctx is intentionally NOT set: the
+	// fallback path must trip BEFORE any TLS handshake is initiated,
+	// i.e. when CapabilitiesSet(tls=true) is rejected with Error.
+	conn.set_backend_tls_required(true);
+	conn.set_backend_tls_fallback_allowed(true);
+
+	// CapGet -> CapabilitiesSet(tls=true).
+	conn.step_auth();
+	{
+		uint8_t buf[4096];
+		usleep(5000);
+		read(fds[1], buf, sizeof(buf));  // drain CapGet from wire
+	}
+
+	// Backend returns capabilities with no TLS available, then we
+	// send CapabilitiesSet(tls=true), then it rejects with Error.
+	Mysqlx::Connection::Capabilities caps;
+	std::string caps_str;
+	caps.SerializeToString(&caps_str);
+	write_x_frame(fds[1], Mysqlx::ServerMessages_Type_CONN_CAPABILITIES,
+		reinterpret_cast<const uint8_t*>(caps_str.data()), caps_str.size());
+
+	conn.step_auth();
+	{
+		uint8_t buf[4096];
+		usleep(5000);
+		read(fds[1], buf, sizeof(buf));  // drain CapSet from wire
+	}
+	ok(conn.get_auth_state() == MysqlxConnection::BACKEND_AUTH_CAPABILITIES_SET_SENT,
+	   "preferred-mode: state is CAPABILITIES_SET_SENT after CapSet emitted");
+
+	// Inject the Mysqlx::Error response from the backend.
+	Mysqlx::Error err;
+	err.set_severity(Mysqlx::Error::ERROR);
+	err.set_code(5001);
+	err.set_msg("Capability prepare failed: tls");
+	err.set_sql_state("HY000");
+	std::string err_str;
+	err.SerializeToString(&err_str);
+	write_x_frame(fds[1], Mysqlx::ServerMessages_Type_ERROR,
+		reinterpret_cast<const uint8_t*>(err_str.data()), err_str.size());
+
+	usleep(5000);
+	int rc = conn.step_auth();
+	ok(rc == 1,
+	   "preferred-mode: step_auth returns 1 (in-progress) after Error -> fallback path taken");
+	ok(conn.get_auth_state() == MysqlxConnection::BACKEND_AUTH_AUTHENTICATE_START_SENT,
+	   "preferred-mode: fallback transitions to AUTHENTICATE_START_SENT");
+	ok(!conn.is_backend_tls_required(),
+	   "preferred-mode: backend_tls_required_ cleared so subsequent steps don't reattempt TLS");
+	ok(!conn.is_tls_active(),
+	   "preferred-mode: tls_active stays false after fallback (no handshake performed)");
+
+	// Verify the SESS_AUTHENTICATE_START frame landed on the wire.
+	uint8_t buf[4096];
+	usleep(5000);
+	ssize_t r = read(fds[1], buf, sizeof(buf));
+	ok(r >= 5 && buf[4] == Mysqlx::ClientMessages_Type_SESS_AUTHENTICATE_START,
+	   "preferred-mode: AuthenticateStart frame emitted on plaintext socket after fallback");
+
+	close(fds[0]);
+	close(fds[1]);
+}
+
+// required-mode TLS hard-fail (issue #5693).
+// Counterpart to the preferred-mode test: same Error injection, but
+// fallback_allowed=false (matches mysqlx_tls_backend_mode=required and
+// AsClient + frontend-TLS combinations). Expect the connection to
+// fail with rc=-1 and BACKEND_AUTH_ERROR — NOT to silently downgrade.
+static void test_backend_auth_required_mode_no_fallback_on_error() {
+	diag(">>> %s", __func__);
+	int fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+
+	MysqlxConnection conn;
+	conn.set_fd(fds[0]);
+	conn.set_backend_user("testuser");
+	conn.init_backend_ds(fds[0]);
+	conn.set_state(MysqlxConnection::AUTHENTICATING);
+
+	conn.set_backend_tls_required(true);
+	conn.set_backend_tls_fallback_allowed(false);
+
+	conn.step_auth();
+	{
+		uint8_t buf[4096];
+		usleep(5000);
+		read(fds[1], buf, sizeof(buf));
+	}
+
+	Mysqlx::Connection::Capabilities caps;
+	std::string caps_str;
+	caps.SerializeToString(&caps_str);
+	write_x_frame(fds[1], Mysqlx::ServerMessages_Type_CONN_CAPABILITIES,
+		reinterpret_cast<const uint8_t*>(caps_str.data()), caps_str.size());
+
+	conn.step_auth();
+	{
+		uint8_t buf[4096];
+		usleep(5000);
+		read(fds[1], buf, sizeof(buf));
+	}
+
+	write_x_frame(fds[1], Mysqlx::ServerMessages_Type_ERROR, nullptr, 0);
+
+	usleep(5000);
+	int rc = conn.step_auth();
+	ok(rc == -1,
+	   "required-mode: step_auth returns -1 on Error when fallback not allowed");
+	ok(conn.get_auth_state() == MysqlxConnection::BACKEND_AUTH_ERROR,
+	   "required-mode: auth_state is ERROR (no silent downgrade)");
+
+	close(fds[0]);
+	close(fds[1]);
+}
+
 static void test_backend_auth_not_started_returns_progress() {
 	diag(">>> %s", __func__);
 	MysqlxConnection conn;
@@ -296,7 +437,7 @@ static void test_backend_reset_clears_auth() {
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(34);
+	plan(42);
 	diag("=== mysqlx_backend_auth_unit-t starting ===");
 
 	test_backend_auth_state_transitions();
@@ -304,6 +445,8 @@ int main() {
 	test_backend_auth_notice_skip();
 	test_backend_auth_error_on_wrong_caps_response();
 	test_backend_auth_error_on_set_caps_reject();
+	test_backend_auth_preferred_mode_fallback_to_plaintext();
+	test_backend_auth_required_mode_no_fallback_on_error();
 	test_backend_auth_not_started_returns_progress();
 	test_backend_reset_clears_auth();
 

--- a/test/tap/tests/unit/mysqlx_config_store_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_config_store_unit-t.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<SQLite3DB> create_test_db() {
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(24);
+	plan(33);
 	diag("=== mysqlx_config_store_unit-t starting ===");
 
 	MysqlxResolvedIdentity identity {};
@@ -190,6 +190,79 @@ int main() {
 	   store.install_variables_from_admin(*db, err) && err.empty() &&
 	   store.get_backend_tls_mode() == MysqlxBackendTlsMode::required,
 	   "absent mysqlx_tls_backend_mode row leaves cached mode untouched");
+
+	// --- per-route tls_mode (issue #5692, TLS passthrough) ---
+	//
+	// Parser exercise (mirrors the backend-tls-mode block above).
+	ok(mysqlx_route_tls_mode_from_string("inherit") ==
+	   std::optional<MysqlxRouteTlsMode>(MysqlxRouteTlsMode::inherit) &&
+	   mysqlx_route_tls_mode_from_string("DISABLED") ==
+	   std::optional<MysqlxRouteTlsMode>(MysqlxRouteTlsMode::disabled) &&
+	   mysqlx_route_tls_mode_from_string("Preferred") ==
+	   std::optional<MysqlxRouteTlsMode>(MysqlxRouteTlsMode::preferred) &&
+	   mysqlx_route_tls_mode_from_string("required") ==
+	   std::optional<MysqlxRouteTlsMode>(MysqlxRouteTlsMode::required) &&
+	   mysqlx_route_tls_mode_from_string("PASSTHROUGH") ==
+	   std::optional<MysqlxRouteTlsMode>(MysqlxRouteTlsMode::passthrough),
+	   "route tls mode parser accepts all five documented values case-insensitively");
+	ok(mysqlx_route_tls_mode_from_string("") ==
+	   std::optional<MysqlxRouteTlsMode>(MysqlxRouteTlsMode::inherit),
+	   "route tls mode parser collapses empty/NULL to inherit");
+	ok(!mysqlx_route_tls_mode_from_string("nonsense").has_value(),
+	   "route tls mode parser rejects unknown values");
+	ok(std::string(mysqlx_route_tls_mode_to_string(MysqlxRouteTlsMode::passthrough)) == "passthrough" &&
+	   std::string(mysqlx_route_tls_mode_to_string(MysqlxRouteTlsMode::inherit)) == "inherit",
+	   "route tls mode renders to canonical lowercase string");
+
+	// Default value: any route loaded without an explicit tls_mode
+	// remains inherit (already the case for the 'rw' route loaded above
+	// via install_all_from_admin against the legacy mysqlx_routes DDL,
+	// which has no tls_mode column).
+	ok(store.route_tls_mode("rw") == MysqlxRouteTlsMode::inherit,
+	   "route loaded from legacy schema (no tls_mode column) defaults to inherit");
+	ok(store.route_tls_mode("nonexistent") == MysqlxRouteTlsMode::inherit,
+	   "unknown route reports inherit (safest default)");
+
+	// Round-trip: SAVE a route with passthrough mode, then re-LOAD it
+	// against a schema that DOES have the tls_mode column.
+	{
+		auto db2 = create_test_db();
+		ok(db2->execute(ADMIN_SQLITE_RUNTIME_MYSQL_USERS) &&
+		   db2->execute(ADMIN_SQLITE_TABLE_RUNTIME_MYSQL_SERVERS) &&
+		   db2->execute(
+			   "CREATE TABLE mysqlx_routes ("
+			   " name VARCHAR NOT NULL PRIMARY KEY,"
+			   " bind VARCHAR NOT NULL,"
+			   " destination_hostgroup INT NOT NULL,"
+			   " fallback_hostgroup INT,"
+			   " strategy VARCHAR NOT NULL DEFAULT 'first_available',"
+			   " active INT NOT NULL DEFAULT 1,"
+			   " attributes VARCHAR NOT NULL DEFAULT '',"
+			   " comment VARCHAR NOT NULL DEFAULT '',"
+			   " tls_mode VARCHAR NOT NULL DEFAULT 'inherit')") &&
+		   db2->execute(
+			   "INSERT INTO mysqlx_routes "
+			   "(name, bind, destination_hostgroup, strategy, tls_mode) VALUES "
+			   "('compliance', '127.0.0.1:7777', 99, 'first_available', 'passthrough')") &&
+		   db2->execute(
+			   "INSERT INTO mysqlx_routes "
+			   "(name, bind, destination_hostgroup, strategy, tls_mode) VALUES "
+			   "('admin', '127.0.0.1:7778', 99, 'first_available', 'inherit')"),
+		   "schema with tls_mode column and two passthrough/inherit rows is created");
+
+		MysqlxConfigStore store2 {};
+		std::string err2;
+		ok(store2.install_routes_from_admin(*db2, err2) && err2.empty() &&
+		   store2.route_tls_mode("compliance") == MysqlxRouteTlsMode::passthrough &&
+		   store2.route_tls_mode("admin") == MysqlxRouteTlsMode::inherit,
+		   "install_routes_from_admin reads tls_mode column for each row");
+
+		// Reject a malformed value.
+		ok(db2->execute("UPDATE mysqlx_routes SET tls_mode='garbage' WHERE name='compliance'") &&
+		   !store2.install_routes_from_admin(*db2, err2) &&
+		   err2.find("garbage") != std::string::npos,
+		   "install_routes_from_admin surfaces malformed tls_mode with descriptive error");
+	}
 
 	return exit_status();
 }

--- a/test/tap/tests/unit/mysqlx_config_store_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_config_store_unit-t.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<SQLite3DB> create_test_db() {
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(16);
+	plan(24);
 	diag("=== mysqlx_config_store_unit-t starting ===");
 
 	MysqlxResolvedIdentity identity {};
@@ -140,6 +140,56 @@ int main() {
 	store.bump_topology_generation();
 	ok(store.topology_generation() == 1,
 	   "topology generation increments on demand");
+
+	// --- mysqlx_tls_backend_mode (asymmetric TLS / AsClient mode) ---
+
+	// String parser exercise: each documented value parses, unknown
+	// values produce nullopt so the install path can surface a useful
+	// error to the operator instead of silently coercing to default.
+	ok(mysqlx_backend_tls_mode_from_string("disabled") ==
+	   std::optional<MysqlxBackendTlsMode>(MysqlxBackendTlsMode::disabled) &&
+	   mysqlx_backend_tls_mode_from_string("PREFERRED") ==
+	   std::optional<MysqlxBackendTlsMode>(MysqlxBackendTlsMode::preferred) &&
+	   mysqlx_backend_tls_mode_from_string("Required") ==
+	   std::optional<MysqlxBackendTlsMode>(MysqlxBackendTlsMode::required) &&
+	   mysqlx_backend_tls_mode_from_string("as_client") ==
+	   std::optional<MysqlxBackendTlsMode>(MysqlxBackendTlsMode::as_client),
+	   "backend tls mode parser accepts all four documented values case-insensitively");
+	ok(!mysqlx_backend_tls_mode_from_string("nonsense").has_value() &&
+	   !mysqlx_backend_tls_mode_from_string("").has_value(),
+	   "backend tls mode parser rejects unknown values");
+	ok(std::string(mysqlx_backend_tls_mode_to_string(MysqlxBackendTlsMode::as_client)) == "as_client",
+	   "backend tls mode renders to canonical lowercase string");
+
+	// Default value: as_client matches the legacy implicit behaviour
+	// where backend TLS was tied to client TLS at resolve time.
+	ok(store.get_backend_tls_mode() == MysqlxBackendTlsMode::as_client,
+	   "store defaults backend tls mode to as_client (matches legacy behaviour)");
+
+	// LOAD round-trip: an explicit row should be parsed and cached.
+	ok(db->execute("INSERT INTO mysqlx_variables (variable_name, variable_value) VALUES "
+	               "('mysqlx_tls_backend_mode', 'required')") &&
+	   store.install_variables_from_admin(*db, err) && err.empty() &&
+	   store.get_backend_tls_mode() == MysqlxBackendTlsMode::required,
+	   "store parses explicit mysqlx_tls_backend_mode='required' from admin");
+
+	// Invalid value: install must fail with a non-empty err describing the bad value.
+	ok(db->execute("UPDATE mysqlx_variables SET variable_value='garbage' "
+	               "WHERE variable_name='mysqlx_tls_backend_mode'") &&
+	   !store.install_variables_from_admin(*db, err) &&
+	   err.find("garbage") != std::string::npos,
+	   "store rejects invalid mysqlx_tls_backend_mode with descriptive error");
+	ok(store.get_backend_tls_mode() == MysqlxBackendTlsMode::required,
+	   "store retains last-good backend tls mode after rejected install");
+
+	// Absent row: removing the variable leaves the cached value alone.
+	// Reset `err` first because the previous failing call left a message
+	// in it; install_variables_from_admin only writes on failure.
+	err.clear();
+	ok(db->execute("DELETE FROM mysqlx_variables WHERE variable_name='mysqlx_tls_backend_mode'") &&
+	   store.install_variables_from_admin(*db, err) && err.empty() &&
+	   store.get_backend_tls_mode() == MysqlxBackendTlsMode::required,
+	   "absent mysqlx_tls_backend_mode row leaves cached mode untouched");
 
 	return exit_status();
 }

--- a/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
@@ -13,6 +13,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <vector>
@@ -628,6 +629,304 @@ static void test_return_backend_on_session_close() {
 	close(fds[1]);
 }
 
+// ------------------------------------------------------------------
+// Per-message response-state validation tests (#5694).
+//
+// Each test drives an authenticated session into a specific
+// response_state_, hands the session a fake backend over a socketpair,
+// writes one or more synthetic server frames into the backend half of
+// the pair, then calls handler() and inspects what was forwarded to
+// the client and whether the session was rejected. The fixture mirrors
+// check_dispatch_routes_to_backend's setup but uses the test-only
+// set_response_state_for_test() to avoid having to drive a full client
+// message round-trip per scenario.
+// ------------------------------------------------------------------
+
+// Helper to send a server-shaped X-Protocol frame. Wire format is
+// direction-agnostic (5-byte header: little-endian length + msg type),
+// so this is a renamed alias of write_x_frame for reader clarity at
+// the call site.
+static inline void write_server_frame(int fd, uint8_t msg_type,
+                                       const uint8_t* payload, size_t payload_len) {
+	write_x_frame(fd, msg_type, payload, payload_len);
+}
+
+// Returns true iff the next frame on `fd` has the given server msg
+// type. Drains the frame; non-blocking via the socketpair's default.
+static bool client_received_frame(int fd, uint8_t expected_msg_type) {
+	uint8_t buf[4096];
+	usleep(5000);
+	ssize_t r = read_x_frame(fd, buf, sizeof(buf));
+	return (r > 4 && buf[4] == expected_msg_type);
+}
+
+// Drains and discards any frames pending on `fd`. Used to clear the
+// auth round-trip's leftover bytes before a test starts asserting on
+// what the validation hook produced. fd is made non-blocking so the
+// drain returns instead of waiting on an empty socket.
+static void drain_frames(int fd) {
+	int flags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	uint8_t buf[4096];
+	usleep(5000);
+	while (true) {
+		ssize_t r = read(fd, buf, sizeof(buf));
+		if (r <= 0) break;
+	}
+	fcntl(fd, F_SETFL, flags);
+}
+
+// Common setup: build an authenticated session backed by a fake idle
+// backend over a socketpair, drain the auth-OK frame from the client
+// side, parking the session in WAITING_SERVER_XMSG with the requested
+// response_state_ so the next handler() call enters the validation
+// loop. Returns the four fds via out-params; caller closes.
+static void setup_session_for_validation(MysqlxSession& sess,
+                                          int client_fds[2],
+                                          int backend_fds[2],
+                                          MysqlxResponseState rs) {
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+
+	setup_authenticated_session(client_fds, sess);
+	drain_frames(client_fds[1]);
+
+	MysqlxConnection* conn = new MysqlxConnection();
+	conn->set_fd(backend_fds[0]);
+	conn->set_state(MysqlxConnection::IDLE);
+	conn->set_reusable(true);
+	sess.backend_conn() = conn;
+	sess.server_ds().init(XDS_BACKEND, backend_fds[0]);
+
+	sess.set_status(MysqlxSession::WAITING_SERVER_XMSG);
+	sess.set_response_state_for_test(rs);
+	sess.to_process = true;
+}
+
+// Test 1: STMT_EXECUTE → ROW (without preceding ColumnMetaData) →
+// reject. Canonical hostile-backend case in the issue.
+static void test_validation_stmt_execute_row_without_metadata() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_STMT_EXECUTE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	sess.handler();
+
+	ok(client_received_frame(client_fds[1], Mysqlx::ServerMessages_Type_ERROR),
+	   "validation rejects ROW-without-metadata with X-Protocol Error");
+	ok(!sess.is_healthy(),
+	   "session marked unhealthy after rejected backend frame");
+	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSING,
+	   "session transitions to X_SESSION_CLOSING on validation reject");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 2: STMT_EXECUTE → ColumnMetaData → ROW → SQL_STMT_EXECUTE_OK →
+// happy-path forward. Validates the gating doesn't reject legitimate
+// well-ordered traffic.
+static void test_validation_stmt_execute_metadata_then_row() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_STMT_EXECUTE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "happy-path STMT_EXECUTE response is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets to IDLE after terminal");
+	ok(!sess.seen_column_metadata_for_test(),
+	   "seen_column_metadata_ cleared at terminal-frame flush");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 3: CURSOR_OPEN → ColumnMetaData → ROW → FETCH_SUSPENDED →
+// terminal, but seen_column_metadata_ is preserved per X-Protocol
+// (Cursor::Fetch reuses the metadata from Cursor::Open).
+static void test_validation_cursor_open_fetch_suspended() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_CURSOR_OPEN);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_FETCH_SUSPENDED, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "CursorOpen with FETCH_SUSPENDED is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets after FETCH_SUSPENDED terminal");
+	// Documented invariant: the column-metadata flag is cleared at
+	// terminal-frame flush regardless of which response shape ended.
+	// Cursor::Fetch's allowed-set unconditionally accepts ROW (the
+	// metadata was sent at Cursor::Open and carries on the wire to
+	// the client; the proxy's flag does not need to track this).
+	ok(!sess.seen_column_metadata_for_test(),
+	   "seen_column_metadata_ cleared at FETCH_SUSPENDED terminal "
+	   "(Cursor::Fetch's allow-set does not consult the flag)");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 4: CURSOR_OPEN → ColumnMetaData → ROW → FETCH_DONE → terminal
+// with the flag cleared. Mirrors test 3 for the fully-drained cursor
+// path.
+static void test_validation_cursor_open_fetch_done() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_CURSOR_OPEN);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(), "CursorOpen with FETCH_DONE is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets after FETCH_DONE terminal");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 5: PREPARE_PREPARE → SQL_STMT_EXECUTE_OK → reject (only Mysqlx.Ok
+// is the valid terminal for Prepare::Prepare).
+static void test_validation_prepare_prepare_rejects_stmt_execute_ok() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_PREPARE_PREPARE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK, nullptr, 0);
+	sess.handler();
+
+	ok(client_received_frame(client_fds[1], Mysqlx::ServerMessages_Type_ERROR),
+	   "PREPARE_PREPARE rejects SQL_STMT_EXECUTE_OK with X-Protocol Error");
+	ok(!sess.is_healthy(),
+	   "session marked unhealthy after PREPARE_PREPARE rejection");
+	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSING,
+	   "session transitions to X_SESSION_CLOSING on PREPARE_PREPARE reject");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 6: PREPARE_PREPARE → OK → terminal. Happy-path counterpart
+// to test 5.
+static void test_validation_prepare_prepare_accepts_ok() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_PREPARE_PREPARE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_OK, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(), "PREPARE_PREPARE happy-path OK is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "response_state_ resets after PREPARE_PREPARE OK terminal");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 7: STMT_EXECUTE → ColumnMetaData → NOTICE → ROW →
+// SQL_STMT_EXECUTE_OK. NOTICE is non-terminal in every state and must
+// not consume the terminal slot or trigger rejection.
+static void test_validation_notice_mid_result() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_STMT_EXECUTE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_NOTICE, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "NOTICE mid-result is not rejected");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "STMT_EXECUTE_OK terminates response after intermixed NOTICE");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 8: CURSOR_FETCH → ROW (with no preceding ColumnMetaData in this
+// response sequence) → forwarded, NOT rejected. Validates the
+// per-state-pair carve-out — Cursor::Fetch's allowed-set accepts ROW
+// unconditionally because the metadata was sent at Cursor::Open time.
+static void test_validation_cursor_fetch_row_without_metadata_allowed() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_CURSOR_FETCH);
+
+	// Note: seen_column_metadata_ is *false* here — we deliberately
+	// did NOT pre-set it. The point is to prove CURSOR_FETCH does not
+	// consult the flag.
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "CURSOR_FETCH accepts ROW without per-response metadata "
+	   "(metadata carried over from Cursor::Open in the X-Protocol)");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "FETCH_DONE terminates the CURSOR_FETCH response");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
 	// Plan count rationale (per assertion source):
@@ -676,6 +975,16 @@ int main() {
 	test_forward_to_backend_no_connection();
 	test_forward_to_backend_with_socketpair();
 	test_return_backend_on_session_close();
+
+	// Per-message response-state validation (#5694).
+	test_validation_stmt_execute_row_without_metadata();
+	test_validation_stmt_execute_metadata_then_row();
+	test_validation_cursor_open_fetch_suspended();
+	test_validation_cursor_open_fetch_done();
+	test_validation_prepare_prepare_rejects_stmt_execute_ok();
+	test_validation_prepare_prepare_accepts_ok();
+	test_validation_notice_mid_result();
+	test_validation_cursor_fetch_row_without_metadata_allowed();
 
 	return exit_status();
 }

--- a/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
@@ -457,11 +457,11 @@ static void test_connection_pool_matching() {
 	c1->set_state(MysqlxConnection::IDLE);
 	thr.return_connection_to_cache(c1);
 
-	MysqlxConnection* found = thr.get_connection_from_cache(0, "root", "test");
+	MysqlxConnection* found = thr.get_connection_from_cache(0, "root", "test", /*tls_active=*/false);
 	ok(found != nullptr, "found by hostgroup/user/schema");
 	ok(found == c1, "got correct connection");
 
-	MysqlxConnection* nf1 = thr.get_connection_from_cache(1, "root", "test");
+	MysqlxConnection* nf1 = thr.get_connection_from_cache(1, "root", "test", /*tls_active=*/false);
 	ok(nf1 == nullptr, "wrong hostgroup not found");
 
 	MysqlxConnection* c2 = new MysqlxConnection();
@@ -472,13 +472,13 @@ static void test_connection_pool_matching() {
 	c2->set_state(MysqlxConnection::IDLE);
 	thr.return_connection_to_cache(c2);
 
-	MysqlxConnection* nf2 = thr.get_connection_from_cache(0, "other", "test");
+	MysqlxConnection* nf2 = thr.get_connection_from_cache(0, "other", "test", /*tls_active=*/false);
 	ok(nf2 == nullptr, "wrong user not found");
 
-	MysqlxConnection* nf3 = thr.get_connection_from_cache(0, "root", "other");
+	MysqlxConnection* nf3 = thr.get_connection_from_cache(0, "root", "other", /*tls_active=*/false);
 	ok(nf3 == nullptr, "wrong schema not found");
 
-	MysqlxConnection* f2 = thr.get_connection_from_cache(0, "root", "test");
+	MysqlxConnection* f2 = thr.get_connection_from_cache(0, "root", "test", /*tls_active=*/false);
 	ok(f2 != nullptr, "found second cached connection");
 }
 
@@ -927,6 +927,98 @@ static void test_validation_cursor_fetch_row_without_metadata_allowed() {
 	close(backend_fds[0]); close(backend_fds[1]);
 }
 
+// =====================================================================
+// Backend TLS mode resolution (issue #5693, P1: asymmetric TLS /
+// AsClient mode parity gap with MySQL Router 8.0).
+//
+// `mysqlx_resolve_backend_tls_decision` is the per-session decision
+// function lifted out of MysqlxSession::handler_connecting_server so
+// the 8 (mode x frontend_tls) combinations called out in the issue
+// can be unit-tested directly. Each cell of the matrix asserts both
+// `require_tls` (whether CapabilitiesSet(tls=true) gets sent) and
+// `fallback_allowed` (whether a Mysqlx::Error from that exchange is
+// allowed to downgrade to plaintext).
+//
+// The 8 documented combinations:
+//
+//   | mode      | frontend TLS | require_tls | fallback_allowed |
+//   |-----------|--------------|-------------|------------------|
+//   | disabled  | plaintext    | false       | false            |
+//   | disabled  | TLS          | false       | false            |
+//   | preferred | plaintext    | true        | true             |
+//   | preferred | TLS          | true        | true             |
+//   | required  | plaintext    | true        | false            |
+//   | required  | TLS          | true        | false            |
+//   | as_client | plaintext    | false       | false            |
+//   | as_client | TLS          | true        | false            |
+//
+// Plus three orthogonal cases:
+//   * endpoint use_ssl=1 promotes plaintext -> TLS under mode=disabled
+//   * endpoint use_ssl=1 leaves TLS-already-required mode unchanged
+//   * endpoint use_ssl=1 under mode=preferred preserves fallback semantics
+static void check_tls_decision(MysqlxBackendTlsMode mode,
+                               bool endpoint_override,
+                               bool frontend_tls,
+                               bool expected_require_tls,
+                               bool expected_fallback,
+                               const char* desc) {
+	auto d = mysqlx_resolve_backend_tls_decision(mode, endpoint_override, frontend_tls);
+	ok(d.require_tls == expected_require_tls && d.fallback_allowed == expected_fallback,
+	   "%s: require_tls=%d fallback_allowed=%d (got require_tls=%d fallback_allowed=%d)",
+	   desc,
+	   expected_require_tls ? 1 : 0,
+	   expected_fallback ? 1 : 0,
+	   d.require_tls ? 1 : 0,
+	   d.fallback_allowed ? 1 : 0);
+}
+
+static void test_backend_tls_mode_resolution_8_combinations() {
+	diag(">>> %s", __func__);
+	// disabled: plaintext output regardless of frontend TLS.
+	check_tls_decision(MysqlxBackendTlsMode::disabled,  false, false, false, false,
+	                   "mode=disabled  frontend=plaintext");
+	check_tls_decision(MysqlxBackendTlsMode::disabled,  false, true,  false, false,
+	                   "mode=disabled  frontend=TLS");
+
+	// preferred: TLS attempted both times, fallback always allowed.
+	check_tls_decision(MysqlxBackendTlsMode::preferred, false, false, true,  true,
+	                   "mode=preferred frontend=plaintext");
+	check_tls_decision(MysqlxBackendTlsMode::preferred, false, true,  true,  true,
+	                   "mode=preferred frontend=TLS");
+
+	// required: TLS mandatory, fallback never allowed.
+	check_tls_decision(MysqlxBackendTlsMode::required,  false, false, true,  false,
+	                   "mode=required  frontend=plaintext");
+	check_tls_decision(MysqlxBackendTlsMode::required,  false, true,  true,  false,
+	                   "mode=required  frontend=TLS");
+
+	// as_client: backend posture mirrors frontend.
+	check_tls_decision(MysqlxBackendTlsMode::as_client, false, false, false, false,
+	                   "mode=as_client frontend=plaintext (mirrors)");
+	check_tls_decision(MysqlxBackendTlsMode::as_client, false, true,  true,  false,
+	                   "mode=as_client frontend=TLS (mirrors)");
+}
+
+static void test_backend_tls_mode_endpoint_override() {
+	diag(">>> %s", __func__);
+	// Endpoint override promotes plaintext to TLS even under mode=disabled.
+	check_tls_decision(MysqlxBackendTlsMode::disabled,  true,  false, true, false,
+	                   "endpoint use_ssl=1 promotes plaintext to TLS under mode=disabled");
+	// Endpoint override is idempotent under mode=required.
+	check_tls_decision(MysqlxBackendTlsMode::required,  true,  false, true, false,
+	                   "endpoint use_ssl=1 idempotent under mode=required");
+	// Endpoint override under mode=preferred preserves the soft "preferred"
+	// fallback semantics — promoting plaintext to TLS doesn't strip the
+	// best-effort downgrade path that the operator chose at the mode level.
+	check_tls_decision(MysqlxBackendTlsMode::preferred, true,  false, true, true,
+	                   "endpoint use_ssl=1 under mode=preferred preserves fallback");
+	// Endpoint override under mode=as_client + plaintext frontend is a way
+	// for an operator to force a single backend to TLS while leaving the
+	// rest of the fleet at the AsClient default.
+	check_tls_decision(MysqlxBackendTlsMode::as_client, true,  false, true, false,
+	                   "endpoint use_ssl=1 promotes plaintext->TLS under mode=as_client");
+}
+
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
 	// Plan count rationale (per assertion source):
@@ -985,6 +1077,10 @@ int main() {
 	test_validation_prepare_prepare_accepts_ok();
 	test_validation_notice_mid_result();
 	test_validation_cursor_fetch_row_without_metadata_allowed();
+
+	// Backend TLS mode resolution (#5693).
+	test_backend_tls_mode_resolution_8_combinations();
+	test_backend_tls_mode_endpoint_override();
 
 	return exit_status();
 }

--- a/test/tap/tests/unit/mysqlx_session_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_session_unit-t.cpp
@@ -778,9 +778,235 @@ static void test_session_timestamps() {
 	close(fds[1]);
 }
 
+#include <fcntl.h>
+
+// Passthrough splice tests (issue #5692). These exercise the
+// X_PASSTHROUGH_FORWARD state in isolation: the test sets up a
+// session with a socketpair as the "client" and a second socketpair
+// as the "backend", drives the session into the splice state via the
+// MYSQLX_TEST_BUILD-only enter_passthrough_for_test() helper, then
+// asserts that bytes written to one socket emerge unchanged from the
+// other after a pump.
+
+static void set_nonblocking_fd(int fd) {
+	int flags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+static void test_passthrough_listener_route_propagation() {
+	diag(">>> %s", __func__);
+	int fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+	set_nonblocking_fd(fds[0]);
+	MysqlxSession sess;
+	// init() with a logical route name records it before any
+	// X-Protocol traffic is exchanged.
+	sess.init(fds[0], nullptr, "compliance_route");
+	ok(sess.listener_route_name_for_test() == "compliance_route",
+	   "listener_route_name_ captured at init time");
+
+	// reset() must clear the route name so a recycled session does
+	// not leak the prior route's identity.
+	sess.reset();
+	ok(sess.listener_route_name_for_test().empty(),
+	   "reset() clears listener_route_name_");
+
+	close(fds[0]);
+	close(fds[1]);
+}
+
+static void test_passthrough_forward_client_to_backend() {
+	diag(">>> %s", __func__);
+	// Two socketpairs: one for the client side (sess <-> client_peer),
+	// one for the backend side (sess <-> backend_peer). Both sess fds
+	// must be non-blocking so the splice's read(2)/write(2) pump exits
+	// on EAGAIN instead of deadlocking on the empty side.
+	int client_fds[2], backend_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+	set_nonblocking_fd(client_fds[0]);
+	set_nonblocking_fd(backend_fds[0]);
+
+	MysqlxSession sess;
+	sess.init(client_fds[0], nullptr);
+	sess.enter_passthrough_for_test(backend_fds[0]);
+	ok(sess.get_status() == MysqlxSession::X_PASSTHROUGH_FORWARD,
+	   "session enters X_PASSTHROUGH_FORWARD via test helper");
+
+	// Push opaque bytes from the "client" peer toward the backend.
+	const char payload[] = "Hello backend, this is a TLS ClientHello surrogate.";
+	const ssize_t plen = static_cast<ssize_t>(sizeof(payload));
+	ssize_t written = write(client_fds[1], payload, plen);
+	ok(written == plen, "client peer wrote payload bytes");
+	usleep(5000);
+
+	// Drive one pump; bytes available on client_fds[0] should be
+	// read by the splice loop and forwarded to backend_fds[0].
+	sess.run_passthrough_pump_for_test();
+
+	char recv_buf[256] = {0};
+	ssize_t r = read(backend_fds[1], recv_buf, sizeof(recv_buf));
+	ok(r == plen, "backend peer received exactly the bytes the client sent");
+	ok(memcmp(recv_buf, payload, plen) == 0,
+	   "backend payload is byte-for-byte identical to the client payload");
+	ok(sess.is_healthy(), "session remains healthy after a successful pump");
+
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+static void test_passthrough_forward_backend_to_client() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+	set_nonblocking_fd(client_fds[0]);
+	set_nonblocking_fd(backend_fds[0]);
+
+	MysqlxSession sess;
+	sess.init(client_fds[0], nullptr);
+	sess.enter_passthrough_for_test(backend_fds[0]);
+
+	const char payload[] = "Server response: encrypted TLS record stream.";
+	const ssize_t plen = static_cast<ssize_t>(sizeof(payload));
+	ssize_t written = write(backend_fds[1], payload, plen);
+	ok(written == plen, "backend peer wrote response bytes");
+	usleep(5000);
+
+	sess.run_passthrough_pump_for_test();
+
+	char recv_buf[256] = {0};
+	ssize_t r = read(client_fds[1], recv_buf, sizeof(recv_buf));
+	ok(r == plen, "client peer received exactly the bytes the backend sent");
+	ok(memcmp(recv_buf, payload, plen) == 0,
+	   "client payload is byte-for-byte identical to the backend payload");
+
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+static void test_passthrough_close_on_client_eof() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+	set_nonblocking_fd(client_fds[0]);
+	set_nonblocking_fd(backend_fds[0]);
+
+	MysqlxSession sess;
+	sess.init(client_fds[0], nullptr);
+	sess.enter_passthrough_for_test(backend_fds[0]);
+
+	// Half-close the client peer so the next read on client_fds[0]
+	// returns 0 — the splice loop must transition to closing.
+	close(client_fds[1]);
+	usleep(5000);
+
+	sess.run_passthrough_pump_for_test();
+
+	ok(!sess.is_healthy(),
+	   "passthrough session marked unhealthy after client EOF");
+	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSING,
+	   "passthrough session transitions to X_SESSION_CLOSING after client EOF");
+
+	close(client_fds[0]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+static void test_passthrough_close_on_backend_eof() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+	set_nonblocking_fd(client_fds[0]);
+	set_nonblocking_fd(backend_fds[0]);
+
+	MysqlxSession sess;
+	sess.init(client_fds[0], nullptr);
+	sess.enter_passthrough_for_test(backend_fds[0]);
+
+	// Backend disconnects (e.g. after sending close_notify).
+	close(backend_fds[1]);
+	usleep(5000);
+
+	sess.run_passthrough_pump_for_test();
+
+	ok(!sess.is_healthy(),
+	   "passthrough session marked unhealthy after backend EOF");
+	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSING,
+	   "passthrough session transitions to X_SESSION_CLOSING after backend EOF");
+
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]);
+}
+
+static void test_passthrough_disables_backend_reuse() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+	set_nonblocking_fd(client_fds[0]);
+	set_nonblocking_fd(backend_fds[0]);
+
+	MysqlxSession sess;
+	sess.init(client_fds[0], nullptr);
+	sess.enter_passthrough_for_test(backend_fds[0]);
+
+	ok(sess.backend_conn() != nullptr,
+	   "passthrough session has a backend connection attached");
+	ok(!sess.backend_conn()->is_reusable(),
+	   "passthrough backend connection is non-reusable (never returns to pool)");
+	ok(sess.get_tls_mode() == TLS_PASSTHROUGH,
+	   "session reports TLS_PASSTHROUGH mode while in passthrough");
+
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+static void test_passthrough_handler_dispatch_skips_xprotocol() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+	set_nonblocking_fd(client_fds[0]);
+	set_nonblocking_fd(backend_fds[0]);
+
+	MysqlxSession sess;
+	sess.init(client_fds[0], nullptr);
+	sess.enter_passthrough_for_test(backend_fds[0]);
+
+	// Write a payload that LOOKS like it could be an X-Protocol frame
+	// header (size=4, msg_type=0x01) but is in fact opaque TLS bytes.
+	// In a non-passthrough state, handler() would parse this and
+	// almost certainly emit an error. In passthrough state it must
+	// be forwarded verbatim — proving the handler() fast-path skips
+	// the X-Protocol read/parse stage.
+	const uint8_t fake_frame[] = {0x04, 0x00, 0x00, 0x00, 0x01, 0xAA, 0xBB, 0xCC};
+	ssize_t w = write(client_fds[1], fake_frame, sizeof(fake_frame));
+	ok(w == static_cast<ssize_t>(sizeof(fake_frame)),
+	   "wrote fake-frame-shaped payload to client peer");
+	usleep(5000);
+
+	sess.to_process = true;
+	int rc = sess.handler();
+	ok(rc == 0, "handler() returns 0 in X_PASSTHROUGH_FORWARD state");
+	ok(sess.is_healthy(), "session healthy after splice — no X-Protocol parse");
+
+	uint8_t recv_buf[64] = {0};
+	ssize_t r = read(backend_fds[1], recv_buf, sizeof(recv_buf));
+	ok(r == static_cast<ssize_t>(sizeof(fake_frame)),
+	   "backend received the full opaque payload (no header strip)");
+	ok(memcmp(recv_buf, fake_frame, sizeof(fake_frame)) == 0,
+	   "backend bytes match — header bytes were forwarded, not consumed");
+
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(65);
+	// 65 (existing) + 22 (passthrough block: 2 + 5 + 3 + 2 + 2 + 3 + 5)
+	plan(87);
 	diag("=== mysqlx_session_unit-t starting ===");
 
 	test_session_init();
@@ -803,6 +1029,15 @@ int main() {
 	test_reset();
 	test_parse_error_detection();
 	test_session_timestamps();
+
+	// X_PASSTHROUGH_FORWARD splice mechanics.
+	test_passthrough_listener_route_propagation();
+	test_passthrough_forward_client_to_backend();
+	test_passthrough_forward_backend_to_client();
+	test_passthrough_close_on_client_eof();
+	test_passthrough_close_on_backend_eof();
+	test_passthrough_disables_backend_reuse();
+	test_passthrough_handler_dispatch_skips_xprotocol();
 
 	return exit_status();
 }

--- a/test/tap/tests/unit/mysqlx_stats_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_stats_unit-t.cpp
@@ -15,7 +15,7 @@
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(22);
+	plan(26);
 	diag("=== mysqlx_stats_unit-t starting ===");
 
 	// Test 1-3: Stats counters.
@@ -326,6 +326,59 @@ int main() {
 		writer.join();
 		reader.join();
 		ok(true, "concurrent get_conn_ok while record_conn_ok: no crash");
+	}
+
+	// Test 23-26: bytes_sent / bytes_recv accumulation (P0 of #5691).
+	{
+		MysqlxStatsStore store;
+		store.record_bytes_sent("rw", 1, 100);
+		store.record_bytes_sent("rw", 1, 250);
+		store.record_bytes_sent("ro", 2, 42);
+		store.record_bytes_recv("rw", 1, 1000);
+		store.record_bytes_recv("rw", 1, 1500);
+		store.record_bytes_recv("ro", 2, 7);
+		// Zero-sized payload increments must be a no-op.
+		store.record_bytes_sent("rw", 1, 0);
+		store.record_bytes_recv("rw", 1, 0);
+
+		// Mix in a conn_used so the row carries multiple counters.
+		store.record_conn_used("rw", 1);
+
+		SQLite3DB statsdb;
+		statsdb.open(const_cast<char*>(":memory:"), SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);  // NOSONAR: SQLite3DB::open requires non-const char*
+		statsdb.execute(
+			"CREATE TABLE stats_mysqlx_routes ("
+			" name TEXT PRIMARY KEY,"
+			" destination_hostgroup INT NOT NULL DEFAULT 0,"
+			" ConnOK INT NOT NULL DEFAULT 0,"
+			" ConnERR INT NOT NULL DEFAULT 0,"
+			" ConnUsed INT NOT NULL DEFAULT 0,"
+			" Bytes_data_sent BIGINT NOT NULL DEFAULT 0,"
+			" Bytes_data_recv BIGINT NOT NULL DEFAULT 0)"
+		);
+		store.flush_to_sqlite(statsdb);
+
+		int rw_sent = statsdb.return_one_int(
+			"SELECT Bytes_data_sent FROM stats_mysqlx_routes WHERE name='rw'");
+		int ro_sent = statsdb.return_one_int(
+			"SELECT Bytes_data_sent FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(rw_sent == 350 && ro_sent == 42,
+		   "bytes_sent accumulates per route (rw=%d ro=%d)", rw_sent, ro_sent);
+
+		int rw_recv = statsdb.return_one_int(
+			"SELECT Bytes_data_recv FROM stats_mysqlx_routes WHERE name='rw'");
+		int ro_recv = statsdb.return_one_int(
+			"SELECT Bytes_data_recv FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(rw_recv == 2500 && ro_recv == 7,
+		   "bytes_recv accumulates per route (rw=%d ro=%d)", rw_recv, ro_recv);
+
+		int rw_used = statsdb.return_one_int(
+			"SELECT ConnUsed FROM stats_mysqlx_routes WHERE name='rw'");
+		ok(rw_used == 1, "ConnUsed flushes to SQLite alongside bytes counters");
+
+		int ro_hg = statsdb.return_one_int(
+			"SELECT destination_hostgroup FROM stats_mysqlx_routes WHERE name='ro'");
+		ok(ro_hg == 2, "destination_hostgroup carried through bytes-only flush");
 	}
 
 	return exit_status();

--- a/test/tap/tests/unit/mysqlx_thread_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_thread_unit-t.cpp
@@ -116,7 +116,7 @@ static void test_connection_cache() {
 	thr.return_connection_to_cache(c1);
 	ok(thr.get_cached_connection_count() == 1, "cache has 1 connection");
 
-	MysqlxConnection* found = thr.get_connection_from_cache(0, "user1", "db1");
+	MysqlxConnection* found = thr.get_connection_from_cache(0, "user1", "db1", /*tls_active=*/false);
 	ok(found != nullptr, "found connection in cache");
 	ok(found == c1, "got the same connection back");
 	ok(thr.get_cached_connection_count() == 0, "cache empty after get");
@@ -124,7 +124,7 @@ static void test_connection_cache() {
 	thr.return_connection_to_cache(found);
 	ok(thr.get_cached_connection_count() == 1, "cache has 1 again");
 
-	MysqlxConnection* nf = thr.get_connection_from_cache(0, "wrong", "db1");
+	MysqlxConnection* nf = thr.get_connection_from_cache(0, "wrong", "db1", /*tls_active=*/false);
 	ok(nf == nullptr, "not found with wrong user");
 
 	for (int i = 0; i < 3; i++) {
@@ -139,9 +139,58 @@ static void test_connection_cache() {
 	ok(thr.get_cached_connection_count() == 3, "cache at max capacity after eviction");
 }
 
+// Connection-cache key: tls_active is a hard partition. A plaintext-
+// pooled connection MUST NOT be returned to a TLS-frontend session
+// (and vice versa); the encryption posture is part of the cache
+// identity. Without this dimension the AsClient/required modes would
+// hand TLS-required sessions plaintext backends and corrupt the wire
+// protocol.
+static void test_connection_cache_tls_partition() {
+	diag(">>> %s", __func__);
+	Mysqlx_Thread thr;
+	thr.init(0);
+	thr.set_max_cached_connections(10);
+
+	// Insert one plaintext and one encrypted connection at the same
+	// (hostgroup, user, schema) key.
+	MysqlxConnection* plaintext = new MysqlxConnection();
+	plaintext->set_hostgroup(7);
+	plaintext->set_user("u");
+	plaintext->set_schema("s");
+	plaintext->set_reusable(true);
+	plaintext->set_state(MysqlxConnection::IDLE);
+	plaintext->set_tls_active(false);
+	thr.return_connection_to_cache(plaintext);
+
+	MysqlxConnection* encrypted = new MysqlxConnection();
+	encrypted->set_hostgroup(7);
+	encrypted->set_user("u");
+	encrypted->set_schema("s");
+	encrypted->set_reusable(true);
+	encrypted->set_state(MysqlxConnection::IDLE);
+	encrypted->set_tls_active(true);
+	thr.return_connection_to_cache(encrypted);
+
+	// Plaintext lookup must return the plaintext connection only.
+	MysqlxConnection* got_pt = thr.get_connection_from_cache(7, "u", "s", /*tls_active=*/false);
+	ok(got_pt == plaintext, "plaintext lookup returns the plaintext-pooled conn");
+
+	// Now only the encrypted one is left. A plaintext lookup must miss.
+	MysqlxConnection* miss_pt = thr.get_connection_from_cache(7, "u", "s", /*tls_active=*/false);
+	ok(miss_pt == nullptr, "plaintext lookup misses an encrypted-pooled conn");
+
+	// The encrypted lookup picks up the remaining one.
+	MysqlxConnection* got_tls = thr.get_connection_from_cache(7, "u", "s", /*tls_active=*/true);
+	ok(got_tls == encrypted, "tls lookup returns the encrypted-pooled conn");
+
+	// Cleanup: tests own the conns once pulled out of the cache.
+	delete got_pt;
+	delete got_tls;
+}
+
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(22);
+	plan(25);
 	diag("=== mysqlx_thread_unit-t starting ===");
 
 	test_thread_init();
@@ -149,6 +198,7 @@ int main() {
 	test_thread_start_stop();
 	test_thread_accept_connection();
 	test_connection_cache();
+	test_connection_cache_tls_partition();
 
 	return exit_status();
 }


### PR DESCRIPTION
Implements per-route TLS Passthrough for the mysqlx plugin (issue #5692, P1 parity gap with MySQL Router 8.0). With this PR, ProxySQL exposes all five Router TLS modes — Disabled, Preferred, Required, AsClient, **and Passthrough**.

This stacks on PRs #5707 (asymmetric TLS / AsClient), #5706, and #5704; please merge those first.

## Summary

- **Per-route opt-in.** New `mysqlx_routes.tls_mode` column with values `inherit` (default — defer to global `mysqlx_tls_mode`), `disabled`, `preferred`, `required`, `passthrough`. Per-route was chosen over per-deployment because operators with mixed workloads typically want one compliance-pinned route on passthrough while keeping the others on the default proxy-terminated path with pooling and per-query routing.
- **Splice mechanics.** New `MysqlxSession::Status::X_PASSTHROUGH_FORWARD` state with a `read(2)`/`write(2)` pump that ferries opaque bytes (TLS handshake + application data) between the client and a single dedicated backend fd. Once entered, X-Protocol parsing is bypassed entirely. Pooling and multiplexing are disabled — the backend connection is non-reusable.
- **Listener-route propagation.** `Mysqlx_Thread::accept_new_connection` now looks the listener fd up in its parallel `listener_route_names_` vector and passes the route name into the new session at accept time. This is the hook the entry path (CapabilitiesSet on a passthrough route) needs to fire policies before any X-Protocol message is exchanged.
- **Docs updated.** README §8.1 grows a per-route override subsection covering all five values; new §8.4 covers the operator trade-offs (no pooling, no multiplexing, no per-query routing, byte-level observability only) with a worked example. MYSQL_ROUTER_PARITY.md flips the passthrough row from \"No\" to \"Yes\" and strikes through the corresponding P1 gap entry.

## Commits

1. `feat(mysqlx): add per-route tls_mode column with passthrough enum value` — schema + config-store wiring (parser, install with PRAGMA-probe for legacy schemas, save round-trip, runtime-view projection). Behaviour-preserving: `passthrough` is parsed and stored but the data-plane is wired in commit 2.
2. `feat(mysqlx): X_PASSTHROUGH_FORWARD session state — raw byte splice` — adds the state, the splice pump, the listener-route propagation, and the `MYSQLX_TEST_BUILD`-only `enter_passthrough_for_test()` injection helper used by the unit tests.
3. `docs(mysqlx): document tls_mode='passthrough' + Router parity matrix update` — README §4.3, §8.1, new §8.4; MYSQL_ROUTER_PARITY.md table + narrative + gap list + summary.

## Scope adjustment

The production entry path (CapabilitiesSet on a passthrough route triggering a backend connect followed by the splice transition) is **deferred to a follow-up**. It needs CONNECTING_SERVER-style state plumbing for pre-auth backend establishment, which is a much larger refactor than fits in a single P1 gap PR. This PR ships:
- the splice mechanics,
- the listener-route plumbing the entry path will need,
- the schema + config store needed for any wiring.

Unit-tests drive `X_PASSTHROUGH_FORWARD` directly via `enter_passthrough_for_test()` so the splice contract is asserted in isolation. Production wiring will land as a separate PR with its own behavioural tests against a real X-Protocol backend.

## Test plan

- [x] mysqlx_session_unit-t — 65 -> 87 (+22 assertions for splice mechanics, EOF handling, reuse-disabling, handler dispatch fast-path)
- [x] mysqlx_config_store_unit-t — 24 -> 33 (+9 assertions for tls_mode parser, schema round-trip, malformed-value rejection)
- [x] mysqlx_tls_unit-t, mysqlx_thread_unit-t, mysqlx_concurrent_unit-t, mysqlx_admin_schema_unit-t, mysqlx_message_dispatch_unit-t, mysqlx_route_store_unit-t — all unchanged, all passing under ASAN
- [ ] TAP behavioural tests against a real X-Protocol backend (out of scope for this PR — driven by the production-wiring follow-up)

All unit tests pass with `NOJEMALLOC=1 WITHASAN=1 PROXYSQLGENAI=1` and zero `not ok`. ASAN reports no leaks or use-after-free across the 87 + 33 + ... = 318 assertions in the 8 affected suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced TLS configuration with separate frontend and backend TLS mode settings.
  * Added per-route TLS mode override capability with support for passthrough mode.
  * Added TLS-aware connection pooling to prevent incompatible session reuse.
  * New traffic monitoring metrics tracking bytes sent and received per route.
  * Enhanced processlist statistics for improved session visibility.

* **Documentation**
  * Expanded TLS configuration guide with examples for all supported modes and configurations.
  * Updated runtime views schema to reflect new TLS and statistics capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->