### PR TITLE
fix(deps): patch libconfig 1.8.1 to restore \a \b \v passthrough (#5766)

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -295,6 +295,7 @@ sqlite-vec: sqlite3/sqlite3/vec.o
 libconfig/libconfig/out/libconfig++.a:
 	cd libconfig && rm -rf libconfig-*/ || true
 	cd libconfig && tar -zxf libconfig-*.tar.gz
+	cd libconfig/libconfig && patch -p1 < ../restore_unknown_escape_passthrough.patch
 	cd libconfig/libconfig && cmake -DBUILD_SHARED_LIBS=0 -DBUILD_EXAMPLES=0 -DBUILD_TESTS=0 -DBUILD_FUZZERS=0 .
 	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
 

--- a/deps/libconfig/restore_unknown_escape_passthrough.patch
+++ b/deps/libconfig/restore_unknown_escape_passthrough.patch
@@ -1,0 +1,73 @@
+Restore libconfig 1.7.3 passthrough behavior for the escape sequences
+that were newly introduced in 1.8.1 (\a, \b, \v).
+
+Background
+----------
+libconfig 1.7.3 only recognized \n, \r, \t, \f, \\, \" and \xHH inside
+quoted strings.  Any other backslash sequence (\a, \b, \v, \z, ...)
+fell through to the catch-all `<STRING>\\.` rule and the backslash
+was preserved.
+
+libconfig 1.8.1 added explicit rules for \a, \b and \v that collapse
+the two-character sequence into a single control byte (0x07, 0x08,
+0x0B respectively).  This silently corrupts ProxySQL configuration
+values that happen to contain those literal sequences -- most visibly
+passwords -- because the operator-supplied two-character sequence is
+not what the lexer ends up storing.  See sysown/proxysql#5766.
+
+Fix
+---
+Patch the (still-matched) \a / \b / \v rules so they emit the
+backslash and the letter as two literal characters, restoring the
+1.7.3 wire-for-wire result.  The regex itself is unchanged so the
+generated state machine in scanner.c keeps working with the surgical
+edits applied to scanner.c below.
+
+\f, \n, \r, \t are intentionally left as escape sequences: they were
+already interpreted by libconfig 1.7.3 and changing them would be a
+behavioural regression for users who rely on them.
+
+--- a/lib/scanner.c
++++ b/lib/scanner.c
+@@ -1330,12 +1330,12 @@
+ case 10:
+ YY_RULE_SETUP
+ #line 85 "scanner.l"
+-{ libconfig_scanctx_append_char(yyextra, '\a'); }
++{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'a'); }
+ 	YY_BREAK
+ case 11:
+ YY_RULE_SETUP
+ #line 86 "scanner.l"
+-{ libconfig_scanctx_append_char(yyextra, '\b'); }
++{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'b'); }
+ 	YY_BREAK
+ case 12:
+ YY_RULE_SETUP
+@@ -1355,7 +1355,7 @@
+ case 15:
+ YY_RULE_SETUP
+ #line 90 "scanner.l"
+-{ libconfig_scanctx_append_char(yyextra, '\v'); }
++{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'v'); }
+ 	YY_BREAK
+ case 16:
+ YY_RULE_SETUP
+--- a/lib/scanner.l
++++ b/lib/scanner.l
+@@ -82,12 +82,12 @@
+
+ \"                { BEGIN STRING; }
+ <STRING>[^\"\\]+  { libconfig_scanctx_append_string(yyextra, yytext); }
+-<STRING>\\a       { libconfig_scanctx_append_char(yyextra, '\a'); }
+-<STRING>\\b       { libconfig_scanctx_append_char(yyextra, '\b'); }
++<STRING>\\a       { libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'a'); }
++<STRING>\\b       { libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'b'); }
+ <STRING>\\n       { libconfig_scanctx_append_char(yyextra, '\n'); }
+ <STRING>\\r       { libconfig_scanctx_append_char(yyextra, '\r'); }
+ <STRING>\\t       { libconfig_scanctx_append_char(yyextra, '\t'); }
+-<STRING>\\v       { libconfig_scanctx_append_char(yyextra, '\v'); }
++<STRING>\\v       { libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'v'); }
+ <STRING>\\f       { libconfig_scanctx_append_char(yyextra, '\f'); }
+ <STRING>\\\\      { libconfig_scanctx_append_char(yyextra, '\\'); }
+ <STRING>\\\"      { libconfig_scanctx_append_char(yyextra, '\"'); }

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -258,6 +258,7 @@
   "reg_test_5233_set_warning-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1","set_parser_algorithm_3-g1" ],
   "reg_test_5306-show_warnings_with_comment-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_5389-flush_logs_no_drop-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "reg_test_5766_libconfig_escape_passthrough-t" : [ "mysql95-g4" ],
   "reg_test__ssl_client_busy_wait-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_com_change_user_malformed_packet-t" : [ "mysql84-g6","mysql95-g1" ],
   "reg_test_compression_split_packets-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],

--- a/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
+++ b/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
@@ -17,9 +17,14 @@
  * It also verifies that `\n` and `\xHH` (hex escapes) -- which were
  * already interpreted by libconfig 1.7.3 -- still work as expected.
  */
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <string>
+#include <string_view>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "mysql.h"
 
@@ -28,14 +33,17 @@
 #include "command_line.h"
 
 using std::string;
+using std::string_view;
 
 /* Probe values exercised below.  Every literal `\` in C++ source maps to
  * a single backslash byte in the rendered config; libconfig should then
- * leave it untouched (for \a \b \v) or interpret it (for \n \x). */
+ * leave it untouched (for \a \b \v) or interpret it (for \n \x).
+ * `expected_value` is a string_view so the comparison length is the
+ * compile-time literal size and we do not call strlen at runtime. */
 struct Probe {
     const char* var_name;
-    const char* config_literal; /* what we write between the quotes in the .cnf */
-    const char* expected_value; /* bytes we expect to read back via admin */
+    string_view config_literal; /* what we write between the quotes in the .cnf */
+    string_view expected_value; /* bytes we expect to read back via admin */
     const char* description;
 };
 
@@ -50,16 +58,16 @@ static const Probe probes[] = {
 };
 static const size_t n_probes = sizeof(probes) / sizeof(probes[0]);
 
-static void write_config(const string& path) {
+static void write_config(const string& path, const string& datadir) {
     std::ofstream cfg(path);
-    cfg << "datadir=\"/tmp\"\n";
-    cfg << "errorlog=\"/tmp/proxysql.log\"\n";
+    cfg << "datadir=\"" << datadir << "\"\n";
+    cfg << "errorlog=\"" << datadir << "/proxysql.log\"\n";
     cfg << "mysql_variables=\n{\n";
     for (size_t i = 0; i < n_probes; ++i) {
         /* Strip the "mysql-" prefix when writing into the mysql_variables
          * group; libconfig stores it as `mysql-<name>` after loading. */
-        const char* var = probes[i].var_name;
-        if (strncmp(var, "mysql-", 6) == 0) var += 6;
+        string_view var{probes[i].var_name};
+        if (var.substr(0, 6) == "mysql-") var.remove_prefix(6);
         cfg << "    " << var << "=\"" << probes[i].config_literal << "\"\n";
     }
     cfg << "}\n";
@@ -87,11 +95,23 @@ int main(int argc, char** argv) {
         return exit_status();
     }
 
-    const char* datadir = getenv("REGULAR_INFRA_DATADIR");
-    string cfg_path = (datadir ? string(datadir) : "/tmp");
-    if (cfg_path.back() != '/') cfg_path += '/';
-    cfg_path += "reg_test_5766.cfg";
-    write_config(cfg_path);
+    /* Write the cnf into the test infra's private datadir when it is
+     * provided; otherwise create a fresh 0700 directory via mkdtemp so we
+     * never touch a publicly-writable path like /tmp directly. */
+    string cfg_dir;
+    if (const char* datadir = getenv("REGULAR_INFRA_DATADIR")) {
+        cfg_dir = datadir;
+    } else {
+        char tmpl[] = "/tmp/reg_test_5766_XXXXXX";
+        if (!mkdtemp(tmpl)) {
+            fprintf(stderr, "mkdtemp failed: %s\n", strerror(errno));
+            return exit_status();
+        }
+        cfg_dir = tmpl;
+    }
+    while (cfg_dir.size() > 1 && cfg_dir.back() == '/') cfg_dir.pop_back();
+    string cfg_path = cfg_dir + "/reg_test_5766.cfg";
+    write_config(cfg_path, cfg_dir);
 
     string set_cfg = "PROXYSQL SET CONFIG FILE '" + cfg_path + "'";
     MYSQL_QUERY_T(admin, set_cfg.c_str());
@@ -112,16 +132,16 @@ int main(int argc, char** argv) {
         unsigned long* lens = res ? mysql_fetch_lengths(res) : NULL;
 
         bool match = false;
+        const string_view& exp = probes[i].expected_value;
         if (row && row[0] && lens) {
-            size_t expected_len = strlen(probes[i].expected_value);
-            if (lens[0] == expected_len && memcmp(row[0], probes[i].expected_value, expected_len) == 0) {
+            if (lens[0] == exp.size() && string_view(row[0], lens[0]) == exp) {
                 match = true;
             } else {
-                diag("Mismatch for %s: expected %zu bytes (%s), got %lu bytes",
-                     probes[i].var_name, expected_len, probes[i].expected_value, lens[0]);
+                diag("Mismatch for %s: expected %zu bytes, got %lu bytes",
+                     probes[i].var_name, exp.size(), lens[0]);
                 /* Hex-dump both for easier triage. */
                 fprintf(stderr, "  expected hex: ");
-                for (size_t k = 0; k < expected_len; ++k) fprintf(stderr, "%02x ", (unsigned char)probes[i].expected_value[k]);
+                for (size_t k = 0; k < exp.size(); ++k) fprintf(stderr, "%02x ", (unsigned char)exp[k]);
                 fprintf(stderr, "\n  actual hex:   ");
                 for (size_t k = 0; k < lens[0]; ++k) fprintf(stderr, "%02x ", (unsigned char)row[0][k]);
                 fprintf(stderr, "\n");

--- a/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
+++ b/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
@@ -17,14 +17,11 @@
  * It also verifies that `\n` and `\xHH` (hex escapes) -- which were
  * already interpreted by libconfig 1.7.3 -- still work as expected.
  */
-#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <fstream>
 #include <string>
 #include <string_view>
-#include <sys/stat.h>
 #include <unistd.h>
 #include "mysql.h"
 
@@ -95,19 +92,18 @@ int main(int argc, char** argv) {
         return exit_status();
     }
 
-    /* Write the cnf into the test infra's private datadir when it is
-     * provided; otherwise create a fresh 0700 directory via mkdtemp so we
-     * never touch a publicly-writable path like /tmp directly. */
+    /* Prefer the TAP-managed workdir (TAP_WORKDIR / cl.workdir, defaults
+     * to "./"). REGULAR_INFRA_DATADIR is honoured first when set by the
+     * infra so the cnf lands in the same private datadir the proxysql
+     * instance uses, matching test_load_from_config_*-t. No hardcoded
+     * /tmp path. */
     string cfg_dir;
     if (const char* datadir = getenv("REGULAR_INFRA_DATADIR")) {
         cfg_dir = datadir;
+    } else if (cl.workdir && *cl.workdir) {
+        cfg_dir = cl.workdir;
     } else {
-        char tmpl[] = "/tmp/reg_test_5766_XXXXXX";
-        if (!mkdtemp(tmpl)) {
-            fprintf(stderr, "mkdtemp failed: %s\n", strerror(errno));
-            return exit_status();
-        }
-        cfg_dir = tmpl;
+        cfg_dir = ".";
     }
     while (cfg_dir.size() > 1 && cfg_dir.back() == '/') cfg_dir.pop_back();
     string cfg_path = cfg_dir + "/reg_test_5766.cfg";

--- a/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
+++ b/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
@@ -1,0 +1,139 @@
+/**
+ * @file reg_test_5766_libconfig_escape_passthrough-t.cpp
+ * @brief Regression test for https://github.com/sysown/proxysql/issues/5766
+ *
+ * libconfig 1.8.1 introduced new escape rules (\a, \b, \v) that did not
+ * exist in 1.7.3.  When a proxysql.cnf string contains the literal
+ * two-character sequence `\v` (backslash + v), 1.8.1 silently collapses
+ * it to the single byte 0x0B (vertical tab), corrupting passwords and
+ * other config values.  The bundled libconfig is patched (see
+ * deps/libconfig/restore_unknown_escape_passthrough.patch) to restore
+ * 1.7.3 passthrough behaviour for these three escape sequences.
+ *
+ * This test creates a config file containing values with literal `\a`,
+ * `\b` and `\v` sequences, loads it via `LOAD ... VARIABLES FROM CONFIG`,
+ * and asserts that each value is read back byte-for-byte unchanged.
+ *
+ * It also verifies that `\n` and `\xHH` (hex escapes) -- which were
+ * already interpreted by libconfig 1.7.3 -- still work as expected.
+ */
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include "mysql.h"
+
+#include "tap.h"
+#include "utils.h"
+#include "command_line.h"
+
+using std::string;
+
+/* Probe values exercised below.  Every literal `\` in C++ source maps to
+ * a single backslash byte in the rendered config; libconfig should then
+ * leave it untouched (for \a \b \v) or interpret it (for \n \x). */
+struct Probe {
+    const char* var_name;
+    const char* config_literal; /* what we write between the quotes in the .cnf */
+    const char* expected_value; /* bytes we expect to read back via admin */
+    const char* description;
+};
+
+static const Probe probes[] = {
+    /* The three regressions introduced by libconfig 1.8.1. */
+    { "mysql-server_version",     "pass\\vword",        "pass\\vword",      "\\v preserved as two bytes (was 0x0B in 1.8.1)" },
+    { "mysql-default_schema",     "ho\\ame",            "ho\\ame",          "\\a preserved as two bytes (was 0x07 in 1.8.1)" },
+    { "mysql-init_connect",       "se\\bt names utf8",  "se\\bt names utf8","\\b preserved as two bytes (was 0x08 in 1.8.1)" },
+    /* Already-interpreted escapes -- must keep their 1.7.3 behaviour. */
+    { "mysql-ldap_user_variable", "line1\\nline2",      "line1\nline2",     "\\n still collapsed to 0x0A (unchanged from 1.7.3)" },
+    { "mysql-add_ldap_user_comment","tab\\x09sep",      "tab\tsep",         "\\xHH still interpreted as hex (unchanged from 1.7.3)" },
+};
+static const size_t n_probes = sizeof(probes) / sizeof(probes[0]);
+
+static void write_config(const string& path) {
+    std::ofstream cfg(path);
+    cfg << "datadir=\"/tmp\"\n";
+    cfg << "errorlog=\"/tmp/proxysql.log\"\n";
+    cfg << "mysql_variables=\n{\n";
+    for (size_t i = 0; i < n_probes; ++i) {
+        /* Strip the "mysql-" prefix when writing into the mysql_variables
+         * group; libconfig stores it as `mysql-<name>` after loading. */
+        const char* var = probes[i].var_name;
+        if (strncmp(var, "mysql-", 6) == 0) var += 6;
+        cfg << "    " << var << "=\"" << probes[i].config_literal << "\"\n";
+    }
+    cfg << "}\n";
+    cfg.close();
+}
+
+int main(int argc, char** argv) {
+    CommandLine cl;
+
+    if (cl.getEnv()) {
+        diag("Failed to get the required environmental variables.");
+        return EXIT_FAILURE;
+    }
+
+    plan(n_probes);
+
+    MYSQL* admin = mysql_init(NULL);
+    if (!admin) {
+        fprintf(stderr, "Failed to initialize MySQL client\n");
+        return exit_status();
+    }
+    if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+                            NULL, cl.admin_port, NULL, 0)) {
+        fprintf(stderr, "Failed to connect to admin: %s\n", mysql_error(admin));
+        return exit_status();
+    }
+
+    const char* datadir = getenv("REGULAR_INFRA_DATADIR");
+    string cfg_path = (datadir ? string(datadir) : "/tmp");
+    if (cfg_path.back() != '/') cfg_path += '/';
+    cfg_path += "reg_test_5766.cfg";
+    write_config(cfg_path);
+
+    string set_cfg = "PROXYSQL SET CONFIG FILE '" + cfg_path + "'";
+    MYSQL_QUERY_T(admin, set_cfg.c_str());
+
+    /* Wipe any prior value so a stale row can't mask a regression. */
+    for (size_t i = 0; i < n_probes; ++i) {
+        string del = string("DELETE FROM global_variables WHERE variable_name='") + probes[i].var_name + "'";
+        MYSQL_QUERY_T(admin, del.c_str());
+    }
+
+    MYSQL_QUERY_T(admin, "LOAD MYSQL VARIABLES FROM CONFIG");
+
+    for (size_t i = 0; i < n_probes; ++i) {
+        string sel = string("SELECT variable_value FROM global_variables WHERE variable_name='") + probes[i].var_name + "'";
+        MYSQL_QUERY_T(admin, sel.c_str());
+        MYSQL_RES* res = mysql_store_result(admin);
+        MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+        unsigned long* lens = res ? mysql_fetch_lengths(res) : NULL;
+
+        bool match = false;
+        if (row && row[0] && lens) {
+            size_t expected_len = strlen(probes[i].expected_value);
+            if (lens[0] == expected_len && memcmp(row[0], probes[i].expected_value, expected_len) == 0) {
+                match = true;
+            } else {
+                diag("Mismatch for %s: expected %zu bytes (%s), got %lu bytes",
+                     probes[i].var_name, expected_len, probes[i].expected_value, lens[0]);
+                /* Hex-dump both for easier triage. */
+                fprintf(stderr, "  expected hex: ");
+                for (size_t k = 0; k < expected_len; ++k) fprintf(stderr, "%02x ", (unsigned char)probes[i].expected_value[k]);
+                fprintf(stderr, "\n  actual hex:   ");
+                for (size_t k = 0; k < lens[0]; ++k) fprintf(stderr, "%02x ", (unsigned char)row[0][k]);
+                fprintf(stderr, "\n");
+            }
+        } else {
+            diag("Variable %s not found after LOAD MYSQL VARIABLES FROM CONFIG", probes[i].var_name);
+        }
+        ok(match, "%s", probes[i].description);
+        if (res) mysql_free_result(res);
+    }
+
+    unlink(cfg_path.c_str());
+    mysql_close(admin);
+    return exit_status();
+}


### PR DESCRIPTION
Fixes #5766.

## Summary

- Patch the bundled libconfig 1.8.1 to restore libconfig 1.7.3 passthrough behaviour for `\a`, `\b` and `\v` inside quoted strings.
- Add a TAP regression test that loads a config file with literal `\a`, `\b`, `\v`, `\n` and `\xHH` and asserts every value round-trips byte-for-byte through `LOAD MYSQL VARIABLES FROM CONFIG`.
- Register the test in `mysql95-g4`.

## Root cause

libconfig was bumped from 1.7.3 to 1.8.1 in 88c34b30a. 1.8.1 added these new rules to `lib/scanner.l` that did not exist in 1.7.3:

```
<STRING>\\a       { libconfig_scanctx_append_char(yyextra, '\a'); }   /* 0x07 */
<STRING>\\b       { libconfig_scanctx_append_char(yyextra, '\b'); }   /* 0x08 */
<STRING>\\v       { libconfig_scanctx_append_char(yyextra, '\v'); }   /* 0x0B */
```

Under 1.7.3 the two-character sequence `\v` in `proxysql.cnf` (bytes `0x5C 0x76`) fell through to the catch-all `<STRING>\\` rule and was preserved verbatim. Under 1.8.1 it is collapsed to a single `0x0B` byte before ProxySQL ever sees it, so:

- the value stored in `global_variables` no longer matches the source-of-truth in `proxysql.cnf`
- monitor / `mysql_users` passwords containing literal `\v` fail authentication against the MySQL backend
- the on-disk config file is unchanged so the operator has no signal that anything was rewritten

Reproduction (1.8.1):

| input in cnf | hex stored |
|---|---|
| `"pass\vword"` | `70 61 73 73 0B 77 6F 72 64` |
| `"ho\ame"`     | `68 6F 07 6D 65` |
| `"se\bt"`      | `73 65 08 74` |

## Considered alternatives

| Option | Why not |
|---|---|
| Pin libconfig back to 1.7.3 | Loses whatever 88c34b30a was upgrading for; harder to reason about silent reverts |
| Escape on read in `Read_Global_Variables_from_configfile()` | Fragile -- can't distinguish a real `0x0B` written via `\xHH` from a corrupted `\v`; would have to be repeated in every libconfig consumer (`mysql_users.password`, scheduler args, server comments, ...) |
| Escape on write | ProxySQL doesn't write `proxysql.cnf`; the operator does |
| Document the workaround only | Silent corruption keeps biting anyone who hasn't read the docs |
| **Patch the bundled libconfig (this PR)** | 3-line surgical change; restores 1.7.3 behaviour for exactly the new-in-1.8.1 escapes while keeping every other 1.8.1 improvement; matches the existing `deps/prometheus-cpp/*.patch` pattern |

## Fix

`deps/libconfig/restore_unknown_escape_passthrough.patch` rewrites only the three new-in-1.8.1 actions in `lib/scanner.l` and `lib/scanner.c` to emit the two literal characters instead of the control byte:

```c
case 10: /* \a */
-{ libconfig_scanctx_append_char(yyextra, '\a'); }
+{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'a'); }
case 11: /* \b */
-{ libconfig_scanctx_append_char(yyextra, '\b'); }
+{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'b'); }
case 15: /* \v */
-{ libconfig_scanctx_append_char(yyextra, '\v'); }
+{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'v'); }
```

The regex stays unchanged so the generated state machine is unaffected; only the action body differs. `\f`, `\n`, `\r`, `\t`, `\xHH`, `\\`, `\"` are left alone because they were already interpreted in 1.7.3 and changing them would be its own behavioural regression.

The patch is applied at extraction time by `deps/Makefile`, the same way `deps/prometheus-cpp/*.patch` are applied.

## Verification

Before fix (unpatched libconfig 1.8.1 build), regression test:

```
not ok 1 - \v preserved as two bytes (was 0x0B in 1.8.1)
  expected hex: 70 61 73 73 5c 76 77 6f 72 64
  actual   hex: 70 61 73 73 0b 77 6f 72 64
not ok 2 - \a preserved as two bytes (was 0x07 in 1.8.1)
  expected hex: 68 6f 5c 61 6d 65
  actual   hex: 68 6f 07 6d 65
not ok 3 - \b preserved as two bytes (was 0x08 in 1.8.1)
  expected hex: 73 65 5c 62 74 20 6e 61 6d 65 73 20 75 74 66 38
  actual   hex: 73 65 08 74 20 6e 61 6d 65 73 20 75 74 66 38
ok 4 - \n still collapsed to 0x0A (unchanged from 1.7.3)
ok 5 - \xHH still interpreted as hex (unchanged from 1.7.3)
```

After fix (patched build): all 5 pass.

## Test plan

- [x] Reproduce locally against unpatched libconfig 1.8.1 -- bug observed exactly as in #5766.
- [x] `make cleanall && make build_deps` rebuilds libconfig with the patch applied at extraction.
- [x] `make` builds proxysql with the patched static libconfig++.a.
- [x] `make build_tap_tests` builds `reg_test_5766_libconfig_escape_passthrough-t`.
- [x] Test passes on patched build; explicitly verified it fails on unpatched build with the exact hex pattern from the bug report.
- [ ] CI green on `mysql95-g4`.

## Risk

Behavioural change is intentionally scoped to three escape sequences that no operator should rely on for control bytes (anyone who genuinely wants a `0x0B` byte can still write `\x0B`). For anyone whose previous build was 1.7.3, this is a return to the prior behaviour. For anyone whose previous build was 1.8.x, the only visible change is that strings containing literal `\a` / `\b` / `\v` now round-trip instead of being silently corrupted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore passthrough handling of `\a`, `\b`, and `\v` in configuration strings so they remain literal two-character sequences instead of being converted to control bytes.

* **Chores**
  * Apply an upstream patch during the dependency build to enable the restored escape behavior.

* **Tests**
  * Added a regression test and test-group mapping to verify escape-sequence handling during config load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5773)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->