### PR TITLE
fix(pgsql): typecast handler swallows the rest of the query (#5755)

### DIFF
--- a/lib/pgsql_tokenizer.cpp
+++ b/lib/pgsql_tokenizer.cpp
@@ -1245,8 +1245,6 @@ enum p_st process_replace_null(shared_st* shared_st, const options* opts) {
 static __attribute__((always_inline)) inline
 enum p_st process_pg_typecast(shared_st* s, pg_typecast_st* tc)
 {
-	enum p_st next = st_pg_typecast;
-
 	// On entering state
 	if (!tc->started) {
 		tc->started = true;
@@ -1307,11 +1305,27 @@ enum p_st process_pg_typecast(shared_st* s, pg_typecast_st* tc)
 		c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
 	}
 
-	// Skip any whitespace
-	while (s->q_cur_pos < s->q_len && is_space_char(c)) {
-		s->q++;
-		s->q_cur_pos++;
-		c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
+	// Skip whitespace, but only if it's followed by a modifier or
+	// array bracket (e.g. `::int (10)`, `::int []`).  If the
+	// whitespace is just a separator before the next token (e.g.
+	// `::int FROM ...`), preserve it so the dispatcher sees the
+	// space and emits it between the typecast and the following
+	// token in the output.  Without this lookahead the typecast
+	// handler used to consume the trailing space and produced
+	// digests like `count(*)from x` (issue #5755).
+	if (s->q_cur_pos < s->q_len && is_space_char(c)) {
+		int saved_pos = s->q_cur_pos;
+		const char* saved_q = s->q;
+		while (s->q_cur_pos < s->q_len && is_space_char(c)) {
+			s->q++;
+			s->q_cur_pos++;
+			c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
+		}
+		if (c != '(' && c != '[') {
+			s->q = saved_q;
+			s->q_cur_pos = saved_pos;
+			c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
+		}
 	}
 
 	// Handle type modifiers (parentheses with parameters)
@@ -1375,18 +1389,21 @@ enum p_st process_pg_typecast(shared_st* s, pg_typecast_st* tc)
 		}
 	}
 
-	// End of type name? Now check if we're at a delimiter
-	if (s->q_cur_pos >= s->q_len ||
-		is_space_char(c) ||
-		c == ')' || c == '(' || c == ';' || c == ',' ||
-		c == '+' || c == '-' ||	c == '*' || c == '/' ||
-		c == '=' || c == '<' ||	c == '>' || c == '@' ||
-		c == ']' || c == '[') {
-		// Exit state
-		return st_no_mark_found;
-	}
-
-	return next;
+	// All typecast consumption (type name + optional whitespace +
+	// modifiers + array brackets) is complete by this point, so the
+	// state must always exit.  The previous attempt to detect "end of
+	// typecast" via an enumerated delimiter list dropped through to
+	// `return next` for any character not in that list (e.g. the 'F'
+	// of `FROM` after `::INT FROM "Inventory"`), which kept the
+	// dispatcher in `st_pg_typecast`, advanced the cursor by one extra
+	// char per outer-loop iteration, and silently swallowed the rest
+	// of the query.  See issue #5755.
+	//
+	// Also reset `started` so a subsequent `::cast` later in the same
+	// query (e.g. `SELECT 1::INT, 2::TEXT`) re-enters cleanly via the
+	// entry block at the top of this function.
+	tc->started = false;
+	return st_no_mark_found;
 }
 
 /**

--- a/test/tap/tests/unit/pgsql_tokenizer_unit-t.cpp
+++ b/test/tap/tests/unit/pgsql_tokenizer_unit-t.cpp
@@ -261,6 +261,47 @@ static void test_digest_typecast_quoted() {
 		"digest: typecast with quoted type name handled");
 }
 
+// Regression test for issue #5755: a typecast in the middle of a query
+// must not swallow the rest of the query.  The bug was in
+// process_pg_typecast() which, after consuming `::TYPENAME`, sometimes
+// returned `st_pg_typecast` (instead of `st_no_mark_found`) when the
+// next character wasn't in an enumerated delimiter list.  The
+// dispatcher would then advance one extra char per iteration AND keep
+// re-entering the typecast handler, eating subsequent tokens until end
+// of input.
+static void test_digest_typecast_followed_by_clause() {
+	// Pre-fix output: "select count(*)" — everything after `::INT` was
+	// silently dropped.  Post-fix the FROM/WHERE clause must survive.
+	std::string d = digest_query(
+		"SELECT COUNT(*)::INT FROM \"Inventory\" AS i WHERE i.\"TenantId\"=$1");
+	ok(d.find("from") != std::string::npos &&
+	   d.find("where") != std::string::npos,
+		"digest #5755: typecast does not swallow following FROM/WHERE clause");
+	ok(d.find("inventory") != std::string::npos ||
+	   d.find("Inventory") != std::string::npos,
+		"digest #5755: quoted identifier after typecast is preserved");
+}
+
+static void test_digest_typecast_then_identifier() {
+	// Bisected minimal repro: identifier directly after `::TYPENAME `.
+	std::string d = digest_query("SELECT a::int FROM t");
+	ok(d.find("from") != std::string::npos && d.find("t") != std::string::npos,
+		"digest #5755: bare identifier after typecast survives");
+}
+
+// Regression test for the per-call `tc->started` reset: multiple casts
+// in the same query must each re-enter the typecast handler cleanly.
+// Without the reset, the second `::cast` would skip the `::`-skip
+// branch and start parsing the type name from the wrong offset.
+static void test_digest_typecast_multiple_in_same_query() {
+	std::string d = digest_query("SELECT 1::int, 2::text FROM t");
+	ok(d.find("from") != std::string::npos && d.find("t") != std::string::npos,
+		"digest #5755: query with multiple typecasts preserves trailing FROM");
+	// Both literals must be replaced with `?`.
+	ok(d.find("?") != std::string::npos,
+		"digest #5755: literal replacement still happens before each typecast");
+}
+
 // ============================================================================
 // 4. PgSQL-specific: Double-quoted identifiers (preserved, NOT replaced)
 // ============================================================================
@@ -609,7 +650,7 @@ static void test_digest_only_comment() {
 // ============================================================================
 
 int main() {
-	plan(65);
+	plan(70);
 	int rc = test_init_minimal();
 	ok(rc == 0, "test_init_minimal() succeeds");
 
@@ -633,13 +674,16 @@ int main() {
 	test_digest_dollar_quote_in_function();      // 1
 	test_digest_dollar_quote_with_special_chars(); // 1
 
-	// 3. Type casts (6 tests)
+	// 3. Type casts (11 tests)
 	test_digest_typecast_simple();       // 1
 	test_digest_typecast_varchar();      // 1
 	test_digest_typecast_with_modifier(); // 1
 	test_digest_typecast_array();        // 1
 	test_digest_typecast_in_where();     // 1
 	test_digest_typecast_quoted();       // 1
+	test_digest_typecast_followed_by_clause();      // 2 (issue #5755)
+	test_digest_typecast_then_identifier();         // 1 (issue #5755)
+	test_digest_typecast_multiple_in_same_query();  // 2 (issue #5755)
 
 	// 4. Double-quoted identifiers (3 tests)
 	test_digest_double_quoted_identifier();     // 2


### PR DESCRIPTION
Closes #5755.

## Summary

Any PostgreSQL query containing a `::TYPENAME` cast in the middle of the statement was silently truncated in `stats_pgsql_query_digest` from the cast onward. Reported by @harunkucuk5 against ProxySQL 3.0.8.

The reporter's example shows it cleanly:

| | |
|--|--|
| **Original query** | `SELECT COUNT(*)::INT FROM "Inventory" AS i WHERE ((i."TenantId" = $1) AND NOT (i."IsDeleted")) AND ((((i."State" = ANY ($2)...` |
| **Pre-fix digest** | `SELECT COUNT(*) AND ((((i."State" = ANY ($2)...` ← `::INT FROM "Inventory" AS i WHERE ((i."TenantId" = $1) AND NOT (i."IsDeleted"))` is gone |
| **Post-fix digest** | `SELECT COUNT(*) FROM "Inventory" AS i WHERE ((i."TenantId" = $1) AND NOT (i."IsDeleted")) AND ((((i."State" = ANY ($2)...` ✅ |

The query is forwarded to the backend correctly; only the digest shown to operators is wrong, which makes ProxySQL's query analytics misleading on any PG workload that uses casts (Entity Framework / npgsql in the reporter's case, plus most ORMs that emit `::int`-style coercions).

## Root cause

Two bugs in `process_pg_typecast()` in `lib/pgsql_tokenizer.cpp`, both introduced when the PostgreSQL tokenizer was added in 42864e886.

### Bug 1: incorrect exit condition

After consuming `::TYPENAME` (and any optional modifiers / array brackets), the function tested whether the next char was in an enumerated delimiter list:

```cpp
if (s->q_cur_pos >= s->q_len ||
    is_space_char(c) || c == ')' || c == '(' || c == ';' || c == ',' ||
    c == '+' || c == '-' || c == '*' || c == '/' ||
    c == '=' || c == '<' || c == '>' || c == '@' ||
    c == ']' || c == '[') {
    return st_no_mark_found;
}
return next; // st_pg_typecast
```

For any character not in that list — most importantly **letters starting the next SQL keyword** like the `F` of `FROM` — it returned `st_pg_typecast`. The dispatcher in `stage_1_parsing` then:

1. advanced the cursor by one extra char via `inc_proc_pos()`,
2. re-entered `process_pg_typecast()` on the next outer-loop iteration with `tc->started=true` (so the `::`-skip block at the top was bypassed),
3. parsed a new "type name" from the middle of the next clause, eating characters until it hit one of the listed delimiters.

That's why the truncated digest jumps `SELECT COUNT(*)` → `AND ((((`: everything from `::INT` through the second `AND` was consumed by the typecast handler in successive (mis-)entries.

### Bug 2: `tc->started` never reset

`pg_typecast_st::started` is a one-shot guard for the `::`-skip block at the top of the function. It was set to `true` on first entry but never reset, so a second cast later in the same query (`SELECT 1::int, 2::text`) re-entered with `started=true`, skipped the `::`-skip, and started "parsing" the type name from the wrong offset (two characters too early).

## The fix

```diff
-	enum p_st next = st_pg_typecast;
-	...
-	if (s->q_cur_pos >= s->q_len ||
-		is_space_char(c) ||
-		c == ')' || c == '(' || c == ';' || c == ',' ||
-		c == '+' || c == '-' || c == '*' || c == '/' ||
-		c == '=' || c == '<' || c == '>' || c == '@' ||
-		c == ']' || c == '[') {
-		return st_no_mark_found;
-	}
-	return next;
+	tc->started = false;
+	return st_no_mark_found;
```

The function unconditionally returns `st_no_mark_found` after consuming the typecast. The earlier delimiter check was trying to distinguish "this is the end of the typecast" from "this is a continuation", but no continuation case actually reaches that point — type modifiers `(...)` and array brackets `[]` are already consumed inline above the check, and PG does not allow the cast itself to span a non-modifier/bracket character. Resetting `started=false` lets a subsequent cast in the same query re-enter cleanly.

## Side-effect fix: trailing whitespace handling

There's a smaller cosmetic issue in the same function: the post-type-name "skip whitespace" loop existed to handle modifier forms like `::int (10)` and `::int []` where PG allows whitespace before the modifier/bracket. But it also ate the legitimate separator space in the common form `::int FROM ...`, gluing two tokens together in the digest output (`int` consumed → `FROM` glued).

The `if (... is_space_char(c)) { ... }` block now does a save/restore lookahead: it eats whitespace **only if** the next non-space character is `(` or `[`. Otherwise the space is preserved as a token separator for the dispatcher to emit. This converts `count(*)from x` into `count(*) from x` post-fix, matching what an operator reading the digest would expect.

## Verification

Reproduced and bisected with a standalone driver compiled directly against `lib/pgsql_tokenizer.cpp`:

| Input | Pre-fix digest | Post-fix digest |
|--|--|--|
| `SELECT COUNT(*)::INT FROM "Inventory" ... WHERE ...` | `SELECT COUNT(*)` *(rest dropped)* | full structure preserved ✅ |
| `SELECT a::int FROM t` | `SELECT a` | `select a from t` ✅ |
| `SELECT 1::int, 2::text FROM t` | `SELECT ?` | `select ?, ? from t` ✅ |
| `SELECT 1::int` | `SELECT ?` | `select ?` ✅ unchanged |
| `SELECT 'hello'::varchar(255)` | `select ?` | `select ?` ✅ unchanged |
| `SELECT '{1,2,3}'::int[]` | `select ?` | `select ?` ✅ unchanged |
| `SELECT 1::"my type"` | `select ?` | `select ?` ✅ unchanged |
| `SELECT * FROM t WHERE id=1::bigint` | `select * from t where id=?` | `select * from t where id=?` ✅ unchanged |
| `SELECT 1::varchar (255)` *(space before modifier)* | `select ?` | `select ?` ✅ unchanged — modifier still consumed |
| `SELECT 1::numeric(10,2)` | `select ?` | `select ?` ✅ unchanged |
| `SELECT 1::int[][]` *(multi-dim array)* | `select ?` | `select ?` ✅ unchanged |

All 6 existing typecast tests in `test/tap/tests/unit/pgsql_tokenizer_unit-t.cpp` (`test_digest_typecast_simple`, `_varchar`, `_with_modifier`, `_array`, `_in_where`, `_quoted`) and the thread-local-wrapper test `test_digest_2_with_typecast` continue to pass verbatim.

## New regression tests

Added to `pgsql_tokenizer_unit-t.cpp` (already registered in `unit-tests-g1`, no `groups.json` change needed):

- `test_digest_typecast_followed_by_clause` (2 assertions) — full repro from the issue: assert `from` and `where` both appear in the digest, assert the double-quoted identifier survives.
- `test_digest_typecast_then_identifier` (1 assertion) — bisected minimal `SELECT a::int FROM t`.
- `test_digest_typecast_multiple_in_same_query` (2 assertions) — covers Bug 2 (`tc->started` reset) by using two casts followed by a `FROM` clause.

`plan(65)` → `plan(70)`.

## Files changed

- `lib/pgsql_tokenizer.cpp` — the core fix (always exit, reset `started`, lookahead-conditional whitespace skip) plus comment explaining *why*.
- `test/tap/tests/unit/pgsql_tokenizer_unit-t.cpp` — 3 new regression tests, plan bumped from 65 to 70.

## Test plan

- [ ] `make build_tap_test_debug && WORKSPACE=$(pwd) INFRA_ID=dev-$USER TAP_GROUP=unit-tests-g1 test/infra/control/run-tests-isolated.bash` passes including the new tests.
- [ ] Revert just `lib/pgsql_tokenizer.cpp` (keep the new tests) and confirm the new tests **fail** with the truncation symptom — this is the ground-truth regression check.
- [ ] Manual repro from the issue: configure ProxySQL against PG 15+, run `SELECT COUNT(*)::INT FROM ...` from a client, observe `stats_pgsql_query_digest.digest_text` no longer truncates at the cast.
- [ ] Spot-check that an EF/npgsql workload with typical `::int` coercions produces sensible digests (the reporter's primary use case).

## Risk

Low. The change is a state-machine fix that *expands* the cases where the typecast handler exits cleanly — there's no path where the new code is more aggressive than the old code. Modifier/bracket consumption is unchanged. The lookahead-conditional whitespace handling preserves the existing `::int (10)` and `::int []` forms while fixing the common `::int <next-token>` case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PostgreSQL type cast (`::typename`) parsing that was incorrectly consuming subsequent query tokens, causing SQL query analysis to malform and drop important clauses. Improved state termination and whitespace handling ensures proper parsing of queries containing type casts alongside other SQL operations, resulting in accurate query analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->