### PR TITLE
fix(core): validate_charset must replace collation 255 on MariaDB backends (#5790)

### DIFF
--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -746,31 +746,37 @@ void MySQL_Monitor_State_Data::init_async() {
 			" wsrep_cluster_status, pxc_maint_mode FROM HOST_STATUS_GALERA WHERE hostgroup_id=";
 		query_ += std::to_string(writer_hostgroup) + " AND hostname='" + std::string(hostname) + "' AND port=" + std::to_string(port);
 #else
-		// performance_schema.global_status is a MySQL-only table (added in 5.7).
-		// INFORMATION_SCHEMA.GLOBAL_STATUS was deprecated in MySQL 8.0 and
-		// removed in MySQL 8.4, so MySQL >= 5.7 must use performance_schema
-		// (otherwise the monitor query fails on MySQL 8.4+/9.x). MariaDB never
-		// implemented the performance_schema status tables and keeps
-		// GLOBAL_STATUS in information_schema across all versions, so it must
-		// be excluded explicitly (atoi("10.x-MariaDB") >= 8 would otherwise
-		// route it to the performance_schema branch).
-		const char *sv = mysql->server_version;
-		bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
-		int sv_major = (sv != NULL) ? atoi(sv) : 0;
-		bool use_perf_schema = !is_mariadb &&
-			(sv_major >= 8 || (sv_major == 5 && sv != NULL && strncmp(sv, "5.7", 3) == 0));
-		if (use_perf_schema) {
-			query_ = "SELECT (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
-				"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
-				"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
-				"(SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , "
-				"(SELECT COALESCE(MAX(VARIABLE_VALUE),'DISABLED') FROM performance_schema.global_variables WHERE variable_name='pxc_maint_mode') pxc_maint_mode ";
-		} else {
-			// MariaDB Galera (any version) and legacy MySQL/PXC < 5.7
-			query_ = "SELECT (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
-				"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
-				"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
-				"(SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , (SELECT 'DISABLED') pxc_maint_mode";
+		{
+			// performance_schema.global_status is a MySQL-only table (added in 5.7).
+			// INFORMATION_SCHEMA.GLOBAL_STATUS was deprecated in MySQL 8.0 and
+			// removed in MySQL 8.4, so MySQL >= 5.7 must use performance_schema
+			// (otherwise the monitor query fails on MySQL 8.4+/9.x). MariaDB never
+			// implemented the performance_schema status tables and keeps
+			// GLOBAL_STATUS in information_schema across all versions, so it must
+			// be excluded explicitly (atoi("10.x-MariaDB") >= 8 would otherwise
+			// route it to the performance_schema branch).
+			// (The enclosing braces are required: this is a `switch` case body
+			// and the variable declarations below are jumped over by sibling
+			// `case` labels — without a scope, GCC errors with "jump to case
+			// label" / "crosses initialization".)
+			const char *sv = mysql->server_version;
+			bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
+			int sv_major = (sv != NULL) ? atoi(sv) : 0;
+			bool use_perf_schema = !is_mariadb &&
+				(sv_major >= 8 || (sv_major == 5 && sv != NULL && strncmp(sv, "5.7", 3) == 0));
+			if (use_perf_schema) {
+				query_ = "SELECT (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
+					"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
+					"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
+					"(SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , "
+					"(SELECT COALESCE(MAX(VARIABLE_VALUE),'DISABLED') FROM performance_schema.global_variables WHERE variable_name='pxc_maint_mode') pxc_maint_mode ";
+			} else {
+				// MariaDB Galera (any version) and legacy MySQL/PXC < 5.7
+				query_ = "SELECT (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
+					"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
+					"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
+					"(SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , (SELECT 'DISABLED') pxc_maint_mode";
+			}
 		}
 #endif // TEST_GALERA
 		task_timeout_ = mysql_thread___monitor_galera_healthcheck_timeout;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -746,15 +746,27 @@ void MySQL_Monitor_State_Data::init_async() {
 			" wsrep_cluster_status, pxc_maint_mode FROM HOST_STATUS_GALERA WHERE hostgroup_id=";
 		query_ += std::to_string(writer_hostgroup) + " AND hostname='" + std::string(hostname) + "' AND port=" + std::to_string(port);
 #else
-		if (strncmp(mysql->server_version, (char*)"5.7", 3) == 0 || strncmp(mysql->server_version, (char*)"8", 1) == 0) {
-			// the backend is either MySQL 5.7 or MySQL 8 : INFORMATION_SCHEMA.GLOBAL_STATUS is deprecated
+		// performance_schema.global_status is a MySQL-only table (added in 5.7).
+		// INFORMATION_SCHEMA.GLOBAL_STATUS was deprecated in MySQL 8.0 and
+		// removed in MySQL 8.4, so MySQL >= 5.7 must use performance_schema
+		// (otherwise the monitor query fails on MySQL 8.4+/9.x). MariaDB never
+		// implemented the performance_schema status tables and keeps
+		// GLOBAL_STATUS in information_schema across all versions, so it must
+		// be excluded explicitly (atoi("10.x-MariaDB") >= 8 would otherwise
+		// route it to the performance_schema branch).
+		const char *sv = mysql->server_version;
+		bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
+		int sv_major = (sv != NULL) ? atoi(sv) : 0;
+		bool use_perf_schema = !is_mariadb &&
+			(sv_major >= 8 || (sv_major == 5 && sv != NULL && strncmp(sv, "5.7", 3) == 0));
+		if (use_perf_schema) {
 			query_ = "SELECT (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
 				"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
 				"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
 				"(SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , "
 				"(SELECT COALESCE(MAX(VARIABLE_VALUE),'DISABLED') FROM performance_schema.global_variables WHERE variable_name='pxc_maint_mode') pxc_maint_mode ";
 		} else {
-			// any other version
+			// MariaDB Galera (any version) and legacy MySQL/PXC < 5.7
 			query_ = "SELECT (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
 				"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
 				"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
@@ -2293,16 +2305,23 @@ void * monitor_galera_thread(const std::vector<MySQL_Monitor_State_Data*>& data)
 		mmsd->async_exit_status = mysql_query_start(&mmsd->interr, mmsd->mysql, q2);
 		free(q2);
 #else
-		char *sv = mmsd->mysql->server_version;
-		if (strncmp(sv,(char *)"5.7",3)==0 || strncmp(sv,(char *)"8",1)==0) {
-			// the backend is either MySQL 5.7 or MySQL 8 : INFORMATION_SCHEMA.GLOBAL_STATUS is deprecated
+		// Same MariaDB / MySQL 8.4+ consideration as the synchronous Galera
+		// healthcheck above (lib/MySQL_Monitor.cpp:749): MariaDB always uses
+		// INFORMATION_SCHEMA; non-MariaDB MySQL >= 5.7 must use
+		// performance_schema (INFORMATION_SCHEMA.GLOBAL_STATUS removed in 8.4).
+		const char *sv = mmsd->mysql->server_version;
+		bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
+		int sv_major = (sv != NULL) ? atoi(sv) : 0;
+		bool use_perf_schema = !is_mariadb &&
+			(sv_major >= 8 || (sv_major == 5 && sv != NULL && strncmp(sv, "5.7", 3) == 0));
+		if (use_perf_schema) {
 			mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,"SELECT (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
 			"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
 			"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "
 			"(SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='WSREP_CLUSTER_STATUS') wsrep_cluster_status , "
 			"(SELECT COALESCE(MAX(VARIABLE_VALUE),'DISABLED') FROM performance_schema.global_variables WHERE variable_name='pxc_maint_mode') pxc_maint_mode ");
 		} else {
-			// any other version
+			// MariaDB Galera (any version) and legacy MySQL/PXC < 5.7
 			mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,"SELECT (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_STATE') "
 			"wsrep_local_state, @@read_only read_only, (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='WSREP_LOCAL_RECV_QUEUE') wsrep_local_recv_queue , "
 			"@@wsrep_desync wsrep_desync, @@wsrep_reject_queries wsrep_reject_queries, @@wsrep_sst_donor_rejects_queries wsrep_sst_donor_rejects_queries, "

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -2604,15 +2604,25 @@ bool MySQL_Session::handler_again___status_SETTING_GENERIC_VARIABLE(int *_rc, co
 		}
 		query=(char *)malloc(strlen(q)+strlen(var_name)+strlen(var_value));
 		if (strncasecmp("tx_isolation", var_name, 12) == 0) {
-			char *sv = mybe->server_myds->myconn->mysql->server_version;
-			if (strncmp(sv,(char *)"8",1)==0) {
+			// MySQL 8.0+ uses `transaction_isolation`; `tx_isolation` was
+			// deprecated in 8.0 and removed in 8.4 (so MySQL 9.x also
+			// requires the modern name). MariaDB (any version, including
+			// 11.x where atoi(server_version) >= 11) keeps `tx_isolation`,
+			// so the major-version check must exclude MariaDB explicitly.
+			const char *sv = mybe->server_myds->myconn->mysql->server_version;
+			bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
+			int sv_major = (sv != NULL) ? atoi(sv) : 0;
+			if (!is_mariadb && sv_major >= 8) {
 				sprintf(query,q,"transaction_isolation", var_value);
 			} else {
 				sprintf(query,q,"tx_isolation", var_value);
 			}
 		} else if (strncasecmp("tx_read_only", var_name, 12) == 0) {
-			char* sv = mybe->server_myds->myconn->mysql->server_version;
-			if (strncmp(sv, (char *)"8", 1) == 0) {
+			// Same MariaDB / MySQL 9.x consideration as `tx_isolation` above.
+			const char *sv = mybe->server_myds->myconn->mysql->server_version;
+			bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
+			int sv_major = (sv != NULL) ? atoi(sv) : 0;
+			if (!is_mariadb && sv_major >= 8) {
 				sprintf(query,q,"transaction_read_only", var_value);
 			} else {
 				sprintf(query,q,"tx_read_only", var_value);

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -345,7 +345,11 @@ bool validate_charset(MySQL_Session* session, int idx, int &_rc) {
 		//     major version (10.x, 11.x would otherwise pass an atoi() < 8 check).
 		const char *sv = myconn->mysql->server_version;
 		bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
-		if (charset >= 255 && (is_mariadb || atoi(sv) < 8)) {
+		// `atoi(NULL)` is undefined behavior; in practice `sv` should not be
+		// NULL here (validate_charset runs after a backend handshake has
+		// populated server_version), but the guard is essentially free.
+		int sv_major = (sv != NULL) ? atoi(sv) : 0;
+		if (charset >= 255 && (is_mariadb || sv_major < 8)) {
 			switch(mysql_thread___handle_unknown_charset) {
 				case HANDLE_UNKNOWN_CHARSET__DISCONNECT_CLIENT:
 					snprintf(msg,sizeof(msg),"Can't initialize character set %s", mysql_variables.client_get_value(session, idx));

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -337,9 +337,15 @@ bool validate_charset(MySQL_Session* session, int idx, int &_rc) {
 		unsigned int replace_collation_nr = 0;
 		std::stringstream ss;
 		int charset = atoi(mysql_variables.client_get_value(session, idx));
-		// Pre-8.0 MySQL cannot handle collations with id >= 255.
-		// MySQL 8.x, 9.x and later can — match by numeric major version, not first character.
-		if (charset >= 255 && atoi(myconn->mysql->server_version) < 8) {
+		// Collations with id >= 255 (e.g. utf8mb4_0900_ai_ci) are a MySQL 8.0+
+		// feature. They are not understood by:
+		//   - MySQL < 8.0 (any major version below 8)
+		//   - MariaDB (any version): MariaDB uses different collation IDs and
+		//     does not implement utf8mb4_0900_ai_ci, regardless of its numeric
+		//     major version (10.x, 11.x would otherwise pass an atoi() < 8 check).
+		const char *sv = myconn->mysql->server_version;
+		bool is_mariadb = (sv != NULL && strstr(sv, "MariaDB") != NULL);
+		if (charset >= 255 && (is_mariadb || atoi(sv) < 8)) {
 			switch(mysql_thread___handle_unknown_charset) {
 				case HANDLE_UNKNOWN_CHARSET__DISCONNECT_CLIENT:
 					snprintf(msg,sizeof(msg),"Can't initialize character set %s", mysql_variables.client_get_value(session, idx));

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -262,6 +262,7 @@
   "reg_test_5389-flush_logs_no_drop-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
   "reg_test_5620_fast_routing_qr_leak-t" : [ "legacy-g6" ],
   "reg_test_5766_libconfig_escape_passthrough-t" : [ "mysql95-g4" ],
+  "reg_test_5790-mariadb_collation_255-t" : [ "mariadb10-galera-g1" ],
   "reg_test__ssl_client_busy_wait-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_com_change_user_malformed_packet-t" : [ "mysql84-g6","mysql95-g1" ],
   "reg_test_compression_split_packets-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],

--- a/test/tap/tests/reg_test_5790-mariadb_collation_255-t.cpp
+++ b/test/tap/tests/reg_test_5790-mariadb_collation_255-t.cpp
@@ -1,0 +1,154 @@
+/**
+ * @file reg_test_5790-mariadb_collation_255-t.cpp
+ * @brief Regression for issue #5790: SET NAMES utf8mb4 COLLATE utf8mb4_0900_ai_ci
+ *        against a MariaDB backend must NOT propagate collation 255 to the backend.
+ *
+ * @details Collation id 255 (utf8mb4_0900_ai_ci) is a MySQL 8.0+ feature.
+ * MariaDB does not implement it, so ProxySQL must replace it with the configured
+ * default (per mysql-handle_unknown_charset) before opening / changing the
+ * backend session, otherwise the backend returns:
+ *   ERROR 1273 (HY000): Unknown collation: 'utf8mb4_0900_ai_ci'
+ *
+ * A regression introduced after v3.0.8 changed the version guard in
+ * validate_charset() from `server_version[0] != '8'` to
+ * `atoi(server_version) < 8`, which inadvertently treats MariaDB 10.x / 11.x
+ * (atoi() = 10 / 11) the same as MySQL >= 8 and skips the replacement.
+ *
+ * The test:
+ *   1. Skips unless the backend reports as MariaDB.
+ *   2. Configures handle_unknown_charset = REPLACE_WITH_DEFAULT_VERBOSE (1)
+ *      and default_collation_connection = utf8mb4_general_ci.
+ *   3. Opens a frontend connection, issues SET NAMES utf8mb4 COLLATE
+ *      utf8mb4_0900_ai_ci, then runs a query that forces a backend
+ *      SET NAMES via handler_again___status_CHANGING_CHARSET.
+ *   4. Verifies the query succeeds and that collation_connection on the
+ *      backend was replaced (i.e. it is NOT utf8mb4_0900_ai_ci).
+ */
+
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+#include <string>
+#include "mysql.h"
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+using std::string;
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv())
+		return exit_status();
+
+	plan(3);
+
+	// ---- 1. Detect MariaDB backend ---------------------------------------
+	MYSQL* mysql_probe = mysql_init(NULL);
+	if (!mysql_probe) return exit_status();
+	if (!mysql_real_connect(mysql_probe, cl.host, cl.username, cl.password,
+	                        NULL, cl.port, NULL, 0)) {
+		diag("Frontend connect for probe failed: %s", mysql_error(mysql_probe));
+		return exit_status();
+	}
+	string backend_version;
+	get_server_version(mysql_probe, backend_version);
+	mysql_close(mysql_probe);
+	diag("Backend server_version reported through ProxySQL: '%s'",
+	     backend_version.c_str());
+
+	if (backend_version.find("MariaDB") == string::npos) {
+		diag("Backend is not MariaDB; this regression only applies to MariaDB "
+		     "backends. Skipping.");
+		skip(3, "Backend is not MariaDB");
+		return exit_status();
+	}
+
+	// ---- 2. Configure ProxySQL ------------------------------------------
+	MYSQL* admin = mysql_init(NULL);
+	if (!admin) return exit_status();
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+	                        NULL, cl.admin_port, NULL, 0)) {
+		diag("Admin connect failed: %s", mysql_error(admin));
+		return exit_status();
+	}
+
+	// REPLACE_WITH_DEFAULT_VERBOSE so we also log the replacement in the
+	// proxysql error log (useful for forensics).
+	set_admin_global_variable(admin, "mysql-handle_unknown_charset", "1");
+	set_admin_global_variable(admin, "mysql-default_charset", "utf8mb4");
+	set_admin_global_variable(admin, "mysql-default_collation_connection",
+	                          "utf8mb4_general_ci");
+	if (mysql_query(admin, "LOAD MYSQL VARIABLES TO RUNTIME")) {
+		diag("LOAD failed: %s", mysql_error(admin));
+		return exit_status();
+	}
+	mysql_close(admin);
+
+	// ---- 3. Frontend connection + reproducer -----------------------------
+	MYSQL* mysql = mysql_init(NULL);
+	if (!mysql) return exit_status();
+	if (!mysql_real_connect(mysql, cl.host, cl.username, cl.password,
+	                        NULL, cl.port, NULL, 0)) {
+		diag("Frontend connect failed: %s", mysql_error(mysql));
+		return exit_status();
+	}
+
+	// Force a fresh backend connection so the SET NAMES propagates via
+	// handler_again___status_CHANGING_CHARSET on the first backend round-trip.
+	const char* set_names_q =
+	    "SET NAMES utf8mb4 COLLATE utf8mb4_0900_ai_ci";
+	int set_rc = mysql_query(mysql, set_names_q);
+	ok(set_rc == 0,
+	   "Client `%s` accepted by ProxySQL (no client-side error). "
+	   "errno=%u, err=`%s`",
+	   set_names_q, mysql_errno(mysql), mysql_error(mysql));
+
+	// This SELECT requires a backend connection. With the bug, the SET NAMES
+	// against MariaDB fails with errno 1273 and the connection is destroyed;
+	// the client sees the propagated error. With the fix, validate_charset()
+	// has already swapped 255 for the configured default (45), so SET NAMES
+	// utf8mb4_general_ci succeeds on MariaDB and the SELECT returns 1.
+	const char* select_q =
+	    "SELECT /* create_new_connection=1 */ 1";
+	int sel_rc = mysql_query(mysql, select_q);
+	if (sel_rc != 0) {
+		diag("Backend query failed: errno=%u err=`%s`",
+		     mysql_errno(mysql), mysql_error(mysql));
+	}
+	ok(sel_rc == 0,
+	   "Backend query after unsupported COLLATE must succeed. "
+	   "errno=%u, err=`%s`",
+	   mysql_errno(mysql), mysql_error(mysql));
+
+	// Drain the result if any.
+	if (sel_rc == 0) {
+		MYSQL_RES* r = mysql_store_result(mysql);
+		if (r) mysql_free_result(r);
+	}
+
+	// Inspect what the backend actually ended up with. With the fix, the
+	// backend session's collation_connection should be the configured default
+	// (utf8mb4_general_ci), never utf8mb4_0900_ai_ci.
+	const string collation_query {
+	    "SELECT /* create_new_connection=1 */ @@collation_connection"
+	};
+	ext_val_t<string> col_ext { mysql_query_ext_val(mysql, collation_query, string{}) };
+	if (col_ext.err) {
+		diag("collation_connection query failed: %s",
+		     get_ext_val_err(mysql, col_ext).c_str());
+	}
+	diag("Backend collation_connection after replacement: '%s'",
+	     col_ext.val.c_str());
+	ok(col_ext.val != "utf8mb4_0900_ai_ci" && !col_ext.val.empty(),
+	   "Backend collation_connection must not be utf8mb4_0900_ai_ci. "
+	   "Actual: '%s'",
+	   col_ext.val.c_str());
+
+	mysql_close(mysql);
+	return exit_status();
+}


### PR DESCRIPTION
## Summary

Fix a regression on `v3.0` HEAD where `SET NAMES utf8mb4 COLLATE utf8mb4_0900_ai_ci` is forwarded unmodified to MariaDB backends and fails with `ERROR 1273: Unknown collation: 'utf8mb4_0900_ai_ci'`. The same bug is present on `v3.1` / `v4.0` HEAD and shipped in tags `v3.1.8` / `v4.0.8` (not in `v3.0.7` / `v3.0.8` themselves).

Root cause: commit `7c6f42bcd` ("fix: MySQL 9.x charset handling…") changed the version guard in `lib/MySQL_Variables.cpp:validate_charset()` from `server_version[0] != '8'` to `atoi(server_version) < 8`. The new form correctly extends id-255 support to MySQL 9.x but silently treats MariaDB 10.x / 11.x (`atoi() == 10 / 11`) as if they were MySQL ≥ 8, so the unsupported collation is no longer rewritten before `SET NAMES` is sent to the backend.

| `server_version` | old guard `[0] != '8'` | new guard `atoi(...) < 8` |
|---|---|---|
| `5.7.x` | replace ✓ | replace ✓ |
| `8.0.x` | skip ✓ | skip ✓ |
| `9.x.y` | replace (wrong) | skip ✓ |
| **`10.11.13-MariaDB`** | replace ✓ | **skip — BUG** |
| **`11.x.x-MariaDB`** | replace ✓ | **skip — BUG** |

Primary fix: detect MariaDB by the `"MariaDB"` suffix in `server_version` and apply the same `handle_unknown_charset` replacement as for pre-8.0 MySQL.

Closes #5790. No backport — ships in 3.0.9 / 3.1.9 / 4.0.9.

## Expanded scope — sibling sites with the same class of bug

Independent review (subagents) surfaced four other sites in core that do version detection by indexing or string-prefix-matching `server_version`. Each misclassifies MariaDB, MySQL 9.x, or both. The two `MySQL_Monitor.cpp` sites are an **active break on MySQL 9.x Galera/PXC** (because `INFORMATION_SCHEMA.GLOBAL_STATUS` was removed in MySQL 8.4); the two `MySQL_Session.cpp` sites are latent (MariaDB happens to fall on a still-working branch).

All four are fixed in this PR using the same `is_mariadb + sv_major` pattern as `validate_charset`:

| File:line | Pre-fix branch logic | Pre-fix break | Post-fix |
|---|---|---|---|
| `lib/MySQL_Session.cpp:2607-2615` | `strncmp(sv,"8",1)==0` → `transaction_isolation` / `transaction_read_only`, else `tx_isolation` / `tx_read_only` | MySQL 9.x: `tx_isolation` removed in 8.4 → SET fails | `!is_mariadb && sv_major >= 8` → modern name on MySQL 8.0+ (incl. 9.x); MariaDB keeps `tx_isolation` |
| `lib/MySQL_Monitor.cpp:749` (sync MON_GALERA) | `strncmp(sv,"5.7",3)==0 || strncmp(sv,"8",1)==0` → `performance_schema`, else `INFORMATION_SCHEMA` | MySQL 9.x Galera: `INFORMATION_SCHEMA.GLOBAL_STATUS` removed in 8.4 → monitor query fails | `!is_mariadb && (sv_major >= 8 || prefix("5.7"))` → `performance_schema` for MySQL 5.7+; MariaDB Galera keeps `INFORMATION_SCHEMA` (where it lives there) |
| `lib/MySQL_Monitor.cpp:2297` (async MON_GALERA) | duplicate of above | same | same |

## Commits

1. `d8e51349e` — primary fix in `validate_charset` + TAP regression `reg_test_5790-mariadb_collation_255-t` registered in `mariadb10-galera-g1`.
2. `79414c10f` — Gemini review follow-up: null-safety guard on `atoi(server_version)` in `validate_charset`.
3. `81bcc802d` — extend the MariaDB / MySQL 9.x detection pattern to the four sibling sites above.

## Test plan

- [ ] CI: `mariadb10-galera-g1` runs `reg_test_5790-mariadb_collation_255-t` and passes.
- [ ] Manual regression check: revert `lib/MySQL_Variables.cpp` change → confirm `reg_test_5790-…-t` fails with errno 1273 on MariaDB backend.
- [ ] CI: no regression in `test_utf8mb4_as_ci-4841-t` (MySQL 8+ id-255 path) or `charset_unsigned_int-t`.
- [ ] CI: MariaDB Galera monitor groups (`mariadb10-galera-g*`) continue to pass — confirms `MySQL_Monitor.cpp` fix did not break the MariaDB Galera path that previously fell through the buggy condition by accident.
- [ ] CI: any `mysql95-*` / `mysql93-*` group with Galera or `SET SESSION TRANSACTION ISOLATION LEVEL …` coverage exercises the `MySQL_Session.cpp` / `MySQL_Monitor.cpp` fixes on MySQL 9.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-type and version detection so ProxySQL stops sending unsupported MySQL 8+ collations and incompatible variable names to MariaDB backends; Galera/status queries and session variable handling now use the appropriate form per server type/version.

* **Tests**
  * Added a regression test and test group to verify collation compatibility and that unsupported collations are not propagated to MariaDB.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->