### PR TITLE
Enable cluster startup in g5 CI workflows

### DIFF
--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -78,7 +78,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-legacy-g5"
         export TAP_GROUP="legacy-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g5 tests
@@ -86,7 +85,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-legacy-g5"
         export TAP_GROUP="legacy-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -78,7 +78,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mysql84-g5"
         export TAP_GROUP="mysql84-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g5 tests
@@ -86,7 +85,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mysql84-g5"
         export TAP_GROUP="mysql84-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions workflow layer for the `CI-legacy-g5` and `CI-mysql84-g5` jobs.

Both workflow files were exporting `SKIP_CLUSTER_START=1` before running the g5 test groups. That prevented the required ProxySQL cluster nodes from being started, which means the cluster-oriented TAP tests in those groups were never exercising the real CI setup.

## Root cause

The g5 workflows were effectively disabling the cluster bootstrap step:

- `.github/workflows/ci-legacy-g5.yml`
- `.github/workflows/ci-mysql84-g5.yml`

Those jobs include cluster tests such as `test_cluster1-t` and `test_cluster_sync-t`, so skipping cluster startup breaks the intended test environment.

## Changes

- Remove `SKIP_CLUSTER_START=1` from the g5 setup step in `ci-legacy-g5.yml`.
- Remove `SKIP_CLUSTER_START=1` from the g5 setup step in `ci-mysql84-g5.yml`.
- Keep the rest of the workflow logic unchanged.

## Impact

With cluster startup enabled again, the g5 jobs should provision the required ProxySQL cluster nodes before running the TAP groups, which allows the cluster tests to run in the same environment they expect locally.

## Validation

This is a workflow-only change. I verified the diff is limited to the two YAML files and checked the patch with:

```bash
git diff --check
```

The branch was committed and pushed as:

- `f47fa9f90` - `Enable cluster startup in g5 workflows`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configuration to adjust cluster startup behavior during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->