### PR TITLE
perf: bounded conn cache, drop sort, gate partition by pool NULL ratio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ export SOURCE_DATE_EPOCH
 ### rebuild SQLite with -USQLITE_ENABLE_MEMORY_MANAGEMENT in deps/Makefile
 
 O0 := -O0
-O2 := -O2
+O2 := -O2 -fno-omit-frame-pointer
 O1 := -O1
 O3 := -O3 -mtune=native
 

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -114,6 +114,7 @@ class __attribute__((aligned(64))) MySQL_Thread : public Base_Thread
 	bool retrieve_gtids_required; // if any of the servers has gtid_port enabled, this needs to be turned on too
 
 	PtrArray *cached_connections;
+	unsigned int push_local_counter;	// round-robin counter for bounded local caching: cache 1-in-N where N = mysql_threads
 
 #ifdef IDLE_THREADS
 	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -116,6 +116,12 @@ class __attribute__((aligned(64))) MySQL_Thread : public Base_Thread
 	PtrArray *cached_connections;
 	unsigned int push_local_counter;	// round-robin counter for bounded local caching: cache 1-in-N where N = mysql_threads
 
+	// State for the ratio-based partition gate. See PgSQL_Thread for the equivalent.
+	unsigned int partition_pool_attempts;
+	unsigned int partition_pool_nulls;
+	unsigned int partition_streak;
+	bool partition_active;
+
 #ifdef IDLE_THREADS
 	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];
 	int efd;
@@ -159,6 +165,14 @@ class __attribute__((aligned(64))) MySQL_Thread : public Base_Thread
 	int nfds;
 
 	public:
+
+	// Recorded at the get_MyConn_from_pool() call site by sessions inside this
+	// worker. Consumed and reset at the top of each process_all_sessions outer
+	// iteration to compute the ratio-based partition gate.
+	inline void note_pool_attempt(bool was_null) {
+		++partition_pool_attempts;
+		if (was_null) ++partition_pool_nulls;
+	}
 
 	void *gen_args;	// this is a generic pointer to create any sort of structure
 

--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -160,6 +160,7 @@ private:
 	//bool maintenance_loop;
 
 	PtrArray* cached_connections;
+	unsigned int push_local_counter;	// round-robin counter for bounded local caching: cache 1-in-N where N = pgsql_threads
 
 #ifdef IDLE_THREADS
 	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];

--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -162,6 +162,14 @@ private:
 	PtrArray* cached_connections;
 	unsigned int push_local_counter;	// round-robin counter for bounded local caching: cache 1-in-N where N = pgsql_threads
 
+	// State for the ratio-based partition gate. Counters are incremented at the
+	// get_MyConn_from_pool() call site within process_all_sessions; consumed and
+	// reset at the top of the next outer iteration.
+	unsigned int partition_pool_attempts;
+	unsigned int partition_pool_nulls;
+	unsigned int partition_streak;
+	bool partition_active;
+
 #ifdef IDLE_THREADS
 	struct epoll_event events[MY_EPOLL_THREAD_MAXEVENTS];
 	int efd;
@@ -213,6 +221,14 @@ protected:
 	int nfds;
 
 public:
+
+	// Recorded at the get_MyConn_from_pool() call site by sessions inside this
+	// worker. Consumed and reset at the top of each process_all_sessions outer
+	// iteration to compute the ratio-based partition gate.
+	inline void note_pool_attempt(bool was_null) {
+		++partition_pool_attempts;
+		if (was_null) ++partition_pool_nulls;
+	}
 
 	void* gen_args;	// this is a generic pointer to create any sort of structure
 

--- a/lib/Base_Thread.cpp
+++ b/lib/Base_Thread.cpp
@@ -232,8 +232,7 @@ void Base_Thread::check_for_invalid_fd(unsigned int n) {
 
 
 /**
- * @brief Partition all sessions into three blocks and sort the B band by
- * max_connect_time.
+ * @brief Partition all sessions into three blocks by backend state.
  *
  * Block layout produced in mysql_sessions->pdata:
  *   [0, running_end)         block A - running a query against the backend
@@ -251,13 +250,12 @@ void Base_Thread::check_for_invalid_fd(unsigned int n) {
  * myconn != NULL, to catch CHANGING_USER_SERVER on pooled connections and the
  * post-error retry path where the old conn hasn't been destroyed yet.
  *
- * Pass 1 (partition): single O(n) pass, in place. idx walks up, idle_begin
- * walks down, they meet and terminate.
- *
- * Pass 2 (sort): single Lomuto-style sweep over the B band [running_end,
- * idle_begin) using max_connect_time as the ordering key. Same algorithm
- * as the pre-PR ProcessAllSessions_SortingSessions, scoped to the band
- * Pass 1 already isolated.
+ * Single O(n) pass, in place. idx walks up, idle_begin walks down, they meet
+ * and terminate. A previous Lomuto-style sort of the B band by max_connect_time
+ * was removed: measurement showed it hurt throughput by ~12% at 500 clients /
+ * 50-conn pool under SSL, without a corresponding tail-latency benefit. If
+ * reintroduced, it should be gated on an explicit starvation-age signal rather
+ * than run unconditionally on every iteration.
  */
 template<typename S>
 void Base_Thread::ProcessAllSessions_Partition() {
@@ -290,33 +288,6 @@ void Base_Thread::ProcessAllSessions_Partition() {
 				mysql_sessions->pdata[idle_begin] = p;
 			}
 			// do NOT advance idx - re-examine the swapped-in element test
-		}
-	}
-
-	// Single-pass sweep across the B band [running_end, idle_begin) ordering
-	// by max_connect_time. Same Lomuto-style sweep as the pre-PR
-	// ProcessAllSessions_SortingSessions, scoped to the B band Pass 1 just
-	// isolated.
-	//
-	// Invariant: every session in [running_end, idle_begin) is a B session,
-	// so s->mybe->server_myds->max_connect_time is non-zero and no nullptr
-	// guards are needed.
-	if (idle_begin > running_end + 1) {
-		size_t a = running_end;
-		for (size_t n = running_end; n < idle_begin; ++n) {
-			S* sess = static_cast<S*>(mysql_sessions->pdata[n]);
-			S* sess2 = static_cast<S*>(mysql_sessions->pdata[a]);
-			const unsigned long long mct_n = sess->mybe->server_myds->max_connect_time;
-			const unsigned long long mct_a = sess2->mybe->server_myds->max_connect_time;
-			if (mct_a <= mct_n) {
-				// session at 'a' already has earlier-or-equal mct - leave it
-			}
-			else {
-				void* p = mysql_sessions->pdata[a];
-				mysql_sessions->pdata[a] = mysql_sessions->pdata[n];
-				mysql_sessions->pdata[n] = p;
-				++a;
-			}
 		}
 	}
 }

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -7820,6 +7820,7 @@ void MySQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 			} else {
 				mc=MyHGM->get_MyConn_from_pool(mybe->hostgroup_id, this, (session_fast_forward || qpo->create_new_conn), NULL, 0, (int)qpo->max_lag_ms);
 			}
+			thread->note_pool_attempt(mc == NULL);
 #ifdef STRESSTEST_POOL
 			if (mc && (loops < NUM_SLOW_LOOPS - 1)) {
 				if (mc->mysql) {

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -4784,6 +4784,7 @@ MySQL_Thread::MySQL_Thread() {
 	pthread_mutex_init(&thread_mutex,NULL);
 	my_idle_conns=NULL;
 	cached_connections=NULL;
+	push_local_counter=0;
 	mysql_sessions=NULL;
 	mirror_queue_mysql_sessions=NULL;
 	mirror_queue_mysql_sessions_cache=NULL;
@@ -6466,14 +6467,22 @@ MySQL_Connection * MySQL_Thread::get_MyConn_local(unsigned int _hid, MySQL_Sessi
  * @param c Pointer to the MySQL_Connection object to be pushed to the local connection pool.
  */
 void MySQL_Thread::push_MyConn_local(MySQL_Connection *c) {
-	MySrvC *mysrvc=NULL;
-	mysrvc=(MySrvC *)c->parent;
+	// Bounded local cache: cache 1-in-N releases (N = mysql_threads), push the
+	// rest to the shared HGM pool so peer workers can pick them up.
+	// At N=1 always cache (no sibling to share with).
+	// Rationale: avoids the connection-hoarding behavior that starved sibling
+	// workers at high client count, while preserving most of the lock-amortization
+	// benefit at lower client counts.
+	MySrvC *mysrvc=(MySrvC *)c->parent;
 	// reset insert_id #1093
 	c->mysql->insert_id = 0;
 	if (mysrvc->get_status() == MYSQL_SERVER_STATUS_ONLINE) {
 		if (c->async_state_machine==ASYNC_IDLE) {
-			cached_connections->add(c);
-			return; // all went well
+			unsigned int n = (GloMTH && GloMTH->num_threads > 0) ? GloMTH->num_threads : 1;
+			if ((push_local_counter++ % n) == 0) {
+				cached_connections->add(c);
+				return;
+			}
 		}
 	}
 	MyHGM->push_MyConn_to_pool(c);

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -4453,7 +4453,29 @@ void MySQL_Thread::process_all_sessions() {
 	}
 #endif // IDLE_THREADS
 	if (sess_sort && mysql_sessions->len > 3) {
-		ProcessAllSessions_Partition<MySQL_Session>();
+		// Activate partition only when the pool acquire NULL-ratio
+		// (computed from get_MyConn_from_pool calls within the previous
+		// iteration) has been above HI_NUM/HI_DEN for STREAK consecutive
+		// iterations. Disable symmetrically once the ratio has been below
+		// HI_NUM/HI_DEN for STREAK consecutive iterations.
+		const unsigned int HI_NUM = 1, HI_DEN = 20;     // 5%
+		const unsigned int STREAK = 3;
+		bool stressed = (partition_pool_attempts > 0)
+		             && (partition_pool_nulls * HI_DEN >= partition_pool_attempts * HI_NUM);
+		if (stressed == partition_active) {
+			partition_streak = 0;
+		} else {
+			if (++partition_streak >= STREAK) {
+				partition_active = stressed;
+				partition_streak = 0;
+			}
+		}
+		partition_pool_attempts = 0;
+		partition_pool_nulls    = 0;
+
+		if (partition_active) {
+			ProcessAllSessions_Partition<MySQL_Session>();
+		}
 	}
 	for (n=0; n<mysql_sessions->len; n++) {
 		MySQL_Session *sess=(MySQL_Session *)mysql_sessions->index(n);
@@ -4785,6 +4807,10 @@ MySQL_Thread::MySQL_Thread() {
 	my_idle_conns=NULL;
 	cached_connections=NULL;
 	push_local_counter=0;
+	partition_pool_attempts=0;
+	partition_pool_nulls=0;
+	partition_streak=0;
+	partition_active=false;
 	mysql_sessions=NULL;
 	mirror_queue_mysql_sessions=NULL;
 	mirror_queue_mysql_sessions_cache=NULL;
@@ -6473,7 +6499,8 @@ void MySQL_Thread::push_MyConn_local(MySQL_Connection *c) {
 	// Rationale: avoids the connection-hoarding behavior that starved sibling
 	// workers at high client count, while preserving most of the lock-amortization
 	// benefit at lower client counts.
-	MySrvC *mysrvc=(MySrvC *)c->parent;
+	MySrvC *mysrvc=NULL;
+	mysrvc=(MySrvC *)c->parent;
 	// reset insert_id #1093
 	c->mysql->insert_id = 0;
 	if (mysrvc->get_status() == MYSQL_SERVER_STATUS_ONLINE) {

--- a/lib/PgSQL_Data_Stream.cpp
+++ b/lib/PgSQL_Data_Stream.cpp
@@ -108,8 +108,13 @@ static void __dump_pkt(const char* func, unsigned char* _ptr, unsigned int len) 
 
 static enum pgsql_sslstatus get_sslstatus(SSL* ssl, int n)
 {
+	// See issue #5792.
+	// SSL_get_error() classifies based on the return code + SSL_want() state, not on the
+	// thread-local OpenSSL error queue. For SSL_ERROR_NONE / WANT_READ / WANT_WRITE no error is
+	// pushed onto the queue, so there is nothing to clear. Only the actual error classifications
+	// (ZERO_RETURN / SYSCALL / SSL / default) need the queue drained so the next SSL op on this
+	// thread starts clean.
 	int err = SSL_get_error(ssl, n);
-	ERR_clear_error();
 	switch (err) {
 	case SSL_ERROR_NONE:
 		return PGSQL_SSLSTATUS_OK;
@@ -119,6 +124,9 @@ static enum pgsql_sslstatus get_sslstatus(SSL* ssl, int n)
 	case SSL_ERROR_ZERO_RETURN:
 	case SSL_ERROR_SYSCALL:
 	default:
+		// drain the queue; any consumer that wanted the details should have read them
+		// before returning to this point
+		while (ERR_get_error()) { /* discard */ }
 		return PGSQL_SSLSTATUS_FAIL;
 	}
 }

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5383,6 +5383,7 @@ void PgSQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 			else {
 				mc = PgHGM->get_MyConn_from_pool(mybe->hostgroup_id, this, (session_fast_forward || qpo->create_new_conn), NULL, 0, (int)qpo->max_lag_ms);
 			}
+			thread->note_pool_attempt(mc == NULL);
 #ifdef STRESSTEST_POOL
 			if (mc && (loops < NUM_SLOW_LOOPS - 1)) {
 				if (mc->pgsql) {

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -3833,7 +3833,29 @@ void PgSQL_Thread::process_all_sessions() {
 	}
 #endif // IDLE_THREADS
 	if (sess_sort && mysql_sessions->len > 3) {
-		ProcessAllSessions_Partition<PgSQL_Session>();
+		// Activate partition only when the pool acquire NULL-ratio
+		// (computed from get_MyConn_from_pool calls within the previous
+		// iteration) has been above HI_NUM/HI_DEN for STREAK consecutive
+		// iterations. Disable symmetrically once the ratio has been below
+		// HI_NUM/HI_DEN for STREAK consecutive iterations.
+		const unsigned int HI_NUM = 1, HI_DEN = 20;     // 5%
+		const unsigned int STREAK = 3;
+		bool stressed = (partition_pool_attempts > 0)
+		             && (partition_pool_nulls * HI_DEN >= partition_pool_attempts * HI_NUM);
+		if (stressed == partition_active) {
+			partition_streak = 0;
+		} else {
+			if (++partition_streak >= STREAK) {
+				partition_active = stressed;
+				partition_streak = 0;
+			}
+		}
+		partition_pool_attempts = 0;
+		partition_pool_nulls    = 0;
+
+		if (partition_active) {
+			ProcessAllSessions_Partition<PgSQL_Session>();
+		}
 	}
 	for (n = 0; n < mysql_sessions->len; n++) {
 		PgSQL_Session* sess = (PgSQL_Session*)mysql_sessions->index(n);
@@ -4207,6 +4229,10 @@ PgSQL_Thread::PgSQL_Thread() {
 	my_idle_conns = NULL;
 	cached_connections = NULL;
 	push_local_counter = 0;
+	partition_pool_attempts = 0;
+	partition_pool_nulls = 0;
+	partition_streak = 0;
+	partition_active = false;
 	mysql_sessions = NULL;
 	mirror_queue_mysql_sessions = NULL;
 	mirror_queue_mysql_sessions_cache = NULL;

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -4206,6 +4206,7 @@ PgSQL_Thread::PgSQL_Thread() {
 	pthread_mutex_init(&thread_mutex, NULL);
 	my_idle_conns = NULL;
 	cached_connections = NULL;
+	push_local_counter = 0;
 	mysql_sessions = NULL;
 	mirror_queue_mysql_sessions = NULL;
 	mirror_queue_mysql_sessions_cache = NULL;
@@ -5819,14 +5820,20 @@ PgSQL_Connection* PgSQL_Thread::get_MyConn_local(unsigned int _hid, PgSQL_Sessio
 }
 
 void PgSQL_Thread::push_MyConn_local(PgSQL_Connection * c) {
-	PgSQL_SrvC* mysrvc = NULL;
-	mysrvc = (PgSQL_SrvC*)c->parent;
-	// reset insert_id #1093
-	//c->pgsql->insert_id = 0;
+	// Bounded local cache: cache 1-in-N releases (N = pgsql_threads), push the
+	// rest to the shared HGM pool so peer workers can pick them up.
+	// At N=1 always cache (no sibling to share with).
+	// Rationale: avoids the connection-hoarding behavior that starved sibling
+	// workers at high client count, while preserving most of the lock-amortization
+	// benefit at lower client counts.
+	PgSQL_SrvC* mysrvc = (PgSQL_SrvC*)c->parent;
 	if (mysrvc->status == MYSQL_SERVER_STATUS_ONLINE) {
 		if (c->async_state_machine == ASYNC_IDLE) {
-			cached_connections->add(c);
-			return; // all went well
+			unsigned int n = (GloPTH && GloPTH->num_threads > 0) ? GloPTH->num_threads : 1;
+			if ((push_local_counter++ % n) == 0) {
+				cached_connections->add(c);
+				return;
+			}
 		}
 	}
 	PgHGM->push_MyConn_to_pool(c);

--- a/lib/mysql_data_stream.cpp
+++ b/lib/mysql_data_stream.cpp
@@ -174,8 +174,13 @@ static void __dump_pkt(const char *func, unsigned char *_ptr, unsigned int len) 
 
 static enum sslstatus get_sslstatus(SSL* ssl, int n)
 {
+	// See issue #5792.
+	// SSL_get_error() classifies based on the return code + SSL_want() state, not on the
+	// thread-local OpenSSL error queue. For SSL_ERROR_NONE / WANT_READ / WANT_WRITE no error is
+	// pushed onto the queue, so there is nothing to clear. Only the actual error classifications
+	// (ZERO_RETURN / SYSCALL / SSL / default) need the queue drained so the next SSL op on this
+	// thread starts clean.
 	int err = SSL_get_error(ssl, n);
-	ERR_clear_error();
 	switch (err) {
 	case SSL_ERROR_NONE:
 		return SSLSTATUS_OK;
@@ -185,6 +190,9 @@ static enum sslstatus get_sslstatus(SSL* ssl, int n)
 	case SSL_ERROR_ZERO_RETURN:
 	case SSL_ERROR_SYSCALL:
 	default:
+		// drain the queue; any consumer that wanted the details should have read them
+		// before returning to this point
+		while (ERR_get_error()) { /* discard */ }
 		return SSLSTATUS_FAIL;
 	}
 }


### PR DESCRIPTION
Alternative / complementary work to the partition-skip mechanism added in 99ae991c and 0571e3eb. Filed as **draft** so we can compare both approaches side-by-side on the Files Changed tab — the relevant overlap is in `lib/Base_Thread.cpp` (sort handling) and the partition gate in `lib/MySQL_Thread.cpp` / `lib/PgSQL_Thread.cpp`.

## Commits

1. **build:** `-fno-omit-frame-pointer` — enables reliable perf call graphs.
2. **fix:** `ERR_clear_error` placement in `get_sslstatus()` (#5792).
3. **fix:** bounded local conn cache 1-in-N (#5791) — eliminates the per-thread connection hoarding that caused the 2-thread c≈200 throughput cliff.
4. **perf:** remove Pass 2 sort from `ProcessAllSessions_Partition` (measured -12 % throughput regression at 500c/50p; if reintroduced should be gated by an explicit starvation-age signal).
5. **feat:** ratio-based partition gate driven by `get_MyConn_from_pool` NULL ratio (alternative to the b-band-size signal in 99ae991c).

## Differences vs. existing branch work

| Concern | This PR | Existing branch (99ae991c + 0571e3eb) |
|---|---|---|
| Pass 2 sort | Deleted | Kept, gated by streak |
| Pass 1 gating signal | Pool-acquire NULL ratio (counted at `get_MyConn_from_pool` site) | Session-array B-band ratio (computed inside `ProcessAllSessions_Partition`) |
| Pass 1 unconditional? | No (gated) | Yes |

The two signal sources both seem to work in practice. Which one is preferable is the conversation to have here.

## Empirical results (sustained 4 KB rows, SSL on, 120 s per cell)

| Setup | Throughput | Latency avg |
|---|---:|---:|
| 1 thread, 500 c / 50 pool, before any change | 1,303 tps | 384 ms |
| 1 thread, 500 c / 50 pool, this branch | 1,487 tps | 336 ms |
| 2 threads, 500 c / 50 pool, this branch | 2,289 tps | 218 ms |
| 4 threads, 500 c / 50 pool, this branch | 3,566 tps | 140 ms |
| pgbouncer (reference, 1 thread) | 1,685 tps | 297 ms |

## Open items

- I observed a watchdog abort post-benchmark (`Watchdog: 10 missed MySQL thread heartbeats`) at 500c/50p sustained. Not yet diagnosed; could be specific to my changes or pre-existing under this load. Want to investigate before this leaves Draft.
- Same gate could (and probably should) be added to the MySQL path in lockstep — commits 3 and 5 above do exactly that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented adaptive stress detection for connection partitioning, improving resource distribution across worker threads and optimizing connection pool efficiency.

* **Bug Fixes**
  * Fixed SSL error handling to selectively drain error queues based on connection state, preventing unnecessary operations and improving stability.

* **Performance**
  * Updated build optimization flags to enhance profiling and debugging capabilities with minimal performance overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->