### PR TITLE
ci(trigger): tolerate per-call HTTP 401 in cleanup step (fixes #5811)

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -40,6 +40,18 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "Cleanup skipped ..."
-        gh -R ${{ github.repository }} run list -s skipped -L 100 --json databaseId  -q '.[].databaseId' | xargs -r -n1 gh -R ${{ github.repository }} run delete
+        # Housekeeping only: opportunistically delete skipped runs. Per-call
+        # failures (typically HTTP 401 "Bad credentials" on runs that the
+        # PR-scoped GITHUB_TOKEN does not have rights to delete -- e.g. runs
+        # from forked PRs or other branches) MUST NOT fail this step,
+        # because failing this step marks the CI-trigger job as 'failure',
+        # which prevents every downstream test workflow from firing (they
+        # gate on workflow_run.conclusion == 'success'). See issue #5811.
+        gh -R ${{ github.repository }} run list -s skipped -L 100 --json databaseId -q '.[].databaseId' \
+            | while read -r id; do
+                if ! gh -R ${{ github.repository }} run delete "$id" 2>&1; then
+                    echo "  skip run $id (no rights / already gone)"
+                fi
+            done
         echo "Triggered workflow_run[completed]: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'"
         


### PR DESCRIPTION
## Summary

Fixes #5811.

The "Trigger workflow_run[completed]" step in `.github/workflows/ci-trigger.yml` opportunistically deletes skipped runs as housekeeping. The original implementation:

```bash
gh run list -s skipped -L 100 --json databaseId -q '.[].databaseId' \
    | xargs -r -n1 gh run delete
```

`xargs -r -n1` propagates the first non-zero exit. Some `gh run delete` calls return `HTTP 401: Bad credentials` (typically on runs from forked PRs, other branches, or runs the PR-scoped `GITHUB_TOKEN` doesn't have rights to). One 401 → `xargs` exits 123 → step fails → `CI-trigger` job concludes `failure` → every downstream test workflow gated on `workflow_run.conclusion == 'success'` (legacy-g\*, mysql84-\*, mysql84-gr-\*, set_parser_algorithm_3-g1, …) silently skips.

This has been today's recurring "why is CI failing on my PR" — hit at least PR #5803, PR #5809 (multiple times), and is documented with the smoking-gun log lines in #5811.

## The fix

Replace `xargs` with a `while read` loop so per-call failures are caught individually, logged, and don't abort the step:

```diff
-        gh run list -s skipped -L 100 --json databaseId -q '.[].databaseId' \
-            | xargs -r -n1 gh run delete
+        gh run list -s skipped -L 100 --json databaseId -q '.[].databaseId' \
+            | while read -r id; do
+                if ! gh run delete "$id" 2>&1; then
+                    echo "  skip run $id (no rights / already gone)"
+                fi
+            done
```

## What changes

* Cleanup scope: **unchanged** (still repo-wide, still the most recent 100 skipped runs).
* Error handling: per-call failures (auth, already-deleted, etc.) are now caught with a single log line each, instead of aborting the entire step.
* Job conclusion: `CI-trigger` now reflects whether the *trigger* worked, not whether housekeeping was completely clean.

## Test plan

- [x] Diff is minimal — only the error-handling shape of the cleanup pipeline.
- [ ] Verified by next PR push that exercises `CI-trigger` — the cleanup step should run cleanly (or log "skip" lines for runs it can't delete) and the job should conclude `success` instead of `failure`.

## Alternatives considered (from #5811)

1. **Scope cleanup to current branch** — cleaner long-term (eliminates the 401s instead of tolerating them), but changes behavior. Worth doing as a follow-up.
2. **`continue-on-error: true` on the step** — cheapest, but loses signal entirely.
3. **Delete the cleanup step** — relies on GitHub's retention. Worth considering if the housekeeping isn't actually needed.

Going with the minimal-behavior-change option (per-call tolerance) here. (1) can land as a separate PR if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow robustness by improving the housekeeping process for skipped workflow runs with more graceful error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->