### PR TITLE
fix(deps): patch jemalloc for GCC 16; add fedora44 to build matrix

### DIFF
--- a/.github/workflows/CI-package-amd64-fedora44-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-clang.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-clang
+      MATRIX: '(amd64,fedora44-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-dbg.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-dbg
+      MATRIX: '(amd64,fedora44-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-clang
+      MATRIX: '(amd64,fedora44-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-dbg
+      MATRIX: '(amd64,fedora44-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(amd64,fedora44-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-clang
+      MATRIX: '(amd64,fedora44-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-dbg
+      MATRIX: '(amd64,fedora44-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(amd64,fedora44-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44.yml
+++ b/.github/workflows/CI-package-amd64-fedora44.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(amd64,fedora44)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-genai.yml
@@ -1,0 +1,149 @@
+name: CI-package-arm64-fedora44-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(arm64,fedora44-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-v31.yml
@@ -1,0 +1,149 @@
+name: CI-package-arm64-fedora44-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(arm64,fedora44-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora44.yml
+++ b/.github/workflows/CI-package-arm64-fedora44.yml
@@ -1,0 +1,149 @@
+name: CI-package-arm64-fedora44
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(arm64,fedora44)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensu
 amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux9-clang almalinux9-dbg almalinux10 almalinux10-clang almalinux10-dbg
 amd64-centos: centos9 centos9-clang centos9-dbg centos10 centos10-clang centos10-dbg
 amd64-debian: debian12 debian12-clang debian12-dbg debian13 debian13-clang debian13-dbg
-amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg
+amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg fedora44 fedora44-clang fedora44-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
@@ -444,7 +444,7 @@ arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensu
 arm64-almalinux: almalinux8 almalinux9 almalinux10
 arm64-centos: centos9 centos10
 arm64-debian: debian12 debian13
-arm64-fedora: fedora42 fedora43
+arm64-fedora: fedora42 fedora43 fedora44
 arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -195,6 +195,7 @@ jemalloc/jemalloc/lib/libjemalloc.a:
 	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue823.520.patch
 	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue2358.patch
 	cd jemalloc/jemalloc && patch -p0 < ../nothrow.patch
+	cd jemalloc/jemalloc && patch src/jemalloc_cpp.cpp < ../throw-bad-alloc.patch
 	cd jemalloc/jemalloc && ./configure ${MYJEOPT}
 #	cd jemalloc/jemalloc && sed -i -e 's/-O3 /-O3 -fPIC /' Makefile
 	cd jemalloc/jemalloc && CC=${CC} CXX=${CXX} ${MAKE}

--- a/deps/jemalloc/throw-bad-alloc.patch
+++ b/deps/jemalloc/throw-bad-alloc.patch
@@ -1,0 +1,25 @@
+Fix build against libstdc++ shipped with GCC 16, which no longer
+exposes the internal symbol std::__throw_bad_alloc() through <new>.
+
+Backports the user-visible part of jemalloc upstream commit 1a15fe33
+("Replace std::__throw_bad_alloc call with standard C++"), restricted
+to the call site itself.  jemalloc's upstream patch also adds a
+configure-time check that conditionally compiles either
+'throw std::bad_alloc()' or 'std::terminate()' depending on whether
+C++ exceptions are enabled, but ProxySQL always builds with C++
+exceptions, so the simpler unconditional form is sufficient.
+
+Refs:
+  https://github.com/sysown/proxysql/issues/5770
+  https://github.com/jemalloc/jemalloc/commit/1a15fe33a48c52bfe26ea83e49f0d317a47da3ea
+
+--- src/jemalloc_cpp.cpp.orig
++++ src/jemalloc_cpp.cpp
+@@ -67,7 +67,7 @@
+ 	}
+
+ 	if (ptr == nullptr && !nothrow)
+-		std::__throw_bad_alloc();
++		throw std::bad_alloc();
+ 	return ptr;
+ }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,34 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
 
 ####################################################################################################
+  fedora44_build:
+    extends:
+      service: _build
+    image: proxysql/packaging:build-fedora44-v4.0.0
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
+      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - PKG_RELEASE=fedora44
+      - PROXYSQL_BUILD_TYPE=clickhouse
+
+  fedora44_clang_build:
+    extends:
+      service: fedora44_build
+    image: proxysql/packaging:build-clang-fedora44-v4.0.0
+    environment:
+      - PKG_RELEASE=fedora44-clang
+
+  fedora44_dbg_build:
+    extends:
+      service: fedora44_build
+    environment:
+      - PKG_RELEASE=dbg-fedora44
+      - PROXYSQL_BUILD_TYPE=debug
+
+####################################################################################################
 ####################################################################################################
   debian12_build:
     extends:


### PR DESCRIPTION
## Summary

- **Fixes #5770** — bundled jemalloc 5.2.0 calls the libstdc++ internal symbol `std::__throw_bad_alloc()` in `src/jemalloc_cpp.cpp:70`, which GCC 16's libstdc++ no longer exposes through `<new>`. The build fails on any GCC 16 distro.
- New `deps/jemalloc/throw-bad-alloc.patch` replaces that single call with `throw std::bad_alloc()`, applied alongside the existing three patches in `deps/Makefile`. This is the user-visible part of upstream jemalloc commit [`1a15fe33`](https://github.com/jemalloc/jemalloc/commit/1a15fe33a48c52bfe26ea83e49f0d317a47da3ea); the upstream change additionally introduces a configure-time check that conditionally compiles `throw std::bad_alloc()` vs `std::terminate()` depending on whether C++ exceptions are enabled — ProxySQL always builds with exceptions, so the simpler unconditional form is sufficient. Upstream jemalloc has no tagged release containing this fix yet (5.3.0 also has the bug), so a backport is the only option without a version bump.
- Adds **Fedora 44** to the packaging matrix as the automated regression net (Fedora 44 ships GCC 16.1.1 by default, verified in both `fedora:44` and `fedora:rawhide` containers).
  - `docker-compose.yml`: three new services `fedora44_build`, `fedora44_clang_build`, `fedora44_dbg_build`, cloned from the fedora43 block.
  - `Makefile`: `fedora44 fedora44-clang fedora44-dbg` added to `amd64-fedora`; `fedora44` added to `arm64-fedora`.
  - `.github/workflows/CI-package-{amd64,arm64}-fedora44*.yml`: 12 new workflow files, exact `s/fedora43/fedora44/g` clones of the existing fedora43 set. All trigger on `workflow_dispatch:` only, none reference `@GH-Actions`, so no paired reusable workflow is needed (single PR is enough).
- Packaging images come from [ProxySQL/docker-images#18](https://github.com/ProxySQL/docker-images/pull/18) (merged). The 12 workflows here will run once `proxysql/packaging:build-fedora44-v4.0.0` and `proxysql/packaging:build-clang-fedora44-v4.0.0` are pushed to Docker Hub.

## Test plan

- [x] `deps/jemalloc/throw-bad-alloc.patch` applies cleanly to pristine jemalloc-5.2.0 (`patch --dry-run` succeeds).
- [x] In a `gcc:16` container (Debian trixie + GCC 16.1.0) **without** the patch, the build reproduces the exact error from #5770: `'__throw_bad_alloc' is not a member of 'std'; did you mean '__throw_bad_cast'?`
- [x] In the same `gcc:16` container **with** the patch, jemalloc builds cleanly; `nm` on the resulting `jemalloc_cpp.pic.o` confirms `std::bad_alloc` symbols are referenced and `__throw_bad_alloc` is no longer present.
- [ ] After publishing the fedora44 packaging images, run `make fedora44` locally to confirm the full proxysql build succeeds on GCC 16.
- [ ] Trigger `CI-package-amd64-fedora44` from the Actions tab and verify the rpm is produced and uploaded to the draft release.
- [ ] Sanity-check at least one existing distro (e.g. `make fedora43`) still builds — the patch is appended after the existing three and only edits `src/jemalloc_cpp.cpp`, so prior toolchains are unaffected, but a smoke test is cheap.
- [ ] No new compiler warnings introduced by the patch on existing toolchains (GCC ≤15, clang).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Introduced Fedora 44 packaging support with automated CI/CD workflows for amd64 and arm64 architectures, supporting standard, debug, clang, and GenAI build variants.
  * Updated build configuration and Docker services to include new Fedora 44 targets.

* **Bug Fixes**
  * Enhanced memory allocation error handling in jemalloc.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5774)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->