### PR TITLE
Blue/Green Deployment fast switchover support - Step 1 - decide on appropriate topology metadata check

### DIFF
--- a/include/MySQL_Monitor.hpp
+++ b/include/MySQL_Monitor.hpp
@@ -68,13 +68,9 @@ struct cmp_str {
 
 #define AWS_ENDPOINT_SUFFIX_STRING "rds.amazonaws."
 #define QUERY_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.read_only AS read_only, EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema='mysql' AND table_name='rds_topology') AS has_rds_topology"
-#define QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.innodb_read_only AS read_only, EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema='mysql' AND table_name='rds_topology') AS has_rds_topology"
 #define QUERY_READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.read_only AS read_only, COUNT(*) AS has_version_col FROM information_schema.columns WHERE table_schema='mysql' AND table_name='rds_topology' AND column_name='version'"
-#define QUERY_INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.innodb_read_only AS read_only, COUNT(*) AS has_version_col FROM information_schema.columns WHERE table_schema='mysql' AND table_name='rds_topology' AND column_name='version'"
 #define QUERY_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.read_only read_only, id, endpoint, port from mysql.rds_topology"
-#define QUERY_INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only read_only, id, endpoint, port from mysql.rds_topology"
 #define QUERY_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.read_only AS read_only, id, endpoint, port, role, status, version FROM mysql.rds_topology"
-#define QUERY_INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only AS read_only, id, endpoint, port, role, status, version FROM mysql.rds_topology"
 
 #define SUPPORTED_AWS_RDS_TOPOLOGY_VERSION "1.0"
 
@@ -104,14 +100,10 @@ A single AWS_Aurora_monitor_node will have a AWS_Aurora_status_entry per check.
 
 #define TEST_QUERY___READ_ONLY "SELECT @@global.read_only read_only "
 #define TEST_QUERY___READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.read_only AS read_only, 1 AS has_rds_topology "
-#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.innodb_read_only AS read_only, 1 AS has_rds_topology "
 #define TEST_QUERY___READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.read_only AS read_only, 1 AS has_version_col "
-#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.innodb_read_only AS read_only, 1 AS has_version_col "
 #define TEST_QUERY___READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.read_only read_only, id, endpoint, port "
-#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only read_only, id, endpoint, port "
 
 #define TEST_QUERY___READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.read_only AS read_only, id, endpoint, port, role, status, version "
-#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only AS read_only, id, endpoint, port, role, status, version "
 
 #define TEST_QUERY___SQLITE3_AWS_RDS_TOPOLOGY "SELECT read_only read_only, id, endpoint, port "
 
@@ -310,13 +302,9 @@ enum MySQL_Monitor_State_Data_Task_Type {
 	MON_GALERA,
 	MON_AWS_AURORA,
 	MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS,
-	MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS,
 	MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK,
-	MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK,
 	MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY,
-	MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY,
 	MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY,
-	MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY,
 };
 
 enum MySQL_Monitor_Aws_Metadata_Check {

--- a/include/MySQL_Monitor.hpp
+++ b/include/MySQL_Monitor.hpp
@@ -66,9 +66,13 @@ struct cmp_str {
 
 #define N_L_ASE 16
 
-#define AWS_ENDPOINT_SUFFIX_STRING "rds.amazonaws.com"
-#define QUERY_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY "SELECT @@global.read_only read_only, id, endpoint, port from mysql.rds_topology"
-#define QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only read_only, id, endpoint, port from mysql.rds_topology"
+#define AWS_ENDPOINT_SUFFIX_STRING "rds.amazonaws."
+#define QUERY_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.read_only AS read_only, EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema='mysql' AND table_name='rds_topology') AS has_rds_topology"
+#define QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.innodb_read_only AS read_only, EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema='mysql' AND table_name='rds_topology') AS has_rds_topology"
+#define QUERY_READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.read_only AS read_only, COUNT(*) AS has_version_col FROM information_schema.columns WHERE table_schema='mysql' AND table_name='rds_topology' AND column_name='version'"
+#define QUERY_INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.innodb_read_only AS read_only, COUNT(*) AS has_version_col FROM information_schema.columns WHERE table_schema='mysql' AND table_name='rds_topology' AND column_name='version'"
+#define QUERY_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.read_only read_only, id, endpoint, port from mysql.rds_topology"
+#define QUERY_INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only read_only, id, endpoint, port from mysql.rds_topology"
 #define QUERY_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.read_only AS read_only, id, endpoint, port, role, status, version FROM mysql.rds_topology"
 #define QUERY_INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only AS read_only, id, endpoint, port, role, status, version FROM mysql.rds_topology"
 
@@ -99,8 +103,12 @@ A single AWS_Aurora_monitor_node will have a AWS_Aurora_status_entry per check.
 #if defined(TEST_AWS_RDS) || defined(TEST_READONLY)
 
 #define TEST_QUERY___READ_ONLY "SELECT @@global.read_only read_only "
-#define TEST_QUERY___READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY "SELECT @@global.read_only read_only, id, endpoint, port "
-#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only read_only, id, endpoint, port "
+#define TEST_QUERY___READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.read_only AS read_only, 1 AS has_rds_topology "
+#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS "SELECT @@global.innodb_read_only AS read_only, 1 AS has_rds_topology "
+#define TEST_QUERY___READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.read_only AS read_only, 1 AS has_version_col "
+#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK "SELECT @@global.innodb_read_only AS read_only, 1 AS has_version_col "
+#define TEST_QUERY___READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.read_only read_only, id, endpoint, port "
+#define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only read_only, id, endpoint, port "
 
 #define TEST_QUERY___READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.read_only AS read_only, id, endpoint, port, role, status, version "
 #define TEST_QUERY___INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY "SELECT @@global.innodb_read_only AS read_only, id, endpoint, port, role, status, version "
@@ -301,14 +309,20 @@ enum MySQL_Monitor_State_Data_Task_Type {
 	MON_REPLICATION_LAG,
 	MON_GALERA,
 	MON_AWS_AURORA,
-	MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY,
-	MON_INNODB_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY,
+	MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS,
+	MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS,
+	MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK,
+	MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK,
+	MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY,
+	MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY,
 	MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY,
 	MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY,
 };
 
 enum MySQL_Monitor_Aws_Metadata_Check {
-	AWS_RDS_TOPOLOGY_CHECK,
+	AWS_RDS_TABLE_EXISTS_CHECK,
+	AWS_RDS_VERSION_CHECK,
+	AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK,
 	AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK,
 	NONE
 };
@@ -331,6 +345,15 @@ struct gr_host_def_t {
 	bool writer_is_also_reader;
 	int max_transactions_behind;
 	int max_transactions_behind_count;
+};
+
+/**
+ * @brief Per-host state for the mysql.rds_topology table schema.
+ */
+enum class RDS_Table_State {
+	NEEDS_CHECK,    // Table absent or state unknown; probe for existence
+	MULTIAZ_TABLE,  // Legacy 4-column table (read_only, id, endpoint, port)
+	BGD_TABLE       // v1.0 full schema (read_only, id, endpoint, port, role, status, version)
 };
 
 /**

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -706,7 +706,7 @@ class ProxySQL_Admin {
 	/**
 	 * @brief Creates RDS monitoring threads.
 	 * @details It uses the provided 'mysql_replication_hostgroups' and the promoted 'mysql_servers'
-	 *  resultset to filter the hostnames ending with '.rds.amazonaws.com'. Hostgroups containing at
+	 *  resultset to filter the hostnames containing '.rds.amazonaws.'. Hostgroups containing at
 	 *  least one of the previous instances are candidates for RDS monitoring, and a thread will be
 	 *  spawned to monitor that particular 'mysql_replication_hostgroups' entry. If config changes,
 	 *  threads are expected signal its exit, if config changes back, threads will be recreated.

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2012,7 +2012,7 @@ void MySQL_HostGroups_Manager::generate_mysql_aws_rds_hostgroups_monitor_results
 			"SELECT writer_hostgroup, reader_hostgroup, hostname, port, MAX(use_ssl) use_ssl"
 			" FROM mysql_servers JOIN mysql_replication_hostgroups"
 				" ON hostgroup_id=writer_hostgroup OR hostgroup_id=reader_hostgroup"
-			" WHERE status NOT IN (2,3) AND hostname LIKE '%rds.amazonaws.com'"
+			" WHERE status NOT IN (2,3) AND hostname LIKE '%rds.amazonaws.%'"
 			" GROUP BY hostname, port ORDER BY RANDOM()"
 		};
 		char* error { nullptr };

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -678,20 +678,8 @@ void MySQL_Monitor_State_Data::init_async() {
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS:
-		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
 	case MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
 		query_ = QUERY_READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
-		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
@@ -705,20 +693,8 @@ void MySQL_Monitor_State_Data::init_async() {
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY:
-		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
 	case MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY:
 		query_ = QUERY_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY:
-		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
@@ -742,20 +718,8 @@ void MySQL_Monitor_State_Data::init_async() {
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS:
-		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS } + " " + hostname;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
 	case MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
 		query_ = string { TEST_QUERY___READ_ONLY_AND_AWS_RDS_VERSION_CHECK } + " " + hostname;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
-		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK } + " " + hostname;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
@@ -766,20 +730,8 @@ void MySQL_Monitor_State_Data::init_async() {
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY:
-		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY } + " " + hostname;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
 	case MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY:
 		query_ = string { TEST_QUERY___READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY } + " " + hostname;
-		async_state_machine_ = ASYNC_QUERY_START;
-		task_timeout_ = mysql_thread___monitor_read_only_timeout;
-		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
-		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY:
-		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY } + " " + hostname;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
@@ -1845,20 +1797,12 @@ void * monitor_read_only_thread(const std::vector<MySQL_Monitor_State_Data*>& da
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,"SELECT @@global.read_only|@@global.innodb_read_only read_only");
 	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS);
-	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
-		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS);
 	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_RDS_VERSION_CHECK);
-	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
-		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK);
 	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY);
-	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
-		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY);
 	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY);
-	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
-		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY);
 	} else { // default
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,"SELECT @@global.read_only read_only");
 	}
@@ -1867,20 +1811,12 @@ void * monitor_read_only_thread(const std::vector<MySQL_Monitor_State_Data*>& da
 		auto get_task_query = [] (MySQL_Monitor_State_Data_Task_Type task_type) -> std::string {
 			if (task_type == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
 				return TEST_QUERY___READ_ONLY_AND_AWS_RDS_TABLE_EXISTS;
-			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
-				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS;
 			} else if (task_type == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
 				return TEST_QUERY___READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
-			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
-				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
 			} else if (task_type == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
 				return TEST_QUERY___READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
-			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
-				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
 			} else if (task_type == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
 				return TEST_QUERY___READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY;
-			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
-				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY;
 			} else {
 				assert(0);
 			}
@@ -9090,14 +9026,12 @@ pair<rds_srv_st_t,vector<rds_srv_st_t>> extract_rds_srv_st(MySQL_Monitor_State_D
 
 		bool check_task_fields =
 			(
-				(mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY
-				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY)
+				mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY
 				 && num_fields == 4
 			)
 			||
 			(
-				(mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY
-				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY)
+				mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY
 				&& num_fields == 7
 			);
 
@@ -9133,10 +9067,7 @@ pair<rds_srv_st_t,vector<rds_srv_st_t>> extract_rds_srv_st(MySQL_Monitor_State_D
 				rds_srv_st.endpoint = row[2] ? row[2] : "";
 				rds_srv_st.port = row[3] ? atol(row[3]) : -1;
 
-				if (
-					mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY
-					|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY
-				) {
+				if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
 					rds_srv_st.role = row[4] ? row[4] : "";
 					rds_srv_st.status = row[5] ? row[5] : "";
 					rds_srv_st.version = row[6] ? row[6] : "";
@@ -9472,10 +9403,7 @@ rds_mon_st_t async_rds_mon_actions_handler(
 	MySQL_Monitor_State_Data* mmsd, const rds_mon_st_t& cur_mon_st
 ) {
 	// Handle TABLE_EXISTS check — result format: (read_only, has_rds_topology)
-	if (
-		mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
-		|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
-	) {
+	if ( mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS ) {
 		rds_mon_st_t next_mon_st { cur_mon_st };
 
 		if (mmsd->interr == 0 && mmsd->result) {
@@ -9514,10 +9442,7 @@ rds_mon_st_t async_rds_mon_actions_handler(
 	}
 
 	// Handle VERSION_CHECK — result format: (read_only, has_version_col)
-	if (
-		mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
-		|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
-	) {
+	if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
 		rds_mon_st_t next_mon_st { cur_mon_st };
 
 		if (mmsd->interr == 0 && mmsd->result) {
@@ -9872,10 +9797,7 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 			const string host_key { string(mmsd->hostname) + ":" + to_string(mmsd->port) };
 
 			// Update per-host check map based on results
-			if (
-				mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
-				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
-			) {
+			if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
 				if (mmsd->cur_rds_mon_st.check_type == AWS_RDS_VERSION_CHECK) {
 					// Table found — transition to VERSION_CHECK on next iteration
 					host_check_map[host_key] = AWS_RDS_VERSION_CHECK;
@@ -9888,10 +9810,7 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 				continue;
 			}
 
-			if (
-				mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
-				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
-			) {
+			if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
 				// VERSION_CHECK completed — classify the host permanently
 				host_check_map[host_key] = mmsd->cur_rds_mon_st.check_type;
 				continue;

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -9235,7 +9235,7 @@ pair<rds_mon_st_t,vector<rds_srv_st_t>> process_discovered_topology(
 			if (!peer.version.empty()) { all_version_empty = false; break; }
 		}
 		if (all_version_empty) {
-			proxy_info("AWS RDS BGD check returned Multi-AZ topology (version=NULL), treating as MULTIAZ\n");
+			proxy_info("AWS RDS BGD check returned Multi-AZ topology (version=NULL), treating as Multi-AZ\n");
 			next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
 			// Fall through to validation below
 		}
@@ -9399,83 +9399,59 @@ rds_mon_st_t rds_mon_action_over_resp_srv(
 	return next_mon_st;
 }
 
+/**
+ * @brief Allows quick handling of rds_topology table checks that don't return table contents
+ *
+ * @param mmsd The 'mmsd' holding info about the query run on the server.
+ * @param next_mon_st A reference to the next rds monitoring task. Is modified according to mmsd.
+ * @param check_type Information about which check was performed.
+ * 
+ * @return A bool indicating if it was a precheck scenario.
+ */
+bool handle_rds_topology_precheck_cases(MySQL_Monitor_State_Data* mmsd, rds_mon_st_t& next_mon_st) {
+	MySQL_Monitor_Aws_Metadata_Check check_type = mmsd->get_task_type();
+	if (check_type != MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS && check_type != MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK)	 {
+		return false;
+	}
+
+	if (mmsd->interr == 0 && mmsd->result) {
+		MYSQL_ROW row = mysql_fetch_row(mmsd->result);
+		if (row) {
+			bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
+			bool check_result = (row[1] && !strcasecmp(row[1], "1"));
+
+			// TODO: remove this call once monitor_read_only is configured to also check RDS servers again
+			MyHGM->read_only_action_v2({
+				{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
+			});
+
+			if (check_result && check_type == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
+				// Transition to VERSION_CHECK with 1s delay
+				next_mon_st.check_type = AWS_RDS_VERSION_CHECK;
+				next_mon_st.next_check_delay = 1000;
+			} else if (check_result && check_type == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
+				next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
+			} else {
+				next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
+			}
+		}
+		mysql_free_result(mmsd->result);
+		mmsd->result = NULL;
+	} else {
+		rds_report_fetching_errs(mmsd);
+	}
+
+	handle_mmsd_mysql_conn(mmsd);
+	return true;
+}
+
 rds_mon_st_t async_rds_mon_actions_handler(
 	MySQL_Monitor_State_Data* mmsd, const rds_mon_st_t& cur_mon_st
 ) {
+	rds_mon_st_t next_mon_st { cur_mon_st };
+
 	// Handle TABLE_EXISTS check — result format: (read_only, has_rds_topology)
-	if ( mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS ) {
-		rds_mon_st_t next_mon_st { cur_mon_st };
-
-		if (mmsd->interr == 0 && mmsd->result) {
-			MYSQL_ROW row = mysql_fetch_row(mmsd->result);
-			if (row) {
-				bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
-				bool has_table = (row[1] && !strcasecmp(row[1], "1"));
-
-				MyHGM->read_only_action_v2({
-					{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
-				});
-
-				if (has_table) {
-					proxy_info(
-						"AWS RDS host %s:%d has mysql.rds_topology, proceeding to version check\n",
-						mmsd->hostname, mmsd->port
-					);
-					// Transition to VERSION_CHECK with 1s delay
-					next_mon_st.check_type = AWS_RDS_VERSION_CHECK;
-					next_mon_st.next_check_delay = 1000;
-				} else {
-					proxy_info(
-						"AWS RDS host %s:%d does not have mysql.rds_topology\n",
-						mmsd->hostname, mmsd->port
-					);
-				}
-			}
-			mysql_free_result(mmsd->result);
-			mmsd->result = NULL;
-		} else {
-			rds_report_fetching_errs(mmsd);
-		}
-
-		handle_mmsd_mysql_conn(mmsd);
-		return next_mon_st;
-	}
-
-	// Handle VERSION_CHECK — result format: (read_only, has_version_col)
-	if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
-		rds_mon_st_t next_mon_st { cur_mon_st };
-
-		if (mmsd->interr == 0 && mmsd->result) {
-			MYSQL_ROW row = mysql_fetch_row(mmsd->result);
-			if (row) {
-				bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
-				bool has_version_col = (row[1] && !strcasecmp(row[1], "1"));
-
-				MyHGM->read_only_action_v2({
-					{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
-				});
-
-				if (has_version_col) {
-					proxy_info(
-						"AWS RDS host %s:%d has BGD table schema (version column present)\n",
-						mmsd->hostname, mmsd->port
-					);
-					next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
-				} else {
-					proxy_info(
-						"AWS RDS host %s:%d has Multi-AZ cluster table schema (no version column)\n",
-						mmsd->hostname, mmsd->port
-					);
-					next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
-				}
-			}
-			mysql_free_result(mmsd->result);
-			mmsd->result = NULL;
-		} else {
-			rds_report_fetching_errs(mmsd);
-		}
-
-		handle_mmsd_mysql_conn(mmsd);
+	if (handle_rds_topology_precheck_cases(mmsd, next_mon_st)) {
 		return next_mon_st;
 	}
 
@@ -9500,7 +9476,7 @@ rds_mon_st_t async_rds_mon_actions_handler(
 
 	// Perform monitoring actions; tables updates and server placement operations
 	const auto nodes_info { rds_update_hosts_map(start_time, p_node_peers_t, mmsd) };
-	rds_mon_st_t next_mon_st { rds_mon_action_over_resp_srv(mmsd, nodes_info, cur_mon_st) };
+	next_mon_st = rds_mon_action_over_resp_srv(mmsd, nodes_info, cur_mon_st);
 
 	proxy_info("AWS RDS topology action for %s:%d: next_check_type=%d\n",
 		mmsd->hostname, mmsd->port, (int)next_mon_st.check_type);

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -9409,8 +9409,8 @@ rds_mon_st_t rds_mon_action_over_resp_srv(
  * @return A bool indicating if it was a precheck scenario.
  */
 bool handle_rds_topology_precheck_cases(MySQL_Monitor_State_Data* mmsd, rds_mon_st_t& next_mon_st) {
-	MySQL_Monitor_State_Data_Task_Type check_type = mmsd->get_task_type();
-	if (check_type != MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS && check_type != MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK)	 {
+	MySQL_Monitor_State_Data_Task_Type check_task = mmsd->get_task_type();
+	if (check_task != MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS && check_task != MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK)	 {
 		return false;
 	}
 
@@ -9425,11 +9425,11 @@ bool handle_rds_topology_precheck_cases(MySQL_Monitor_State_Data* mmsd, rds_mon_
 				{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
 			});
 
-			if (check_result && check_type == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
+			if (check_result && check_task == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
 				// Transition to VERSION_CHECK with 1s delay
 				next_mon_st.check_type = AWS_RDS_VERSION_CHECK;
 				next_mon_st.next_check_delay = 1000;
-			} else if (check_result && check_type == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
+			} else if (check_result && check_task == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
 				next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
 			} else {
 				next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
@@ -9711,6 +9711,8 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		// selected for discovery and topology check (of discovered instances). This might not be the desired
 		// behavior, for instance, multi-instance topology check might be desired, and only auto-discovery
 		// actions for one instance.
+		// Yes, there are situations where we would want to discover the topology either through a specific
+		// server in the HG or even multiple. Especially relevant for switchover (-> Step 3)
 		int rnd_discoverer = conn_mmsds.size() == 0 ? -1 : rand() % conn_mmsds.size();
 		if (rnd_discoverer != -1) {
 			conn_mmsds[rnd_discoverer]->cur_monitored_rds_srvs = &hosts_defs;
@@ -9740,6 +9742,7 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		// 3. Perform the async fetch + actions over the 'MySQL_Monitor_State_Data'
 		if (conn_mmsds.empty() == false) {
 			GloMyMon->monitor_rds_async_actions_handler(conn_mmsds);
+			// Once a result is acquired, the mmsds in conn_mmsds contain updated cur_rds_mon_st data.
 		}
 		///////////////////////////////////////////////////////////////////////////////////////
 
@@ -9780,6 +9783,7 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 			}
 
 			// Topology check results — propagate next_mon_st for topology-aware hosts
+			// TODO: Check if this isn't redundant now with the new host_check_map
 			if (mmsd->cur_rds_mon_st.check_type != MySQL_Monitor_Aws_Metadata_Check::NONE) {
 				next_mon_st.check_type = mmsd->cur_rds_mon_st.check_type;
 			}
@@ -9799,6 +9803,7 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		// Set the time for the next iteration
 		if (next_mon_st.next_check_delay) {
 			next_check_time = curtime + next_mon_st.next_check_delay * 1000;
+			next_mon_st.next_check_delay = mysql_thread___monitor_read_only_interval;
 		} else {
 			next_check_time = curtime + mysql_thread___monitor_read_only_interval * 1000;
 		}

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -672,17 +672,41 @@ void MySQL_Monitor_State_Data::init_async() {
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	// NOTE: Reusing 'MySQL_Monitor_State_Data::read_only_handler' is intentional. For now there
-	// aren't enough differences in the fetching logic to justify a custom handler.
-	///////////////////////////////////////////////////////////////////////////
-	case MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY:
-		query_ = QUERY_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY;
+	case MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS:
+		query_ = QUERY_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY:
-		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY;
+	case MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS:
+		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	case MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
+		query_ = QUERY_READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	case MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
+		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	// NOTE: Reusing 'MySQL_Monitor_State_Data::read_only_handler' is intentional. For now there
+	// aren't enough differences in the fetching logic to justify a custom handler.
+	///////////////////////////////////////////////////////////////////////////
+	case MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY:
+		query_ = QUERY_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	case MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY:
+		query_ = QUERY_INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
@@ -712,14 +736,38 @@ void MySQL_Monitor_State_Data::init_async() {
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	case MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY:
-		query_ = string { TEST_QUERY___READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY } + " " + hostname;
+	case MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS:
+		query_ = string { TEST_QUERY___READ_ONLY_AND_AWS_RDS_TABLE_EXISTS } + " " + hostname;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
 		break;
-	case MON_INNODB_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY:
-		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY } + " " + hostname;
+	case MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS:
+		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS } + " " + hostname;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	case MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
+		query_ = string { TEST_QUERY___READ_ONLY_AND_AWS_RDS_VERSION_CHECK } + " " + hostname;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	case MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK:
+		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK } + " " + hostname;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	case MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY:
+		query_ = string { TEST_QUERY___READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY } + " " + hostname;
+		async_state_machine_ = ASYNC_QUERY_START;
+		task_timeout_ = mysql_thread___monitor_read_only_timeout;
+		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
+		break;
+	case MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY:
+		query_ = string { TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY } + " " + hostname;
 		async_state_machine_ = ASYNC_QUERY_START;
 		task_timeout_ = mysql_thread___monitor_read_only_timeout;
 		task_handler_ = &MySQL_Monitor_State_Data::read_only_handler;
@@ -1795,10 +1843,18 @@ void * monitor_read_only_thread(const std::vector<MySQL_Monitor_State_Data*>& da
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,"SELECT @@global.read_only&@@global.innodb_read_only read_only");
 	} else if (mmsd->get_task_type() == MON_READ_ONLY__OR__INNODB_READ_ONLY) {
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql,"SELECT @@global.read_only|@@global.innodb_read_only read_only");
-	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY) {
-		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY);
-	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY) {
-		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY);
+	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
+		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS);
+	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
+		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS);
+	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
+		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_RDS_VERSION_CHECK);
+	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
+		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK);
+	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
+		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY);
+	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
+		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY);
 	} else if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
 		mmsd->async_exit_status=mysql_query_start(&mmsd->interr,mmsd->mysql, QUERY_READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY);
 	} else if (mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
@@ -1809,10 +1865,18 @@ void * monitor_read_only_thread(const std::vector<MySQL_Monitor_State_Data*>& da
 #else // TEST_READONLY || TEST_AWS_RDS
 	{
 		auto get_task_query = [] (MySQL_Monitor_State_Data_Task_Type task_type) -> std::string {
-			if (task_type == MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY) {
-				return TEST_QUERY___READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY;
-			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY) {
-				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TOPOLOGY_DISCOVERY;
+			if (task_type == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
+				return TEST_QUERY___READ_ONLY_AND_AWS_RDS_TABLE_EXISTS;
+			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
+				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_TABLE_EXISTS;
+			} else if (task_type == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
+				return TEST_QUERY___READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
+			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
+				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_VERSION_CHECK;
+			} else if (task_type == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
+				return TEST_QUERY___READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
+			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY) {
+				return TEST_QUERY___INNODB_READ_ONLY_AND_AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
 			} else if (task_type == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
 				return TEST_QUERY___READ_ONLY_AND_AWS_BLUE_GREEN_TOPOLOGY_DISCOVERY;
 			} else if (task_type == MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY) {
@@ -1825,8 +1889,12 @@ void * monitor_read_only_thread(const std::vector<MySQL_Monitor_State_Data*>& da
 		string task_query {};
 
 		if (
-			mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY
-			|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY
+			mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
+			|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
+			|| mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
+			|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
+			|| mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY
+			|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY
 			|| mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY
 			|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY
 		) {
@@ -3533,7 +3601,7 @@ void * MySQL_Monitor::monitor_read_only() {
 			"SELECT hostname, port, MAX(use_ssl) use_ssl, check_type, reader_hostgroup"
 			" FROM mysql_servers JOIN mysql_replication_hostgroups ON"
 			" hostgroup_id=writer_hostgroup OR hostgroup_id=reader_hostgroup"
-			" WHERE status NOT IN (2,3) AND hostname NOT LIKE '%" AWS_ENDPOINT_SUFFIX_STRING "'"
+			" WHERE status NOT IN (2,3) AND hostname NOT LIKE '%" AWS_ENDPOINT_SUFFIX_STRING "%'"
 			" GROUP BY hostname, port ORDER BY RANDOM()"
 		};
 		t1=monotonic_time();
@@ -8910,10 +8978,17 @@ unique_ptr<MySQL_Monitor_State_Data> init_mmsd_with_conn_rds(
 	const rds_mon_st_t& cur_mon_st
 ) {
 	MySQL_Monitor_State_Data_Task_Type task_type {};
+	
 
 	switch (cur_mon_st.check_type) {
-		case AWS_RDS_TOPOLOGY_CHECK:
-			task_type = MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY;
+		case AWS_RDS_TABLE_EXISTS_CHECK:
+			task_type = MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS;
+			break;
+		case AWS_RDS_VERSION_CHECK:
+			task_type = MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK;
+			break;
+		case AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK:
+			task_type = MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY;
 			break;
 		case AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK:
 			task_type = MON_READ_ONLY__AND__AWS_RDS_BLUE_GREEN_TOPOLOGY_DISCOVERY;
@@ -9015,8 +9090,8 @@ pair<rds_srv_st_t,vector<rds_srv_st_t>> extract_rds_srv_st(MySQL_Monitor_State_D
 
 		bool check_task_fields =
 			(
-				(mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY
-				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TOPOLOGY_DISCOVERY)
+				(mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY
+				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_DISCOVERY)
 				 && num_fields == 4
 			)
 			||
@@ -9204,7 +9279,7 @@ bool is_aws_rds_multi_az_db_cluster_topology(const string& host, const vector<rd
 pair<rds_mon_st_t,vector<rds_srv_st_t>> process_discovered_topology(
 	const rds_mon_st_t& cur_mon_st, const pair<rds_node_info_t,vector<rds_srv_st_t>>& p_node_peers
 ) {
-	rds_mon_st_t next_mon_st {};
+	rds_mon_st_t next_mon_st { cur_mon_st.check_type };
 	std::vector<rds_srv_st_t> validated_peers {};
 
 	const std::string& host { p_node_peers.first.srv_st.endpoint };
@@ -9212,26 +9287,43 @@ pair<rds_mon_st_t,vector<rds_srv_st_t>> process_discovered_topology(
 
 	// Check if the query needs to be changed because it matches a blue/green deployment:
 	// exactly 3 entries for Multi-AZ DB Clusters, even number for blue/green deployment
-	if (cur_mon_st.check_type == AWS_RDS_TOPOLOGY_CHECK && (node_peers.size() + 1) % 2 == 0) {
-		// With the AWS_RDS_TOPOLOGY_CHECK, we didn't get the role and status data,
+	if (cur_mon_st.check_type == AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK && (node_peers.size() + 1) % 2 == 0) {
+		// With the AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK, we didn't get the role and status data,
 		// so we retry with the correct query on the next read_only check
 		next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
 		next_mon_st.next_check_delay = mysql_thread___monitor_aws_rds_topology_discovery_interval;
 
 		return { next_mon_st, {} };
 	} else if (
-		(cur_mon_st.check_type == AWS_RDS_TOPOLOGY_CHECK && (node_peers.size() + 1) != 3)
+		cur_mon_st.check_type == AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK
+		&& (node_peers.size() + 1) == 3
+	) {
+		// BGD query returned 3 entries — check if version is NULL (Multi-AZ cluster with 7-col table)
+		bool all_version_empty = p_node_peers.first.srv_st.version.empty();
+		for (const auto& peer : node_peers) {
+			if (!peer.version.empty()) { all_version_empty = false; break; }
+		}
+		if (all_version_empty) {
+			proxy_info("AWS RDS BGD check returned Multi-AZ topology (version=NULL), treating as MULTIAZ\n");
+			next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
+			// Fall through to validation below
+		}
+		// If version is populated, it's a 3-node BGD (odd count) — fall through to validation
+	} else if (
+		(cur_mon_st.check_type == AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK && (node_peers.size() + 1) != 3)
 		||
 		(
-			next_mon_st.check_type == AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK
+			cur_mon_st.check_type == AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK
 			&&
 			(node_peers.size() + 1) % 2 != 0
+			&&
+			(node_peers.size() + 1) != 3
 		)
 	) {
 		// Query result matches neither a Multi-AZ DB Cluster nor a Blue/Green deployment
 		// TODO: Account for topology metadata towards the end of a blue/green deployment switchover (possibly
 		// odd number of entries)
-		next_mon_st.check_type = AWS_RDS_TOPOLOGY_CHECK; // Set back to default rds_topology check
+		next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK; // Set back to default rds_topology check
 		// TODO: This needs to be notified to the user; potential cluster misconfiguration, for now,
 		// this message will be promoted to WARNING. If this is expected behavior it should be
 		// reverted to DEBUG.
@@ -9275,13 +9367,13 @@ pair<rds_mon_st_t,vector<rds_srv_st_t>> process_discovered_topology(
 		validated_peers.push_back(server_info);
 	}
 
-	// Return the peers ONLY IF topology passed validation. AWS_RDS_TOPOLOGY_CHECK is currently meant to only
+	// Return the peers ONLY IF topology passed validation. AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK is currently meant to only
 	// be used with RDS Multi-AZ DB clusters
 	if (
 		!validated_peers.empty()
 		&&
 		(
-			next_mon_st.check_type != AWS_RDS_TOPOLOGY_CHECK
+			next_mon_st.check_type != AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK
 			||
 			is_aws_rds_multi_az_db_cluster_topology(host, validated_peers)
 		)
@@ -9379,6 +9471,89 @@ rds_mon_st_t rds_mon_action_over_resp_srv(
 rds_mon_st_t async_rds_mon_actions_handler(
 	MySQL_Monitor_State_Data* mmsd, const rds_mon_st_t& cur_mon_st
 ) {
+	// Handle TABLE_EXISTS check — result format: (read_only, has_rds_topology)
+	if (
+		mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
+		|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
+	) {
+		rds_mon_st_t next_mon_st { cur_mon_st };
+
+		if (mmsd->interr == 0 && mmsd->result) {
+			MYSQL_ROW row = mysql_fetch_row(mmsd->result);
+			if (row) {
+				bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
+				bool has_table = (row[1] && !strcasecmp(row[1], "1"));
+
+				MyHGM->read_only_action_v2({
+					{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
+				});
+
+				if (has_table) {
+					proxy_info(
+						"AWS RDS host %s:%d has mysql.rds_topology, proceeding to version check\n",
+						mmsd->hostname, mmsd->port
+					);
+					// Transition to VERSION_CHECK with 1s delay
+					next_mon_st.check_type = AWS_RDS_VERSION_CHECK;
+					next_mon_st.next_check_delay = 1000;
+				} else {
+					proxy_info(
+						"AWS RDS host %s:%d does not have mysql.rds_topology\n",
+						mmsd->hostname, mmsd->port
+					);
+				}
+			}
+			mysql_free_result(mmsd->result);
+			mmsd->result = NULL;
+		} else {
+			rds_report_fetching_errs(mmsd);
+		}
+
+		handle_mmsd_mysql_conn(mmsd);
+		return next_mon_st;
+	}
+
+	// Handle VERSION_CHECK — result format: (read_only, has_version_col)
+	if (
+		mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
+		|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
+	) {
+		rds_mon_st_t next_mon_st { cur_mon_st };
+
+		if (mmsd->interr == 0 && mmsd->result) {
+			MYSQL_ROW row = mysql_fetch_row(mmsd->result);
+			if (row) {
+				bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
+				bool has_version_col = (row[1] && !strcasecmp(row[1], "1"));
+
+				MyHGM->read_only_action_v2({
+					{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
+				});
+
+				if (has_version_col) {
+					proxy_info(
+						"AWS RDS host %s:%d has BGD table schema (version column present)\n",
+						mmsd->hostname, mmsd->port
+					);
+					next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
+				} else {
+					proxy_info(
+						"AWS RDS host %s:%d has Multi-AZ cluster table schema (no version column)\n",
+						mmsd->hostname, mmsd->port
+					);
+					next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
+				}
+			}
+			mysql_free_result(mmsd->result);
+			mmsd->result = NULL;
+		} else {
+			rds_report_fetching_errs(mmsd);
+		}
+
+		handle_mmsd_mysql_conn(mmsd);
+		return next_mon_st;
+	}
+
 	// We base 'start_time' on the conn init for 'MySQL_Monitor_State_Data'. If a conn creation was
 	// required, we take into account this time into account, otherwise we assume that 'start_time=t1'.
 	uint64_t start_time = 0;
@@ -9394,9 +9569,16 @@ rds_mon_st_t async_rds_mon_actions_handler(
 	// Report fetch errors; logs should report 'cause -> effect'
 	rds_report_fetching_errs(mmsd);
 
+	proxy_info("AWS RDS topology check for %s:%d: peers=%zu, error=%s\n",
+		mmsd->hostname, mmsd->port, p_node_peers_t.second.size(),
+		mmsd->mysql_error_msg ? mmsd->mysql_error_msg : "none");
+
 	// Perform monitoring actions; tables updates and server placement operations
 	const auto nodes_info { rds_update_hosts_map(start_time, p_node_peers_t, mmsd) };
 	rds_mon_st_t next_mon_st { rds_mon_action_over_resp_srv(mmsd, nodes_info, cur_mon_st) };
+
+	proxy_info("AWS RDS topology action for %s:%d: next_check_type=%d\n",
+		mmsd->hostname, mmsd->port, (int)next_mon_st.check_type);
 
 	// Handle 'mmsd' MySQL conn return to 'ConnectionPool'
 	handle_mmsd_mysql_conn(mmsd);
@@ -9516,9 +9698,20 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 	vector<rds_host_def_t> hosts_defs { extract_rds_host_defs(wHG, rHG, GloMyMon->AWS_RDS_Hosts_resultset) };
 	pthread_mutex_unlock(&GloMyMon->aws_rds_mutex);
 
+	// Per-host check state map: tracks what check each host should run next
+	// Key: "host:port", Value: the check type to execute for this host
+	auto build_host_check_map = [](const vector<rds_host_def_t>& defs) {
+		std::map<string, MySQL_Monitor_Aws_Metadata_Check> m;
+		for (const auto& d : defs) {
+			m[d.host + ":" + to_string(d.port)] = AWS_RDS_TABLE_EXISTS_CHECK;
+		}
+		return m;
+	};
+	std::map<string, MySQL_Monitor_Aws_Metadata_Check> host_check_map { build_host_check_map(hosts_defs) };
+
 	uint64_t next_check_time { 0 };
 	uint64_t MAX_CHECK_DELAY_US { 500000 };
-	rds_mon_st_t next_mon_st { AWS_RDS_TOPOLOGY_CHECK };
+	rds_mon_st_t next_mon_st { AWS_RDS_TABLE_EXISTS_CHECK };
 
 	while (GloMyMon->shutdown == false && mysql_thread___monitor_enabled == true) {
 		if (!GloMTH) { break; } // quick exit during shutdown/restart
@@ -9543,6 +9736,11 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 				if (hosts_defs.empty()) {
 					break;
 				}
+
+				// Reset per-host table state — all hosts need re-checking
+				host_check_map = build_host_check_map(hosts_defs);
+				initial_raw_checksum = current_raw_checksum;
+				proxy_info("AWS RDS config changed for HG writer=%lu, resetting table state map\n", wHG);
 			}
 		}
 
@@ -9574,7 +9772,7 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		// Get the current 'pingable' status for the servers.
 		const vector<rds_host_def_t>& resp_srvs { find_resp_srvs_rds(hosts_defs) };
 		if (resp_srvs.empty()) {
-			proxy_error("No node is pingable for AWS RDS cluster with writer HG %lu\n", wHG);
+			proxy_info("AWS RDS HG %lu: no pingable nodes, skipping iteration\n", wHG);
 
 			if (next_mon_st.next_check_delay) {
 				next_check_time = curtime + next_mon_st.next_check_delay * 1000;
@@ -9597,8 +9795,21 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 
 		// 1. Separate the 'mmsds' based on success of obtaining a conn
 		for (const rds_host_def_t& host_def : resp_srvs) {
+			// Determine per-host check type from the host check map
+			const string host_key { host_def.host + ":" + to_string(host_def.port) };
+			rds_mon_st_t host_mon_st { next_mon_st };
+			auto it = host_check_map.find(host_key);
+			if (it != host_check_map.end()) {
+				host_mon_st.check_type = it->second;
+			} else {
+				host_mon_st.check_type = AWS_RDS_TABLE_EXISTS_CHECK;
+			}
+
+			proxy_info("AWS RDS HG %lu: host %s check_type=%d\n",
+				wHG, host_key.c_str(), (int)host_mon_st.check_type);
+
 			unique_ptr<MySQL_Monitor_State_Data> mmsd {
-				init_mmsd_with_conn_rds(host_def, wHG, rHG, curtime, next_mon_st)
+				init_mmsd_with_conn_rds(host_def, wHG, rHG, curtime, host_mon_st)
 			};
 
 			if (mmsd->mysql_error_msg) {
@@ -9658,18 +9869,41 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		// re-attempted.
 
 		for (const unique_ptr<MySQL_Monitor_State_Data>& mmsd : conn_mmsds) {
-			next_mon_st.check_type = MySQL_Monitor_Aws_Metadata_Check::NONE;
+			const string host_key { string(mmsd->hostname) + ":" + to_string(mmsd->port) };
 
-			// TODO: This is an assumption; for now, we consider that if there is any failure during
-			// topology processing we default to 'AWS_RDS_TOPOLOGY_CHECK' as the next check. Due to
-			// this, once this state is returned by any 'mmsd' is preserved over the rest.
-			if (next_mon_st.check_type != AWS_RDS_TOPOLOGY_CHECK) {
-				next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
+			// Update per-host check map based on results
+			if (
+				mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
+				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS
+			) {
+				if (mmsd->cur_rds_mon_st.check_type == AWS_RDS_VERSION_CHECK) {
+					// Table found — transition to VERSION_CHECK on next iteration
+					host_check_map[host_key] = AWS_RDS_VERSION_CHECK;
+					if (mmsd->cur_rds_mon_st.next_check_delay
+						&& mmsd->cur_rds_mon_st.next_check_delay < next_mon_st.next_check_delay) {
+						next_mon_st.next_check_delay = mmsd->cur_rds_mon_st.next_check_delay;
+					}
+				}
+				// If still TABLE_EXISTS_CHECK, table not found — stays as is
+				continue;
 			}
 
-			// TODO: This is an assumption; for now, we consider than the smallest computed
-			// 'next_check_delay' during topology processing should be honored.
-			if (next_mon_st.next_check_delay > mmsd->cur_rds_mon_st.check_type) {
+			if (
+				mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
+				|| mmsd->get_task_type() == MON_INNODB_READ_ONLY__AND__AWS_RDS_VERSION_CHECK
+			) {
+				// VERSION_CHECK completed — classify the host permanently
+				host_check_map[host_key] = mmsd->cur_rds_mon_st.check_type;
+				continue;
+			}
+
+			// Topology check results — propagate next_mon_st for topology-aware hosts
+			if (mmsd->cur_rds_mon_st.check_type != MySQL_Monitor_Aws_Metadata_Check::NONE) {
+				next_mon_st.check_type = mmsd->cur_rds_mon_st.check_type;
+			}
+
+			if (mmsd->cur_rds_mon_st.next_check_delay
+				&& mmsd->cur_rds_mon_st.next_check_delay < next_mon_st.next_check_delay) {
 				next_mon_st.next_check_delay = mmsd->cur_rds_mon_st.next_check_delay;
 			}
 		}
@@ -9686,6 +9920,9 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		} else {
 			next_check_time = curtime + mysql_thread___monitor_read_only_interval * 1000;
 		}
+		proxy_info("AWS RDS HG %lu: iteration complete, next_check_delay=%lums\n",
+			wHG, (unsigned long)(next_mon_st.next_check_delay ? next_mon_st.next_check_delay
+				: mysql_thread___monitor_read_only_interval));
 	}
 
 	proxy_info("Stopping Monitor thread for AWS RDS replication HG writer=%lu\n", wHG);

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -9470,16 +9470,9 @@ rds_mon_st_t async_rds_mon_actions_handler(
 	// Report fetch errors; logs should report 'cause -> effect'
 	rds_report_fetching_errs(mmsd);
 
-	proxy_info("AWS RDS topology check for %s:%d: peers=%zu, error=%s\n",
-		mmsd->hostname, mmsd->port, p_node_peers_t.second.size(),
-		mmsd->mysql_error_msg ? mmsd->mysql_error_msg : "none");
-
 	// Perform monitoring actions; tables updates and server placement operations
 	const auto nodes_info { rds_update_hosts_map(start_time, p_node_peers_t, mmsd) };
 	next_mon_st = rds_mon_action_over_resp_srv(mmsd, nodes_info, cur_mon_st);
-
-	proxy_info("AWS RDS topology action for %s:%d: next_check_type=%d\n",
-		mmsd->hostname, mmsd->port, (int)next_mon_st.check_type);
 
 	// Handle 'mmsd' MySQL conn return to 'ConnectionPool'
 	handle_mmsd_mysql_conn(mmsd);
@@ -9641,7 +9634,6 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 				// Reset per-host table state — all hosts need re-checking
 				host_check_map = build_host_check_map(hosts_defs);
 				initial_raw_checksum = current_raw_checksum;
-				proxy_info("AWS RDS config changed for HG writer=%lu, resetting table state map\n", wHG);
 			}
 		}
 
@@ -9673,8 +9665,6 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		// Get the current 'pingable' status for the servers.
 		const vector<rds_host_def_t>& resp_srvs { find_resp_srvs_rds(hosts_defs) };
 		if (resp_srvs.empty()) {
-			proxy_info("AWS RDS HG %lu: no pingable nodes, skipping iteration\n", wHG);
-
 			if (next_mon_st.next_check_delay) {
 				next_check_time = curtime + next_mon_st.next_check_delay * 1000;
 			} else {
@@ -9705,9 +9695,6 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 			} else {
 				host_mon_st.check_type = AWS_RDS_TABLE_EXISTS_CHECK;
 			}
-
-			proxy_info("AWS RDS HG %lu: host %s check_type=%d\n",
-				wHG, host_key.c_str(), (int)host_mon_st.check_type);
 
 			unique_ptr<MySQL_Monitor_State_Data> mmsd {
 				init_mmsd_with_conn_rds(host_def, wHG, rHG, curtime, host_mon_st)
@@ -9815,9 +9802,6 @@ void* monitor_AWS_RDS_thread_HG(void* th_args) {
 		} else {
 			next_check_time = curtime + mysql_thread___monitor_read_only_interval * 1000;
 		}
-		proxy_info("AWS RDS HG %lu: iteration complete, next_check_delay=%lums\n",
-			wHG, (unsigned long)(next_mon_st.next_check_delay ? next_mon_st.next_check_delay
-				: mysql_thread___monitor_read_only_interval));
 	}
 
 	proxy_info("Stopping Monitor thread for AWS RDS replication HG writer=%lu\n", wHG);

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -9235,7 +9235,7 @@ pair<rds_mon_st_t,vector<rds_srv_st_t>> process_discovered_topology(
 			if (!peer.version.empty()) { all_version_empty = false; break; }
 		}
 		if (all_version_empty) {
-			proxy_info("AWS RDS BGD check returned Multi-AZ topology (version=NULL), treating as MULTIAZ\n");
+			proxy_info("AWS RDS BGD check returned Multi-AZ topology (version=NULL), treating as Multi-AZ\n");
 			next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
 			// Fall through to validation below
 		}
@@ -9399,83 +9399,59 @@ rds_mon_st_t rds_mon_action_over_resp_srv(
 	return next_mon_st;
 }
 
+/**
+ * @brief Allows quick handling of rds_topology table checks that don't return table contents
+ *
+ * @param mmsd The 'mmsd' holding info about the query run on the server.
+ * @param next_mon_st A reference to the next rds monitoring task. Is modified according to mmsd.
+ * @param check_type Information about which check was performed.
+ * 
+ * @return A bool indicating if it was a precheck scenario.
+ */
+bool handle_rds_topology_precheck_cases(MySQL_Monitor_State_Data* mmsd, rds_mon_st_t& next_mon_st) {
+	MySQL_Monitor_State_Data_Task_Type check_type = mmsd->get_task_type();
+	if (check_type != MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS && check_type != MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK)	 {
+		return false;
+	}
+
+	if (mmsd->interr == 0 && mmsd->result) {
+		MYSQL_ROW row = mysql_fetch_row(mmsd->result);
+		if (row) {
+			bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
+			bool check_result = (row[1] && !strcasecmp(row[1], "1"));
+
+			// TODO: remove this call once monitor_read_only is configured to also check RDS servers again
+			MyHGM->read_only_action_v2({
+				{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
+			});
+
+			if (check_result && check_type == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS) {
+				// Transition to VERSION_CHECK with 1s delay
+				next_mon_st.check_type = AWS_RDS_VERSION_CHECK;
+				next_mon_st.next_check_delay = 1000;
+			} else if (check_result && check_type == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
+				next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
+			} else {
+				next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
+			}
+		}
+		mysql_free_result(mmsd->result);
+		mmsd->result = NULL;
+	} else {
+		rds_report_fetching_errs(mmsd);
+	}
+
+	handle_mmsd_mysql_conn(mmsd);
+	return true;
+}
+
 rds_mon_st_t async_rds_mon_actions_handler(
 	MySQL_Monitor_State_Data* mmsd, const rds_mon_st_t& cur_mon_st
 ) {
+	rds_mon_st_t next_mon_st { cur_mon_st };
+
 	// Handle TABLE_EXISTS check — result format: (read_only, has_rds_topology)
-	if ( mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_TABLE_EXISTS ) {
-		rds_mon_st_t next_mon_st { cur_mon_st };
-
-		if (mmsd->interr == 0 && mmsd->result) {
-			MYSQL_ROW row = mysql_fetch_row(mmsd->result);
-			if (row) {
-				bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
-				bool has_table = (row[1] && !strcasecmp(row[1], "1"));
-
-				MyHGM->read_only_action_v2({
-					{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
-				});
-
-				if (has_table) {
-					proxy_info(
-						"AWS RDS host %s:%d has mysql.rds_topology, proceeding to version check\n",
-						mmsd->hostname, mmsd->port
-					);
-					// Transition to VERSION_CHECK with 1s delay
-					next_mon_st.check_type = AWS_RDS_VERSION_CHECK;
-					next_mon_st.next_check_delay = 1000;
-				} else {
-					proxy_info(
-						"AWS RDS host %s:%d does not have mysql.rds_topology\n",
-						mmsd->hostname, mmsd->port
-					);
-				}
-			}
-			mysql_free_result(mmsd->result);
-			mmsd->result = NULL;
-		} else {
-			rds_report_fetching_errs(mmsd);
-		}
-
-		handle_mmsd_mysql_conn(mmsd);
-		return next_mon_st;
-	}
-
-	// Handle VERSION_CHECK — result format: (read_only, has_version_col)
-	if (mmsd->get_task_type() == MON_READ_ONLY__AND__AWS_RDS_VERSION_CHECK) {
-		rds_mon_st_t next_mon_st { cur_mon_st };
-
-		if (mmsd->interr == 0 && mmsd->result) {
-			MYSQL_ROW row = mysql_fetch_row(mmsd->result);
-			if (row) {
-				bool read_only = !(row[0] && !strcasecmp(row[0], "0"));
-				bool has_version_col = (row[1] && !strcasecmp(row[1], "1"));
-
-				MyHGM->read_only_action_v2({
-					{ string(mmsd->hostname), static_cast<uint32_t>(mmsd->port), static_cast<int>(read_only) }
-				});
-
-				if (has_version_col) {
-					proxy_info(
-						"AWS RDS host %s:%d has BGD table schema (version column present)\n",
-						mmsd->hostname, mmsd->port
-					);
-					next_mon_st.check_type = AWS_RDS_BLUE_GREEN_DEPLOYMENT_STATE_CHECK;
-				} else {
-					proxy_info(
-						"AWS RDS host %s:%d has Multi-AZ cluster table schema (no version column)\n",
-						mmsd->hostname, mmsd->port
-					);
-					next_mon_st.check_type = AWS_RDS_MULTIAZ_CLUSTER_TOPOLOGY_CHECK;
-				}
-			}
-			mysql_free_result(mmsd->result);
-			mmsd->result = NULL;
-		} else {
-			rds_report_fetching_errs(mmsd);
-		}
-
-		handle_mmsd_mysql_conn(mmsd);
+	if (handle_rds_topology_precheck_cases(mmsd, next_mon_st)) {
 		return next_mon_st;
 	}
 
@@ -9500,7 +9476,7 @@ rds_mon_st_t async_rds_mon_actions_handler(
 
 	// Perform monitoring actions; tables updates and server placement operations
 	const auto nodes_info { rds_update_hosts_map(start_time, p_node_peers_t, mmsd) };
-	rds_mon_st_t next_mon_st { rds_mon_action_over_resp_srv(mmsd, nodes_info, cur_mon_st) };
+	next_mon_st = rds_mon_action_over_resp_srv(mmsd, nodes_info, cur_mon_st);
 
 	proxy_info("AWS RDS topology action for %s:%d: next_check_type=%d\n",
 		mmsd->hostname, mmsd->port, (int)next_mon_st.check_type);


### PR DESCRIPTION
RDS publishes a topology metadata table in certain cirucmstances. This table can let ProxySQL know of related hosts in a topology that should also be monitored in addition to the configured one. This PR handles executing the right query on the right endpoint. It differentiates between Multi-AZ DB Clusters, blue/green deployments and RDS servers with no metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broader AWS RDS endpoint matching to detect more hosts.
  * RDS topology discovery split into separate checks (table existence, schema/version, multi-AZ discovery).
  * Per-host tracking of RDS schema/state with clearer state classifications and staged checks.
  * More robust discovery flow with improved retry/fallback behavior and refined scheduling for read-only monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysown/proxysql/pull/5831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->