### PR TITLE
fix(ci): start the proxysql cluster on mariadb10-galera-g5

### DIFF
--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -85,7 +85,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g5"
         export TAP_GROUP="mariadb10-galera-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g5 tests
@@ -93,7 +92,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g5"
         export TAP_GROUP="mariadb10-galera-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup


### PR DESCRIPTION
## Summary

The `mariadb10-galera-g5` TAP group includes `test_cluster1-t`, which exercises ProxySQL's config-sync mechanism across a **10-node ProxySQL cluster** (primary on 6032 + 9 satellites on 26001-26009). The reusable workflow was setting `SKIP_CLUSTER_START=1` in both the `ensure-infras` step and the `run-tests-isolated` step, so `cluster_init.bash` / `cluster_start.bash` skipped spawning the 9 satellite instances. `test_cluster1-t` then could not reach ports 26001-26009 and failed at its first connection attempt.

The diagnostic comes through clearly post sysown/proxysql#5782 (which added a readiness probe to the test):

```
wait_for_proxysql_cluster: 9/10 endpoint(s) did not respond within 60s
  not ready: proxysql:26001  last error: Can't connect to server on 'proxysql' (115)
  not ready: proxysql:26002  ...
```

(Before #5782 the same condition crashed with a cryptic `errno 115/EINPROGRESS` deep inside `create_connections()`.)

## What this change does

Removes the two `export SKIP_CLUSTER_START=1` lines from `.github/workflows/ci-mariadb10-galera-g5.yml`. The other `mariadb10-galera-g[1-9]` workflows are intentionally left alone — none of them runs `test_cluster1-t` and they don't need the satellite cluster. After this change, the g5 workflow matches the corresponding `mysql84-g5`, `mysql84-gr-g5`, `legacy-g5` etc. workflows, none of which set `SKIP_CLUSTER_START` (so all of them get the default `0` and start the cluster).

Diff:
```diff
@@ -85,7 +85,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g5"
         export TAP_GROUP="mariadb10-galera-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/ensure-infras.bash
@@ -93,7 +92,6 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g5"
         export TAP_GROUP="mariadb10-galera-g5"
-        export SKIP_CLUSTER_START=1
         test/infra/control/run-tests-isolated.bash
```

## Test plan

- [ ] After merge: trigger `CI-mariadb10-galera-g5` and confirm the 9 satellite ProxySQL instances start (cluster_start.bash logs visible in the run).
- [ ] `test_cluster1-t` runs to completion with 208/208 OK on this workflow.
- [ ] The other 8 `mariadb10-galera-g*` workflows continue to pass — unchanged.

## Related

- sysown/proxysql#5782 — added `wait_for_proxysql_cluster()` readiness probe and the clear "9/10 endpoint(s) did not respond" diagnostic that exposed this misconfiguration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized test infrastructure setup sequence in the continuous integration pipeline to ensure proper initialization before test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5787)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->