### PR TITLE
fix(pkg): force xz compression on DEB output for dpkg-sig compatibility

### DIFF
--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -140,13 +140,28 @@ if grep -q '^PKG_PLUGIN_FILES_PLACEHOLDER$' ./proxysql.ctl; then
     exit 1
 fi
 DEB_BUILD_OPTIONS=nostrip equivs-build proxysql.ctl
-cp ./proxysql_${CURVER}_${ARCH}.deb ../binaries/proxysql_${CURVER}-${PKG_RELEASE}_${ARCH}.deb
-# get SHA1 of the packaged executable
-if [[ -x $(command -v unzstd) ]]; then
-	ar -p proxysql_${CURVER}_${ARCH}.deb $(ar t proxysql_${CURVER}_${ARCH}.deb | grep data.tar) | unzstd -c - | tar xvf - ./usr/bin/proxysql -O > tmp/proxysql
-else
-	ar -p proxysql_${CURVER}_${ARCH}.deb $(ar t proxysql_${CURVER}_${ARCH}.deb | grep data.tar) | unxz -c - | tar xvf - ./usr/bin/proxysql -O > tmp/proxysql
+
+# Force xz compression for the data tarball.  Ubuntu 22/24's dpkg-deb
+# defaults to zstd, while Debian 12/13 still defaults to xz.  The
+# release server signs with dpkg-sig 0.13 on dpkg 1.21.1, which
+# accepts the signature but then reports BADSIG on `dpkg-sig --verify`
+# for the zstd-compressed Ubuntu DEBs.  Repacking to xz makes the
+# format consistent across all distros and unblocks signing.  The
+# check on data.tar.xz also covers any future dpkg-deb default change
+# (e.g. lzma, gzip) by triggering the repack whenever the format
+# isn't already xz.  See issue #5580.
+PKG="proxysql_${CURVER}_${ARCH}.deb"
+if ! ar t "${PKG}" | grep -q '^data\.tar\.xz$'; then
+	echo "==> Repacking ${PKG} with xz compression (was: $(ar t "${PKG}" | grep '^data\.tar'))"
+	REPACK_DIR=$(mktemp -d)
+	dpkg-deb -R "${PKG}" "${REPACK_DIR}"
+	dpkg-deb -Zxz -b "${REPACK_DIR}" "${PKG}"
+	rm -rf "${REPACK_DIR}"
 fi
+
+cp "./${PKG}" "../binaries/proxysql_${CURVER}-${PKG_RELEASE}_${ARCH}.deb"
+# get SHA1 of the packaged executable (always xz after the repack above)
+ar -p "${PKG}" $(ar t "${PKG}" | grep '^data\.tar') | unxz -c - | tar xvf - ./usr/bin/proxysql -O > tmp/proxysql
 sha1sum tmp/proxysql | sed 's|tmp/||' | tee tmp/proxysql.sha1
 cp tmp/proxysql.sha1 ../binaries/proxysql_${CURVER}-${PKG_RELEASE}_${ARCH}.id-hash
 popd


### PR DESCRIPTION
## Summary
- Ubuntu 22/24 `dpkg-deb` defaults to zstd while Debian 12/13 still defaults to xz, producing DEBs with different `data.tar` compressors across distros.
- The release server's `dpkg-sig 0.13` (dpkg 1.21.1) applies signatures successfully but then reports `BADSIG` on `dpkg-sig --verify` for the zstd-compressed Ubuntu packages.
- After `equivs-build`, repack the DEB with `dpkg-deb -Zxz` whenever the data tarball is not already xz. This normalizes the format for all distros (Ubuntu 22/24, Debian 12/13, both amd64 and arm64) at a single chokepoint — the shared `deb-compliant` entrypoint.
- The check is on `^data\.tar\.xz$` rather than `^data\.tar\.zst$` so any future dpkg-deb default change (lzma, gz, etc.) is also normalized to xz. The SHA1 extraction below the repack is simplified to call `unxz` unconditionally now that the format is guaranteed.

GitHub Actions packaging workflows (`.github/workflows/CI-package-*.yml`) don't need changes — they only run `make ${MAKE_TARGET}` and upload artefacts; the actual packaging happens inside the docker container via the entrypoint fixed here.

Closes #5580

## Test plan
- [ ] Run `make ubuntu22` and confirm `ar t binaries/proxysql_*_amd64.deb | grep ^data.tar` reports `data.tar.xz` (was `data.tar.zst` before the fix).
- [ ] Run `make ubuntu24` (amd64) and `make ubuntu22`/`ubuntu24` for arm64 — same expectation.
- [ ] Run `make debian12` and `make debian13` and confirm packages are still `data.tar.xz` (no-op path: repack should not trigger).
- [ ] Verify `dpkg-sig --sign builder <pkg>.deb && dpkg-sig --verify <pkg>.deb` reports `GOODSIG` on the release server for both Ubuntu and Debian DEBs.
- [ ] Spot-check installation: `dpkg -i` and `dpkg -X` on the repacked DEBs to confirm the data tarball is recoverable end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized DEB package compression format across Ubuntu and Debian releases for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->