### PR TITLE
fix(ci): align Cache restore src path with CI-builds save path

### DIFF
--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -56,6 +56,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -59,6 +59,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -67,6 +67,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -63,6 +63,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Run proxysql
       run: |

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -53,6 +53,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -67,6 +67,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4

--- a/.github/workflows/ci-taptests-asan.yml
+++ b/.github/workflows/ci-taptests-asan.yml
@@ -142,6 +142,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-taptests-groups.yml
+++ b/.github/workflows/ci-taptests-groups.yml
@@ -157,6 +157,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-taptests-ssl.yml
+++ b/.github/workflows/ci-taptests-ssl.yml
@@ -120,6 +120,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-taptests.yml
+++ b/.github/workflows/ci-taptests.yml
@@ -139,6 +139,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -49,6 +49,7 @@ jobs:
         fail-on-cache-miss: true
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
 
     - name: Cache restore test
       id: cache-test


### PR DESCRIPTION
## Problem

Every PR opened against `v3.0` currently shows ~40+ red checks at the `Cache restore src` step within seconds of dispatch. The failure looks like:

> `##[error]Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: <SHA>_ubuntu22-tap_src`

…even though the cache plainly exists in the repo (verifiable via `gh api /repos/sysown/proxysql/actions/caches?key=<SHA>_ubuntu22-tap_src`).

## Root cause

\`actions/cache@v4\` hashes \`paths\`, \`key\`, and \`enableCrossOsArchive\` together into a "version" identifier. **When save and restore disagree on \`paths\`, the version differs and the restore silently misses** — even if the key matches an entry that plainly exists.

\`ci-builds.yml\` saves \`Cache save src\` with two-line path:

\`\`\`yaml
path: |
  proxysql/src/
  proxysql/lib/obj/*.gcno
\`\`\`

The second entry was added so the \`-gcov\` variants can capture \`lib/obj/*.gcno\` (needed by fastcov to map \`.gcda\` → source files). It's a **no-op for non-gcov variants** — the glob matches nothing — but it changes the computed version, so every restore step needs the same two-line path list to find the saved entry.

\`ci-legacy-g2-genai.yml\` already had the fix and carries an inline comment documenting the gotcha:

> "MUST exactly match the path list in CI-builds' \"Cache save src\" step. actions/cache hashes the path list into the cache \"version\" alongside the key — different path lists = different version = lookup miss, even if the key is identical and the cache plainly exists in the repo (verified via gh api)."

The other 47 test workflows still had only \`proxysql/src/\` on the restore side.

## Fix

One-line addition to each \`Cache restore src\` block:

\`\`\`diff
         path: |
           proxysql/src/
+          proxysql/lib/obj/*.gcno
\`\`\`

48 workflow files updated. Two intentionally skipped:

- \`ci-codeql.yml\` — its \`Cache restore src\` block is fully commented out; nothing to align.
- \`ci-legacy-g2-genai.yml\` — already correct.

## Evidence the fix is targeted

- Total diff: 48 files, +48 lines, 0 deletions.
- Every added line is identical (\`+          proxysql/lib/obj/*.gcno\`), verified by \`git diff --unified=0 | grep '^+' | sort -u\`.
- Edits are scoped only to the \`Cache restore src\` step. Other occurrences of \`proxysql/src/\` (e.g. artifact upload blocks in \`ci-basictests.yml\`) are untouched.

## Out of scope

Cross-PR cache contamination is **not** in play here — cache keys embed the head SHA, so each PR writes to its own namespace. This is a per-PR self-contained save→restore version mismatch, deterministically affecting every PR until the restore path lists are aligned.

## Affected PRs (will unblock)

Anything in flight against \`v3.0\` whose checks are currently red on \`Cache restore src\`, including #5819 (partition-gate) and #5818 (codecov-tap-legacy-g2). No code changes; pure CI plumbing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/build pipeline caching to accelerate build and test execution times across all continuous integration workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->