### PR TITLE
Fix legacy-g5 cluster sync TAP assertion for disabled admin_variables sync

### DIFF
--- a/test/tap/tests/test_cluster_sync-t.cpp
+++ b/test/tap/tests/test_cluster_sync-t.cpp
@@ -968,11 +968,19 @@ int check_module_checksums_sync(
 		};
 
 		int sync_res = wait_for_node_sync(admin, { wait_remote_chksm_syn.str }, CHECKSUM_SYNC_TIMEOUT);
-		ok(
-			sync_res == 0,
-			"Primary(%s:%d) has detected the new checksum '%s' in the replica(%s:%d)",
-			admin->host, admin->port, ext_checksum.str.c_str(), r_admin->host, r_admin->port
-		);
+		if (module == "admin_variables" && diffs_sync == 0) {
+			ok(
+				sync_res == 1,
+				"Primary(%s:%d) has not detected disabled admin_variables checksum '%s' in the replica(%s:%d)",
+				admin->host, admin->port, ext_checksum.str.c_str(), r_admin->host, r_admin->port
+			);
+		} else {
+			ok(
+				sync_res == 0,
+				"Primary(%s:%d) has detected the new checksum '%s' in the replica(%s:%d)",
+				admin->host, admin->port, ext_checksum.str.c_str(), r_admin->host, r_admin->port
+			);
+		}
 
 		sync_res = wait_for_node_sync(admin, { wait_own_chksm_sync.str }, CHECKSUM_SYNC_TIMEOUT);
 		ok(


### PR DESCRIPTION
## Summary

This fixes the `test_cluster_sync-t` failure seen in the `legacy-g5` TAP group when `admin_variables` synchronization is intentionally disabled.

The test already verifies the correct disabled-sync behavior on the replica side, but it then performed one final primary-side assertion that contradicted that scenario. For `admin_variables` with sync disabled, the replica is expected to detect the primary checksum without applying it to runtime state. Because of that, the primary should not observe the primary checksum as the replica's runtime checksum.

## Root cause

`check_module_checksums_sync()` always expected the primary node to detect the newly generated checksum on the replica:

```cpp
sync_res == 0
```

That is correct for normal module sync, but it is wrong for this specific path:

```cpp
module == "admin_variables" && diffs_sync == 0
```

In that case, the test has intentionally disabled admin variable synchronization through the diff/checksum controls. The replica should not apply the primary's admin variable checksum to runtime state, and the primary should therefore not see that checksum reported back by the replica.

This is why the local `legacy-g5` run failed at the two disabled `admin_variables` cases:

```text
not ok 350 - Primary(proxysql:6032) has detected the new checksum '0xCCF9D028BE5E6790' in the replica(test-runner:16062)
not ok 387 - Primary(proxysql:6032) has detected the new checksum '0xCFBD52455090AC68' in the replica(test-runner:16062)
```

## Changes

- Keep the existing positive primary-side checksum assertion for normal synchronization cases.
- Add the matching negative assertion for `admin_variables` when `diffs_sync == 0`.
- Preserve the TAP plan count by replacing the incorrect assertion rather than adding or removing assertions.

## Validation

Built from a clean debug state before testing:

```bash
make cleanall
make debug -j$(nproc)
make build_tap_test_debug -j$(nproc)
```

Verified the binaries were debug builds:

```text
src/proxysql: with debug_info, not stripped
test/tap/tests/test_cluster_sync-t: with debug_info, not stripped
ProxySQL version 3.0.8-687-g849fad9_DEBUG, codename Truls
```

Ran the focused failing test under the `legacy-g5` environment after the fix:

```bash
export WORKSPACE="$PWD"
export INFRA_ID="local-legacy-g5-debug-fix-sync-1777690141"
export TAP_GROUP="legacy-g5"
export TEST_PY_TAP_INCL="^test_cluster_sync-t$"
unset SKIP_CLUSTER_START
source test/infra/common/env.sh
./test/infra/control/ensure-infras.bash
./test/infra/control/run-tests-isolated.bash
```

Result:

```text
SUMMARY: 'tests' PASS 1/336 : FAIL 0/336 : SKIP 335/336
tap_tests RC0:[]
SUMMARY: ret_rc = [0]
```

Ran the full `legacy-g5` group after the fix:

```bash
export WORKSPACE="$PWD"
export INFRA_ID="local-legacy-g5-debug-full-fix-1777690812"
export TAP_GROUP="legacy-g5"
unset TEST_PY_TAP_INCL
unset SKIP_CLUSTER_START
source test/infra/common/env.sh
./test/infra/control/ensure-infras.bash
./test/infra/control/run-tests-isolated.bash
```

Result:

```text
SUMMARY: 'tests' PASS 5/336 : FAIL 0/336 : SKIP 331/336
tap_tests RC0:[]
SUMMARY: ret_rc = [0]
```

Also checked the patch with:

```bash
git diff --check
```

## CI note

This PR fixes the source-level TAP assertion failure in `legacy-g5`. During investigation, the GitHub Actions `g5` workflow configuration was also found to export `SKIP_CLUSTER_START=1`, which prevents the cluster tests from having the required ProxySQL cluster nodes. That workflow configuration lives on the CI workflow branch and should be corrected separately for the GitHub Actions jobs to exercise these tests properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cluster synchronization test assertions to properly validate checksum detection behavior when specific modules are disabled, improving test accuracy for replica synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->