### PR TITLE
fix(ci): stop leaking backticks from coverage trap into outer shell

### DIFF
--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -394,7 +394,14 @@ docker run \
                                 # codecov-cli's network_root_folder is the runner's
                                 # /home/runner/work/proxysql/proxysql and the repo content
                                 # lives at <network_root>/proxysql/, so only paths shaped
-                                # as `SF:proxysql/...` get resolved -- the other two forms
+                                # as 'SF:proxysql/...' get resolved -- the other two forms
+                                # (note: single quotes, not backticks -- this whole bash
+                                # script is wrapped in `bash -c "..."`, and inside the
+                                # outer double quotes backticks trigger command
+                                # substitution, so `SF:proxysql/...` would make the outer
+                                # shell try to execute SF:proxysql/... as a command and
+                                # log "No such file or directory" before the inner script
+                                # even starts).
                                 # are silently dropped server-side. On the previous green
                                 # run that meant Codecov stored 27 files / 5694 lines out
                                 # of the 84621 lines fastcov actually measured.


### PR DESCRIPTION
## Summary

Every TAP-group run currently logs:

```
test/infra/control/run-tests-isolated.bash: line 275: SF:proxysql/...: No such file or directory
```

This is **cosmetic, not functional** — coverage upload to Codecov has
been working — but it's confusing and easy to mistake for a real
failure (came up in review of the #5828 cascade).

## Root cause

The coverage-collection trap inside `run-tests-isolated.bash` is
embedded in a `docker run ... /bin/bash -c "..."` block. The script
body is the argument to `bash -c`, **double-quoted**. Inside double
quotes, backticks are still command substitution.

One comment line in the SF: path-normalization block used
markdown-style backticks for code formatting:

```bash
# as `SF:proxysql/...` get resolved -- the other two forms
```

The outer shell sees `` `SF:proxysql/...` `` as command substitution,
tries to execute `SF:proxysql/...` as a command before passing the
body to docker, fails with "No such file or directory", and points at
line 275 (where the `docker run \` compound command begins).

The substitution then evaluates to the empty string, the inner bash
receives a still-inert comment, and the actual `sed -i` normalization
runs correctly.

## Fix

Swap the backticks for single quotes and add a sibling comment so the
next author doesn't reintroduce the trap. One file changed, eight
lines added.

## Test plan

- [ ] Next TAP-group run after merge no longer logs the
      `SF:proxysql/...: No such file or directory` line.
- [ ] Codecov upload still produces a valid LCOV `.info` with
      normalized `SF:proxysql/...` paths (the actual sed step is
      unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced inline documentation in test infrastructure to clarify configuration and script behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->