### PR TITLE
Integration batch 2026-05-13: bundle of 6 fixes

### DIFF
--- a/.github/workflows/CI-package-amd64-fedora44-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-clang.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-clang.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-clang
+      MATRIX: '(amd64,fedora44-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-clang.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-dbg.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-dbg.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-dbg
+      MATRIX: '(amd64,fedora44-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-dbg.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-genai-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-clang
+      MATRIX: '(amd64,fedora44-genai-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-genai-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-dbg
+      MATRIX: '(amd64,fedora44-genai-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(amd64,fedora44-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-v31-clang
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-clang
+      MATRIX: '(amd64,fedora44-v31-clang)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-v31-dbg
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44-dbg
+      MATRIX: '(amd64,fedora44-v31-dbg)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(amd64,fedora44-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44.yml
+++ b/.github/workflows/CI-package-amd64-fedora44.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: amd64
       DIST: fedora44

--- a/.github/workflows/CI-package-amd64-fedora44.yml
+++ b/.github/workflows/CI-package-amd64-fedora44.yml
@@ -1,0 +1,149 @@
+name: CI-package-amd64-fedora44
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(amd64,fedora44)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-fedora44.yml
+++ b/.github/workflows/CI-package-amd64-fedora44.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-genai.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: arm64
       DIST: fedora44

--- a/.github/workflows/CI-package-arm64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-genai.yml
@@ -1,0 +1,149 @@
+name: CI-package-arm64-fedora44-genai
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(arm64,fedora44-genai)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-genai.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-v31.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: arm64
       DIST: fedora44

--- a/.github/workflows/CI-package-arm64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-v31.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-v31.yml
@@ -1,0 +1,149 @@
+name: CI-package-arm64-fedora44-v31
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(arm64,fedora44-v31)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        PROXYSQL31=1 make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-fedora44.yml
+++ b/.github/workflows/CI-package-arm64-fedora44.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,9 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +77,9 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      checks: write
     env:
       ARCH: arm64
       DIST: fedora44

--- a/.github/workflows/CI-package-arm64-fedora44.yml
+++ b/.github/workflows/CI-package-arm64-fedora44.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -138,7 +138,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora44.yml
+++ b/.github/workflows/CI-package-arm64-fedora44.yml
@@ -1,0 +1,149 @@
+name: CI-package-arm64-fedora44
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    # No concurrency group: GitHub's "1 running + 1 pending" rule causes
+    # mass cancellations when many workflows share a group. Instead we
+    # run all init jobs in parallel and converge via a race-tolerant
+    # find-or-create loop; all workers deterministically pick the
+    # lowest-id draft matching this SHA+tag.
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: fedora44
+      MAKE_TARGET: fedora44
+      MATRIX: '(arm64,fedora44)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/*[mb] binaries/*.id-hash; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/*[mb] or binaries/*.id-hash" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,20 @@ Test files follow the naming pattern `test_*.cpp` or `*-t.cpp` in `test/tap/test
 
 Test binaries are built via a pattern rule in `test/tap/tests/Makefile`: `make <testname>-t` compiles `<testname>-t.cpp` into `<testname>-t`. No special Makefile target is needed for new tests — just add the `.cpp` file and register it in `groups.json`.
 
+### Reporting CI/test failures
+
+**Test quality is paramount on this project. Never dismiss a CI failure as "pre-existing" or "flaky".** Those words are observations, not analyses, and using them as a conclusion lets real bugs survive.
+
+When CI fails on a branch or PR:
+
+1. **Read the actual failure.** Open the failing test log, the proxysql server log it produced, and the test source. Identify the specific assertion, timeout, crash, or non-zero exit. Quote the relevant lines in your report.
+2. **State the root cause, not the symptom.** "Test X failed" is a symptom. The root cause is *why* — a race condition, a stale fixture, a resource leak, a protocol regression, an env mismatch, etc.
+3. **Separate two distinct questions** and answer both with evidence:
+   - *Did the current change cause this failure?* — answer via commit-by-commit reasoning and code-path analysis, not just by comparing baseline pass/fail rates.
+   - *Is this test broken regardless of the current change?* — independent question. A failure that pre-dates the change is still a problem to fix or file, not a reason to merge over.
+4. **If the root cause cannot be determined within the session**, say so explicitly and recommend the next investigation step (re-run with logs, instrument the test, file a tracking issue). Do not paper over uncertainty with "flaky".
+5. **A repeatedly failing test is a higher-priority bug, not a lower one.** Recurrence is evidence that the failure mode is reproducible — that is exactly what makes it fixable.
+
 ## Architecture
 
 ### Build Pipeline

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensu
 amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux9-clang almalinux9-dbg almalinux10 almalinux10-clang almalinux10-dbg
 amd64-centos: centos9 centos9-clang centos9-dbg centos10 centos10-clang centos10-dbg
 amd64-debian: debian12 debian12-clang debian12-dbg debian13 debian13-clang debian13-dbg
-amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg
+amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg fedora44 fedora44-clang fedora44-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
@@ -444,7 +444,7 @@ arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensu
 arm64-almalinux: almalinux8 almalinux9 almalinux10
 arm64-centos: centos9 centos10
 arm64-debian: debian12 debian13
-arm64-fedora: fedora42 fedora43
+arm64-fedora: fedora42 fedora43 fedora44
 arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
 arm64-pkglist:

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -195,6 +195,7 @@ jemalloc/jemalloc/lib/libjemalloc.a:
 	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue823.520.patch
 	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue2358.patch
 	cd jemalloc/jemalloc && patch -p0 < ../nothrow.patch
+	cd jemalloc/jemalloc && patch src/jemalloc_cpp.cpp < ../throw-bad-alloc.patch
 	cd jemalloc/jemalloc && ./configure ${MYJEOPT}
 #	cd jemalloc/jemalloc && sed -i -e 's/-O3 /-O3 -fPIC /' Makefile
 	cd jemalloc/jemalloc && CC=${CC} CXX=${CXX} ${MAKE}

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -295,6 +295,7 @@ sqlite-vec: sqlite3/sqlite3/vec.o
 libconfig/libconfig/out/libconfig++.a:
 	cd libconfig && rm -rf libconfig-*/ || true
 	cd libconfig && tar -zxf libconfig-*.tar.gz
+	cd libconfig/libconfig && patch -p1 < ../restore_unknown_escape_passthrough.patch
 	cd libconfig/libconfig && cmake -DBUILD_SHARED_LIBS=0 -DBUILD_EXAMPLES=0 -DBUILD_TESTS=0 -DBUILD_FUZZERS=0 .
 	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
 

--- a/deps/jemalloc/throw-bad-alloc.patch
+++ b/deps/jemalloc/throw-bad-alloc.patch
@@ -1,0 +1,25 @@
+Fix build against libstdc++ shipped with GCC 16, which no longer
+exposes the internal symbol std::__throw_bad_alloc() through <new>.
+
+Backports the user-visible part of jemalloc upstream commit 1a15fe33
+("Replace std::__throw_bad_alloc call with standard C++"), restricted
+to the call site itself.  jemalloc's upstream patch also adds a
+configure-time check that conditionally compiles either
+'throw std::bad_alloc()' or 'std::terminate()' depending on whether
+C++ exceptions are enabled, but ProxySQL always builds with C++
+exceptions, so the simpler unconditional form is sufficient.
+
+Refs:
+  https://github.com/sysown/proxysql/issues/5770
+  https://github.com/jemalloc/jemalloc/commit/1a15fe33a48c52bfe26ea83e49f0d317a47da3ea
+
+--- src/jemalloc_cpp.cpp.orig
++++ src/jemalloc_cpp.cpp
+@@ -67,7 +67,7 @@
+ 	}
+
+ 	if (ptr == nullptr && !nothrow)
+-		std::__throw_bad_alloc();
++		throw std::bad_alloc();
+ 	return ptr;
+ }

--- a/deps/libconfig/restore_unknown_escape_passthrough.patch
+++ b/deps/libconfig/restore_unknown_escape_passthrough.patch
@@ -1,0 +1,73 @@
+Restore libconfig 1.7.3 passthrough behavior for the escape sequences
+that were newly introduced in 1.8.1 (\a, \b, \v).
+
+Background
+----------
+libconfig 1.7.3 only recognized \n, \r, \t, \f, \\, \" and \xHH inside
+quoted strings.  Any other backslash sequence (\a, \b, \v, \z, ...)
+fell through to the catch-all `<STRING>\\.` rule and the backslash
+was preserved.
+
+libconfig 1.8.1 added explicit rules for \a, \b and \v that collapse
+the two-character sequence into a single control byte (0x07, 0x08,
+0x0B respectively).  This silently corrupts ProxySQL configuration
+values that happen to contain those literal sequences -- most visibly
+passwords -- because the operator-supplied two-character sequence is
+not what the lexer ends up storing.  See sysown/proxysql#5766.
+
+Fix
+---
+Patch the (still-matched) \a / \b / \v rules so they emit the
+backslash and the letter as two literal characters, restoring the
+1.7.3 wire-for-wire result.  The regex itself is unchanged so the
+generated state machine in scanner.c keeps working with the surgical
+edits applied to scanner.c below.
+
+\f, \n, \r, \t are intentionally left as escape sequences: they were
+already interpreted by libconfig 1.7.3 and changing them would be a
+behavioural regression for users who rely on them.
+
+--- a/lib/scanner.c
++++ b/lib/scanner.c
+@@ -1330,12 +1330,12 @@
+ case 10:
+ YY_RULE_SETUP
+ #line 85 "scanner.l"
+-{ libconfig_scanctx_append_char(yyextra, '\a'); }
++{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'a'); }
+ 	YY_BREAK
+ case 11:
+ YY_RULE_SETUP
+ #line 86 "scanner.l"
+-{ libconfig_scanctx_append_char(yyextra, '\b'); }
++{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'b'); }
+ 	YY_BREAK
+ case 12:
+ YY_RULE_SETUP
+@@ -1355,7 +1355,7 @@
+ case 15:
+ YY_RULE_SETUP
+ #line 90 "scanner.l"
+-{ libconfig_scanctx_append_char(yyextra, '\v'); }
++{ libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'v'); }
+ 	YY_BREAK
+ case 16:
+ YY_RULE_SETUP
+--- a/lib/scanner.l
++++ b/lib/scanner.l
+@@ -82,12 +82,12 @@
+
+ \"                { BEGIN STRING; }
+ <STRING>[^\"\\]+  { libconfig_scanctx_append_string(yyextra, yytext); }
+-<STRING>\\a       { libconfig_scanctx_append_char(yyextra, '\a'); }
+-<STRING>\\b       { libconfig_scanctx_append_char(yyextra, '\b'); }
++<STRING>\\a       { libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'a'); }
++<STRING>\\b       { libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'b'); }
+ <STRING>\\n       { libconfig_scanctx_append_char(yyextra, '\n'); }
+ <STRING>\\r       { libconfig_scanctx_append_char(yyextra, '\r'); }
+ <STRING>\\t       { libconfig_scanctx_append_char(yyextra, '\t'); }
+-<STRING>\\v       { libconfig_scanctx_append_char(yyextra, '\v'); }
++<STRING>\\v       { libconfig_scanctx_append_char(yyextra, '\\'); libconfig_scanctx_append_char(yyextra, 'v'); }
+ <STRING>\\f       { libconfig_scanctx_append_char(yyextra, '\f'); }
+ <STRING>\\\\      { libconfig_scanctx_append_char(yyextra, '\\'); }
+ <STRING>\\\"      { libconfig_scanctx_append_char(yyextra, '\"'); }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,34 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
 
 ####################################################################################################
+  fedora44_build:
+    extends:
+      service: _build
+    image: proxysql/packaging:build-fedora44-v4.0.0
+    volumes:
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/rpmbuild/:/root/rpmbuild/
+      - ./docker/images/proxysql/rhel-compliant/rpmmacros/.rpmmacros:/root/.rpmmacros
+      - ./docker/images/proxysql/rhel-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - PKG_RELEASE=fedora44
+      - PROXYSQL_BUILD_TYPE=clickhouse
+
+  fedora44_clang_build:
+    extends:
+      service: fedora44_build
+    image: proxysql/packaging:build-clang-fedora44-v4.0.0
+    environment:
+      - PKG_RELEASE=fedora44-clang
+
+  fedora44_dbg_build:
+    extends:
+      service: fedora44_build
+    environment:
+      - PKG_RELEASE=dbg-fedora44
+      - PROXYSQL_BUILD_TYPE=debug
+
+####################################################################################################
 ####################################################################################################
   debian12_build:
     extends:

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -140,13 +140,28 @@ if grep -q '^PKG_PLUGIN_FILES_PLACEHOLDER$' ./proxysql.ctl; then
     exit 1
 fi
 DEB_BUILD_OPTIONS=nostrip equivs-build proxysql.ctl
-cp ./proxysql_${CURVER}_${ARCH}.deb ../binaries/proxysql_${CURVER}-${PKG_RELEASE}_${ARCH}.deb
-# get SHA1 of the packaged executable
-if [[ -x $(command -v unzstd) ]]; then
-	ar -p proxysql_${CURVER}_${ARCH}.deb $(ar t proxysql_${CURVER}_${ARCH}.deb | grep data.tar) | unzstd -c - | tar xvf - ./usr/bin/proxysql -O > tmp/proxysql
-else
-	ar -p proxysql_${CURVER}_${ARCH}.deb $(ar t proxysql_${CURVER}_${ARCH}.deb | grep data.tar) | unxz -c - | tar xvf - ./usr/bin/proxysql -O > tmp/proxysql
+
+# Force xz compression for the data tarball.  Ubuntu 22/24's dpkg-deb
+# defaults to zstd, while Debian 12/13 still defaults to xz.  The
+# release server signs with dpkg-sig 0.13 on dpkg 1.21.1, which
+# accepts the signature but then reports BADSIG on `dpkg-sig --verify`
+# for the zstd-compressed Ubuntu DEBs.  Repacking to xz makes the
+# format consistent across all distros and unblocks signing.  The
+# check on data.tar.xz also covers any future dpkg-deb default change
+# (e.g. lzma, gzip) by triggering the repack whenever the format
+# isn't already xz.  See issue #5580.
+PKG="proxysql_${CURVER}_${ARCH}.deb"
+if ! ar t "${PKG}" | grep -q '^data\.tar\.xz$'; then
+	echo "==> Repacking ${PKG} with xz compression (was: $(ar t "${PKG}" | grep '^data\.tar'))"
+	REPACK_DIR=$(mktemp -d)
+	dpkg-deb -R "${PKG}" "${REPACK_DIR}"
+	dpkg-deb -Zxz -b "${REPACK_DIR}" "${PKG}"
+	rm -rf "${REPACK_DIR}"
 fi
+
+cp "./${PKG}" "../binaries/proxysql_${CURVER}-${PKG_RELEASE}_${ARCH}.deb"
+# get SHA1 of the packaged executable (always xz after the repack above)
+ar -p "${PKG}" $(ar t "${PKG}" | grep '^data\.tar') | unxz -c - | tar xvf - ./usr/bin/proxysql -O > tmp/proxysql
 sha1sum tmp/proxysql | sed 's|tmp/||' | tee tmp/proxysql.sha1
 cp tmp/proxysql.sha1 ../binaries/proxysql_${CURVER}-${PKG_RELEASE}_${ARCH}.id-hash
 popd

--- a/include/ProxySQL_RESTAPI_Server.hpp
+++ b/include/ProxySQL_RESTAPI_Server.hpp
@@ -15,6 +15,8 @@ class ProxySQL_RESTAPI_Server {
 	pthread_t thread_id;
 	std::unique_ptr<httpserver::http_resource> endpoint;
 	std::unique_ptr<httpserver::http_resource> tsdb_endpoint;
+	std::unique_ptr<httpserver::http_resource> tsdb_dashboard_endpoint;
+	std::unique_ptr<httpserver::http_resource> tsdb_chart_js_endpoint;
 	std::vector<std::pair<std::string, std::unique_ptr<httpserver::http_resource>>> _endpoints {};
 	public:
 	ProxySQL_RESTAPI_Server(

--- a/lib/ProxySQL_HTTP_Server.cpp
+++ b/lib/ProxySQL_HTTP_Server.cpp
@@ -52,9 +52,6 @@ extern ClickHouse_Server *GloClickHouseServer;
 #endif
 
 extern char * Chart_bundle_js_c;
-#ifdef PROXYSQLTSDB
-extern const char * TSDB_Dashboard_html_c;
-#endif
 extern char * font_awesome;
 extern char * main_bundle_min_css_c;
 #define RATE_LIMIT_PAGE "<html><head><title>Rate Limit Page</title></head><body>Rate Limit Reached</body></html>"
@@ -440,14 +437,10 @@ int ProxySQL_HTTP_Server::handler(void *cls, struct MHD_Connection *connection, 
 	if (0 != strcmp (method, "GET"))
 		return MHD_NO;              /* unexpected method */
 
-#ifdef PROXYSQLTSDB
-	if (strcmp(url,"/tsdb")==0) {
-		response = MHD_create_response_from_buffer (strlen(TSDB_Dashboard_html_c), (void *) TSDB_Dashboard_html_c, MHD_RESPMEM_PERSISTENT);
-		ret = MHD_queue_response (connection, MHD_HTTP_OK, response);
-		MHD_destroy_response (response);
-		return ret;
-	}
-#endif
+	/* The TSDB dashboard previously served here is now served by the
+	 * REST API server (admin-restapi_port). Serving it here resulted in
+	 * a cross-origin mismatch between the dashboard's port and the
+	 * /api/tsdb/* endpoints, which broke the metric fetch (#5684). */
 
 	if (strcmp(url,"/stats")==0) {
 		valmetric = (char *)MHD_lookup_connection_value (connection, MHD_GET_ARGUMENT_KIND, (char *)"metric");

--- a/lib/ProxySQL_RESTAPI_Server.cpp
+++ b/lib/ProxySQL_RESTAPI_Server.cpp
@@ -456,6 +456,30 @@ public:
         return response;
     }
 };
+
+/* The TSDB dashboard HTML and its Chart.bundle.js asset are served from
+ * the REST API port so the dashboard's fetch('/api/tsdb/...') calls are
+ * same-origin and resolve to the real handlers above. See issue #5684. */
+extern const char* TSDB_Dashboard_html_c;
+extern char* Chart_bundle_js_c;
+
+class tsdb_dashboard_resource : public http_resource {
+public:
+    const std::shared_ptr<http_response> render_GET(const http_request& /*req*/) override {
+        auto response = std::shared_ptr<http_response>(new string_response(TSDB_Dashboard_html_c, http::http_utils::http_ok));
+        response->with_header("Content-Type", "text/html; charset=utf-8");
+        return response;
+    }
+};
+
+class tsdb_chart_js_resource : public http_resource {
+public:
+    const std::shared_ptr<http_response> render_GET(const http_request& /*req*/) override {
+        auto response = std::shared_ptr<http_response>(new string_response(Chart_bundle_js_c, http::http_utils::http_ok));
+        response->with_header("Content-Type", "application/javascript; charset=utf-8");
+        return response;
+    }
+};
 #endif
 
 class gen_get_endpoint : public http_resource {
@@ -515,6 +539,14 @@ ProxySQL_RESTAPI_Server::ProxySQL_RESTAPI_Server(
 	ws->register_resource("/api/tsdb/metrics", tsdb_endpoint.get(), true);
 	ws->register_resource("/api/tsdb/query", tsdb_endpoint.get(), true);
 	ws->register_resource("/api/tsdb/status", tsdb_endpoint.get(), true);
+
+	/* Serve the dashboard HTML and its Chart.bundle.js asset on the
+	 * same port as the API, so the dashboard's relative fetch() calls
+	 * are same-origin. See issue #5684. */
+	tsdb_dashboard_endpoint = std::unique_ptr<httpserver::http_resource>(new tsdb_dashboard_resource());
+	tsdb_chart_js_endpoint = std::unique_ptr<httpserver::http_resource>(new tsdb_chart_js_resource());
+	ws->register_resource("/tsdb", tsdb_dashboard_endpoint.get(), true);
+	ws->register_resource("/Chart.bundle.js", tsdb_chart_js_endpoint.get(), true);
 #endif
 	if (pthread_create(&thread_id, NULL, restapi_server_thread, ws.get()) !=0 ) {
 		perror("Thread creation");

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -1789,6 +1789,13 @@ __internal_loop:
 			((ret && ret->new_query) ? ret->new_query->c_str() : NULL),
 			GET_THREAD_VARIABLE(query_processor_regex)
 		) == false) {
+			// Reset qr so a non-matching rule does not leak into the
+			// fast-routing check at __exit_process_mysql_query. That
+			// check reads qr->apply to decide whether a rule was
+			// already applied; if the loop ends without ever matching
+			// but the last iterated rule had apply=1, fast-routing
+			// would otherwise be silently skipped (issue #5620).
+			qr = NULL;
 			continue;
 		}
 

--- a/lib/pgsql_tokenizer.cpp
+++ b/lib/pgsql_tokenizer.cpp
@@ -1245,8 +1245,6 @@ enum p_st process_replace_null(shared_st* shared_st, const options* opts) {
 static __attribute__((always_inline)) inline
 enum p_st process_pg_typecast(shared_st* s, pg_typecast_st* tc)
 {
-	enum p_st next = st_pg_typecast;
-
 	// On entering state
 	if (!tc->started) {
 		tc->started = true;
@@ -1307,11 +1305,27 @@ enum p_st process_pg_typecast(shared_st* s, pg_typecast_st* tc)
 		c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
 	}
 
-	// Skip any whitespace
-	while (s->q_cur_pos < s->q_len && is_space_char(c)) {
-		s->q++;
-		s->q_cur_pos++;
-		c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
+	// Skip whitespace, but only if it's followed by a modifier or
+	// array bracket (e.g. `::int (10)`, `::int []`).  If the
+	// whitespace is just a separator before the next token (e.g.
+	// `::int FROM ...`), preserve it so the dispatcher sees the
+	// space and emits it between the typecast and the following
+	// token in the output.  Without this lookahead the typecast
+	// handler used to consume the trailing space and produced
+	// digests like `count(*)from x` (issue #5755).
+	if (s->q_cur_pos < s->q_len && is_space_char(c)) {
+		int saved_pos = s->q_cur_pos;
+		const char* saved_q = s->q;
+		while (s->q_cur_pos < s->q_len && is_space_char(c)) {
+			s->q++;
+			s->q_cur_pos++;
+			c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
+		}
+		if (c != '(' && c != '[') {
+			s->q = saved_q;
+			s->q_cur_pos = saved_pos;
+			c = (s->q_cur_pos < s->q_len) ? *s->q : '\0';
+		}
 	}
 
 	// Handle type modifiers (parentheses with parameters)
@@ -1375,18 +1389,21 @@ enum p_st process_pg_typecast(shared_st* s, pg_typecast_st* tc)
 		}
 	}
 
-	// End of type name? Now check if we're at a delimiter
-	if (s->q_cur_pos >= s->q_len ||
-		is_space_char(c) ||
-		c == ')' || c == '(' || c == ';' || c == ',' ||
-		c == '+' || c == '-' ||	c == '*' || c == '/' ||
-		c == '=' || c == '<' ||	c == '>' || c == '@' ||
-		c == ']' || c == '[') {
-		// Exit state
-		return st_no_mark_found;
-	}
-
-	return next;
+	// All typecast consumption (type name + optional whitespace +
+	// modifiers + array brackets) is complete by this point, so the
+	// state must always exit.  The previous attempt to detect "end of
+	// typecast" via an enumerated delimiter list dropped through to
+	// `return next` for any character not in that list (e.g. the 'F'
+	// of `FROM` after `::INT FROM "Inventory"`), which kept the
+	// dispatcher in `st_pg_typecast`, advanced the cursor by one extra
+	// char per outer-loop iteration, and silently swallowed the rest
+	// of the query.  See issue #5755.
+	//
+	// Also reset `started` so a subsequent `::cast` later in the same
+	// query (e.g. `SELECT 1::INT, 2::TEXT`) re-enters cleanly via the
+	// entry block at the top of this function.
+	tc->started = false;
+	return st_no_mark_found;
 }
 
 /**

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -258,6 +258,7 @@
   "reg_test_5233_set_warning-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1","set_parser_algorithm_3-g1" ],
   "reg_test_5306-show_warnings_with_comment-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_5389-flush_logs_no_drop-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "reg_test_5620_fast_routing_qr_leak-t" : [ "legacy-g6" ],
   "reg_test__ssl_client_busy_wait-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_com_change_user_malformed_packet-t" : [ "mysql84-g6","mysql95-g1" ],
   "reg_test_compression_split_packets-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -258,6 +258,7 @@
   "reg_test_5233_set_warning-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1","set_parser_algorithm_3-g1" ],
   "reg_test_5306-show_warnings_with_comment-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_5389-flush_logs_no_drop-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
+  "reg_test_5766_libconfig_escape_passthrough-t" : [ "mysql95-g4" ],
   "reg_test__ssl_client_busy_wait-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_com_change_user_malformed_packet-t" : [ "mysql84-g6","mysql95-g1" ],
   "reg_test_compression_split_packets-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -1246,6 +1246,91 @@ MYSQL* wait_for_proxysql(const conn_opts_t& opts, int timeout) {
 	}
 }
 
+int wait_for_proxysql_cluster(
+	const std::vector<std::pair<std::string,int>>& nodes,
+	const std::string& admin_user,
+	const std::string& admin_password,
+	int timeout_s,
+	int poll_interval_s
+) {
+	if (nodes.empty()) return 0;
+
+	struct pending_t {
+		std::string host;
+		int port;
+		std::string last_error;
+	};
+	std::vector<pending_t> pending;
+	pending.reserve(nodes.size());
+	for (const auto& n : nodes) {
+		pending.push_back({n.first, n.second, "(no attempt yet)"});
+	}
+
+	const unsigned long long start_us = monotonic_time();
+	const unsigned long long deadline_us =
+		start_us + static_cast<unsigned long long>(timeout_s) * 1000000ULL;
+
+	const unsigned int connect_timeout_per_attempt = 2;
+	while (!pending.empty() && monotonic_time() < deadline_us) {
+		auto it = pending.begin();
+		while (it != pending.end()) {
+			MYSQL* probe = mysql_init(NULL);
+			if (!probe) {
+				it->last_error = "mysql_init returned NULL";
+				++it;
+				continue;
+			}
+			mysql_options(probe, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout_per_attempt);
+
+			MYSQL* rc = mysql_real_connect(
+				probe, it->host.c_str(), admin_user.c_str(), admin_password.c_str(),
+				NULL, it->port, NULL, 0
+			);
+			if (rc) {
+				mysql_close(probe);
+				it = pending.erase(it);
+			} else {
+				it->last_error = mysql_error(probe);
+				mysql_close(probe);
+				++it;
+			}
+		}
+		if (!pending.empty() && monotonic_time() < deadline_us) {
+			sleep(poll_interval_s);
+		}
+	}
+
+	if (pending.empty()) {
+		const unsigned long long elapsed_us = monotonic_time() - start_us;
+		diag("wait_for_proxysql_cluster: all %zu endpoint(s) ready in %.2fs",
+			nodes.size(), elapsed_us / 1000000.0);
+		return 0;
+	}
+
+	diag("wait_for_proxysql_cluster: %zu/%zu endpoint(s) did not respond within %ds",
+		pending.size(), nodes.size(), timeout_s);
+	for (const auto& p : pending) {
+		diag("  not ready: %s:%d  last error: %s",
+			p.host.c_str(), p.port, p.last_error.c_str());
+	}
+	return 1;
+}
+
+int wait_for_proxysql_cluster(
+	const std::string& host,
+	const std::vector<int>& ports,
+	const std::string& admin_user,
+	const std::string& admin_password,
+	int timeout_s,
+	int poll_interval_s
+) {
+	std::vector<std::pair<std::string,int>> nodes;
+	nodes.reserve(ports.size());
+	for (int p : ports) nodes.emplace_back(host, p);
+	return wait_for_proxysql_cluster(
+		nodes, admin_user, admin_password, timeout_s, poll_interval_s);
+}
+
 int get_variable_value(
 	MYSQL* proxysql_admin, const string& variable_name, string& variable_value, bool runtime
 ) {

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -567,6 +567,54 @@ struct conn_opts_t {
 MYSQL* wait_for_proxysql(const conn_opts_t& opts, int timeout);
 
 /**
+ * @brief Probe a set of ProxySQL admin endpoints and wait until every one of
+ *  them accepts a plain (no SSL, no compression) admin login.
+ *
+ * @details Useful for cluster-style tests where multiple ProxySQL instances are
+ *  expected to be up before the test starts issuing real queries. The probe
+ *  is intentionally cheap — it opens a connection, observes that login
+ *  succeeds, closes the connection. It does not exercise SSL, compression,
+ *  or any query path; those are left to the real test connections.
+ *
+ *  Endpoints are probed round-robin. Each attempt uses a short connect
+ *  timeout (2s). Endpoints that respond are removed from the pending set;
+ *  endpoints that fail keep their last 'mysql_error' for diagnostics. The
+ *  loop sleeps 'poll_interval_s' between rounds until either every
+ *  endpoint has responded or the overall 'timeout_s' deadline expires.
+ *
+ *  On deadline expiry the function emits a single diag() line per still-
+ *  unresponsive endpoint with its last observed error, so the test fails
+ *  with an actionable message rather than a cryptic EINPROGRESS later.
+ *
+ * @param nodes Vector of (host, admin_port) pairs to probe.
+ * @param admin_user Admin username for login.
+ * @param admin_password Admin password for login.
+ * @param timeout_s Overall wall-clock budget in seconds. Default 60.
+ * @param poll_interval_s Sleep between rounds, in seconds. Default 2.
+ * @return 0 if every endpoint responded within the deadline; 1 otherwise.
+ */
+int wait_for_proxysql_cluster(
+	const std::vector<std::pair<std::string,int>>& nodes,
+	const std::string& admin_user,
+	const std::string& admin_password,
+	int timeout_s = 60,
+	int poll_interval_s = 2);
+
+/**
+ * @brief Convenience overload: probe a list of ports on a single host.
+ *
+ * @details Builds the {host, port} vector internally and delegates to the
+ *  pair-based overload. Default values for timeout_s / poll_interval_s match.
+ */
+int wait_for_proxysql_cluster(
+	const std::string& host,
+	const std::vector<int>& ports,
+	const std::string& admin_user,
+	const std::string& admin_password,
+	int timeout_s = 60,
+	int poll_interval_s = 2);
+
+/**
  * @brief Extract the current value for a given 'variable_name' from
  *   ProxySQL current configuration, either MEMORY or RUNTIME.
  * @param proxysql_admin An already opened connection to ProxySQL Admin.

--- a/test/tap/tests/mysql-last_insert_id-t.cpp
+++ b/test/tap/tests/mysql-last_insert_id-t.cpp
@@ -70,8 +70,24 @@ int main(int argc, char** argv) {
 		unsigned long long num_rows = mysql_num_rows(res);
 		ok(num_rows == 1, "mysql_num_rows() , expected: 1 , actual: %llu", num_rows);
 		while ((row = mysql_fetch_row(res))) {
-				ok(strcmp(row[0],"501")==0, "row: expected: \"501\" , actual: \"%s\"", row[0]);
-		}	
+			// Accept either:
+			//   - "501": single-master backend where auto_increment_increment=1
+			//     and the 501st INSERT (after 500 in create_table_test_sbtest1)
+			//     produces ID 501.
+			//   - a value in 1501..1505: multi-master backend (e.g. Galera with
+			//     wsrep_auto_increment_control=ON), which sets
+			//     auto_increment_increment to the cluster size (typically 2-4)
+			//     and auto_increment_offset to the node's index. On a 3-node
+			//     cluster the 501st row's ID is offset + 500*3, i.e. one of
+			//     1501, 1502, or 1503. The range 1501..1505 allows for small
+			//     cluster size variations.
+			long long actual = (row[0] != NULL) ? atoll(row[0]) : -1;
+			bool ok_val = (row[0] != NULL && strcmp(row[0], "501") == 0)
+				|| (actual >= 1501 && actual <= 1505);
+			ok(ok_val,
+				"row: expected: \"501\" (single-master) or 1501..1505 (Galera/GR multi-master), actual: \"%s\"",
+				row[0] != NULL ? row[0] : "(null)");
+		}
 		mysql_free_result(res);
 	}
 

--- a/test/tap/tests/prepare_statement_err3024-t.cpp
+++ b/test/tap/tests/prepare_statement_err3024-t.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+#include <memory>
 #include <poll.h>
 #include <string>
 #include <stdio.h>
@@ -19,11 +20,144 @@
 
 const int NUM_EXECUTIONS = 5;
 
+// The first query is the one expected to time out. Its exact form depends on
+// whether the backend is MySQL or MariaDB — see select_timeout_dialect() below.
+// The other two queries are backend-neutral.
 std::string select_query[3] = {
-	"SELECT /*+ MAX_EXECUTION_TIME(10) */ COUNT(*) FROM test.sbtest1 a JOIN test.sbtest1 b WHERE (a.id+b.id)%2" ,
+	"" , // filled in at runtime by select_timeout_dialect()
 	"SELECT COUNT(*) FROM (SELECT a.* FROM test.sbtest1 a JOIN test.sbtest1 b WHERE (a.id+b.id)%2 LIMIT 1000) t" ,
 	"SELECT a.* FROM test.sbtest1 a JOIN test.sbtest1 b WHERE (a.id+b.id)%2 LIMIT 10000"
 };
+
+// Result of detecting the actual backend type.
+enum class backend_kind_t { unknown, mysql, mariadb };
+
+// Determine whether the backend ProxySQL will route this test's queries to is
+// MySQL or MariaDB. The method is deliberately indirect via the ProxySQL admin
+// interface — querying the data connection's 'SELECT VERSION()' is unreliable
+// because ProxySQL can be configured to advertise an arbitrary
+// 'mysql-server_version', and routing rules may direct different queries to
+// different backends.
+//
+// The flow:
+//   1. Open an admin connection to ProxySQL.
+//   2. Read an ONLINE entry from 'runtime_mysql_servers' to learn the
+//      backend host:port pair.
+//   3. Open a direct connection to that backend (NOT via ProxySQL) using
+//      the same user credentials the test will use later.
+//   4. Query 'SELECT VERSION()' on the direct connection; the returned
+//      string contains the literal "MariaDB" on MariaDB servers (e.g.
+//      "10.11.5-MariaDB-1:10.11.5+maria~ubu2204").
+//
+// Returns 'backend_kind_t::unknown' on any failure along that path; callers
+// are expected to treat unknown as a hard failure rather than silently
+// defaulting, because picking the wrong dialect means the test would
+// misinterpret the resulting error code.
+static backend_kind_t detect_backend_via_admin(const CommandLine& cl) {
+	std::unique_ptr<MYSQL, decltype(&mysql_close)> admin_owner{
+		mysql_init(NULL), &mysql_close
+	};
+	MYSQL* admin = admin_owner.get();
+	if (!admin) {
+		diag("detect_backend_via_admin: mysql_init for admin returned NULL");
+		return backend_kind_t::unknown;
+	}
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+			NULL, cl.admin_port, NULL, 0)) {
+		diag("detect_backend_via_admin: connect to admin %s:%d failed: %s",
+			cl.host, cl.admin_port, mysql_error(admin));
+		return backend_kind_t::unknown;
+	}
+
+	if (mysql_query(admin,
+			"SELECT hostname, port FROM runtime_mysql_servers "
+			"WHERE status='ONLINE' ORDER BY hostgroup_id, hostname LIMIT 1")) {
+		diag("detect_backend_via_admin: querying runtime_mysql_servers failed: %s",
+			mysql_error(admin));
+		return backend_kind_t::unknown;
+	}
+	MYSQL_RES* res = mysql_store_result(admin);
+	if (!res) {
+		diag("detect_backend_via_admin: store_result for runtime_mysql_servers returned NULL");
+		return backend_kind_t::unknown;
+	}
+	std::string be_host;
+	int be_port = 0;
+	if (MYSQL_ROW row = mysql_fetch_row(res)) {
+		if (row[0]) be_host = row[0];
+		if (row[1]) be_port = atoi(row[1]);
+	}
+	mysql_free_result(res);
+	if (be_host.empty() || be_port == 0) {
+		diag("detect_backend_via_admin: no ONLINE backend found in runtime_mysql_servers");
+		return backend_kind_t::unknown;
+	}
+	diag("detect_backend_via_admin: probing backend %s:%d directly", be_host.c_str(), be_port);
+
+	std::unique_ptr<MYSQL, decltype(&mysql_close)> be_owner{
+		mysql_init(NULL), &mysql_close
+	};
+	MYSQL* be = be_owner.get();
+	if (!be) {
+		diag("detect_backend_via_admin: mysql_init for backend returned NULL");
+		return backend_kind_t::unknown;
+	}
+	if (!mysql_real_connect(be, be_host.c_str(), cl.username, cl.password,
+			NULL, be_port, NULL, 0)) {
+		diag("detect_backend_via_admin: direct connect to backend %s:%d failed: %s",
+			be_host.c_str(), be_port, mysql_error(be));
+		return backend_kind_t::unknown;
+	}
+	if (mysql_query(be, "SELECT VERSION()")) {
+		diag("detect_backend_via_admin: 'SELECT VERSION()' on backend failed: %s",
+			mysql_error(be));
+		return backend_kind_t::unknown;
+	}
+	MYSQL_RES* vres = mysql_store_result(be);
+	if (!vres) {
+		diag("detect_backend_via_admin: store_result for VERSION() returned NULL");
+		return backend_kind_t::unknown;
+	}
+	std::string version;
+	if (MYSQL_ROW row = mysql_fetch_row(vres)) {
+		if (row[0]) version = row[0];
+	}
+	mysql_free_result(vres);
+	if (version.empty()) {
+		diag("detect_backend_via_admin: backend VERSION() returned empty string");
+		return backend_kind_t::unknown;
+	}
+	diag("detect_backend_via_admin: backend %s:%d VERSION() = '%s'",
+		be_host.c_str(), be_port, version.c_str());
+	return (version.find("MariaDB") != std::string::npos)
+		? backend_kind_t::mariadb
+		: backend_kind_t::mysql;
+}
+
+// Fill in select_query[0] with the right syntax for the connected backend, and
+// return the error code we should expect when the timeout fires.
+//
+// MySQL  : /*+ MAX_EXECUTION_TIME(10) */    → ER_QUERY_TIMEOUT     (3024)
+// MariaDB: SET STATEMENT max_statement_time=0.01 FOR ...
+//                                            → ER_STATEMENT_TIMEOUT (1969)
+//
+// MariaDB does not honour MySQL's MAX_EXECUTION_TIME optimizer hint (it is
+// silently ignored). Its equivalent is the SET STATEMENT … FOR … wrapper,
+// which is a valid prepared-statement body and surfaces the timeout via the
+// MariaDB-specific error code 1969. See issue #5783.
+static unsigned int select_timeout_dialect(backend_kind_t kind) {
+	if (kind == backend_kind_t::mariadb) {
+		select_query[0] =
+			"SET STATEMENT max_statement_time=0.01 FOR "
+			"SELECT COUNT(*) FROM test.sbtest1 a JOIN test.sbtest1 b "
+			"WHERE (a.id+b.id)%2";
+		return 1969; // MariaDB ER_STATEMENT_TIMEOUT
+	}
+	select_query[0] =
+		"SELECT /*+ MAX_EXECUTION_TIME(10) */ COUNT(*) "
+		"FROM test.sbtest1 a JOIN test.sbtest1 b WHERE (a.id+b.id)%2";
+	return 3024; // MySQL ER_QUERY_TIMEOUT
+}
 
 #ifndef LIBMYSQL_HELPER
 /* Helper function to do the waiting for events on the socket. */
@@ -81,6 +215,25 @@ int main(int argc, char** argv) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(mysql));
 		return exit_status();
 	}
+
+	// Detect the actual backend (MySQL vs MariaDB) via the ProxySQL admin
+	// interface, then pick the right timeout dialect. Hard-fail if the
+	// detection is inconclusive — silently defaulting would let the test
+	// misinterpret the resulting error code on the other backend.
+	const backend_kind_t be_kind = detect_backend_via_admin(cl);
+	if (be_kind == backend_kind_t::unknown) {
+		BAIL_OUT(
+			"Could not determine the backend type via ProxySQL admin. "
+			"This test needs to know whether the backend is MySQL or "
+			"MariaDB to choose the correct query-timeout dialect and "
+			"expected error code."
+		);
+		return exit_status();
+	}
+	const unsigned int expected_timeout_err = select_timeout_dialect(be_kind);
+	diag("Backend dialect: %s; expecting timeout error code %u",
+		be_kind == backend_kind_t::mariadb ? "MariaDB" : "MySQL",
+		expected_timeout_err);
 
 	if (create_table_test_sbtest1(1000,mysql)) {
 		fprintf(stderr, "File %s, line %d, Error: create_table_test_sbtest1() failed\n", __FILE__, __LINE__);
@@ -141,11 +294,11 @@ int main(int argc, char** argv) {
 				strerr = mysql_stmt_error(stmt[i]);
 
 				if (i == 0) {
-					check_res = rc == 1 && sterrno == 3024;
+					check_res = rc == 1 && sterrno == expected_timeout_err;
 					string check_err_t {
-						"'mysql_stmt_store_result' at line %d should fail with code 3024. Received code: %u, error: %s"
+						"'mysql_stmt_store_result' at line %d should fail with code %u. Received code: %u, error: %s"
 					};
-					string_format(check_err_t, check_err, __LINE__, sterrno, strerr);
+					string_format(check_err_t, check_err, __LINE__, expected_timeout_err, sterrno, strerr);
 				} else {
 					check_res = rc == 0;
 					check_err = "'mysql_stmt_store_result' should succeed";

--- a/test/tap/tests/reg_test_5620_fast_routing_qr_leak-t.cpp
+++ b/test/tap/tests/reg_test_5620_fast_routing_qr_leak-t.cpp
@@ -1,0 +1,268 @@
+/**
+ * @file reg_test_5620_fast_routing_qr_leak-t.cpp
+ * @brief Regression test for issue #5620: fast-routing rules silently
+ *        skipped when the last `mysql_query_rules` row in the chain has
+ *        `apply=1`, even if no rule matched the query.
+ *
+ * ## Bug summary
+ *
+ * `Query_Processor<QP_DERIVED>::process_query` (in lib/Query_Processor.cpp)
+ * iterates over `_thr_SQP_rules` and assigns the local `qr=*it` at the
+ * top of every iteration *before* the match check. When a rule does not
+ * match, the loop `continue`s but `qr` is left pointing at that
+ * non-matching rule. After the loop ends, the exit block at
+ * `__exit_process_mysql_query` reads `qr->apply` to decide whether to
+ * fall through to `mysql_query_rules_fast_routing`. If the last
+ * iterated rule (matched or not) happens to have `apply=1`, the check
+ * sees a leftover pointer and skips fast-routing entirely — even if no
+ * rule actually matched.
+ *
+ * In production this manifests as a silent fast-routing bypass: the
+ * client connection lands on the user's `default_hostgroup` instead of
+ * the hostgroup named by the fast-routing rule. burnison's original
+ * report (3.0.3 and 3.0.7) saw `ERROR 9001 Max connect timeout reached
+ * while reaching hostgroup 0` because hg=0 was unroutable in his setup;
+ * this test instead checks `stats_mysql_query_digest` directly so the
+ * assertion does not depend on backend reachability.
+ *
+ * ## Test layout
+ *
+ * Backend: ProxySQL's built-in SQLite3 Server on port 6030. Two
+ * `mysql_servers` rows pointing at it — one in `DEFAULT_HG` (the
+ * user's `default_hostgroup`) and one in `FAST_ROUTING_HG` (the
+ * hostgroup the fast-routing rule names). With both hostgroups
+ * routable, a misrouted query still succeeds and we can see in
+ * `stats_mysql_query_digest` which hostgroup it actually went to.
+ *
+ * Phase 1 — baseline. Configure user + fast-routing rule, no
+ *   `mysql_query_rules`. Run a query; it must land in `FAST_ROUTING_HG`.
+ *   This catches setup mistakes (wrong schema, wrong user) before we
+ *   look at the bug condition.
+ *
+ * Phase 2 — bug trigger. Add a single `mysql_query_rules` row with
+ *   `flagIN=99999` (so the FLAGIN-vs-input check forces a non-match)
+ *   and `apply=1`. Reset digest stats. Run the same query again.
+ *   With the bug, the exit-block check `qr->apply==false` is false
+ *   (because qr points at the non-matching trap rule), fast-routing is
+ *   skipped, and the query lands in `DEFAULT_HG`. With the fix, qr is
+ *   reset to NULL on the no-match `continue`, the exit-block check
+ *   correctly enters the fast-routing branch, and the query lands in
+ *   `FAST_ROUTING_HG`.
+ *
+ * ## Environment
+ *
+ * Standard TAP env vars (cl.host, cl.admin_port, cl.port,
+ * cl.admin_username, cl.admin_password, cl.username, cl.password).
+ * Requires ProxySQL built with `--sqlite3-server` enabled (the harness
+ * does this; see test/infra).
+ */
+
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+#include <vector>
+#include <string>
+#include "mysql.h"
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+const int DEFAULT_HG = 0;
+const int FAST_ROUTING_HG = 100;
+const int SQLITE3_SERVER_PORT = 6030;
+
+// flagIN value we use on the trap rule.  Any value the test query
+// could not possibly carry as its flagIN works; 99999 mirrors the
+// value burnison used in the original repro.
+const int NONMATCH_FLAGIN = 99999;
+
+static int run_query(MYSQL* conn, const std::string& q) {
+	diag("Running: %s", q.c_str());
+	if (mysql_query(conn, q.c_str())) {
+		diag("Query failed: %s", mysql_error(conn));
+		return 1;
+	}
+	return 0;
+}
+
+static int run_queries(MYSQL* conn, const std::vector<std::string>& qs) {
+	for (const auto& q : qs) {
+		if (run_query(conn, q)) return 1;
+	}
+	return 0;
+}
+
+// Issue the test query as `client_user` against ProxySQL, then read
+// stats_mysql_query_digest as admin and return the (single) hostgroup
+// the query was routed to.  Returns -1 if no row was found or more
+// than one hostgroup saw traffic for that user.
+static int issue_query_and_get_hostgroup(
+	const CommandLine& cl,
+	MYSQL* admin,
+	const std::string& client_user,
+	const std::string& client_pass,
+	const std::string& test_query
+) {
+	MYSQL* client = mysql_init(NULL);
+	if (!client) {
+		diag("mysql_init() failed");
+		return -1;
+	}
+	if (!mysql_real_connect(client, cl.host, client_user.c_str(), client_pass.c_str(),
+			"main", cl.port, NULL, 0)) {
+		diag("client connect failed: %s", mysql_error(client));
+		mysql_close(client);
+		return -1;
+	}
+
+	if (mysql_query(client, test_query.c_str())) {
+		diag("test query failed: %s", mysql_error(client));
+		mysql_close(client);
+		return -1;
+	}
+	MYSQL_RES* r = mysql_store_result(client);
+	if (r) mysql_free_result(r);
+	mysql_close(client);
+
+	// Give ProxySQL a beat to flush per-thread digest counters into
+	// the admin-visible stats table.  reg_test_2233 uses the same
+	// 1-second pause for the same reason.
+	sleep(1);
+
+	std::string check =
+		"SELECT hostgroup, SUM(count_star) FROM stats_mysql_query_digest "
+		"WHERE username='" + client_user + "' GROUP BY hostgroup";
+	if (mysql_query(admin, check.c_str())) {
+		diag("digest read failed: %s", mysql_error(admin));
+		return -1;
+	}
+	MYSQL_RES* res = mysql_store_result(admin);
+	if (!res) return -1;
+	int found_hg = -1;
+	int rows = 0;
+	MYSQL_ROW row;
+	while ((row = mysql_fetch_row(res))) {
+		diag("  digest row: hostgroup=%s count=%s", row[0], row[1]);
+		found_hg = atoi(row[0]);
+		rows++;
+	}
+	mysql_free_result(res);
+	if (rows != 1) {
+		diag("expected exactly 1 hostgroup row for user '%s', got %d",
+			client_user.c_str(), rows);
+		return -1;
+	}
+	return found_hg;
+}
+
+int main(int /*argc*/, char** /*argv*/) {
+	CommandLine cl;
+	if (cl.getEnv()) {
+		diag("Failed to read TAP env vars");
+		return -1;
+	}
+
+	plan(2);
+	diag("=== reg_test_5620 fast-routing qr-leak ===");
+	diag("ProxySQL %s admin=%d client=%d", cl.host, cl.admin_port, cl.port);
+	diag("DEFAULT_HG=%d FAST_ROUTING_HG=%d SQLite3 backend=%d",
+		DEFAULT_HG, FAST_ROUTING_HG, SQLITE3_SERVER_PORT);
+
+	MYSQL* admin = mysql_init(NULL);
+	if (!admin) return -1;
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+			NULL, cl.admin_port, NULL, 0)) {
+		diag("admin connect failed: %s", mysql_error(admin));
+		return -1;
+	}
+
+	// Pick a test user/password independent of the harness defaults so
+	// we don't accidentally collide with whatever user the runner
+	// pre-creates.  The fast-routing match key is (username, schema,
+	// flagIN); a unique username keeps the digest filter clean.
+	const std::string test_user = "reg_test_5620_user";
+	const std::string test_pass = "reg_test_5620_pass";
+
+	// --- Cleanup ---
+	std::vector<std::string> cleanup = {
+		"DELETE FROM mysql_servers",
+		"DELETE FROM mysql_replication_hostgroups",
+		"DELETE FROM mysql_group_replication_hostgroups",
+		"DELETE FROM mysql_galera_hostgroups",
+		"DELETE FROM mysql_aws_aurora_hostgroups",
+		"DELETE FROM mysql_hostgroup_attributes",
+		"DELETE FROM mysql_query_rules",
+		"DELETE FROM mysql_query_rules_fast_routing",
+		"DELETE FROM mysql_users WHERE username='" + test_user + "'",
+		"LOAD MYSQL SERVERS TO RUNTIME",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+		"LOAD MYSQL USERS TO RUNTIME",
+	};
+	if (run_queries(admin, cleanup)) { mysql_close(admin); return exit_status(); }
+
+	// --- Setup: user + servers + fast-routing rule ---
+	std::vector<std::string> setup = {
+		"INSERT INTO mysql_users (username,password,default_hostgroup,default_schema) "
+			"VALUES ('" + test_user + "','" + test_pass + "'," + std::to_string(DEFAULT_HG) + ",'main')",
+		"INSERT INTO mysql_servers (hostgroup_id,hostname,port) VALUES "
+			"(" + std::to_string(DEFAULT_HG) + ",'127.0.0.1'," + std::to_string(SQLITE3_SERVER_PORT) + ")",
+		"INSERT INTO mysql_servers (hostgroup_id,hostname,port) VALUES "
+			"(" + std::to_string(FAST_ROUTING_HG) + ",'127.0.0.1'," + std::to_string(SQLITE3_SERVER_PORT) + ")",
+		"INSERT INTO mysql_query_rules_fast_routing (username,schemaname,flagIN,destination_hostgroup,comment) "
+			"VALUES ('" + test_user + "','main',0," + std::to_string(FAST_ROUTING_HG) + ",'reg_test_5620')",
+		"LOAD MYSQL SERVERS TO RUNTIME",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+		"LOAD MYSQL USERS TO RUNTIME",
+	};
+	if (run_queries(admin, setup)) { mysql_close(admin); return exit_status(); }
+
+	// --- Phase 1: baseline (no mysql_query_rules at all) ---
+	diag("=== Phase 1: baseline fast-routing (no mysql_query_rules) ===");
+	// Reset digest counters so phase 1 traffic is the only thing we see.
+	MYSQL_QUERY(admin, "SELECT 1 FROM stats_mysql_query_digest_reset LIMIT 1");
+	mysql_free_result(mysql_store_result(admin));
+
+	int phase1_hg = issue_query_and_get_hostgroup(
+		cl, admin, test_user, test_pass, "SELECT 1 /* reg_test_5620 phase1 */");
+	ok(phase1_hg == FAST_ROUTING_HG,
+		"Phase 1 baseline: query lands in FAST_ROUTING_HG (got %d, expected %d)",
+		phase1_hg, FAST_ROUTING_HG);
+
+	// --- Phase 2: bug trigger (non-matching mysql_query_rule with apply=1) ---
+	diag("=== Phase 2: with non-matching apply=1 trap rule ===");
+	std::vector<std::string> trap = {
+		"INSERT INTO mysql_query_rules (rule_id,active,flagIN,apply) VALUES "
+			"(100000,1," + std::to_string(NONMATCH_FLAGIN) + ",1)",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+	};
+	if (run_queries(admin, trap)) { mysql_close(admin); return exit_status(); }
+
+	// Reset digest counters again so phase 2 is isolated from phase 1.
+	MYSQL_QUERY(admin, "SELECT 1 FROM stats_mysql_query_digest_reset LIMIT 1");
+	mysql_free_result(mysql_store_result(admin));
+
+	int phase2_hg = issue_query_and_get_hostgroup(
+		cl, admin, test_user, test_pass, "SELECT 1 /* reg_test_5620 phase2 */");
+	ok(phase2_hg == FAST_ROUTING_HG,
+		"Phase 2 (bug repro): non-matching apply=1 rule must not bypass fast-routing "
+		"(got %d, expected %d; %d would indicate the bug is present)",
+		phase2_hg, FAST_ROUTING_HG, DEFAULT_HG);
+
+	// --- Cleanup ---
+	std::vector<std::string> teardown = {
+		"DELETE FROM mysql_query_rules",
+		"DELETE FROM mysql_query_rules_fast_routing",
+		"DELETE FROM mysql_servers",
+		"DELETE FROM mysql_users WHERE username='" + test_user + "'",
+		"LOAD MYSQL SERVERS TO RUNTIME",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+		"LOAD MYSQL USERS TO RUNTIME",
+	};
+	run_queries(admin, teardown);
+	mysql_close(admin);
+
+	return exit_status();
+}

--- a/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
+++ b/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
@@ -17,9 +17,14 @@
  * It also verifies that `\n` and `\xHH` (hex escapes) -- which were
  * already interpreted by libconfig 1.7.3 -- still work as expected.
  */
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <string>
+#include <string_view>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "mysql.h"
 
@@ -28,14 +33,17 @@
 #include "command_line.h"
 
 using std::string;
+using std::string_view;
 
 /* Probe values exercised below.  Every literal `\` in C++ source maps to
  * a single backslash byte in the rendered config; libconfig should then
- * leave it untouched (for \a \b \v) or interpret it (for \n \x). */
+ * leave it untouched (for \a \b \v) or interpret it (for \n \x).
+ * `expected_value` is a string_view so the comparison length is the
+ * compile-time literal size and we do not call strlen at runtime. */
 struct Probe {
     const char* var_name;
-    const char* config_literal; /* what we write between the quotes in the .cnf */
-    const char* expected_value; /* bytes we expect to read back via admin */
+    string_view config_literal; /* what we write between the quotes in the .cnf */
+    string_view expected_value; /* bytes we expect to read back via admin */
     const char* description;
 };
 
@@ -50,16 +58,16 @@ static const Probe probes[] = {
 };
 static const size_t n_probes = sizeof(probes) / sizeof(probes[0]);
 
-static void write_config(const string& path) {
+static void write_config(const string& path, const string& datadir) {
     std::ofstream cfg(path);
-    cfg << "datadir=\"/tmp\"\n";
-    cfg << "errorlog=\"/tmp/proxysql.log\"\n";
+    cfg << "datadir=\"" << datadir << "\"\n";
+    cfg << "errorlog=\"" << datadir << "/proxysql.log\"\n";
     cfg << "mysql_variables=\n{\n";
     for (size_t i = 0; i < n_probes; ++i) {
         /* Strip the "mysql-" prefix when writing into the mysql_variables
          * group; libconfig stores it as `mysql-<name>` after loading. */
-        const char* var = probes[i].var_name;
-        if (strncmp(var, "mysql-", 6) == 0) var += 6;
+        string_view var{probes[i].var_name};
+        if (var.substr(0, 6) == "mysql-") var.remove_prefix(6);
         cfg << "    " << var << "=\"" << probes[i].config_literal << "\"\n";
     }
     cfg << "}\n";
@@ -87,11 +95,23 @@ int main(int argc, char** argv) {
         return exit_status();
     }
 
-    const char* datadir = getenv("REGULAR_INFRA_DATADIR");
-    string cfg_path = (datadir ? string(datadir) : "/tmp");
-    if (cfg_path.back() != '/') cfg_path += '/';
-    cfg_path += "reg_test_5766.cfg";
-    write_config(cfg_path);
+    /* Write the cnf into the test infra's private datadir when it is
+     * provided; otherwise create a fresh 0700 directory via mkdtemp so we
+     * never touch a publicly-writable path like /tmp directly. */
+    string cfg_dir;
+    if (const char* datadir = getenv("REGULAR_INFRA_DATADIR")) {
+        cfg_dir = datadir;
+    } else {
+        char tmpl[] = "/tmp/reg_test_5766_XXXXXX";
+        if (!mkdtemp(tmpl)) {
+            fprintf(stderr, "mkdtemp failed: %s\n", strerror(errno));
+            return exit_status();
+        }
+        cfg_dir = tmpl;
+    }
+    while (cfg_dir.size() > 1 && cfg_dir.back() == '/') cfg_dir.pop_back();
+    string cfg_path = cfg_dir + "/reg_test_5766.cfg";
+    write_config(cfg_path, cfg_dir);
 
     string set_cfg = "PROXYSQL SET CONFIG FILE '" + cfg_path + "'";
     MYSQL_QUERY_T(admin, set_cfg.c_str());
@@ -112,16 +132,16 @@ int main(int argc, char** argv) {
         unsigned long* lens = res ? mysql_fetch_lengths(res) : NULL;
 
         bool match = false;
+        const string_view& exp = probes[i].expected_value;
         if (row && row[0] && lens) {
-            size_t expected_len = strlen(probes[i].expected_value);
-            if (lens[0] == expected_len && memcmp(row[0], probes[i].expected_value, expected_len) == 0) {
+            if (lens[0] == exp.size() && string_view(row[0], lens[0]) == exp) {
                 match = true;
             } else {
-                diag("Mismatch for %s: expected %zu bytes (%s), got %lu bytes",
-                     probes[i].var_name, expected_len, probes[i].expected_value, lens[0]);
+                diag("Mismatch for %s: expected %zu bytes, got %lu bytes",
+                     probes[i].var_name, exp.size(), lens[0]);
                 /* Hex-dump both for easier triage. */
                 fprintf(stderr, "  expected hex: ");
-                for (size_t k = 0; k < expected_len; ++k) fprintf(stderr, "%02x ", (unsigned char)probes[i].expected_value[k]);
+                for (size_t k = 0; k < exp.size(); ++k) fprintf(stderr, "%02x ", (unsigned char)exp[k]);
                 fprintf(stderr, "\n  actual hex:   ");
                 for (size_t k = 0; k < lens[0]; ++k) fprintf(stderr, "%02x ", (unsigned char)row[0][k]);
                 fprintf(stderr, "\n");

--- a/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
+++ b/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
@@ -17,14 +17,11 @@
  * It also verifies that `\n` and `\xHH` (hex escapes) -- which were
  * already interpreted by libconfig 1.7.3 -- still work as expected.
  */
-#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <fstream>
 #include <string>
 #include <string_view>
-#include <sys/stat.h>
 #include <unistd.h>
 #include "mysql.h"
 
@@ -95,19 +92,18 @@ int main(int argc, char** argv) {
         return exit_status();
     }
 
-    /* Write the cnf into the test infra's private datadir when it is
-     * provided; otherwise create a fresh 0700 directory via mkdtemp so we
-     * never touch a publicly-writable path like /tmp directly. */
+    /* Prefer the TAP-managed workdir (TAP_WORKDIR / cl.workdir, defaults
+     * to "./"). REGULAR_INFRA_DATADIR is honoured first when set by the
+     * infra so the cnf lands in the same private datadir the proxysql
+     * instance uses, matching test_load_from_config_*-t. No hardcoded
+     * /tmp path. */
     string cfg_dir;
     if (const char* datadir = getenv("REGULAR_INFRA_DATADIR")) {
         cfg_dir = datadir;
+    } else if (cl.workdir && *cl.workdir) {
+        cfg_dir = cl.workdir;
     } else {
-        char tmpl[] = "/tmp/reg_test_5766_XXXXXX";
-        if (!mkdtemp(tmpl)) {
-            fprintf(stderr, "mkdtemp failed: %s\n", strerror(errno));
-            return exit_status();
-        }
-        cfg_dir = tmpl;
+        cfg_dir = ".";
     }
     while (cfg_dir.size() > 1 && cfg_dir.back() == '/') cfg_dir.pop_back();
     string cfg_path = cfg_dir + "/reg_test_5766.cfg";

--- a/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
+++ b/test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp
@@ -1,0 +1,139 @@
+/**
+ * @file reg_test_5766_libconfig_escape_passthrough-t.cpp
+ * @brief Regression test for https://github.com/sysown/proxysql/issues/5766
+ *
+ * libconfig 1.8.1 introduced new escape rules (\a, \b, \v) that did not
+ * exist in 1.7.3.  When a proxysql.cnf string contains the literal
+ * two-character sequence `\v` (backslash + v), 1.8.1 silently collapses
+ * it to the single byte 0x0B (vertical tab), corrupting passwords and
+ * other config values.  The bundled libconfig is patched (see
+ * deps/libconfig/restore_unknown_escape_passthrough.patch) to restore
+ * 1.7.3 passthrough behaviour for these three escape sequences.
+ *
+ * This test creates a config file containing values with literal `\a`,
+ * `\b` and `\v` sequences, loads it via `LOAD ... VARIABLES FROM CONFIG`,
+ * and asserts that each value is read back byte-for-byte unchanged.
+ *
+ * It also verifies that `\n` and `\xHH` (hex escapes) -- which were
+ * already interpreted by libconfig 1.7.3 -- still work as expected.
+ */
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include "mysql.h"
+
+#include "tap.h"
+#include "utils.h"
+#include "command_line.h"
+
+using std::string;
+
+/* Probe values exercised below.  Every literal `\` in C++ source maps to
+ * a single backslash byte in the rendered config; libconfig should then
+ * leave it untouched (for \a \b \v) or interpret it (for \n \x). */
+struct Probe {
+    const char* var_name;
+    const char* config_literal; /* what we write between the quotes in the .cnf */
+    const char* expected_value; /* bytes we expect to read back via admin */
+    const char* description;
+};
+
+static const Probe probes[] = {
+    /* The three regressions introduced by libconfig 1.8.1. */
+    { "mysql-server_version",     "pass\\vword",        "pass\\vword",      "\\v preserved as two bytes (was 0x0B in 1.8.1)" },
+    { "mysql-default_schema",     "ho\\ame",            "ho\\ame",          "\\a preserved as two bytes (was 0x07 in 1.8.1)" },
+    { "mysql-init_connect",       "se\\bt names utf8",  "se\\bt names utf8","\\b preserved as two bytes (was 0x08 in 1.8.1)" },
+    /* Already-interpreted escapes -- must keep their 1.7.3 behaviour. */
+    { "mysql-ldap_user_variable", "line1\\nline2",      "line1\nline2",     "\\n still collapsed to 0x0A (unchanged from 1.7.3)" },
+    { "mysql-add_ldap_user_comment","tab\\x09sep",      "tab\tsep",         "\\xHH still interpreted as hex (unchanged from 1.7.3)" },
+};
+static const size_t n_probes = sizeof(probes) / sizeof(probes[0]);
+
+static void write_config(const string& path) {
+    std::ofstream cfg(path);
+    cfg << "datadir=\"/tmp\"\n";
+    cfg << "errorlog=\"/tmp/proxysql.log\"\n";
+    cfg << "mysql_variables=\n{\n";
+    for (size_t i = 0; i < n_probes; ++i) {
+        /* Strip the "mysql-" prefix when writing into the mysql_variables
+         * group; libconfig stores it as `mysql-<name>` after loading. */
+        const char* var = probes[i].var_name;
+        if (strncmp(var, "mysql-", 6) == 0) var += 6;
+        cfg << "    " << var << "=\"" << probes[i].config_literal << "\"\n";
+    }
+    cfg << "}\n";
+    cfg.close();
+}
+
+int main(int argc, char** argv) {
+    CommandLine cl;
+
+    if (cl.getEnv()) {
+        diag("Failed to get the required environmental variables.");
+        return EXIT_FAILURE;
+    }
+
+    plan(n_probes);
+
+    MYSQL* admin = mysql_init(NULL);
+    if (!admin) {
+        fprintf(stderr, "Failed to initialize MySQL client\n");
+        return exit_status();
+    }
+    if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+                            NULL, cl.admin_port, NULL, 0)) {
+        fprintf(stderr, "Failed to connect to admin: %s\n", mysql_error(admin));
+        return exit_status();
+    }
+
+    const char* datadir = getenv("REGULAR_INFRA_DATADIR");
+    string cfg_path = (datadir ? string(datadir) : "/tmp");
+    if (cfg_path.back() != '/') cfg_path += '/';
+    cfg_path += "reg_test_5766.cfg";
+    write_config(cfg_path);
+
+    string set_cfg = "PROXYSQL SET CONFIG FILE '" + cfg_path + "'";
+    MYSQL_QUERY_T(admin, set_cfg.c_str());
+
+    /* Wipe any prior value so a stale row can't mask a regression. */
+    for (size_t i = 0; i < n_probes; ++i) {
+        string del = string("DELETE FROM global_variables WHERE variable_name='") + probes[i].var_name + "'";
+        MYSQL_QUERY_T(admin, del.c_str());
+    }
+
+    MYSQL_QUERY_T(admin, "LOAD MYSQL VARIABLES FROM CONFIG");
+
+    for (size_t i = 0; i < n_probes; ++i) {
+        string sel = string("SELECT variable_value FROM global_variables WHERE variable_name='") + probes[i].var_name + "'";
+        MYSQL_QUERY_T(admin, sel.c_str());
+        MYSQL_RES* res = mysql_store_result(admin);
+        MYSQL_ROW row = res ? mysql_fetch_row(res) : NULL;
+        unsigned long* lens = res ? mysql_fetch_lengths(res) : NULL;
+
+        bool match = false;
+        if (row && row[0] && lens) {
+            size_t expected_len = strlen(probes[i].expected_value);
+            if (lens[0] == expected_len && memcmp(row[0], probes[i].expected_value, expected_len) == 0) {
+                match = true;
+            } else {
+                diag("Mismatch for %s: expected %zu bytes (%s), got %lu bytes",
+                     probes[i].var_name, expected_len, probes[i].expected_value, lens[0]);
+                /* Hex-dump both for easier triage. */
+                fprintf(stderr, "  expected hex: ");
+                for (size_t k = 0; k < expected_len; ++k) fprintf(stderr, "%02x ", (unsigned char)probes[i].expected_value[k]);
+                fprintf(stderr, "\n  actual hex:   ");
+                for (size_t k = 0; k < lens[0]; ++k) fprintf(stderr, "%02x ", (unsigned char)row[0][k]);
+                fprintf(stderr, "\n");
+            }
+        } else {
+            diag("Variable %s not found after LOAD MYSQL VARIABLES FROM CONFIG", probes[i].var_name);
+        }
+        ok(match, "%s", probes[i].description);
+        if (res) mysql_free_result(res);
+    }
+
+    unlink(cfg_path.c_str());
+    mysql_close(admin);
+    return exit_status();
+}

--- a/test/tap/tests/test_cluster1-t.cpp
+++ b/test/tap/tests/test_cluster1-t.cpp
@@ -290,6 +290,23 @@ int main(int argc, char** argv) {
 
 
 
+        // Probe every cluster admin port before opening the real SSL+COMPRESS
+        // connections used by the test. Without this, a slow-to-start
+        // secondary proxysql triggers a cryptic 'Can't connect to server
+        // (115)' deep inside create_connections() — see issue #5782.
+        int probe_rc;
+        if (cluster_nodes.empty()) {
+                probe_rc = wait_for_proxysql_cluster(
+                        cl.host, cluster_ports, cl.admin_username, cl.admin_password);
+        } else {
+                probe_rc = wait_for_proxysql_cluster(
+                        cluster_nodes, cl.admin_username, cl.admin_password);
+        }
+        if (probe_rc != 0) {
+                diag("Cluster readiness probe failed; aborting before create_connections()");
+                return exit_status();
+        }
+
         int rc = create_connections(cl);
         if (rc != 0) {
                 close_all_connections();

--- a/test/tap/tests/test_tsdb_api-t.cpp
+++ b/test/tap/tests/test_tsdb_api-t.cpp
@@ -80,9 +80,9 @@ static http_result http_get(const string& url, const string& userpwd) {
     curl_easy_setopt(c, CURLOPT_WRITEDATA, &r.body);
     curl_easy_setopt(c, CURLOPT_HEADERFUNCTION, header_cb);
     curl_easy_setopt(c, CURLOPT_HEADERDATA, &hdrs);
-    // Pin to TLS 1.2+ for the test client (rest of options are test-only;
-    // see NOSONAR comments below).
-    curl_easy_setopt(c, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1_2);
+    // Pin to TLS 1.3 minimum for the test client (rest of options are
+    // test-only; see NOSONAR comments below).
+    curl_easy_setopt(c, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1_3);
     // Cert verification is disabled: this test connects to a localhost
     // proxysql instance that serves an auto-generated self-signed
     // certificate. Verifying the chain or hostname requires installing

--- a/test/tap/tests/test_tsdb_api-t.cpp
+++ b/test/tap/tests/test_tsdb_api-t.cpp
@@ -1,13 +1,37 @@
+/**
+ * @file test_tsdb_api-t.cpp
+ * @brief End-to-end TSDB dashboard + REST API test (regression for #5684).
+ *
+ * The TSDB dashboard's JS issues relative-URL fetch() calls:
+ *   <script src="/Chart.bundle.js"></script>
+ *   fetch('/api/tsdb/metrics')
+ *   fetch('/api/tsdb/query?...')
+ *
+ * Those URLs only resolve if the dashboard and the API endpoints share
+ * the same origin (host + port). Issue #5684 reported "Error loading
+ * metrics" because the dashboard was served from admin-web_port while
+ * the API lived on admin-restapi_port. This test pins the new wiring:
+ *
+ *   - Dashboard at http://host:restapi_port/tsdb
+ *   - Chart.bundle.js at http://host:restapi_port/Chart.bundle.js
+ *   - All /api/tsdb/* endpoints at http://host:restapi_port/api/tsdb/*
+ *
+ * Each assertion below executes a real HTTP GET against a running
+ * ProxySQL and inspects the response: status code, content-type, and
+ * for JSON endpoints the parsed payload shape.
+ */
 #include <algorithm>
+#include <map>
+#include <regex>
 #include <string>
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <vector>
-#include <map>
 
 #include "curl/curl.h"
 #include "mysql.h"
+#include "json.hpp"
 
 #include "tap.h"
 #include "command_line.h"
@@ -15,227 +39,246 @@
 
 using std::string;
 using std::vector;
+using json = nlohmann::json;
 
-struct memory {
-   char *response;
-   size_t size;
+struct http_result {
+    long code = 0;
+    string body;
+    string content_type;
 };
 
-static size_t cb(void *data, size_t size, size_t nmemb, void *userp) {
-   size_t realsize = size * nmemb;
-   struct memory *mem = (struct memory *)userp;
-
-   char *ptr = (char *)realloc((void *)mem->response, mem->size + realsize + 1);
-   if(ptr == NULL)
-	 return 0;
-
-   mem->response = ptr;
-   memcpy(&(mem->response[mem->size]), data, realsize);
-   mem->size += realsize;
-   mem->response[mem->size] = 0;
-
-   return realsize;
+static size_t write_cb(void* data, size_t size, size_t nmemb, void* userp) {
+    string* out = static_cast<string*>(userp);
+    out->append(static_cast<char*>(data), size * nmemb);
+    return size * nmemb;
 }
 
-static void drain_results(MYSQL* mysql) {
-	MYSQL_RES* res;
-	while (1) {
-		res = mysql_store_result(mysql);
-		if (res) mysql_free_result(res);
-		if (mysql_next_result(mysql) != 0) break;
-	}
+static size_t header_cb(char* buffer, size_t size, size_t nitems, void* userp) {
+    auto* hdrs = static_cast<std::map<string, string>*>(userp);
+    string line(buffer, size * nitems);
+    auto colon = line.find(':');
+    if (colon != string::npos) {
+        string key = line.substr(0, colon);
+        string val = line.substr(colon + 1);
+        std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+        // trim
+        while (!val.empty() && (val.front() == ' ' || val.front() == '\t')) val.erase(val.begin());
+        while (!val.empty() && (val.back() == '\r' || val.back() == '\n' || val.back() == ' ')) val.pop_back();
+        (*hdrs)[key] = val;
+    }
+    return size * nitems;
 }
 
-long http_get(const char *url, string &response_out, const char* userpwd = "stats:stats") {
-	struct memory chunk;
-	chunk.response = NULL;
-	chunk.size = 0;
+static http_result http_get(const string& url, const string& userpwd) {
+    http_result r;
+    std::map<string, string> hdrs;
+    CURL* c = curl_easy_init();
+    if (!c) return r;
+    curl_easy_setopt(c, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(c, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA, &r.body);
+    curl_easy_setopt(c, CURLOPT_HEADERFUNCTION, header_cb);
+    curl_easy_setopt(c, CURLOPT_HEADERDATA, &hdrs);
+    curl_easy_setopt(c, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(c, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT, 10L);
+    if (!userpwd.empty()) {
+        curl_easy_setopt(c, CURLOPT_USERPWD, userpwd.c_str());
+        curl_easy_setopt(c, CURLOPT_HTTPAUTH, (long)CURLAUTH_ANY);
+    }
+    CURLcode rc = curl_easy_perform(c);
+    if (rc == CURLE_OK) {
+        curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &r.code);
+    } else {
+        diag("curl GET %s failed: %s", url.c_str(), curl_easy_strerror(rc));
+    }
+    auto ct = hdrs.find("content-type");
+    if (ct != hdrs.end()) r.content_type = ct->second;
+    curl_easy_cleanup(c);
+    return r;
+}
 
-	CURL *curl_handle;
-	curl_handle = curl_easy_init();
-	if (!curl_handle) {
-		diag("curl_easy_init() failed");
-		if (chunk.response) free(chunk.response);
-		return 0;
-	}
+static void drain_results(MYSQL* m) {
+    MYSQL_RES* res;
+    while (true) {
+        res = mysql_store_result(m);
+        if (res) mysql_free_result(res);
+        if (mysql_next_result(m) != 0) break;
+    }
+}
 
-	curl_easy_setopt(curl_handle, CURLOPT_URL, url);
-	curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
-	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, cb);
-	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
-	curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 0);
-	curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 0L);
-	curl_easy_setopt(curl_handle, CURLOPT_USERPWD, userpwd);
-	curl_easy_setopt(curl_handle, CURLOPT_HTTPAUTH, (long)CURLAUTH_DIGEST);
-
-	CURLcode res;
-	res = curl_easy_perform(curl_handle);
-	long response_code = 0;
-	if(res == CURLE_OK) {
-		curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
-		if (chunk.response) {
-			response_out = string(chunk.response);
-		}
-	} else {
-		diag("libcurl error for %s: %s", url, curl_easy_strerror(res));
-	}
-
-	if (chunk.response) free(chunk.response);
-	curl_easy_cleanup(curl_handle);
-	return response_code;
+/* Extract every same-origin URL the dashboard HTML references --
+ * src="/...", href="/...", or fetch("/..."). These are the URLs the
+ * browser would issue against the page origin. */
+static vector<string> extract_relative_urls(const string& html) {
+    vector<string> urls;
+    std::regex pat(R"REX((?:src|href)\s*=\s*"(/[^"\s]*)"|fetch\(\s*['"`](/[^'"`\s?]+)(?:\?[^'"`]*)?['"`])REX");
+    auto begin = std::sregex_iterator(html.begin(), html.end(), pat);
+    auto end = std::sregex_iterator();
+    for (auto it = begin; it != end; ++it) {
+        string match = (*it)[1].matched ? (*it)[1].str() : (*it)[2].str();
+        if (std::find(urls.begin(), urls.end(), match) == urls.end()) urls.push_back(match);
+    }
+    return urls;
 }
 
 int main() {
-	CommandLine cl;
-	if (cl.getEnv()) {
-		diag("Failed to get the required environmental variables.");
-		return EXIT_FAILURE;
-	}
+    CommandLine cl;
+    if (cl.getEnv()) {
+        diag("Failed to get environmental variables");
+        return EXIT_FAILURE;
+    }
+    curl_global_init(CURL_GLOBAL_ALL);
 
-	curl_global_init(CURL_GLOBAL_ALL);
-	plan(10);
+    /* Plan:
+     *   1  - admin reachable
+     *   2  - dashboard 200 on restapi_port
+     *   3  - dashboard Content-Type is text/html
+     *   4  - dashboard body contains the title
+     *   5  - dashboard body contains the canvas
+     *   6  - every relative URL the dashboard references resolves
+     *        on the same origin (this is the core #5684 assertion)
+     *   7  - dashboard returns 404 on web_port (regression guard)
+     *   8  - /api/tsdb/status JSON has the expected keys
+     *   9  - /api/tsdb/metrics returns a JSON array
+     *   10 - /api/tsdb/query returns rows with expected shape
+     */
+    plan(10);
 
-	diag("TSDB API Test Configuration:");
-	diag("  ProxySQL host: %s", cl.host);
-	diag("  Admin port: %d", cl.admin_port);
-	diag("  Admin username: %s", cl.admin_username);
+    MYSQL* admin = mysql_init(NULL);
+    if (!mysql_real_connect(admin, cl.admin_host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+        diag("Admin connect failed: %s", mysql_error(admin));
+        ok(false, "admin reachable");
+        return exit_status();
+    }
+    ok(true, "admin reachable at %s:%d", cl.admin_host, cl.admin_port);
 
-	MYSQL* admin = mysql_init(NULL);
-	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
-		diag("Connection failed: %s", mysql_error(admin));
-		return EXIT_FAILURE;
-	}
-	diag("Connected to ProxySQL admin interface");
+    /* Configure TSDB + restapi + web. Both ports must be enabled so we
+     * can also assert the dashboard is *not* served on the web port. */
+    const char* setup_sql[] = {
+        "SET tsdb-enabled='1'",
+        "SET tsdb-sample_interval='1'",
+        "SET admin-restapi_enabled='1'",
+        "SET admin-web_enabled='1'",
+        "LOAD TSDB VARIABLES TO RUNTIME",
+        "LOAD ADMIN VARIABLES TO RUNTIME",
+    };
+    for (const char* q : setup_sql) {
+        if (mysql_query(admin, q)) {
+            diag("%s failed: %s", q, mysql_error(admin));
+        }
+        drain_results(admin);
+    }
 
-	// 1. Enable TSDB and REST API
-	diag("Enabling TSDB, Web, and REST API...");
-	int rc;
-	rc = mysql_query(admin, "SET tsdb-enabled='1'");
-	if (rc) {
-		diag("SET tsdb-enabled failed: %s", mysql_error(admin));
-		return EXIT_FAILURE;
-	}
-	drain_results(admin);
+    /* Read the live restapi_port / web_port so the test honours
+     * non-default values. */
+    int restapi_port = 6070, web_port = 6080;
+    if (!mysql_query(admin, "SELECT variable_name, variable_value FROM runtime_global_variables WHERE variable_name IN ('admin-restapi_port', 'admin-web_port')")) {
+        MYSQL_RES* res = mysql_store_result(admin);
+        if (res) {
+            MYSQL_ROW row;
+            while ((row = mysql_fetch_row(res))) {
+                if (string(row[0]) == "admin-restapi_port") restapi_port = atoi(row[1]);
+                else if (string(row[0]) == "admin-web_port") web_port = atoi(row[1]);
+            }
+            mysql_free_result(res);
+        }
+    }
+    drain_results(admin);
+    diag("restapi_port=%d  web_port=%d", restapi_port, web_port);
 
-	rc = mysql_query(admin, "SET tsdb-sample_interval='1'");
-	if (rc) {
-		diag("SET tsdb-sample_interval failed: %s", mysql_error(admin));
-		return EXIT_FAILURE;
-	}
-	drain_results(admin);
+    /* Sleep long enough for restapi + web to bind, and for at least one
+     * tsdb sample to land in the DB so query/metrics return non-empty. */
+    diag("waiting 8s for HTTP servers to come up and for tsdb samples to land");
+    sleep(8);
 
-	rc = mysql_query(admin, "SET admin-restapi_enabled='1'");
-	if (rc) {
-		diag("SET admin-restapi_enabled failed: %s", mysql_error(admin));
-		return EXIT_FAILURE;
-	}
-	drain_results(admin);
+    const string restapi_origin = string("http://") + cl.admin_host + ":" + std::to_string(restapi_port);
+    const string web_origin     = string("https://") + cl.admin_host + ":" + std::to_string(web_port);
+    const string admin_creds    = string(cl.admin_username) + ":" + cl.admin_password;
+    const string stats_creds    = "stats:stats";
 
-	rc = mysql_query(admin, "SET admin-web_enabled='1'");
-	if (rc) {
-		diag("SET admin-web_enabled failed: %s", mysql_error(admin));
-		return EXIT_FAILURE;
-	}
-	drain_results(admin);
+    /* (2-5) Dashboard on the REST API port. */
+    http_result dash = http_get(restapi_origin + "/tsdb", admin_creds);
+    ok(dash.code == 200, "dashboard /tsdb on restapi_port returns 200 (got %ld)", dash.code);
+    ok(dash.content_type.find("text/html") != string::npos,
+       "dashboard Content-Type is text/html (got '%s')", dash.content_type.c_str());
+    ok(dash.body.find("ProxySQL TSDB Dashboard") != string::npos, "dashboard body contains title");
+    ok(dash.body.find("tsdbChart") != string::npos, "dashboard body contains canvas id");
 
-	rc = mysql_query(admin, "LOAD TSDB VARIABLES TO RUNTIME");
-	if (rc) {
-		diag("LOAD TSDB VARIABLES failed: %s", mysql_error(admin));
-		return EXIT_FAILURE;
-	}
-	drain_results(admin);
+    /* (6) The same-origin assertion that catches #5684: every relative
+     * URL the dashboard references must be served on the dashboard's
+     * own origin. We probe each URL with no arguments. The bug was that
+     * these URLs 404'd on the dashboard's port; for API routes the
+     * arg-less probe legitimately returns 4xx ("missing parameter"),
+     * which proves the route IS wired here. Anything 404 or 5xx is a
+     * failure -- the dashboard's fetch() would have produced exactly
+     * the "Error loading metrics" the bug reported. */
+    vector<string> rels = extract_relative_urls(dash.body);
+    diag("dashboard references %zu relative URLs", rels.size());
+    bool all_same_origin_ok = !rels.empty();
+    for (const string& path : rels) {
+        http_result sub = http_get(restapi_origin + path, admin_creds);
+        diag("  GET %s%s -> %ld", restapi_origin.c_str(), path.c_str(), sub.code);
+        if (sub.code == 0 || sub.code == 404 || sub.code >= 500) all_same_origin_ok = false;
+    }
+    ok(all_same_origin_ok, "every relative URL in the dashboard resolves on restapi_port (#5684)");
 
-	rc = mysql_query(admin, "LOAD ADMIN VARIABLES TO RUNTIME");
-	if (rc) {
-		diag("LOAD ADMIN VARIABLES failed: %s", mysql_error(admin));
-		return EXIT_FAILURE;
-	}
-	drain_results(admin);
+    /* (7) Regression guard: the dashboard must NOT be reachable on the
+     * web port. If someone re-introduces the /tsdb handler in
+     * ProxySQL_HTTP_Server the bug returns. */
+    http_result web_dash = http_get(web_origin + "/tsdb", stats_creds);
+    ok(web_dash.code == 404,
+       "dashboard /tsdb on web_port returns 404 (got %ld); else #5684 has regressed", web_dash.code);
 
-	// Verify the settings were applied
-	MYSQL_RES* res;
-	rc = mysql_query(admin, "SELECT variable_name, variable_value FROM runtime_global_variables WHERE variable_name IN ('admin-restapi_enabled', 'admin-web_enabled', 'tsdb-enabled')");
-	if (rc == 0) {
-		res = mysql_store_result(admin);
-		if (res) {
-			diag("Runtime variable status:");
-			MYSQL_ROW row;
-			while ((row = mysql_fetch_row(res))) {
-				diag("  %s = %s", row[0], row[1]);
-			}
-			mysql_free_result(res);
-		}
-	}
-	drain_results(admin);
+    /* (8) /api/tsdb/status -- real JSON, real keys. */
+    http_result st = http_get(restapi_origin + "/api/tsdb/status", admin_creds);
+    bool status_ok = false;
+    if (st.code == 200) {
+        try {
+            json j = json::parse(st.body);
+            status_ok = j.contains("total_series") && j.contains("total_datapoints")
+                     && j.contains("disk_size_bytes") && j.contains("oldest_datapoint")
+                     && j.contains("newest_datapoint");
+        } catch (...) { status_ok = false; }
+    }
+    ok(status_ok, "/api/tsdb/status returns 200 JSON with the documented keys (code=%ld body='%s')",
+       st.code, st.body.substr(0, 120).c_str());
 
-	// 2. Wait for background loops to collect data and HTTP server to start
-	diag("Waiting for initialization and data collection (7s)...");
-	sleep(7);
+    /* (9) /api/tsdb/metrics -- must be a JSON array. */
+    http_result mtr = http_get(restapi_origin + "/api/tsdb/metrics", admin_creds);
+    bool metrics_ok = false;
+    string first_metric;
+    if (mtr.code == 200) {
+        try {
+            json j = json::parse(mtr.body);
+            if (j.is_array()) {
+                metrics_ok = true;
+                if (!j.empty()) first_metric = j[0].get<string>();
+            }
+        } catch (...) { metrics_ok = false; }
+    }
+    ok(metrics_ok, "/api/tsdb/metrics returns 200 with a JSON array (code=%ld body='%s')",
+       mtr.code, mtr.body.substr(0, 120).c_str());
 
-	// Use admin interface host for HTTP endpoints
-	string base_url = string("https://") + cl.admin_host + ":6080";
-	string rest_url = string("http://") + cl.admin_host + ":6070";
-	diag("Web dashboard URL: %s", base_url.c_str());
-	diag("REST API URL: %s", rest_url.c_str());
+    /* (10) /api/tsdb/query -- real time series with shape {ts,metric,labels,value}. */
+    string metric_to_query = !first_metric.empty() ? first_metric : "proxysql_uptime_seconds_total";
+    http_result q = http_get(restapi_origin + "/api/tsdb/query?metric=" + metric_to_query, admin_creds);
+    bool query_ok = false;
+    if (q.code == 200) {
+        try {
+            json j = json::parse(q.body);
+            if (j.is_array() && !j.empty()) {
+                const auto& row = j[0];
+                query_ok = row.contains("ts") && row.contains("metric")
+                        && row.contains("labels") && row.contains("value")
+                        && row["metric"].get<string>() == metric_to_query;
+            }
+        } catch (...) { query_ok = false; }
+    }
+    ok(query_ok, "/api/tsdb/query?metric=%s returns 200 with rows of {ts,metric,labels,value} (code=%ld body='%s')",
+       metric_to_query.c_str(), q.code, q.body.substr(0, 200).c_str());
 
-	// Prepare auth credentials for HTTP requests
-	// REST API uses admin credentials
-	string auth_creds = string(cl.admin_username) + ":" + string(cl.admin_password);
-	diag("Using REST API authentication with username: %s", cl.admin_username);
-	// Web dashboard uses stats credentials (separate from admin)
-	string stats_creds = "stats:stats";
-	diag("Using Web dashboard authentication with username: stats");
-
-	string response;
-	long http_rc;
-
-	// 3. Test /tsdb Dashboard (HTML)
-	diag("Testing GET /tsdb");
-	response.clear();
-	// Retry multiple times if server returned nothing
-	for (int i=0; i<5; i++) {
-		http_rc = http_get((base_url + "/tsdb").c_str(), response, stats_creds.c_str());
-		if (http_rc != 0) break;
-		diag("Retry %d for /tsdb (got response code 0, connection likely failed)...", i+1);
-		sleep(2);
-	}
-
-	ok(http_rc == 200, "Dashboard /tsdb returns 200 (got %ld)", http_rc);
-	if (http_rc != 200) {
-		diag("Dashboard response code: %ld", http_rc);
-		diag("This may indicate web interface is not enabled or not accessible at %s", base_url.c_str());
-	}
-	ok(response.find("ProxySQL TSDB Dashboard") != string::npos, "Dashboard contains title");
-	ok(response.find("tsdbChart") != string::npos, "Dashboard contains canvas element");
-
-	// 4. Test /api/tsdb/status
-	diag("Testing GET /api/tsdb/status");
-	response.clear();
-	http_rc = http_get((rest_url + "/api/tsdb/status").c_str(), response, auth_creds.c_str());
-	ok(http_rc == 200, "API /api/tsdb/status returns 200 (got %ld)", http_rc);
-	if (http_rc != 200) {
-		diag("REST API may not be enabled or not accessible at %s", rest_url.c_str());
-	}
-	ok(response.find("total_datapoints") != string::npos, "Status contains total_datapoints");
-	diag("Status response (first 200 chars): %s", response.substr(0, 200).c_str());
-
-	// 5. Test /api/tsdb/metrics
-	diag("Testing GET /api/tsdb/metrics");
-	response.clear();
-	http_rc = http_get((rest_url + "/api/tsdb/metrics").c_str(), response, auth_creds.c_str());
-	ok(http_rc == 200, "API /api/tsdb/metrics returns 200 (got %ld)", http_rc);
-	ok(response.length() > 2, "Metrics list is not empty (length: %zu)", response.length());
-	diag("Metrics response (first 200 chars): %s", response.substr(0, 200).c_str());
-
-	// 6. Test /api/tsdb/query
-	diag("Testing GET /api/tsdb/query for proxysql_uptime_seconds_total");
-	response.clear();
-	http_rc = http_get((rest_url + "/api/tsdb/query?metric=proxysql_uptime_seconds_total").c_str(), response, auth_creds.c_str());
-	ok(http_rc == 200, "API /api/tsdb/query returns 200 (got %ld)", http_rc);
-	ok(response.find("\"metric\":\"proxysql_uptime_seconds_total\"") != string::npos, "Query result contains metric name");
-	ok(response.find("\"value\":") != string::npos, "Query result contains data values");
-	diag("Query response (first 200 chars): %s", response.substr(0, 200).c_str());
-
-	mysql_close(admin);
-	return exit_status();
+    mysql_close(admin);
+    return exit_status();
 }

--- a/test/tap/tests/test_tsdb_api-t.cpp
+++ b/test/tap/tests/test_tsdb_api-t.cpp
@@ -80,9 +80,11 @@ static http_result http_get(const string& url, const string& userpwd) {
     curl_easy_setopt(c, CURLOPT_WRITEDATA, &r.body);
     curl_easy_setopt(c, CURLOPT_HEADERFUNCTION, header_cb);
     curl_easy_setopt(c, CURLOPT_HEADERDATA, &hdrs);
-    // Pin to TLS 1.3 minimum for the test client (rest of options are
-    // test-only; see NOSONAR comments below).
-    curl_easy_setopt(c, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1_3);
+    // Pin to TLS 1.3 minimum for the test client. The NOSONAR is needed
+    // because SonarCloud's S4423 matcher flags any CURLOPT_SSLVERSION
+    // line regardless of the value set (TLS 1.3 is the strongest
+    // available).
+    curl_easy_setopt(c, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1_3); // NOSONAR
     // Cert verification is disabled: this test connects to a localhost
     // proxysql instance that serves an auto-generated self-signed
     // certificate. Verifying the chain or hostname requires installing

--- a/test/tap/tests/test_tsdb_api-t.cpp
+++ b/test/tap/tests/test_tsdb_api-t.cpp
@@ -80,8 +80,17 @@ static http_result http_get(const string& url, const string& userpwd) {
     curl_easy_setopt(c, CURLOPT_WRITEDATA, &r.body);
     curl_easy_setopt(c, CURLOPT_HEADERFUNCTION, header_cb);
     curl_easy_setopt(c, CURLOPT_HEADERDATA, &hdrs);
-    curl_easy_setopt(c, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(c, CURLOPT_SSL_VERIFYHOST, 0L);
+    // Pin to TLS 1.2+ for the test client (rest of options are test-only;
+    // see NOSONAR comments below).
+    curl_easy_setopt(c, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1_2);
+    // Cert verification is disabled: this test connects to a localhost
+    // proxysql instance that serves an auto-generated self-signed
+    // certificate. Verifying the chain or hostname requires installing
+    // the per-run cert into the system CA store, which is out of scope
+    // for a TAP test. SonarCloud rules S4423 / S5527 / S4830 do not apply
+    // to a localhost test client. (SonarCloud)
+    curl_easy_setopt(c, CURLOPT_SSL_VERIFYPEER, 0L); // NOSONAR
+    curl_easy_setopt(c, CURLOPT_SSL_VERIFYHOST, 0L); // NOSONAR
     curl_easy_setopt(c, CURLOPT_TIMEOUT, 10L);
     if (!userpwd.empty()) {
         curl_easy_setopt(c, CURLOPT_USERPWD, userpwd.c_str());

--- a/test/tap/tests/test_tsdb_api-t.cpp
+++ b/test/tap/tests/test_tsdb_api-t.cpp
@@ -193,7 +193,9 @@ int main() {
     diag("waiting 8s for HTTP servers to come up and for tsdb samples to land");
     sleep(8);
 
-    const string restapi_origin = string("http://") + cl.admin_host + ":" + std::to_string(restapi_port);
+    // ProxySQL REST API listens on plain HTTP by design; this test
+    // must hit the real endpoint, not a TLS variant. (SonarCloud S5332)
+    const string restapi_origin = string("http://") + cl.admin_host + ":" + std::to_string(restapi_port); // NOSONAR
     const string web_origin     = string("https://") + cl.admin_host + ":" + std::to_string(web_port);
     const string admin_creds    = string(cl.admin_username) + ":" + cl.admin_password;
     const string stats_creds    = "stats:stats";

--- a/test/tap/tests/unit/pgsql_tokenizer_unit-t.cpp
+++ b/test/tap/tests/unit/pgsql_tokenizer_unit-t.cpp
@@ -261,6 +261,47 @@ static void test_digest_typecast_quoted() {
 		"digest: typecast with quoted type name handled");
 }
 
+// Regression test for issue #5755: a typecast in the middle of a query
+// must not swallow the rest of the query.  The bug was in
+// process_pg_typecast() which, after consuming `::TYPENAME`, sometimes
+// returned `st_pg_typecast` (instead of `st_no_mark_found`) when the
+// next character wasn't in an enumerated delimiter list.  The
+// dispatcher would then advance one extra char per iteration AND keep
+// re-entering the typecast handler, eating subsequent tokens until end
+// of input.
+static void test_digest_typecast_followed_by_clause() {
+	// Pre-fix output: "select count(*)" — everything after `::INT` was
+	// silently dropped.  Post-fix the FROM/WHERE clause must survive.
+	std::string d = digest_query(
+		"SELECT COUNT(*)::INT FROM \"Inventory\" AS i WHERE i.\"TenantId\"=$1");
+	ok(d.find("from") != std::string::npos &&
+	   d.find("where") != std::string::npos,
+		"digest #5755: typecast does not swallow following FROM/WHERE clause");
+	ok(d.find("inventory") != std::string::npos ||
+	   d.find("Inventory") != std::string::npos,
+		"digest #5755: quoted identifier after typecast is preserved");
+}
+
+static void test_digest_typecast_then_identifier() {
+	// Bisected minimal repro: identifier directly after `::TYPENAME `.
+	std::string d = digest_query("SELECT a::int FROM t");
+	ok(d.find("from") != std::string::npos && d.find("t") != std::string::npos,
+		"digest #5755: bare identifier after typecast survives");
+}
+
+// Regression test for the per-call `tc->started` reset: multiple casts
+// in the same query must each re-enter the typecast handler cleanly.
+// Without the reset, the second `::cast` would skip the `::`-skip
+// branch and start parsing the type name from the wrong offset.
+static void test_digest_typecast_multiple_in_same_query() {
+	std::string d = digest_query("SELECT 1::int, 2::text FROM t");
+	ok(d.find("from") != std::string::npos && d.find("t") != std::string::npos,
+		"digest #5755: query with multiple typecasts preserves trailing FROM");
+	// Both literals must be replaced with `?`.
+	ok(d.find("?") != std::string::npos,
+		"digest #5755: literal replacement still happens before each typecast");
+}
+
 // ============================================================================
 // 4. PgSQL-specific: Double-quoted identifiers (preserved, NOT replaced)
 // ============================================================================
@@ -609,7 +650,7 @@ static void test_digest_only_comment() {
 // ============================================================================
 
 int main() {
-	plan(65);
+	plan(70);
 	int rc = test_init_minimal();
 	ok(rc == 0, "test_init_minimal() succeeds");
 
@@ -633,13 +674,16 @@ int main() {
 	test_digest_dollar_quote_in_function();      // 1
 	test_digest_dollar_quote_with_special_chars(); // 1
 
-	// 3. Type casts (6 tests)
+	// 3. Type casts (11 tests)
 	test_digest_typecast_simple();       // 1
 	test_digest_typecast_varchar();      // 1
 	test_digest_typecast_with_modifier(); // 1
 	test_digest_typecast_array();        // 1
 	test_digest_typecast_in_where();     // 1
 	test_digest_typecast_quoted();       // 1
+	test_digest_typecast_followed_by_clause();      // 2 (issue #5755)
+	test_digest_typecast_then_identifier();         // 1 (issue #5755)
+	test_digest_typecast_multiple_in_same_query();  // 2 (issue #5755)
 
 	// 4. Double-quoted identifiers (3 tests)
 	test_digest_double_quoted_identifier();     // 2

--- a/test/tap/tests_with_deps/deprecate_eof_support/Makefile
+++ b/test/tap/tests_with_deps/deprecate_eof_support/Makefile
@@ -90,8 +90,16 @@ fwd_eof_query: fwd_eof_query.cpp
 	$(CXX) -DNON_EOF_SUPPORT $< -I$(TEST_MARIADB_IDIR) $(IDIRS) -L$(TEST_MARIADB_LDIR) $(LDIRS) -lmariadbclient $(COMMONARGS) -o $@
 
 # NOTE: Compilation with 'libmysql' instead of 'libmariadb' client to confirm packet sequence id isn't check by 'libmariadb'
+#
+# fwd_eof_ok_query is linked against libmysqlclient (Oracle MySQL connector),
+# so we must compile against libmysqlclient's mysql.h to avoid an ABI mismatch
+# in the MYSQL struct layout. With MariaDB headers in front, sizeof(MYSQL) and
+# offsetof(MYSQL,server_status) differ from what libmysqlclient's mysql_init()
+# allocates, and proxy->server_status reads past the end of the allocation
+# (returning heap-adjacent garbage that looked like the proxysql port number).
+# See issue #5781 for the analysis.
 fwd_eof_ok_query: fwd_eof_query.cpp
-	$(CXX) $< -I$(TEST_MARIADB_IDIR) -I$(TEST_MYSQL_IDIR) -I$(TEST_MYSQL_EDIR) $(IDIRS) -L$(TEST_MYSQL_LDIR) $(LDIRS) -lmysqlclient $(COMMONARGS) -o $@
+	$(CXX) $< -I$(TEST_MYSQL_IDIR) -I$(TEST_MYSQL_EDIR) -I$(TEST_MARIADB_IDIR) $(IDIRS) -L$(TEST_MYSQL_LDIR) $(LDIRS) -lmysqlclient $(COMMONARGS) -o $@
 # NOTE end
 
 deprecate_eof_cache-t: deprecate_eof_cache-t.cpp

--- a/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
+++ b/test/tap/tests_with_deps/deprecate_eof_support/deprecate_eof_cache-t.cpp
@@ -46,7 +46,11 @@ int create_testing_tables(MYSQL* mysql_server) {
 
 std::vector<std::string> queries {
 	"SELECT * FROM test.ok_packet_cache_test WHERE id=%d",
-	"INSERT INTO test.ok_packet_cache_test (c, pad) VALUES ('%s', '%s')",
+	// Insert with an explicit id (first %d) so the value the SELECT loop
+	// looks up below matches deterministically on every backend, including
+	// multi-master ones (Galera, Group Replication) where
+	// auto_increment_increment != 1. See issue #5781.
+	"INSERT INTO test.ok_packet_cache_test (id, c, pad) VALUES (%d, '%s', '%s')",
 	"UPDATE test.ok_packet_cache_test SET c='%s', pad='%s' WHERE id=%d"
 };
 
@@ -109,8 +113,9 @@ int main(int argc, char** argv) {
 		// Store the random generated strings
 		stored_pairs.push_back(pair<string, string>{rnd_c, rnd_pad});
 
-		// Execute the INSERT queries
-		string_format(t_insert_query, insert_query, rnd_c.c_str(), rnd_pad.c_str());
+		// Execute the INSERT queries with an explicit id of i+1 so the
+		// downstream SELECT WHERE id=i+1 always matches (see issue #5781).
+		string_format(t_insert_query, insert_query, i + 1, rnd_c.c_str(), rnd_pad.c_str());
 		int i_res = mysql_query(proxy_mysql, insert_query.c_str());
 		uint64_t i_err = mysql_errno(proxy_mysql);
 


### PR DESCRIPTION
## Summary

This PR bundles six already-reviewed, individually-tested fixes for merge into `v3.0` as a single coordinated landing. Each constituent PR was opened independently, reviewed and approved on its own merits, then retargeted to `integration/v3.0-batch-2026-05-13` and merged here.

Bundling rationale: a single coordinated CI pass on the combined set, a single merge commit on `v3.0`, and an explicit smoke test that the six changes don't interact badly when applied together.

## Constituent PRs (all merged into this branch)

- #5762 — fix(pkg): force xz compression on DEB output for dpkg-sig compatibility
- #5763 — fix(core): non-matching apply=1 query rule silently bypasses fast-routing (#5620)
- #5764 — fix(pgsql): typecast handler swallows the rest of the query (#5755)
- #5773 — fix(deps): patch libconfig 1.8.1 to restore \a \b \v passthrough (#5766)
- #5774 — fix(deps): patch jemalloc for GCC 16; add fedora44 to build matrix (#5770)
- #5775 — fix(tsdb): serve dashboard from REST API port for same-origin fetch (#5684)

## File coverage

```
.github/workflows/CI-package-{amd64,arm64}-fedora44*.yml  (12 new — from #5774)
Makefile                                                   (#5774)
deps/Makefile                                              (#5773 + #5774, disjoint hunks)
deps/jemalloc/throw-bad-alloc.patch                        (#5774)
deps/libconfig/restore_unknown_escape_passthrough.patch    (#5773)
docker-compose.yml                                         (#5774)
docker/.../deb-compliant/entrypoint/entrypoint.bash        (#5762)
include/ProxySQL_RESTAPI_Server.hpp                        (#5775)
lib/ProxySQL_HTTP_Server.cpp                               (#5775)
lib/ProxySQL_RESTAPI_Server.cpp                            (#5775)
lib/Query_Processor.cpp                                    (#5763)
lib/pgsql_tokenizer.cpp                                    (#5764)
test/tap/groups/groups.json                                (#5763 + #5773, conflict resolved alphabetically)
test/tap/tests/reg_test_5620_fast_routing_qr_leak-t.cpp    (#5763, new test)
test/tap/tests/reg_test_5766_libconfig_escape_passthrough-t.cpp (#5773, new test)
test/tap/tests/test_tsdb_api-t.cpp                         (#5775)
test/tap/tests/unit/pgsql_tokenizer_unit-t.cpp             (#5764)
```

Two files are touched by more than one PR; both merged without surprises:
- `deps/Makefile`: #5773 modifies line 295 (libconfig), #5774 modifies line 195 (jemalloc) — disjoint hunks.
- `test/tap/groups/groups.json`: #5763 and #5773 both add an entry at the same alphabetical insertion point — conflict resolved by keeping both lines alphabetically (commit `e5a31efe6`).

## Test plan

- [ ] CI on this integration PR is at least as green as `v3.0` baseline. Any **new** failure (i.e. not already failing on `v3.0`) must be root-caused, not dismissed as "pre-existing" or "flaky" (per `CLAUDE.md` Testing → Reporting CI/test failures).
- [ ] Five pre-existing-baseline test failures are known and have been individually analysed (separate tracking issues to be filed): `test_mysql_connect_retries-t`, `mysql-last_insert_id-t`, `deprecate_eof_cache-t`, `test_cluster1-t`, `prepare_statement_err3024-t`.
- [ ] The fedora44 packaging workflows (12 new) are dispatch-triggered only — they will not run automatically on this PR. Trigger a representative subset (at minimum `CI-package-amd64-fedora44` and `CI-package-amd64-fedora44-clang`) post-merge to confirm the GCC 16 build pipeline.
- [ ] Each constituent PR's own test plan applies. See the linked PR descriptions for the per-change checklists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TSDB dashboard served via REST API (same-origin friendly).
  * Fedora 44 packaging added for amd64/arm64 and new CI workflows to build and publish packages.

* **Bug Fixes**
  * Fixed fast-routing query-rule routing leak.
  * Corrected PostgreSQL typecast parsing.
  * Restored libconfig escape passthrough for \a, \b, \v.
  * Addressed build issues with newer GCC/libstdc++ (jemalloc).

* **Tests**
  * Added regression and unit tests, including TSDB API/HTML checks.

* **Documentation**
  * Added CI/test failure reporting guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5778)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Resolves

- Closes #5780
- Closes #5781
- Closes #5783

`#5782` is **not** in this list intentionally — the test-side fix landed here (commit `84cc0c997` adds the in-test cluster readiness probe), but the workflow-side fix (remove `SKIP_CLUSTER_START=1` from `ci-mariadb10-galera-g5.yml` so the satellite proxysql cluster is actually started) is in #5787 against the `GH-Actions` branch. `#5782` will be closed once both PRs are merged.

`#5779` (test_mysql_connect_retries-t) and `#5788` (pgsql-set_statement_test-t) are not addressed by this PR and remain open for separate investigation.
