### PR TITLE
fix(ci): rename set_parser_algorithm=3 workflow to avoid Docker network issue

### DIFF
--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -1,4 +1,4 @@
-name: CI-set_parser_algorithm=3-g1
+name: CI-set_parser_algorithm_3-g1
 
 on:
   workflow_dispatch:
@@ -76,16 +76,16 @@ jobs:
     - name: Start infrastructure
       run: |
         cd proxysql
-        export INFRA_ID="ci-set_parser_algorithm=3-g1"
-        export TAP_GROUP="set_parser_algorithm=3-g1"
+        export INFRA_ID="ci-set-parser-algorithm-3-g1"
+        export TAP_GROUP="set_parser_algorithm_3-g1"
         export SKIP_CLUSTER_START=1
         test/infra/control/ensure-infras.bash
 
-    - name: Run set_parser_algorithm=3-g1 tests
+    - name: Run set_parser_algorithm_3-g1 tests
       run: |
         cd proxysql
-        export INFRA_ID="ci-set_parser_algorithm=3-g1"
-        export TAP_GROUP="set_parser_algorithm=3-g1"
+        export INFRA_ID="ci-set-parser-algorithm-3-g1"
+        export TAP_GROUP="set_parser_algorithm_3-g1"
         export SKIP_CLUSTER_START=1
         test/infra/control/run-tests-isolated.bash
 
@@ -94,9 +94,9 @@ jobs:
       run: |
         set +e
         cd proxysql
-        export INFRA_ID="ci-set_parser_algorithm=3-g1"
-        export TAP_GROUP="set_parser_algorithm=3-g1"
-        docker logs proxysql.ci-set_parser_algorithm=3-g1 2>&1 | tail -50 || true
+        export INFRA_ID="ci-set-parser-algorithm-3-g1"
+        export TAP_GROUP="set_parser_algorithm_3-g1"
+        docker logs proxysql.ci-set-parser-algorithm-3-g1 2>&1 | tail -50 || true
         test/infra/control/stop-proxysql-isolated.bash
         test/infra/control/destroy-infras.bash
 


### PR DESCRIPTION
## Summary

Rename `ci-set_parser_algorithm=3-g1.yml` → `ci-set_parser_algorithm_3-g1.yml` and update all INFRA_ID/TAP_GROUP references to remove `=` characters.

The `=` character is incompatible with Docker network names (`--network` treats it as key=value), causing CI failure with: `invalid field key ci-set_parser_algorithm`.

## Changes
- Workflow file renamed
- `INFRA_ID` changed to `ci-set-parser-algorithm-3-g1` (all dashes)
- `TAP_GROUP` changed to `set_parser_algorithm_3-g1`
- Container name references updated accordingly

Companion to PR #5748 (v3.0 side).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration identifiers for improved naming consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->