### PR TITLE
fix(ci): coverage — GCOV_PREFIX_STRIP=2 + /opt/proxysql mount in test-runner

### DIFF
--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -279,6 +279,7 @@ docker run \
     --cap-add=NET_ADMIN \
     --cap-add=SYS_ADMIN \
     -v "${WORKSPACE}:${WORKSPACE}" \
+    -v "${WORKSPACE}:/opt/proxysql:ro" \
     -v "${PROXY_DATA_DIR_HOST}:/var/lib/proxysql" \
     -v "${COVERAGE_DATA_DIR_HOST}:/gcov" \
     -e WORKSPACE="${WORKSPACE}" \
@@ -299,7 +300,7 @@ docker run \
     -e TAP_PGSQL_SYNC_REPLICA_PORT="${TAP_PGSQL_SYNC_REPLICA_PORT:-}" \
     -e MULTI_GROUP="${MULTI_GROUP:-0}" \
     -e GCOV_PREFIX="/gcov/tap" \
-    -e GCOV_PREFIX_STRIP="3" \
+    -e GCOV_PREFIX_STRIP="2" \
     proxysql-ci-base:latest \
     /bin/bash -c "
         set -e
@@ -307,8 +308,15 @@ docker run \
         # Coverage collection trap - runs on exit regardless of success/failure/timeout
         #
         # Data layout in /gcov (per-INFRA_ID mount):
-        #   /gcov/proxysql/{lib,src}/obj/*.gcda  — ProxySQL daemon (GCOV_PREFIX=/gcov, STRIP=3)
-        #   /gcov/tap/proxysql/{lib,src}/obj/*.gcda — TAP tests (GCOV_PREFIX=/gcov/tap, STRIP=3)
+        #   /gcov/{lib,src}/obj/*.gcda            — ProxySQL daemon (GCOV_PREFIX=/gcov,     STRIP=2)
+        #   /gcov/tap/{lib,src,test}/.../obj/*.gcda — TAP tests      (GCOV_PREFIX=/gcov/tap, STRIP=2)
+        #
+        # STRIP=2 strips opt/proxysql from the absolute path the .gcno embeds
+        # (/opt/proxysql/{lib,src,test}/obj/X.gcno; the workspace is mounted at
+        # /opt/proxysql in both the build and run containers per docker-compose
+        # and the -v rule on the test-runner below). The remaining
+        # {lib,src,test}/.../obj/ component is what the .gcno copy loop below
+        # uses to copy the matching .gcno next to its .gcda before fastcov runs.
         #
         # This trap always copies .gcno files adjacent to .gcda so the data is
         # ready for fastcov. When MULTI_GROUP=1, fastcov runs centrally later;

--- a/test/infra/control/start-proxysql-isolated.bash
+++ b/test/infra/control/start-proxysql-isolated.bash
@@ -192,6 +192,18 @@ if [ -n "${CLUSTER_SIM_HOST_FILE:-}" ] && [ -f "${CLUSTER_SIM_HOST_FILE}" ]; the
     done < "${CLUSTER_SIM_HOST_FILE}"
 fi
 
+# GCOV_PREFIX_STRIP=2 strips "opt/proxysql" from the absolute path the
+# .gcno embeds — the workspace is mounted at /opt/proxysql in the build
+# container (see docker-compose.yml), so .gcno files record paths like
+# /opt/proxysql/{lib,src}/obj/X.gcno. With STRIP=2 the daemon writes
+# .gcda files to /gcov/{lib,src}/obj/X.gcda, preserving the {lib,src}
+# directory that the collect_coverage trap in run-tests-isolated.bash
+# uses to find each matching .gcno under ${WORKSPACE} and copy it next
+# to its .gcda before fastcov runs. STRIP=3 (the prior value) over-
+# stripped one extra component and dropped .gcda files at
+# /gcov/obj/X.gcda with no {lib,src} directory; the .gcno copy loop
+# couldn't find matches, fastcov produced "files: []" for every entry,
+# and zero daemon-side coverage made it into Codecov.
 echo ">>> Starting ProxySQL container: ${PROXY_CONTAINER} (cluster nodes: ${NUM_NODES})"
 docker run -d \
     --name "${PROXY_CONTAINER}" \
@@ -207,7 +219,7 @@ docker run -d \
     ${GENAI_PLUGIN_MOUNT} \
     ${GCOV_MOUNTS} \
     -e GCOV_PREFIX="/gcov" \
-    -e GCOV_PREFIX_STRIP="3" \
+    -e GCOV_PREFIX_STRIP="2" \
     proxysql-ci-base:latest \
     /bin/bash -c "${STARTUP_CMD}"
 


### PR DESCRIPTION
## Summary

Codecov's coverage report for v3.0 has lib/ at **11.9%** with ~40 of ~100 source files showing flat **0%** — including files clearly hit by every TAP run such as `lib/MySQL_Session.cpp` (5124 lines, 0/5124), `lib/Admin_Handler.cpp` (3233 lines, 0/3233), `lib/MySQL_Monitor.cpp` (4632 lines, 0/4632), `lib/ProxySQL_Cluster.cpp` (2752 lines, 0/2752). The daemon's per-test `PROXYSQL GCOV DUMP` mechanism (via `proxysql-tester.py:880-881`) is correctly wired, and the proxysql binary is built with `WITHGCOV=1` via the `tap-genai-gcov` matrix entry — but the resulting `.gcda` files were being silently dropped by the post-processing pipeline.

Concrete evidence: pulled the `coverage-generation.log` from CI-legacy-g1 run 27276916419 (v3.0 HEAD, mysql57) and found `fastcov` errored on every single `.gcda`:

```
[error]: Missing 'current_working_directory' for data file:
  {'format_version': '1', 'gcc_version': '13.3.0',
   'data_file': '/gcov/obj/MySQL_Query_Processor.gcda', 'files': []}
```

…repeated for every daemon-side `.gcda`. The resulting `ci-legacy-g1.info` contained 211 SF entries, all under `proxysql/include/*.h` — zero entries from `lib/` or `src/`.

## Root cause — two compounding defects

### 1. `GCOV_PREFIX_STRIP=3` overstripped one extra component

The workspace is mounted at `/opt/proxysql` in both the build and run containers (per `docker-compose.yml` volume rule `./:/opt/proxysql/`), so `.gcno` files embed absolute paths shaped `/opt/proxysql/{lib,src}/obj/X.gcno`. With `STRIP=3` the gcov runtime stripped `opt/proxysql/lib` (or `opt/proxysql/src`), and `.gcda` files landed at `/gcov/obj/X.gcda` with no `{lib,src}` component. The `.gcno` copy loop in `run-tests-isolated.bash`'s `collect_coverage` trap then couldn't reconstruct the original directory, and fastcov's `'files': []` is what we observed.

### 2. The test-runner container didn't mount `/opt/proxysql`

fastcov+gcov resolve source-file references via the absolute paths embedded in `.gcno` files (e.g. `/opt/proxysql/lib/MySQL_Session.cpp`). The test-runner only mounted `${WORKSPACE}` at `${WORKSPACE}`, so gcov couldn't open the referenced source files and produced no SF entries for them — even if STRIP had been correct.

## Fix

| File | Change |
|---|---|
| `test/infra/control/start-proxysql-isolated.bash` | `GCOV_PREFIX_STRIP=\"3\"` → `\"2\"`, with comment block explaining why. |
| `test/infra/control/run-tests-isolated.bash` | Same `STRIP` change for the test-runner container; added `-v ${WORKSPACE}:/opt/proxysql:ro`; updated the trap docstring to describe the corrected `/gcov/{lib,src}/obj/*.gcda` layout. |

Both fixes are required: STRIP=2 alone gets `.gcda`+`.gcno` adjacent but gcov still can't open source files; the bind mount alone doesn't help if the `.gcno` paths can't be located under `/gcov`.

## What was NOT broken (and is documented in the commit)

The per-test `PROXYSQL GCOV DUMP` mechanism (`proxysql-tester.py:880-881`) was working all along. The single `Received PROXYSQL GCOV DUMP command` line visible in CI run logs was an artifact of the daemon's stdout only reaching the runner during teardown (its proxysql.log isn't tailed live to the runner stdout); not evidence of the per-test dump being skipped.

## Test plan

- [x] `bash -n` clean on both modified scripts.
- [x] Multi-group flow inherits the fix via `run-multi-group.bash` → `run-tests-isolated.bash`.
- [ ] After merge, the next CI-legacy-g1 / CI-mariadb10-galera-* / CI-mysql84-* run on v3.0 produces a non-empty `lib/` SF set in its uploaded `*.info` (verified at the `coverage-generation.log` artifact).
- [ ] After merge, Codecov's v3.0 dashboard shows lib/ coverage rising substantially from 11.9% (the precise number depends on what each TAP group exercises, but `lib/MySQL_Session.cpp` and friends should move off the 0% rail).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure configuration for improved code coverage collection and Docker container volume handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->