### PR TITLE
ci(coverage): extend Codecov TAP upload to all remaining TAP groups

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'clickhouse23' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -123,6 +137,7 @@ jobs:
         export TAP_GROUP="legacy-clickhouse-g1"
         export SKIP_CLUSTER_START=1
         export TAP_USE_NOISE=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -155,6 +170,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-clickhouse-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-clickhouse-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
+        flags: tap-legacy-clickhouse-g1
+        name: tap-legacy-clickhouse-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-legacy-g1"
         export TAP_GROUP="legacy-g1"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
+        flags: tap-legacy-g1
+        name: tap-legacy-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-legacy-g3"
         export TAP_GROUP="legacy-g3"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g3 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g3` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
+        flags: tap-legacy-g3
+        name: tap-legacy-g3-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -123,6 +137,7 @@ jobs:
         export TAP_GROUP="legacy-g4"
         export SKIP_CLUSTER_START=1
         export TAP_USE_NOISE=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -155,6 +170,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g4 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g4` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
+        flags: tap-legacy-g4
+        name: tap-legacy-g4-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -120,6 +134,7 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-legacy-g5"
         export TAP_GROUP="legacy-g5"
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -152,6 +167,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g5 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g5` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
+        flags: tap-legacy-g5
+        name: tap-legacy-g5-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-legacy-g6"
         export TAP_GROUP="legacy-g6"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g6 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g6` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
+        flags: tap-legacy-g6
+        name: tap-legacy-g6-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-legacy-g7"
         export TAP_GROUP="legacy-g7"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g7 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g7` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
+        flags: tap-legacy-g7
+        name: tap-legacy-g7-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-legacy-g8"
         export TAP_GROUP="legacy-g8"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g8 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g8` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
+        flags: tap-legacy-g8
+        name: tap-legacy-g8-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-legacy-g9"
         export TAP_GROUP="legacy-g9"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the legacy-g9 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-legacy-g9` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
+        flags: tap-legacy-g9
+        name: tap-legacy-g9-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g1"
         export TAP_GROUP="mariadb10-galera-g1"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
+        flags: tap-mariadb10-galera-g1
+        name: tap-mariadb10-galera-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g2"
         export TAP_GROUP="mariadb10-galera-g2"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g2 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g2` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
+        flags: tap-mariadb10-galera-g2
+        name: tap-mariadb10-galera-g2-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g3"
         export TAP_GROUP="mariadb10-galera-g3"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g3 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g3` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
+        flags: tap-mariadb10-galera-g3
+        name: tap-mariadb10-galera-g3-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g4"
         export TAP_GROUP="mariadb10-galera-g4"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g4 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g4` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
+        flags: tap-mariadb10-galera-g4
+        name: tap-mariadb10-galera-g4-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -120,6 +134,7 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g5"
         export TAP_GROUP="mariadb10-galera-g5"
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -145,6 +160,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g5 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g5` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
+        flags: tap-mariadb10-galera-g5
+        name: tap-mariadb10-galera-g5-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g6"
         export TAP_GROUP="mariadb10-galera-g6"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g6 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g6` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
+        flags: tap-mariadb10-galera-g6
+        name: tap-mariadb10-galera-g6-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g7"
         export TAP_GROUP="mariadb10-galera-g7"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g7 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g7` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
+        flags: tap-mariadb10-galera-g7
+        name: tap-mariadb10-galera-g7-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g8"
         export TAP_GROUP="mariadb10-galera-g8"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g8 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g8` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
+        flags: tap-mariadb10-galera-g8
+        name: tap-mariadb10-galera-g8-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mariadb10' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mariadb10-galera-g9"
         export TAP_GROUP="mariadb10-galera-g9"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mariadb10-galera-g9 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mariadb10-galera-g9` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
+        flags: tap-mariadb10-galera-g9
+        name: tap-mariadb10-galera-g9-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -13,6 +13,12 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
@@ -24,8 +30,8 @@ jobs:
         # which points to 'infra-dbdeployer-mysql56-single'.
         infradb: [ 'mysql56' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -57,6 +63,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -65,7 +79,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -128,6 +142,7 @@ jobs:
         export INFRA_ID="ci-mysql56-single-g1"
         export TAP_GROUP="mysql56-single-g1"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -160,6 +175,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql56-single-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql56-single-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
+        flags: tap-mysql56-single-g1
+        name: tap-mysql56-single-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g1"
         export TAP_GROUP="mysql84-g1"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
+        flags: tap-mysql84-g1
+        name: tap-mysql84-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g2"
         export TAP_GROUP="mysql84-g2"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g2 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g2` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
+        flags: tap-mysql84-g2
+        name: tap-mysql84-g2-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g3"
         export TAP_GROUP="mysql84-g3"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g3 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g3` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
+        flags: tap-mysql84-g3
+        name: tap-mysql84-g3-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g4"
         export TAP_GROUP="mysql84-g4"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g4 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g4` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
+        flags: tap-mysql84-g4
+        name: tap-mysql84-g4-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -120,6 +134,7 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mysql84-g5"
         export TAP_GROUP="mysql84-g5"
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -152,6 +167,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g5 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g5` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
+        flags: tap-mysql84-g5
+        name: tap-mysql84-g5-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g6"
         export TAP_GROUP="mysql84-g6"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g6 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g6` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
+        flags: tap-mysql84-g6
+        name: tap-mysql84-g6-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g7"
         export TAP_GROUP="mysql84-g7"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g7 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g7` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
+        flags: tap-mysql84-g7
+        name: tap-mysql84-g7-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g8"
         export TAP_GROUP="mysql84-g8"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g8 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g8` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
+        flags: tap-mysql84-g8
+        name: tap-mysql84-g8-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-g9"
         export TAP_GROUP="mysql84-g9"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-g9 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-g9` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
+        flags: tap-mysql84-g9
+        name: tap-mysql84-g9-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g1"
         export TAP_GROUP="mysql84-gr-g1"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
+        flags: tap-mysql84-gr-g1
+        name: tap-mysql84-gr-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g2"
         export TAP_GROUP="mysql84-gr-g2"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g2 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g2` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
+        flags: tap-mysql84-gr-g2
+        name: tap-mysql84-gr-g2-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g3"
         export TAP_GROUP="mysql84-gr-g3"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g3 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g3` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
+        flags: tap-mysql84-gr-g3
+        name: tap-mysql84-gr-g3-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g4"
         export TAP_GROUP="mysql84-gr-g4"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g4 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g4` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
+        flags: tap-mysql84-gr-g4
+        name: tap-mysql84-gr-g4-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -120,6 +134,7 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g5"
         export TAP_GROUP="mysql84-gr-g5"
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -145,6 +160,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g5 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g5` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
+        flags: tap-mysql84-gr-g5
+        name: tap-mysql84-gr-g5-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g6"
         export TAP_GROUP="mysql84-gr-g6"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g6 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g6` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
+        flags: tap-mysql84-gr-g6
+        name: tap-mysql84-gr-g6-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g7"
         export TAP_GROUP="mysql84-gr-g7"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g7 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g7` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
+        flags: tap-mysql84-gr-g7
+        name: tap-mysql84-gr-g7-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g8"
         export TAP_GROUP="mysql84-gr-g8"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g8 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g8` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
+        flags: tap-mysql84-gr-g8
+        name: tap-mysql84-gr-g8-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-mysql84-gr-g9"
         export TAP_GROUP="mysql84-gr-g9"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -147,6 +162,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the mysql84-gr-g9 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-mysql84-gr-g9` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
+        flags: tap-mysql84-gr-g9
+        name: tap-mysql84-gr-g9-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -13,13 +13,19 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
-      MATRIX: '(${{ matrix.infradb }})'
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
+      MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:
 
@@ -51,6 +57,14 @@ jobs:
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
         path: |
           proxysql/src/
           proxysql/lib/obj/*.gcno
@@ -59,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 
@@ -122,6 +136,7 @@ jobs:
         export INFRA_ID="ci-set-parser-algorithm-3-g1"
         export TAP_GROUP="set_parser_algorithm_3-g1"
         export SKIP_CLUSTER_START=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -154,6 +169,50 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the set_parser_algorithm_3-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-set_parser_algorithm_3-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
+        flags: tap-set_parser_algorithm_3-g1
+        name: tap-set_parser_algorithm_3-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()


### PR DESCRIPTION
## Summary

Fan-out of PR #5818's two-line pattern to every TAP-group reusable
workflow that wasn't yet contributing to Codecov.

After this lands, ProxySQL TAP coverage will be collected from **38
additional groups** instead of just `legacy-g2`. Each group uploads to
Codecov tagged with its own `tap-<group>` flag so the dashboard shows
per-group contribution and merges totals per commit.

## Per-file changes

For every `ci-<group>.yml` listed below:

| Edit | What |
|------|------|
| `permissions: write-all` | OIDC for codecov-action |
| `BLDCACHE: ...ubuntu24-tap-genai-gcov_src` | swap from `ubuntu22-tap_src` |
| test cache key | `..._ubuntu24-tap-genai-gcov_test` |
| `MATRIX: '(${{ matrix.infradb }},genai-gcov)'` | label TAP_USE_NOISE? not changed |
| Run step | `export COVERAGE=1` |
| Archive coverage report | `upload-artifact` of the LCOV `.info` |
| Upload coverage to Codecov | `flags: tap-<group>`, `use_oidc: true`, `disable_file_fixes: true` |

## Groups wired up (38)

- `legacy-clickhouse-g1`
- `legacy-g1`, `legacy-g3` … `legacy-g9`
- `mariadb10-galera-g1` … `mariadb10-galera-g9`
- `mysql56-single-g1`
- `mysql84-g1` … `mysql84-g9`
- `mysql84-gr-g1` … `mysql84-gr-g9`
- `set_parser_algorithm_3-g1`

`legacy-g2` already uploads via the dedicated `ci-legacy-g2-genai.yml`
(PR #5818) — left untouched to avoid a duplicate-flag clash on the
same commit.

## Companion change

The v3.0 caller side (every `CI-<group>.yml` declares
`permissions: write-all` so id-token:write propagates through the
reusable call) is in a parallel PR on `v3.0`. Reusable-workflow
permissions are the intersection of caller + callee, so both grants
are required for OIDC to mint a token.

**Merge order: this PR (GH-Actions) first, then the v3.0 caller PR.**
If v3.0 merges first, every CI run will attempt the Codecov upload
against the un-updated callee path lists and either silently miss
the gcov cache or fail at the OIDC step.

## Cleanup follow-ups (out of scope)

- The `ubuntu22-tap_src` cache produced by `CI-builds` is no longer
  referenced after this lands; the matrix entry can be dropped in a
  follow-up.
- gcov-instrumented binaries run 30-100% slower; the non-genai
  legacy-g2 reusable can be unified or removed once we've watched the
  green runs.

## Test plan

- [ ] PR push triggers nothing on `GH-Actions` (reusable workflows; no
      direct trigger).
- [ ] On the next v3.0 commit after both PRs merge:
  - [ ] `CI-builds` produces the `ubuntu24-tap-genai-gcov` cache.
  - [ ] Every TAP group restores it, runs with `COVERAGE=1`, and emits
        an LCOV `.info` artifact.
  - [ ] Codecov upload step on each group succeeds with HTTP 200.
  - [ ] https://app.codecov.io/github/sysown/proxysql/tree/v3.0 shows
        sessions tagged for every flag listed above.
  - [ ] Aggregate v3.0 coverage rises above the current 15.09%
        baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **CI/Infrastructure Updates**
  * Enhanced code coverage reporting across all test suites with automated uploads to Codecov
  * Updated CI infrastructure to Ubuntu 24 with improved build caching and tooling
  * Improved authentication security for external integrations using OIDC

<!-- end of auto-generated comment: release notes by coderabbit.ai -->