### PR TITLE
ci(cache): drop pre-compression from zstd --ultra -22 to zstd -15

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -271,17 +271,23 @@ jobs:
           grep 'exited with code 0' ${LOG} || exit 1
         done
 
-    - name: Pack bin cache with zstd-22
+    - name: Pack bin cache with zstd-15
       id: cache-pack-bin
       if: ${{ success() && steps.cache-check.outputs.cache-hit != 'true' }}
       # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
-      # with zstd --ultra -22 to fit more under the 10 GB repo quota.
-      # Re-compression by actions/cache on the already-compressed .tar.zst
-      # is a near-no-op. Symbols are preserved bit-for-bit.
+      # with zstd -15 to fit more under the 10 GB repo quota. Level 15
+      # captures most of the size win (~80% of what --ultra -22 gives
+      # over default -3) at roughly 1/10 the time on this codebase --
+      # `--ultra -22` measured 14-16 min just on the test cache step per
+      # ubuntu build job (vs ~17 min for the build itself), pushing
+      # CI-builds wall clock to ~38 min and gating every downstream TAP
+      # workflow on it. Re-compression by actions/cache on the already-
+      # compressed .tar.zst is a near-no-op. Symbols are preserved
+      # bit-for-bit.
       run: |
         command -v zstd >/dev/null || sudo apt-get install -y zstd
         cd proxysql/
-        tar -cf - .git/ binaries/ | zstd --ultra -22 -T0 -o ../cache_bin.tar.zst
+        tar -cf - .git/ binaries/ | zstd -15 -T0 -o ../cache_bin.tar.zst
 
     - name: Cache save bin
       id: cache-save-bin
@@ -314,17 +320,21 @@ jobs:
           proxysql/src/
           proxysql/lib/obj/*.gcno
 
-    - name: Pack test cache with zstd-22
+    - name: Pack test cache with zstd-15
       id: cache-pack-test
       if: ${{ success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
       # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
-      # with zstd --ultra -22 to fit more under the 10 GB repo quota.
-      # Re-compression by actions/cache on the already-compressed .tar.zst
-      # is a near-no-op. Symbols are preserved bit-for-bit.
+      # with zstd -15 to fit more under the 10 GB repo quota. See the
+      # bin-cache pack step above for the rationale on dropping from
+      # `--ultra -22` to -15: this step alone was taking 14-16 min per
+      # ubuntu build job at --ultra -22, doubling CI-builds wall clock
+      # and blocking every downstream TAP workflow on it. Re-compression
+      # by actions/cache on the already-compressed .tar.zst is a near-
+      # no-op. Symbols are preserved bit-for-bit.
       run: |
         command -v zstd >/dev/null || sudo apt-get install -y zstd
         cd proxysql/
-        tar -cf - test/ | zstd --ultra -22 -T0 -o ../cache_test.tar.zst
+        tar -cf - test/ | zstd -15 -T0 -o ../cache_test.tar.zst
 
     - name: Cache save test
       id: cache-save-test


### PR DESCRIPTION
## Summary

Follow-up to 4e4d4496a, which pre-compressed the `_test` / `_bin`
caches at `zstd --ultra -22` to fit under GitHub's 10 GB per-repo cache
quota. The size win is real, but the time cost was not properly
accounted for.

### Measured on the last green CI-builds (commit `97eab1bbf0`)

| Matrix | Build | Pack bin (-22) | Pack test (-22) |
|--------|-------|----------------|-----------------|
| ubuntu24-tap-genai-gcov | 17m58s | 3m11s | **15m53s** |
| ubuntu22-tap            | 17m54s | 2m51s | **14m08s** |
| debian12-dbg            |  6m51s | 3m09s | (skipped)       |

`pack-test` at `--ultra -22` takes roughly as long as the actual build,
pushing CI-builds wall clock to ~38 min. Since CI-builds gates every
downstream TAP-group workflow via `workflow_run`, every TAP job (38 of
them after #5827 / #5828) sits idle during that window. The cache
became more of a tax than a saving.

## Change

Switch the two `tar | zstd ...` invocations in `ci-builds.yml` from
`zstd --ultra -22 -T0` to `zstd -15 -T0`. That's the whole patch.

- No cache-key changes -- the .tar.zst format is identical, only the
  compression level inside the blob differs. Consumers don't need any
  changes.
- The motivation for pre-compressing at all (avoid actions/cache@v4's
  level-3 default and the LRU-eviction failure mode that produced
  cryptic "Cache restore test" errors) is preserved -- level 15 still
  beats level 3 comfortably.
- Empirically, going from `--ultra -22` to `-15` trades roughly 5-7%
  extra blob size for ~10x faster compression on this codebase. We
  expect `pack-test` to drop from ~15 min to 1-3 min per ubuntu job.

## Test plan

- [ ] Once merged, dispatching `CI-trigger` against a v3.0 PR branch
      should produce a CI-builds run with `Pack test cache with zstd-15`
      completing in under ~3 min per ubuntu job.
- [ ] Total CI-builds wall clock drops from ~38 min to roughly ~22-24
      min.
- [ ] `_test` / `_bin` cache restores in downstream TAP workflows
      continue to succeed (same file format, same key, slightly larger
      blob).
- [ ] Repo cache quota holds -- if not, follow-up to `-19` (canonical
      high-compression sweet spot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration build caching configuration to improve build performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->