### PR TITLE
ci: add ubuntu24-tap-tsan build matrix + ci-unit-tests-tsan reusable workflow

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -64,6 +64,17 @@ jobs:
           # ubuntu24 GenAI build with code coverage
           - dist: 'ubuntu24'
             type: '-tap-genai-gcov'
+          # ubuntu24 ThreadSanitizer build for the mysqlx + plugin chassis
+          # concurrent unit tests (issue #5675 phase 2). Scoped to the
+          # mysqlx feature stack — sets PROXYSQL40=1 (chassis tier) but
+          # NOT PROXYSQLGENAI=1; GenAI's modules aren't on the
+          # concurrency-heavy code paths TSAN targets and would inflate
+          # the cache size with no test benefit. WITHTSAN auto-forces
+          # NOJEMALLOC via include/makefiles_vars.mk. The 'tap' marker
+          # is required so the build target picks build_tap_test_debug
+          # (not just src/proxysql) — see Build step regex below.
+          - dist: 'ubuntu24'
+            type: '-tap-tsan'
           # ubuntu22 is needed for ASAN TAP testing
           # disabled to save cache space
           #- dist: 'ubuntu22'
@@ -135,6 +146,20 @@ jobs:
         if [[ "${{ matrix.type }}" =~ "-asan" ]]; then
           sed -i "/command/i \      - WITHASAN=1" docker-compose.yml
           sed -i "/command/i \      - TEST_WITHASAN=1" docker-compose.yml
+        fi
+        if [[ "${{ matrix.type }}" =~ "-tsan" ]]; then
+          # WITHTSAN auto-forces NOJEMALLOC via include/makefiles_vars.mk
+          # (TSAN is incompatible with jemalloc, same as ASAN). PROXYSQL40
+          # is set explicitly because the chassis tier is what enables the
+          # mysqlx plugin build — and TSAN's coverage target is exactly
+          # the mysqlx + plugin-chassis concurrent code paths. We do NOT
+          # set PROXYSQLGENAI here: the GenAI modules aren't on those
+          # concurrency-heavy paths and would inflate the cache for no
+          # test benefit. Note that PROXYSQL40 implies PROXYSQL31 +
+          # PROXYSQLFFTO + PROXYSQLTSDB via the Makefile cascade — those
+          # come along for free.
+          sed -i "/command/i \      - WITHTSAN=1" docker-compose.yml
+          sed -i "/command/i \      - PROXYSQL40=1" docker-compose.yml
         fi
         if [[ "${{ matrix.type }}" =~ "-genai" ]]; then
           sed -i "/command/i \      - PROXYSQLGENAI=1" docker-compose.yml

--- a/.github/workflows/ci-unit-tests-tsan.yml
+++ b/.github/workflows/ci-unit-tests-tsan.yml
@@ -1,0 +1,124 @@
+name: CI-unit-tests-tsan
+
+# Reusable workflow: restore the ${SHA}_ubuntu24-tap-tsan caches that
+# CI-builds populated with WITHTSAN=1 + PROXYSQL40=1, then run the
+# mysqlx-tsan-g1 TAP group (mysqlx + plugin-chassis concurrent unit
+# tests) under ThreadSanitizer.
+#
+# Closes Phase 2 of issue #5675. Mirrors the existing ci-unittests.yml
+# pattern; the only differences are (a) different cache key — the
+# tsan-instrumented build, (b) ASLR sysctl required for TSAN's shadow
+# region on Linux 5.18+ default vm.mmap_rnd_bits=32, (c) different
+# TAP group name (mysqlx-tsan-g1 not unit-tests-g1).
+#
+# Locally, a developer can produce the same effect with:
+#   make ubuntu24-tap-tsan
+#   sudo sysctl -w vm.mmap_rnd_bits=28
+#   WORKSPACE=$(pwd) INFRA_ID=dev-$USER TAP_GROUP=mysqlx-tsan-g1 \
+#       test/infra/control/run-tests-isolated.bash
+# Same harness; same TAP group; same TSAN_OPTIONS.
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+
+env:
+  SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    env:
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-tsan_src
+      MATRIX: '(mysqlx-tsan-g1)'
+
+    steps:
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ env.SHA }}
+        path: 'proxysql'
+        sparse-checkout: |
+          test/infra/control
+          test/tap/groups
+          test/scripts
+
+    - name: Cache restore src
+      id: cache-src
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ env.BLDCACHE }}
+        fail-on-cache-miss: true
+        path: |
+          proxysql/src/
+
+    - name: Cache restore test
+      id: cache-test
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-tsan_test
+        fail-on-cache-miss: true
+        path: |
+          proxysql/test/
+
+    - name: Verify binary
+      run: |
+        chmod +x proxysql/src/proxysql
+        file proxysql/src/proxysql
+
+    - name: Relax ASLR for ThreadSanitizer
+      # TSAN cannot reserve its shadow region on kernels with the
+      # default vm.mmap_rnd_bits=32. Lower it BEFORE any TSAN-instrumented
+      # binary is loaded — including build-helper binaries that may run
+      # later in this job. Same constraint as ASAN; see
+      # include/makefiles_vars.mk's WASAN warning block.
+      run: sudo sysctl -w vm.mmap_rnd_bits=28
+
+    - name: Run mysqlx-tsan-g1 (mysqlx + plugin chassis under TSAN)
+      run: |
+        cd proxysql
+        export INFRA_ID="ci-unit-tests-tsan"
+        export TAP_GROUP="mysqlx-tsan-g1"
+        test/infra/control/run-tests-isolated.bash
+
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories created inside the build container (root-owned).
+        # Make everything readable by the runner user before upload.
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
+    - name: Archive artifacts logs
+      if: ${{ failure() && !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_*_logs/
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
GH-Actions-side companion to the upcoming v3.0 PR for #5675 phase 2 (TSAN automation in CI), via the canonical CI-builds Docker pattern.

## What this PR adds

1. **\`ci-builds.yml\` matrix entry** \`{ dist: 'ubuntu24', type: '-tap-tsan' }\` plus a new \`-tsan\` inject pattern that runtime-amends \`docker-compose.yml\` with \`WITHTSAN=1\` + \`PROXYSQL40=1\`. Same shape as the existing \`-asan\` / \`-genai\` / \`-gcov\` patterns. Populates \`\${SHA}_ubuntu24-tap-tsan_{src,test}\` cache.

2. **New reusable \`ci-unit-tests-tsan.yml\`** that mirrors \`ci-unittests.yml\` but restores the \`-tap-tsan\` cache, sysctl's \`vm.mmap_rnd_bits=28\` (required for TSAN on Linux 5.18+ kernels), and runs \`TAP_GROUP=mysqlx-tsan-g1\` through the canonical \`test/infra/control/run-tests-isolated.bash\` harness.

## Why \`PROXYSQL40\` not \`PROXYSQLGENAI\`

The mysqlx plugin build is gated on \`PROXYSQL40\` (chassis tier). The GenAI/MCP/AI/RAG modules aren't on the concurrency-heavy code paths TSAN targets, so adding them would just inflate the build cache for no test benefit. Per the Makefile cascade, \`PROXYSQL40=1\` implies \`PROXYSQL31=1\` + \`PROXYSQLFFTO=1\` + \`PROXYSQLTSDB=1\`. Tracked under #5722 — the dead-PROXYSQLGENAI cleanup elsewhere in the workflows.

## Local-runnability invariant

A developer can produce the same effect locally:

\`\`\`bash
make ubuntu24-tap-tsan
sudo sysctl -w vm.mmap_rnd_bits=28
WORKSPACE=\$(pwd) INFRA_ID=dev-\$USER TAP_GROUP=mysqlx-tsan-g1 \\
    test/infra/control/run-tests-isolated.bash
\`\`\`

Same harness, same TAP group, same TSAN_OPTIONS as CI. No host-direct \`apt install\` or \`make build_deps_debug\` polluting the dev box — everything happens inside the container the dist-target spins up.

## Companion PR

A v3.0-side companion PR will add:
- The \`mysqlx-tsan-g1\` TAP group definition (\`test/tap/groups/mysqlx-tsan-g1/env.sh\` + \`groups.json\` entries)
- The \`WITHTSAN=1\` plumbing in \`include/makefiles_vars.mk\`
- A \`CI-unit-tests-tsan.yml\` caller workflow that calls into this PR's reusable

**Merge order**: this PR (GH-Actions) first, then the v3.0 PR.

## Refs

- #5675 (parent — TSAN automation in CI)
- #5721 (the broader \"containerize unit-test workflows\" architectural tracker; this PR is the first concrete step)
- Earlier rejected approach: PR #5720 (host-direct, closed in favor of this canonical pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with ThreadSanitizer testing support on Ubuntu 24.04 to improve code quality assurance and detection of threading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->