### PR TITLE
perf(ci): pull pre-built proxysql-ci-base from GHCR

### DIFF
--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -63,6 +63,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -63,10 +63,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -74,10 +74,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -74,6 +74,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -68,10 +68,10 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
-    - name: Build CI base image
+    - name: Pull CI base image
       run: |
-        cd proxysql/test/infra/docker-base
-        docker build -t proxysql-ci-base:latest .
+        docker pull ghcr.io/sysown/proxysql-ci-base:latest
+        docker tag ghcr.io/sysown/proxysql-ci-base:latest proxysql-ci-base:latest
 
     - name: Start infrastructure
       run: |

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -68,6 +68,13 @@ jobs:
         chmod +x proxysql/src/proxysql
         file proxysql/src/proxysql
 
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Pull CI base image
       run: |
         docker pull ghcr.io/sysown/proxysql-ci-base:latest


### PR DESCRIPTION
Replace docker build with docker pull ghcr.io/sysown/proxysql-ci-base:latest in all 23 reusable workflows. See PR #5748 for the push workflow on v3.0. Merge #5748 first, seed the image via workflow_dispatch, then merge this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipelines now authenticate to the container registry and use a prebuilt base image instead of building it during jobs, speeding test runs and reducing pipeline resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->