### PR TITLE
fix(ci): add build job to populate the build-<SHA> cache CI-mysqlx restores

### DIFF
--- a/.github/workflows/CI-mysqlx.yml
+++ b/.github/workflows/CI-mysqlx.yml
@@ -12,9 +12,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # PROXYSQL40 build of proxysql + TAP tests. The cache write at the end of
+  # this job is what the downstream jobs (unit-tests, e2e-tests, soak-tests)
+  # restore. Before this job existed (see issue #5796), the downstream jobs
+  # all aborted immediately at "Restore build cache" with
+  # `fail-on-cache-miss: true` because no upstream workflow ever wrote the
+  # `build-<SHA>` key — CI-trigger doesn't write any cache, and CI-builds
+  # uses a completely different naming scheme (`<SHA>_<dist><type>_*`). The
+  # net effect was that CI-mysqlx had not executed a single test in the
+  # entire workflow run history (500+ runs, 100% red at the same step).
+  #
+  # This job builds with the matching chassis flags so the cached
+  # `src/proxysql` has the same plugin-services struct layout the downstream
+  # `plugins/mysqlx` build will see — keeping the ABI contract intact.
+  build:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Cache build artifacts (restore + save)
+        uses: actions/cache@v4
+        id: build-cache
+        with:
+          path: |
+            src/proxysql
+            test/
+          key: build-${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Build proxysql (PROXYSQL40 chassis) + TAP tests
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        # The same tier flags the downstream `Build mysqlx plugin` step uses
+        # — see the comment on that step. Mismatch here would let the link
+        # succeed but corrupt memory on the first plugin virtual dispatch.
+        run: |
+          export PROXYSQL40=1
+          export PROXYSQL31=1
+          export PROXYSQLFFTO=1
+          export PROXYSQLTSDB=1
+          make -j$(nproc) debug
+          make -j$(nproc) build_tap_test_debug
+
   unit-tests:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     runs-on: ubuntu-22.04
+    needs: build
     steps:
       - name: Checkout (sparse — test/tap)
         uses: actions/checkout@v4
@@ -33,10 +78,12 @@ jobs:
             src/proxysql
             test/
           key: build-${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}
-          # Strict cache dependency when CI-trigger populated the cache
-          # upstream; lenient on manual workflow_dispatch so a missing cache
-          # doesn't block an ad-hoc run.
-          fail-on-cache-miss: ${{ github.event_name == 'workflow_run' }}
+          # Strict cache dependency: the `build` job above writes this key
+          # before this job starts (via `needs: build`). A miss here means
+          # the build job failed or the cache was evicted between save and
+          # restore — either way we should fail loudly, not silently
+          # proceed without a binary. See issue #5796.
+          fail-on-cache-miss: true
 
       - name: Build mysqlx plugin
         # PROXYSQL40=1 (and the implied tier flags) MUST match what the
@@ -82,10 +129,13 @@ jobs:
             src/proxysql
             test/
           key: build-${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}
-          # Strict cache dependency when CI-trigger populated the cache
-          # upstream; lenient on manual workflow_dispatch so a missing cache
-          # doesn't block an ad-hoc run.
-          fail-on-cache-miss: ${{ github.event_name == 'workflow_run' }}
+          # Strict cache dependency: the `build` job at the top of this
+          # workflow writes this key before this job starts (via the
+          # `needs:` chain). A miss means the build job failed or the
+          # cache was evicted between save and restore — either way fail
+          # loudly instead of silently proceeding without a binary. See
+          # issue #5796.
+          fail-on-cache-miss: true
 
       - name: Build mysqlx plugin
         # PROXYSQL40=1 (and the implied tier flags) MUST match what the


### PR DESCRIPTION
## Summary

Fixes #5796. `CI-mysqlx` has failed **100% of its last 500 workflow runs** at the `Restore build cache` step. The three jobs (`unit-tests`, `e2e-tests`, `soak-tests`) all begin with an `actions/cache@v4` restore keyed on `build-<SHA>` with `fail-on-cache-miss: true`, and **no workflow in the repository ever writes that key** — CI-trigger doesn't write any cache, and CI-builds uses a completely different naming scheme. Net effect: every `workflow_run`-triggered CI-mysqlx invocation aborts immediately before any build, infra setup, or test runs. The mysqlx test suite has been dead code in CI for at least 14 days.

## Change

Add a `build` job at the top of `CI-mysqlx.yml` that:

1. **Does a full checkout** (not sparse — needs `deps/`, `lib/`, `src/` to compile).
2. **Tries the cache restore first** so a re-run on the same SHA short-circuits the build.
3. **On cache miss**, runs:
   ```bash
   PROXYSQL40=1 PROXYSQL31=1 PROXYSQLFFTO=1 PROXYSQLTSDB=1 \
       make -j$(nproc) debug && make -j$(nproc) build_tap_test_debug
   ```
4. Lets `actions/cache@v4`'s automatic post-job save write the cache.

The three existing jobs gain `needs: build` (directly for `unit-tests`; transitively for `e2e-tests` and `soak-tests` via the existing `needs: unit-tests` chain). Their `fail-on-cache-miss` flags are flipped from the conditional `${{ github.event_name == 'workflow_run' }}` to unconditional `true` — the build job is now gated by the same `if:` condition as the rest of the workflow, so the cache is guaranteed to exist by the time any downstream job starts.

The PROXYSQL40 tier flags in the build step deliberately match what each downstream job's "Build mysqlx plugin" step uses. See the existing ABI-mismatch comment on those steps: a mismatch here would let the plugin link succeed but corrupt memory on the first plugin virtual dispatch.

## Job dependency graph after this PR

```
build
  ├─→ unit-tests
        ├─→ e2e-tests
        └─→ soak-tests
```

## Test plan

- [ ] CI on this PR: `CI-mysqlx / build` runs and completes (cold build, ~10-15 min on ubuntu-22.04).
- [ ] `CI-mysqlx / unit-tests` (and subsequently e2e-tests, soak-tests) proceed past the `Restore build cache` step that has blocked them for 500+ runs.
- [ ] If subsequent test steps fail, that's expected and tracked separately (see #5796 "After the fix" section) — those are real downstream issues that have been masked by the cache failure. Each should get its own follow-up issue.

## What this is NOT

This PR is the unblocker. It does **not** fix:
- The X-Protocol handshake failures observed locally (auth setup TBD)
- The 10s listener-bind timeout race in `setup-infras.bash`
- The admin localhost-only restriction blocking the test-runner from running route-drop's Stage 3
- Any other latent test-quality issue in the mysqlx suite

Those should each get their own issue once they actually surface in CI.

## Related

- #5796 — Tracking issue for the entire CI-mysqlx situation, with the full evidence (run-history sample, root-cause analysis, two-option fix discussion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration pipeline with improved build caching and stricter test validation to ensure more reliable releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->