### PR TITLE
test(security): use getaddrinfo so oversize_first_pkt-t works with hostnames

### DIFF
--- a/test/tap/tests/reg_test_oversize_first_pkt-t.cpp
+++ b/test/tap/tests/reg_test_oversize_first_pkt-t.cpp
@@ -28,8 +28,10 @@
 #include <arpa/inet.h>
 #include <cerrno>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
@@ -44,20 +46,36 @@
 #include "utils.h"
 
 static int tcp_connect(const char* host, int port) {
-	int fd = socket(AF_INET, SOCK_STREAM, 0);
-	if (fd < 0) return -1;
-	struct sockaddr_in sa;
-	memset(&sa, 0, sizeof(sa));
-	sa.sin_family = AF_INET;
-	sa.sin_port = htons(port);
-	if (inet_pton(AF_INET, host, &sa.sin_addr) != 1) {
-		close(fd);
+	// `host` is whatever cl.host / cl.pgsql_host resolves to. In CI it is
+	// the Docker DNS hostname ("proxysql") of the proxy container, not a
+	// numeric IP, so inet_pton(AF_INET, host, ...) returned 0 and made
+	// every probe in this test fail before any byte was sent. getaddrinfo
+	// handles both hostnames and numeric IPs, which is what we actually
+	// want.
+	char port_str[16];
+	snprintf(port_str, sizeof(port_str), "%d", port);
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	struct addrinfo* res = nullptr;
+	int rc = getaddrinfo(host, port_str, &hints, &res);
+	if (rc != 0 || res == nullptr) {
+		diag("tcp_connect: getaddrinfo(%s:%d) failed: %s",
+		     host, port, gai_strerror(rc));
 		return -1;
 	}
-	if (connect(fd, reinterpret_cast<struct sockaddr*>(&sa), sizeof(sa)) != 0) {
-		close(fd);
+	int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+	if (fd < 0) {
+		freeaddrinfo(res);
 		return -1;
 	}
+	if (connect(fd, res->ai_addr, res->ai_addrlen) != 0) {
+		close(fd);
+		freeaddrinfo(res);
+		return -1;
+	}
+	freeaddrinfo(res);
 	return fd;
 }
 


### PR DESCRIPTION
## Summary

The GHSA-58ww-865x-grpr regression test (`reg_test_oversize_first_pkt-t`)
has been failing in **every** CI run since it merged -- on feature
branches, on PR cascades, and on the v3.0 default-branch cascade.

Root cause: \`tcp_connect()\` resolves the target host with
\`inet_pton(AF_INET, host, &sa.sin_addr)\`, which only accepts numeric
IPv4 strings. In CI, \`cl.host\` / \`cl.pgsql_host\` is set to the Docker
DNS hostname \`proxysql\` (the proxy container's compose service name),
so \`inet_pton\` returns 0 and every probe fails with \`-1\` before
sending any byte. Test output:

\`\`\`
# MySQL probe: connect to proxysql:6033 failed: No such file or directory
not ok 1 - MySQL listener closed connection on oversize first-packet
          pkt_length=32765 (closed=-1)
not ok 2 ... pkt_length=65535 (closed=-1)
not ok 3 ... pkt_length=100000 (closed=-1)
not ok 4 ... pkt_length=16777215 (closed=-1)
# PgSQL listener not reachable at proxysql:6133; skipping PgSQL probes
ok 5 - ProxySQL admin still accepting connections after oversize attacks
# Failed 4 tests!
\`\`\`

(The misleading "No such file or directory" was just stale errno --
inet_pton doesn't set errno on parse failure.)

## Fix

Replace the \`inet_pton\` lookup with \`getaddrinfo\`, which transparently
handles both hostnames and numeric IPs. Probe semantics (4 KB header,
poll for FIN/RST with 3 s timeout, etc.) are unchanged.

## Why this matters

Without this fix, the test cannot exercise the security fix it was
written to regression-guard. On an ASAN build the pre-fix code would
NOT crash here because the probe never lands any bytes -- the
heap-buffer-overflow stays open behind a green ASAN CI signal. The
test must reach \`MySQL_Data_Stream::read_from_net\` /
\`PgSQL_Data_Stream::read_from_net\` to validate the bounds check.

## Test plan

- [ ] CI-legacy-g7 / tests (mysql57): the four MySQL probes pass (test
  192/348 was failing as 4/5 sub-asserts -- they all should pass now).
- [ ] Same on other groups that include this test in their matrix
  (per groups.json).
- [ ] If an infra that exposes the PgSQL listener runs the test
  (e.g. groups that resolve \`cl.pgsql_host\`), the 4 PgSQL probes
  should also pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression test infrastructure with more robust hostname resolution, now reliably handling both DNS names and numeric IP addresses in proxy connectivity testing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->