### PR TITLE
fix: address SonarCloud BLOCKER findings (lock order, double-free, buffer overflow, dead code)

### DIFF
--- a/lib/Base_Session.cpp
+++ b/lib/Base_Session.cpp
@@ -393,9 +393,8 @@ bool Base_Session<S,DS,B,T>::has_any_backend() {
  */
 template<typename S, typename DS, typename B, typename T>
 void Base_Session<S,DS,B,T>::reset_all_backends() {
-	B *mybe;
 	while(mybes->len) {
-		mybe=(B *)mybes->remove_index_fast(0);
+		B *mybe=(B *)mybes->remove_index_fast(0);
 		mybe->reset();
 		delete mybe;
 	}

--- a/lib/ClickHouse_Authentication.cpp
+++ b/lib/ClickHouse_Authentication.cpp
@@ -210,11 +210,11 @@ int ClickHouse_Authentication::dump_all_users(ch_account_details_t ***ads, bool 
 	*ads=_ads;
 __exit_dump_all_users:
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
-	pthread_rwlock_unlock(&creds_frontends.lock);
 	pthread_rwlock_unlock(&creds_backends.lock);
+	pthread_rwlock_unlock(&creds_frontends.lock);
 #else
-	spin_rdunlock(&creds_frontends.lock);
 	spin_rdunlock(&creds_backends.lock);
+	spin_rdunlock(&creds_frontends.lock);
 #endif
 	return total_size;
 }

--- a/lib/MySQL_Authentication.cpp
+++ b/lib/MySQL_Authentication.cpp
@@ -306,11 +306,11 @@ unsigned int MySQL_Authentication::memory_usage() {
 	ret += sizeof(PtrArray);
 	ret += (creds_backends.cred_array->size * sizeof(void *));
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
-	pthread_rwlock_unlock(&creds_frontends.lock);
 	pthread_rwlock_unlock(&creds_backends.lock);
+	pthread_rwlock_unlock(&creds_frontends.lock);
 #else
-	spin_rdunlock(&creds_frontends.lock);
 	spin_rdunlock(&creds_backends.lock);
+	spin_rdunlock(&creds_frontends.lock);
 #endif
 	return ret;
 }
@@ -392,11 +392,11 @@ int MySQL_Authentication::dump_all_users(account_details_t ***ads, bool _complet
 	*ads=_ads;
 __exit_dump_all_users:
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
-	pthread_rwlock_unlock(&creds_frontends.lock);
 	pthread_rwlock_unlock(&creds_backends.lock);
+	pthread_rwlock_unlock(&creds_frontends.lock);
 #else
-	spin_rdunlock(&creds_frontends.lock);
 	spin_rdunlock(&creds_backends.lock);
+	spin_rdunlock(&creds_frontends.lock);
 #endif
 	return total_size;
 }

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -1622,8 +1622,10 @@ int MySQL_Session::handler_again___status_PINGING_SERVER() {
 		} else {
 			myds->destroy_MySQL_Connection_From_Pool(true);
 		}
-		delete mybe->server_myds;
-		mybe->server_myds=NULL;
+		if (mybe->server_myds) {
+			delete mybe->server_myds;
+			mybe->server_myds=NULL;
+		}
 		set_status(session_status___NONE);
 			return -1;
 	} else {
@@ -1641,8 +1643,10 @@ int MySQL_Session::handler_again___status_PINGING_SERVER() {
 			}
 			myds->destroy_MySQL_Connection_From_Pool(false);
 			myds->fd=0;
-			delete mybe->server_myds;
-			mybe->server_myds=NULL;
+			if (mybe->server_myds) {
+				delete mybe->server_myds;
+				mybe->server_myds=NULL;
+			}
 			return -1;
 		} else {
 			// rc==1 , nothing to do for now
@@ -1694,10 +1698,10 @@ int MySQL_Session::handler_again___status_RESETTING_CONNECTION() {
 //		if (mysql_thread___multiplexing && (myconn->reusable==true) && myds->myconn->IsActiveTransaction()==false && myds->myconn->MultiplexDisabled()==false) {
 			myds->return_MySQL_Connection_To_Pool();
 //		} else {
-//			myds->destroy_MySQL_Connection_From_Pool(true);
-//		}
-		delete mybe->server_myds;
-		mybe->server_myds=NULL;
+		if (mybe->server_myds) {
+			delete mybe->server_myds;
+			mybe->server_myds=NULL;
+		}
 		set_status(session_status___NONE);
 		return -1;
 	} else {

--- a/lib/PgSQL_Authentication.cpp
+++ b/lib/PgSQL_Authentication.cpp
@@ -250,11 +250,11 @@ unsigned int PgSQL_Authentication::memory_usage() {
 	ret += sizeof(PtrArray);
 	ret += (creds_backends.cred_array->size * sizeof(void *));
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
-	pthread_rwlock_unlock(&creds_frontends.lock);
 	pthread_rwlock_unlock(&creds_backends.lock);
+	pthread_rwlock_unlock(&creds_frontends.lock);
 #else
-	spin_rdunlock(&creds_frontends.lock);
 	spin_rdunlock(&creds_backends.lock);
+	spin_rdunlock(&creds_frontends.lock);
 #endif
 	return ret;
 }
@@ -327,11 +327,11 @@ int PgSQL_Authentication::dump_all_users(pgsql_account_details_t***ads, bool _co
 	*ads=_ads;
 __exit_dump_all_users:
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
-	pthread_rwlock_unlock(&creds_frontends.lock);
 	pthread_rwlock_unlock(&creds_backends.lock);
+	pthread_rwlock_unlock(&creds_frontends.lock);
 #else
-	spin_rdunlock(&creds_frontends.lock);
 	spin_rdunlock(&creds_backends.lock);
+	spin_rdunlock(&creds_frontends.lock);
 #endif
 	return total_size;
 }

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -1104,8 +1104,10 @@ int PgSQL_Session::handler_again___status_PINGING_SERVER() {
 		} else {
 			myds->destroy_MySQL_Connection_From_Pool(true);
 		}
-		delete mybe->server_myds;
-		mybe->server_myds = NULL;
+		if (mybe->server_myds) {
+			delete mybe->server_myds;
+			mybe->server_myds = NULL;
+		}
 		set_status(session_status___NONE);
 		return -1;
 	}
@@ -1125,8 +1127,10 @@ int PgSQL_Session::handler_again___status_PINGING_SERVER() {
 			}
 			myds->destroy_MySQL_Connection_From_Pool(false);
 			myds->fd = 0;
-			delete mybe->server_myds;
-			mybe->server_myds = NULL;
+			if (mybe->server_myds) {
+				delete mybe->server_myds;
+				mybe->server_myds = NULL;
+			}
 			return -1;
 		}
 		else {
@@ -1156,8 +1160,10 @@ int PgSQL_Session::handler_again___status_RESETTING_CONNECTION() {
 		myds->DSS = STATE_MARIADB_GENERIC;
 		myconn->async_state_machine = ASYNC_IDLE;
 		myds->return_MySQL_Connection_To_Pool();
-		delete mybe->server_myds;
-		mybe->server_myds = NULL;
+		if (mybe->server_myds) {
+			delete mybe->server_myds;
+			mybe->server_myds = NULL;
+		}
 		set_status(session_status___NONE);
 		return -1;
 	} else {

--- a/lib/mysql_backend.cpp
+++ b/lib/mysql_backend.cpp
@@ -27,5 +27,6 @@ void MySQL_Backend::reset() {
 	if (server_myds) {
 		server_myds->reset_connection();
 		delete server_myds;
+		server_myds = NULL;
 	}
 }

--- a/lib/sqlite3db.cpp
+++ b/lib/sqlite3db.cpp
@@ -705,8 +705,8 @@ void SQLite3_result::dump_to_stderr() {
 		size_t len = strlen(r->name);
 		if (len > columns_lengths[i]) {
 			columns_lengths[i] = len;
-			i++;
 		}
+		i++;
 	}
 	for (std::vector<SQLite3_row *>::iterator it=rows.begin() ; it!=rows.end(); ++it) {
 		SQLite3_row *r=*it;

--- a/lib/sqlite3db.cpp
+++ b/lib/sqlite3db.cpp
@@ -103,6 +103,8 @@ void SQLite3_row::add_fields(sqlite3_stmt *stmt) {
 	}
 	if (data_size) {
 		data=(char *)malloc(data_size);
+	} else {
+		data=NULL;
 	}
 	for (i=0;i<cnt;i++) {
 		t=(*proxy_sqlite3_column_type)(stmt,i);
@@ -110,17 +112,18 @@ void SQLite3_row::add_fields(sqlite3_stmt *stmt) {
 		if (t==SQLITE_NULL) {
 			//sizes[i]=0;
 			fields[i]=NULL;
-		} else {
+		} else if (data) {
 			memcpy(data+data_ptr,c,sizes[i]);
 			fields[i]=data+data_ptr;
 			data_ptr+=sizes[i];
-			data[data_ptr]='\0';
+			data[data_ptr]=0;
 			data_ptr++; // leading 0
+		} else {
+			fields[i]=NULL;
 		}
 	}
 	ds=data_size;
 }
-
 /**
  * @brief Adds fields to the SQLite3_row object based on provided field data.
  * 
@@ -141,9 +144,11 @@ void SQLite3_row::add_fields(char **_fields) {
 		}
 		if (data_size) {
 			data=(char *)malloc(data_size);
+		} else {
+			data=NULL;
 		}
 		for (i=0;i<cnt;i++) {
-			if (_fields[i]) {
+			if (_fields[i] && data) {
 				memcpy(data+data_ptr,_fields[i],sizes[i]);
 				fields[i]=data+data_ptr;
 				data_ptr+=sizes[i];

--- a/test/scripts/etc/proxysql-tester.yml
+++ b/test/scripts/etc/proxysql-tester.yml
@@ -1,3 +1,2 @@
 GLOBAL:
-  OG_API_KEY: c4a8af4e-ac7c-4641-81b4-bd4935b46af4
   BENCHMARK_SCRIPT: $WORKSPACE/test/infra/infra-mysql57/bin/local-docker-benchmark.bash

--- a/test/scripts/lib/utils.py
+++ b/test/scripts/lib/utils.py
@@ -5,7 +5,6 @@
 import os
 import yaml
 import pymysql
-import requests
 import subprocess
 import sys
 import re
@@ -37,21 +36,6 @@ def sorted_nicely( l , reverse=False):
     convert = lambda text: int(text) if text.isdigit() else text
     alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
     return sorted(l, key = alphanum_key, reverse = reverse)
-
-def generate_og_alert(service_key, message, description, debug):
-    if debug:
-        log.warn(message, exception=description)
-    else:
-        payload = {
-            "service_key": service_key,
-            "incident_key": message,
-            "event_type": "trigger",
-            "description": description
-        }
-
-        payload = json.dumps(payload)
-        r = requests.post("https://events.pagerduty.com/generic/2010-04-15/create_event.json",
-                          data=payload)
 
 def init_config(cfg_filename):
     # Initialise config file


### PR DESCRIPTION
## Summary

Fixes multiple SonarCloud BLOCKER findings identified during triage:

- **Lock unlock order reversal** in `MySQL_Authentication`, `PgSQL_Authentication`, and `ClickHouse_Authentication` — locks were being unlocked in acquisition order instead of reverse
- **Variable scope in `Base_Session::reset_all_backends`** — `mybe` declared outside loop could appear as potential double-free to static analysis
- **Column index tracking in `SQLite3_result::dump_to_stderr`** — `i` was only incremented conditionally, causing desynchronization from the column iterator and potential out-of-bounds access
- **Null checks for `server_myds` deletes** — defensive null guards in `MySQL_Backend::reset()` and ping handlers in `MySQL_Session`/`PgSQL_Session`
- **Null data pointer in `SQLite3_row::add_fields`** — `memcpy` could execute on unallocated `data` when `data_size == 0`
- **Remove dead OpsGenie alerting code** — `OG_API_KEY` config and `generate_og_alert()` were never wired up or called

## Test plan

- [x] Library compiles cleanly with `make -j$(nproc) build_lib`
- [ ] CI passes full build + TAP tests
- [ ] SonarCloud re-analysis confirms issues resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved memory safety with null-pointer checks in session and connection handlers to prevent invalid memory access.
  * Corrected lock ordering in authentication modules to ensure proper resource synchronization.
  * Fixed SQLite result data buffer initialization.
  * Enhanced backend resource cleanup.

* **Chores**
  * Removed PagerDuty alert integration from test utilities and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->