### PR TITLE
pgsql: omit port when port==0 (unix socket support)

### DIFF
--- a/include/PgSQL_Conninfo_Helper.h
+++ b/include/PgSQL_Conninfo_Helper.h
@@ -1,0 +1,15 @@
+#ifndef PROXYSQL_PGSQL_CONNINFO_HELPER_H
+#define PROXYSQL_PGSQL_CONNINFO_HELPER_H
+
+#include <sstream>
+
+// Append port= only when the configured port is non-zero.
+// Some admin configurations use port=0 to indicate that the hostname
+// is a Unix-domain socket path; passing "port=0" to libpq produces
+// an "invalid port number: \"0\"" error. Centralize the rule here.
+inline void append_pg_conninfo_port(std::ostringstream &conninfo, int port) {
+    if (port == 0) return;
+    conninfo << "port=" << port << " ";
+}
+
+#endif // PROXYSQL_PGSQL_CONNINFO_HELPER_H

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -8,6 +8,7 @@
 using json = nlohmann::json;
 #define PROXYJSON
 #include "PgSQL_HostGroups_Manager.h"
+#include "PgSQL_Conninfo_Helper.h"
 #include "PgSQL_Monitor.hpp"
 #include "proxysql.h"
 #include "cpp.h"
@@ -983,7 +984,7 @@ void PgSQL_Connection::connect_start() {
 			append_conninfo_param(conninfo, "hostaddr", const_cast<char*>(ip.c_str()));
 		}
 	}
-	conninfo << "port=" << parent->port << " "; // backend port
+	append_pg_conninfo_port(conninfo, parent->port); // backend port
 	conninfo << "application_name=proxysql "; // application name
 	//conninfo << "require_auth=" << AUTHENTICATION_METHOD_STR[pgsql_thread___authentication_method]; // authentication method
 	if (parent->use_ssl) {
@@ -3078,7 +3079,7 @@ void* PgSQL_backend_kill_thread(void* arg) {
 		append_conninfo_param(conninfo, "password", backend_kill_args->password); // password
 		append_conninfo_param(conninfo, "dbname", backend_kill_args->dbname); // dbname
 		append_conninfo_param(conninfo, "host", backend_kill_args->hostname); // backend address
-		conninfo << "port=" << backend_kill_args->port << " "; // backend port
+		append_pg_conninfo_port(conninfo, backend_kill_args->port); // backend port
 		conninfo << "application_name=proxysql "; // application name
 		
 		if (backend_kill_args->ssl_config.use_ssl) {

--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -1,4 +1,5 @@
 #include "PgSQL_HostGroups_Manager.h"
+#include "PgSQL_Conninfo_Helper.h"
 #include "PgSQL_Monitor.hpp"
 #include "PgSQL_Thread.h"
 
@@ -1104,7 +1105,7 @@ string build_conn_str(const task_st_t& task_st) {
 	append_conninfo_param(conninfo, "password", user_info.pass); // password
 	append_conninfo_param(conninfo, "dbname", user_info.dbname); // dbname
 	append_conninfo_param(conninfo, "host", srv_info.addr); // backend address
-	conninfo << "port=" << srv_info.port << " "; // backend port
+	append_pg_conninfo_port(conninfo, srv_info.port); // backend port
 	conninfo << "application_name=ProxySQL-Monitor "; // application name
 	if (srv_info.ssl) {
 		conninfo << "sslmode='require' "; // SSL required

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -198,6 +198,7 @@
   "pgsql_tokenizer_unit-t" : [ "unit-tests-g1" ],
   "pgsql_txn_state_unit-t" : [ "unit-tests-g1" ],
   "pgsql_variables_validator_unit-t" : [ "unit-tests-g1" ],
+  "pgsql-conninfo-port-zero-unit-t" : [ "unit-tests-g1" ],
   "plugin_config_unit-t" : [ "mysqlx-tsan-g1","unit-tests-g1","@proxysql_min_version:4.0" ],
   "plugin_dispatch_unit-t" : [ "mysqlx-tsan-g1","unit-tests-g1","@proxysql_min_version:4.0" ],
   "plugin_lifecycle_unit-t" : [ "mysqlx-tsan-g1","unit-tests-g1","@proxysql_min_version:4.0" ],

--- a/test/tap/tests/unit/pgsql-conninfo-port-zero-unit-t.cpp
+++ b/test/tap/tests/unit/pgsql-conninfo-port-zero-unit-t.cpp
@@ -1,0 +1,30 @@
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+#include "PgSQL_Conninfo_Helper.h"
+
+#include <sstream>
+#include <string>
+
+int main(int argc, char** argv) {
+    plan(2);
+
+    // Skip if test harness requests environment-only actions
+    if (cl.getEnv()) return exit_status();
+
+    {
+        std::ostringstream ss;
+        append_pg_conninfo_port(ss, 0);
+        std::string s = ss.str();
+        ok(s.find("port=") == std::string::npos, "append_pg_conninfo_port omits port when port == 0");
+    }
+
+    {
+        std::ostringstream ss;
+        append_pg_conninfo_port(ss, 5432);
+        std::string s = ss.str();
+        ok(s.find("port=5432") != std::string::npos, "append_pg_conninfo_port includes port when non-zero");
+    }
+
+    return exit_status();
+}


### PR DESCRIPTION
Fix: omit port when port==0 so libpq accepts Unix socket hostnames. Adds include/PgSQL_Conninfo_Helper.h and unit test test/tap/tests/unit/pgsql-conninfo-port-zero-unit-t.cpp. Closes #5837.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection handling now omits an invalid port field when the port is unset (zero), preventing rejected connections and improving reliability across connection management.

* **Tests**
  * Added unit tests validating that connection strings omit the port when unset and include the correct port when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->