### PR TITLE
fix(build): add explicit build rule for genai_llm_clients_unit-t

### DIFF
--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -353,10 +353,8 @@ UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 	gen_utils_unit-t \
 	proxy_protocol_unit-t \
 	pgsql_txn_state_unit-t \
-	genai_fts_string_unit-t \
 	sqlite3db_unit-t \
 	pgsql_error_helper_unit-t \
-	genai_llm_clients_unit-t \
 	charset_find_unit-t \
 	config_validation_unit-t \
 	config_write_unit-t \
@@ -381,6 +379,8 @@ UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 # compilable under !PROXYSQL40.
 ifeq ($(PROXYSQL40),1)
 UNIT_TESTS += \
+	genai_fts_string_unit-t \
+	genai_llm_clients_unit-t \
 	plugin_config_unit-t \
 	plugin_dispatch_unit-t \
 	plugin_manager_unit-t \
@@ -708,6 +708,12 @@ genai_plugin_load_unit-t: genai_plugin_load_unit-t.cpp $(GENAI_PLUGIN_SO) $(ODIR
 GENAI_FTS_SRCS := $(PROXYSQL_PATH)/plugins/genai/src/MySQL_FTS.cpp
 genai_fts_string_unit-t: genai_fts_string_unit-t.cpp $(GENAI_FTS_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o $(LIBPROXYSQLAR)
 	$(CXX) $< $(GENAI_FTS_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o \
+		$(GENAI_PLUGIN_DEFINES) $(GENAI_PLUGIN_INCLUDE) $(IDIRS) $(LDIRS) $(OPT) $(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) \
+		$(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
+
+GENAI_LLM_SRCS := $(PROXYSQL_PATH)/plugins/genai/src/LLM_Clients.cpp
+genai_llm_clients_unit-t: genai_llm_clients_unit-t.cpp $(GENAI_LLM_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o $(LIBPROXYSQLAR)
+	$(CXX) $< $(GENAI_LLM_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o \
 		$(GENAI_PLUGIN_DEFINES) $(GENAI_PLUGIN_INCLUDE) $(IDIRS) $(LDIRS) $(OPT) $(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) \
 		$(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
 


### PR DESCRIPTION
## Summary

- Add explicit build rule for `genai_llm_clients_unit-t` that compiles `plugins/genai/src/LLM_Clients.cpp` directly into the test binary
- Move `genai_fts_string_unit-t` and `genai_llm_clients_unit-t` from the unconditional `UNIT_TESTS` list into the `ifeq ($(PROXYSQL40),1)` conditional block

## Root Cause

After the GenAI plugin carve-out (Step 7), `is_retryable_error()` and `LLM_WriteCallback()` were moved from core to `plugins/genai/src/LLM_Clients.cpp`. The `genai_llm_clients_unit-t` test had no explicit build rule and fell through to the generic pattern rule (`%-t`) which only links `libproxysql.a`. The linker failed with undefined references, causing `make build_tap_tests_debug` to exit with `Error 2` before **any** unit tests could be built — including all 26 `mysqlx-tsan-g1` tests, which all reported "not-found".

This is a pre-existing v3.0 CI breakage that affects all PRs targeting v3.0 since the `issue-5729-stats-projection-abi` merge.

## Test Plan

- [x] Verified all genai tests in `UNIT_TESTS` have explicit build rules
- [x] Verified no genai tests remain in the unconditional list
- [ ] CI TSAN workflow should now build all unit tests and run the 26 mysqlx-tsan-g1 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized GenAI unit test build configuration to conditionally compile based on build flags, improving test modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->