### PR TITLE
ci(coverage): grant write-all on TAP-group callers for Codecov OIDC

### DIFF
--- a/.github/workflows/CI-legacy-clickhouse-g1.yml
+++ b/.github/workflows/CI-legacy-clickhouse-g1.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-clickhouse-g1.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g1.yml
+++ b/.github/workflows/CI-legacy-g1.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g1.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g3.yml
+++ b/.github/workflows/CI-legacy-g3.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g3.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g4.yml
+++ b/.github/workflows/CI-legacy-g4.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g4.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g5.yml
+++ b/.github/workflows/CI-legacy-g5.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g5.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g6.yml
+++ b/.github/workflows/CI-legacy-g6.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g6.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g7.yml
+++ b/.github/workflows/CI-legacy-g7.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g7.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g8.yml
+++ b/.github/workflows/CI-legacy-g8.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g8.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g9.yml
+++ b/.github/workflows/CI-legacy-g9.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g9.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g1.yml
+++ b/.github/workflows/CI-mariadb10-galera-g1.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g1.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g2.yml
+++ b/.github/workflows/CI-mariadb10-galera-g2.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g2.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g3.yml
+++ b/.github/workflows/CI-mariadb10-galera-g3.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g3.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g4.yml
+++ b/.github/workflows/CI-mariadb10-galera-g4.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g4.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g5.yml
+++ b/.github/workflows/CI-mariadb10-galera-g5.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g5.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g6.yml
+++ b/.github/workflows/CI-mariadb10-galera-g6.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g6.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g7.yml
+++ b/.github/workflows/CI-mariadb10-galera-g7.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g7.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g8.yml
+++ b/.github/workflows/CI-mariadb10-galera-g8.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g8.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mariadb10-galera-g9.yml
+++ b/.github/workflows/CI-mariadb10-galera-g9.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mariadb10-galera-g9.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql56-single-g1.yml
+++ b/.github/workflows/CI-mysql56-single-g1.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql56-single-g1.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g1.yml
+++ b/.github/workflows/CI-mysql84-g1.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g1.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g2.yml
+++ b/.github/workflows/CI-mysql84-g2.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g2.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g3.yml
+++ b/.github/workflows/CI-mysql84-g3.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g3.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g4.yml
+++ b/.github/workflows/CI-mysql84-g4.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g4.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g5.yml
+++ b/.github/workflows/CI-mysql84-g5.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g5.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g6.yml
+++ b/.github/workflows/CI-mysql84-g6.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g6.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g7.yml
+++ b/.github/workflows/CI-mysql84-g7.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g7.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g8.yml
+++ b/.github/workflows/CI-mysql84-g8.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g8.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-g9.yml
+++ b/.github/workflows/CI-mysql84-g9.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-g9.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g1.yml
+++ b/.github/workflows/CI-mysql84-gr-g1.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g1.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g2.yml
+++ b/.github/workflows/CI-mysql84-gr-g2.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g2.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g3.yml
+++ b/.github/workflows/CI-mysql84-gr-g3.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g3.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g4.yml
+++ b/.github/workflows/CI-mysql84-gr-g4.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g4.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g5.yml
+++ b/.github/workflows/CI-mysql84-gr-g5.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g5.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g6.yml
+++ b/.github/workflows/CI-mysql84-gr-g6.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g6.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g7.yml
+++ b/.github/workflows/CI-mysql84-gr-g7.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g7.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g8.yml
+++ b/.github/workflows/CI-mysql84-gr-g8.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g8.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-mysql84-gr-g9.yml
+++ b/.github/workflows/CI-mysql84-gr-g9.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-mysql84-gr-g9.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/CI-set_parser_algorithm_3-g1.yml
@@ -14,6 +14,13 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-set_parser_algorithm_3-g1.yml@GH-Actions # NOSONAR: branch ref matches all other caller workflows
     secrets: inherit # NOSONAR: matches all other caller workflows
     with:

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -77,17 +77,17 @@ jobs:
     # though the app is installed. We keep `contents: read` (the
     # GitHub default) explicit so granting id-token: write here
     # doesn't implicitly widen any other scope.
-    permissions:
-      contents: read
-      id-token: write
-      # `LouisBrunner/checks-action@v2.0.0` (last step) needs to POST
-      # check-runs to update the workflow's check status; without
-      # checks:write it fails with "Resource not accessible by
-      # integration" on every run, which made the workflow show red
-      # even when build, tests, coverage capture, and Codecov upload
-      # all succeeded. Pre-dates this PR but found while investigating
-      # the #5828 cascade's red lines.
-      checks: write
+    # `write-all` mirrors what every TAP-group reusable workflow on
+    # GH-Actions declares. The narrower
+    #   contents: read / id-token: write / checks: write
+    # set was insufficient: the final `LouisBrunner/checks-action@v2.0.0`
+    # step kept failing with "Resource not accessible by integration"
+    # because this workflow runs via `workflow_run` from CI-trigger and
+    # the GITHUB_TOKEN it gets is the default-branch context, which
+    # can't act on a PR-branch SHA without broader scopes (matches the
+    # exact same reason the legacy-g2-genai pipeline ratcheted up to
+    # write-all in PR #5818). id-token:write is included automatically.
+    permissions: write-all
 
     steps:
 

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -80,6 +80,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # `LouisBrunner/checks-action@v2.0.0` (last step) needs to POST
+      # check-runs to update the workflow's check status; without
+      # checks:write it fails with "Resource not accessible by
+      # integration" on every run, which made the workflow show red
+      # even when build, tests, coverage capture, and Codecov upload
+      # all succeeded. Pre-dates this PR but found while investigating
+      # the #5828 cascade's red lines.
+      checks: write
 
     steps:
 

--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -394,7 +394,14 @@ docker run \
                                 # codecov-cli's network_root_folder is the runner's
                                 # /home/runner/work/proxysql/proxysql and the repo content
                                 # lives at <network_root>/proxysql/, so only paths shaped
-                                # as `SF:proxysql/...` get resolved -- the other two forms
+                                # as 'SF:proxysql/...' get resolved -- the other two forms
+                                # (note: single quotes, not backticks -- this whole bash
+                                # script is wrapped in `bash -c "..."`, and inside the
+                                # outer double quotes backticks trigger command
+                                # substitution, so `SF:proxysql/...` would make the outer
+                                # shell try to execute SF:proxysql/... as a command and
+                                # log "No such file or directory" before the inner script
+                                # even starts).
                                 # are silently dropped server-side. On the previous green
                                 # run that meant Codecov stored 27 files / 5694 lines out
                                 # of the 84621 lines fastcov actually measured.

--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -395,15 +395,16 @@ docker run \
                                 # /home/runner/work/proxysql/proxysql and the repo content
                                 # lives at <network_root>/proxysql/, so only paths shaped
                                 # as 'SF:proxysql/...' get resolved -- the other two forms
-                                # (NB: single quotes throughout this comment, never
-                                # backticks. The whole script body is the argument to
-                                # an outer "bash -c" wrapped in double quotes; inside
-                                # double quotes backticks trigger command substitution,
-                                # so a backtick-quoted token like SF:proxysql/... would
-                                # make the OUTER shell try to execute it as a command,
-                                # log "No such file or directory", and trip set -e at
-                                # the docker-run line before the inner script ever
-                                # starts).
+                                # NB to future editors: this whole script body is the
+                                # argument to an outer bash -c that is wrapped in
+                                # DOUBLE QUOTES. Inside those outer double quotes,
+                                # backticks still trigger command substitution and bare
+                                # double-quote characters terminate the argument early.
+                                # That means comments here must avoid backticks (use
+                                # apostrophes for inline code) and avoid any literal
+                                # double-quote character (use apostrophes, or escape
+                                # as backslash-double-quote like the script body does
+                                # for genuine strings).
                                 # are silently dropped server-side. On the previous green
                                 # run that meant Codecov stored 27 files / 5694 lines out
                                 # of the 84621 lines fastcov actually measured.

--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -395,13 +395,15 @@ docker run \
                                 # /home/runner/work/proxysql/proxysql and the repo content
                                 # lives at <network_root>/proxysql/, so only paths shaped
                                 # as 'SF:proxysql/...' get resolved -- the other two forms
-                                # (note: single quotes, not backticks -- this whole bash
-                                # script is wrapped in `bash -c "..."`, and inside the
-                                # outer double quotes backticks trigger command
-                                # substitution, so `SF:proxysql/...` would make the outer
-                                # shell try to execute SF:proxysql/... as a command and
-                                # log "No such file or directory" before the inner script
-                                # even starts).
+                                # (NB: single quotes throughout this comment, never
+                                # backticks. The whole script body is the argument to
+                                # an outer "bash -c" wrapped in double quotes; inside
+                                # double quotes backticks trigger command substitution,
+                                # so a backtick-quoted token like SF:proxysql/... would
+                                # make the OUTER shell try to execute it as a command,
+                                # log "No such file or directory", and trip set -e at
+                                # the docker-run line before the inner script ever
+                                # starts).
                                 # are silently dropped server-side. On the previous green
                                 # run that meant Codecov stored 27 files / 5694 lines out
                                 # of the 84621 lines fastcov actually measured.

--- a/test/infra/control/start-proxysql-isolated.bash
+++ b/test/infra/control/start-proxysql-isolated.bash
@@ -151,6 +151,34 @@ if [ "${PROXYSQL_LOAD_GENAI_PLUGIN:-0}" = "1" ]; then
     echo ">>> Mounting genai plugin .so into ProxySQL container"
 fi
 
+# Mount .gcno files into the proxysql container at the compile-time path
+# so gcov's runtime (invoked via the `PROXYSQL GCOV DUMP` admin command
+# from the tester) can resolve the .gcda files it writes.
+#
+# The proxysql binary was compiled inside the build container with the
+# source tree bind-mounted at /opt/proxysql/ (docker-compose.yml line:
+# `- ./:/opt/proxysql/`), so .gcno paths embedded in the binary point to
+# /opt/proxysql/{lib,src}/obj/X.gcno. Without these mounts the runtime
+# .gcda files come out with an empty `current_working_directory` field
+# and fastcov reports `files: []` for every one of them -- the bug that
+# silently zeroed out daemon-side coverage for PR #5818 (only ~5,694
+# lines / 27 files from `tap-legacy-g2` were ever real; everything else
+# was missing).
+#
+# Always-on: harmless when the .gcno files aren't present (e.g.
+# non-coverage builds) -- the conditional below just doesn't add
+# anything to GCOV_MOUNTS.
+GCOV_MOUNTS=""
+if compgen -G "${WORKSPACE}/lib/obj/*.gcno" >/dev/null; then
+    GCOV_MOUNTS="${GCOV_MOUNTS} -v ${WORKSPACE}/lib/obj:/opt/proxysql/lib/obj:ro"
+fi
+if compgen -G "${WORKSPACE}/src/obj/*.gcno" >/dev/null; then
+    GCOV_MOUNTS="${GCOV_MOUNTS} -v ${WORKSPACE}/src/obj:/opt/proxysql/src/obj:ro"
+fi
+if [ -n "${GCOV_MOUNTS}" ]; then
+    echo ">>> Mounting .gcno files into ProxySQL container for gcov runtime resolution"
+fi
+
 # Simulator-backed TAP groups (aurora-sim, galera-sim, ...) export a
 # CLUSTER_SIM_HOST_FILE pointing at a plain "hostname ip" list. Inject each
 # entry as --add-host so ProxySQL's container /etc/hosts resolves the simulated
@@ -177,6 +205,7 @@ docker run -d \
     -v "${COVERAGE_DATA_DIR}:/gcov" \
     ${MYSQLX_PLUGIN_MOUNT} \
     ${GENAI_PLUGIN_MOUNT} \
+    ${GCOV_MOUNTS} \
     -e GCOV_PREFIX="/gcov" \
     -e GCOV_PREFIX_STRIP="3" \
     proxysql-ci-base:latest \


### PR DESCRIPTION
## Summary

Caller-side companion to #5827 (`GH-Actions`).

Every `CI-<group>.yml` caller for a TAP group now declares
`permissions: write-all` on its `jobs.run` block so the
`id-token:write` scope that `codecov-action@v4` needs (`use_oidc:
true`) actually reaches the callee. Reusable-workflow permissions are
the intersection of caller + callee, so the caller has to grant
write-all for the callee's declaration to take effect.

Mirrors what `CI-legacy-g2-genai.yml` already does (from PR #5818).

## Workflows touched (38)

- `CI-legacy-clickhouse-g1.yml`
- `CI-legacy-g1.yml`, `CI-legacy-g3.yml` … `CI-legacy-g9.yml`
- `CI-mariadb10-galera-g1.yml` … `CI-mariadb10-galera-g9.yml`
- `CI-mysql56-single-g1.yml`
- `CI-mysql84-g1.yml` … `CI-mysql84-g9.yml`
- `CI-mysql84-gr-g1.yml` … `CI-mysql84-gr-g9.yml`
- `CI-set_parser_algorithm_3-g1.yml`

## Merge order

**This PR must land AFTER #5827 (`GH-Actions`)**. The callees there
already declare `permissions: write-all`; until that's on `GH-Actions`,
the callee side of the OIDC grant doesn't exist and every TAP run on
v3.0 will fail at the Codecov upload step.

If #5827 ever needs to be reverted, this PR should be reverted in the
same window.

## Test plan

- [ ] After #5827 merges to `GH-Actions`, push triggers the
      `CI-trigger -> CI-builds -> CI-<group>` cascade for every group.
- [ ] No "branch is protected" / OIDC mint failures in the Codecov
      upload step on any caller.
- [ ] https://app.codecov.io/github/sysown/proxysql/tree/v3.0 shows a
      session per flag (`tap-<group>`) for the merge commit.
- [ ] Aggregate v3.0 coverage rises above the current 15.09% baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI job permissions across pipelines to ensure coverage uploads and OIDC-based integrations run reliably.
* **Documentation**
  * Added explanatory comments in CI workflows clarifying permission expectations for downstream reusable steps.
* **Tests**
  * Improved test tooling: clarified coverage-path handling and made coverage artifact mounting conditional to enable accurate runtime coverage collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->