### PR TITLE
ci(tsan): drop bogus -p PROJECT from docker compose run

### DIFF
--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -132,15 +132,18 @@ jobs:
       # same volume mounts (defined on ubuntu24_dbg_build →
       # ubuntu24_build → _build).
       #
-      # The compose project name uses the same single-dot strip the
-      # Makefile binaries/proxysql% rule applies (`${GIT_VERSION/./}`,
-      # not `${GIT_VERSION//./}`) so this `run` lands in the namespace
-      # `make ubuntu24-tap` declared. Practically the build recipe
-      # tears its project down before exiting, so the only thing we'd
-      # observe from a mismatched project name is `docker compose`
-      # creating a fresh network/volume set on the fly — but keeping
-      # them consistent is the contract the rest of the build chain
-      # relies on.
+      # No `-p PROJECT` flag: the Makefile's `binaries/proxysql%`
+      # rule writes `-p "${GIT_VERSION/./}"` which *make* expands as
+      # a make variable reference (not bash parameter expansion), so
+      # the project name comes out as the empty string and docker
+      # compose falls back to the directory basename. We rely on the
+      # same default here so we land in the same project namespace.
+      # An earlier follow-up commit attempted to mirror the literal
+      # Makefile expression in bash, which kept a dot in the result
+      # and got rejected by docker compose v2's project-name
+      # validator ("invalid project name '30.8-693-gXXXX': must
+      # consist only of lowercase alphanumeric characters, hyphens,
+      # and underscores").
       #
       # SKIP_PROXYSQL=1 short-circuits the daemon + backend checks in
       # run-tests-isolated.bash, so it just iterates groups.json and
@@ -150,8 +153,6 @@ jobs:
         TAP_GROUP: mysqlx-tsan-g1
         INFRA_ID: ci-unit-tests-tsan
       run: |
-        GIT_VERSION="$(git describe --long --abbrev=7)"
-        PROJECT="${GIT_VERSION/./}"
         # Two on-the-fly apt installs: the build image is package-build-
         # focused, not test-execution-focused, so it ships neither.
         #   * python3-packaging: run-tests-isolated.bash uses it to
@@ -162,7 +163,7 @@ jobs:
         #     build phase, but `docker compose run --rm` starts from
         #     the original image so the runtime lib has to be
         #     re-installed here.
-        docker compose -p "${PROJECT}" run --rm \
+        docker compose run --rm \
           -e WORKSPACE=/opt/proxysql \
           -e INFRA_ID="${INFRA_ID}" \
           -e TAP_GROUP="${TAP_GROUP}" \


### PR DESCRIPTION
## Summary

One-line fix to \`CI-unit-tests-tsan.yml\`: drop the \`-p \"\${PROJECT}\"\` flag from the \`docker compose run\` invocation. Every CI-unit-tests-tsan run on v3.0 currently fails before reaching the test step with:

\`\`\`
invalid project name \"30.8-693-gXXXX\": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number
\`\`\`

## Root cause

Regression from 6099d06c1 (\"ci(tsan): address review findings on PR #5725\"), which mirrored the literal expression \`\${GIT_VERSION/./}\` from the Makefile into the workflow YAML on the assumption that it was bash parameter expansion stripping the first dot. It isn't: the Makefile recipe runs through *make* first, which treats \`\${GIT_VERSION/./}\` as a variable-name reference (the literal name \`GIT_VERSION/./\`), finds no such variable, and expands it to the empty string. So docker compose ends up invoked with \`-p \"\"\`, which falls back to the directory basename — same default a \`-p\`-less invocation gets.

The workflow YAML is interpreted by *bash*, where the same expression really does perform single-dot stripping, producing results with a remaining dot that docker compose v2 rejects.

Fix: drop the flag entirely, matching what the Makefile effectively does.

## Why the bug shipped

A workflow that uses \`workflow_run: workflows: [ CI-trigger ]\` cannot be exercised on its own PR cycle — GitHub Actions only fires workflow_run-triggered workflows from files that already exist on the default branch. So the original PR's CI cycle never actually ran the new workflow; only the post-merge CI on v3.0 did, and by then it was too late to catch without a follow-up.

Worth considering whether the next sanitizer/coverage workflow added should additionally trigger on \`pull_request\` (perhaps gated on a label) so we get one validating run before merge. Tracked separately if anyone wants to take it on.

## Test plan

- [x] Local repro of the v2 project-name validator error confirmed.
- [ ] CI: workflow_dispatch run after merge — same chicken-and-egg as the original PR, since this PR also can't auto-fire CI-unit-tests-tsan on its own cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test workflow configuration for improved containerized test execution.

---

**Note:** This release contains internal infrastructure improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->