### PR TITLE
fix(ci): remove SKIP_CLUSTER_START=1 from mysql84-gr-g5 workflow

### DIFF
--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -85,7 +85,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g5"
         export TAP_GROUP="mysql84-gr-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g5 tests
@@ -93,7 +92,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g5"
         export TAP_GROUP="mysql84-gr-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup


### PR DESCRIPTION
## Summary
- `ci-mysql84-gr-g5.yml` had `SKIP_CLUSTER_START=1` which prevented ProxySQL cluster nodes from starting
- `test_cluster1-t` (the only test in `mysql84-gr-g5`) requires a multi-node ProxySQL cluster (ports 6032, 26001-26009)
- Without cluster nodes, the test fails with `Can't connect to server on 'proxysql' (115)`

## Fix
- Remove `export SKIP_CLUSTER_START=1` from both the "Start infrastructure" and "Run tests" steps
- This matches the behavior of `ci-mysql84-g5.yml` (non-GR) which starts the full cluster

## Requires
- PR #5756 (v3.0) should be merged first to also fix CI-mysql84-gr-g1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow infrastructure setup for MySQL 8.4 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->