### PR TITLE
pgsql: omit port= when port==0 (Unix socket support)

### DIFF
--- a/.github/workflows/CI-pgsql-socket-g1.yml
+++ b/.github/workflows/CI-pgsql-socket-g1.yml
@@ -1,0 +1,27 @@
+name: CI-pgsql-socket-g1
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ completed ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-pgsql-socket-g1.yml@GH-Actions also declares write-all.
+    permissions: write-all
+    uses: sysown/proxysql/.github/workflows/ci-pgsql-socket-g1.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}

--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -980,10 +980,14 @@ void PgSQL_Connection::connect_start() {
 	{
 		const std::string ip = connect_start_DNS_lookup();
 		if (!ip.empty() && ip != std::string(parent->address)) {
-			append_conninfo_param(conninfo, "hostaddr", const_cast<char*>(ip.c_str()));
+		append_conninfo_param(conninfo, "hostaddr", const_cast<char*>(ip.c_str()));
 		}
 	}
-	conninfo << "port=" << parent->port << " "; // backend port
+	// port=0 means hostname is a Unix-domain socket path; libpq rejects
+	// "port=0" with "invalid port number: \"0\"".
+	if (parent->port != 0) {
+		conninfo << "port=" << parent->port << " ";
+	}
 	conninfo << "application_name=proxysql "; // application name
 	//conninfo << "require_auth=" << AUTHENTICATION_METHOD_STR[pgsql_thread___authentication_method]; // authentication method
 	if (parent->use_ssl) {
@@ -3078,7 +3082,11 @@ void* PgSQL_backend_kill_thread(void* arg) {
 		append_conninfo_param(conninfo, "password", backend_kill_args->password); // password
 		append_conninfo_param(conninfo, "dbname", backend_kill_args->dbname); // dbname
 		append_conninfo_param(conninfo, "host", backend_kill_args->hostname); // backend address
-		conninfo << "port=" << backend_kill_args->port << " "; // backend port
+		// port=0 means hostname is a Unix-domain socket path; libpq rejects
+		// "port=0" with "invalid port number: \"0\"".
+		if (backend_kill_args->port != 0) {
+			conninfo << "port=" << backend_kill_args->port << " ";
+		}
 		conninfo << "application_name=proxysql "; // application name
 		
 		if (backend_kill_args->ssl_config.use_ssl) {

--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -1104,7 +1104,11 @@ string build_conn_str(const task_st_t& task_st) {
 	append_conninfo_param(conninfo, "password", user_info.pass); // password
 	append_conninfo_param(conninfo, "dbname", user_info.dbname); // dbname
 	append_conninfo_param(conninfo, "host", srv_info.addr); // backend address
-	conninfo << "port=" << srv_info.port << " "; // backend port
+	// port=0 means address is a Unix-domain socket path; libpq rejects
+	// "port=0" with "invalid port number: \"0\"".
+	if (srv_info.port != 0) {
+		conninfo << "port=" << srv_info.port << " ";
+	}
 	conninfo << "application_name=ProxySQL-Monitor "; // application name
 	if (srv_info.ssl) {
 		conninfo << "sslmode='require' "; // SSL required

--- a/test/infra/control/start-proxysql-isolated.bash
+++ b/test/infra/control/start-proxysql-isolated.bash
@@ -17,6 +17,11 @@ NETWORK_NAME="${INFRA_ID}_backend"
 PROXY_CONTAINER="proxysql.${INFRA_ID}"
 INFRA_LOGS_PATH="${WORKSPACE}/ci_infra_logs"
 PROXY_DATA_DIR="${INFRA_LOGS_PATH}/${INFRA_ID}/proxysql"
+PGSQL_SOCKET_HOST_DIR="${INFRA_LOGS_PATH}/${INFRA_ID}/pgsql-sockets"
+
+# SUDO helper: empty when already root (the CI runner container runs as root).
+SUDO=""
+if [ "$(id -u)" != "0" ]; then SUDO="sudo"; fi
 GENERIC_CONFIG="${SCRIPT_DIR}/proxysql-ci.cnf"
 
 # Per-group override: a TAP group may need a config that differs from
@@ -192,6 +197,18 @@ if [ -n "${CLUSTER_SIM_HOST_FILE:-}" ] && [ -f "${CLUSTER_SIM_HOST_FILE}" ]; the
     done < "${CLUSTER_SIM_HOST_FILE}"
 fi
 
+# Mount the host directory that holds the PostgreSQL Unix-domain socket
+# (created by docker-pgsql16-single's pgdb1 container) into ProxySQL at the
+# same path the PostgreSQL container exposes it, so a pgsql_servers row with
+# hostname='/var/run/postgresql-shared' and port=0 resolves correctly.
+PGSQL_SOCKET_MOUNT=""
+if [ "${PROXYSQL_NEEDS_PGSQL_SOCKET:-0}" = "1" ]; then
+    $SUDO mkdir -p "${PGSQL_SOCKET_HOST_DIR}"
+    $SUDO chmod 777 "${PGSQL_SOCKET_HOST_DIR}"
+    PGSQL_SOCKET_MOUNT="-v ${PGSQL_SOCKET_HOST_DIR}:/var/run/postgresql-shared:rw"
+    echo ">>> Mounting PostgreSQL Unix-socket directory: ${PGSQL_SOCKET_HOST_DIR} -> /var/run/postgresql-shared"
+fi
+
 echo ">>> Starting ProxySQL container: ${PROXY_CONTAINER} (cluster nodes: ${NUM_NODES})"
 docker run -d \
     --name "${PROXY_CONTAINER}" \
@@ -206,6 +223,7 @@ docker run -d \
     ${MYSQLX_PLUGIN_MOUNT} \
     ${GENAI_PLUGIN_MOUNT} \
     ${GCOV_MOUNTS} \
+    ${PGSQL_SOCKET_MOUNT} \
     -e GCOV_PREFIX="/gcov" \
     -e GCOV_PREFIX_STRIP="3" \
     proxysql-ci-base:latest \

--- a/test/infra/docker-pgsql16-single/conf/pgsql/pgsql1/postgresql.conf
+++ b/test/infra/docker-pgsql16-single/conf/pgsql/pgsql1/postgresql.conf
@@ -2,6 +2,11 @@ hba_file = '/etc/postgresql/pg_hba.conf'
 listen_addresses = '*'
 max_connections = 120
 
+# Expose a Unix-domain socket on a path mounted into ProxySQL's
+# container. The /var/run/postgresql directory is also kept so that
+# in-container psql clients still find the default socket.
+unix_socket_directories = '/var/run/postgresql-shared,/var/run/postgresql'
+
 logging_collector = 'on'
 log_directory = '/var/log/postgresql'
 log_filename = 'postgresql.log'

--- a/test/infra/docker-pgsql16-single/docker-compose.yml
+++ b/test/infra/docker-pgsql16-single/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - ${INFRA_LOGS_PATH}/${COMPOSE_PROJECT}/ssl/server.crt:/var/lib/postgresql/server.crt:ro
       - ${INFRA_LOGS_PATH}/${COMPOSE_PROJECT}/ssl/server.key:/var/lib/postgresql/server.key:ro
       - ${INFRA_LOGS_PATH}/${COMPOSE_PROJECT}/pgdb1:/var/log/postgresql
+      # Host path for the Unix-domain socket that ProxySQL reads.
+      # ProxySQL's container mounts the same path via start-proxysql-isolated.bash
+      # when the group sets PROXYSQL_NEEDS_PGSQL_SOCKET=1.
+      - ${INFRA_LOGS_PATH}/${INFRA_ID}/pgsql-sockets:/var/run/postgresql-shared
     networks:
       backend:
         aliases:

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -186,6 +186,7 @@
   "pgsql-transaction_variable_state_tracking-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
   "pgsql-tx_poisoned_extended_query-t" : [ "legacy-g2" ],
   "pgsql-tx_poisoned_recovery-t" : [ "legacy-g2" ],
+  "pgsql-unix_socket-t" : [ "pgsql-socket-g1" ],
   "pgsql-unsupported_feature_test-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1" ],
   "pgsql-watchdog_test-t" : [ "legacy-g4","mysql-auto_increment_delay_multiplex=0-g4","mysql-multiplexing=false-g4","mysql-query_digests=0-g4","mysql-query_digests_keep_comment=1-g4" ],
   "pgsql_command_complete_unit-t" : [ "unit-tests-g1" ],

--- a/test/tap/groups/pgsql-socket/env.sh
+++ b/test/tap/groups/pgsql-socket/env.sh
@@ -1,0 +1,15 @@
+# TAP group dedicated to the PostgreSQL Unix-domain socket code path.
+#
+# `port=0` in pgsql_servers is documented to mean "hostname is a Unix socket
+# path" (see https://www.proxysql.com/documentation/main-runtime/postgresql-tables
+# #pgsql_servers). This group adds a new pgsql_servers row whose hostname is the
+# socket directory shared between the pgdb1 container and the ProxySQL
+# container, exercising the path that libpq would otherwise reject with
+# "invalid port number: \"0\"".
+
+# Mount the PostgreSQL Unix-socket directory into the ProxySQL container.
+# start-proxysql-isolated.bash turns this into a `-v ...:/var/run/postgresql-shared`
+# on the ProxySQL container, matching the path pgdb1 creates the socket at.
+export PROXYSQL_NEEDS_PGSQL_SOCKET=1
+
+export DEFAULT_PGSQL_INFRA="docker-pgsql16-single"

--- a/test/tap/groups/pgsql-socket/infras.lst
+++ b/test/tap/groups/pgsql-socket/infras.lst
@@ -1,0 +1,1 @@
+docker-pgsql16-single

--- a/test/tap/groups/pgsql-socket/setup-infras.bash
+++ b/test/tap/groups/pgsql-socket/setup-infras.bash
@@ -1,0 +1,58 @@
+#!/bin/bash
+# pgsql-socket group setup hook.
+#
+# Runs after docker-pgsql16-single's docker-proxy-post.bash has inserted the
+# default TCP-based pgsql_servers rows. We delete them and reinsert with
+# `port=0` and `hostname='/var/run/postgresql-shared'` so that ProxySQL
+# builds a libpq conninfo string that connects via the Unix-domain socket
+# (the path that triggered the "invalid port number: \"0\"" bug).
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+export WORKSPACE="${REPO_ROOT}"
+
+if [ -z "${INFRA_ID}" ]; then
+    echo "ERROR: INFRA_ID is not set."
+    exit 1
+fi
+
+# Locate the ProxySQL container (docker-pgsql16-single already started it).
+PROXY_HOST="proxysql"
+PROXY_ADMIN_PORT="6032"
+PROXY_ADMIN_USER="radmin"
+PROXY_ADMIN_PASS="radmin"
+
+# Wait for ProxySQL admin to be reachable; the previous infra start
+# (legacy-g1 or pgsql-socket-g1) just brought it up but DNS may not have
+# settled in the host network namespace yet.
+for i in $(seq 1 30); do
+    if docker exec -e PGPASSWORD="${PROXY_ADMIN_PASS}" \
+        "$(docker ps --filter "name=proxysql.${INFRA_ID}" --format '{{.Names}}' | head -1)" \
+        psql -X -h"${PROXY_HOST}" -p"${PROXY_ADMIN_PORT}" -U"${PROXY_ADMIN_USER}" -c "select 1;" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+PROXY_CTNR="$(docker ps --filter "name=proxysql.${INFRA_ID}" --format '{{.Names}}' | head -1)"
+if [ -z "${PROXY_CTNR}" ]; then
+    echo "ERROR: ProxySQL container for INFRA_ID=${INFRA_ID} not running"
+    exit 1
+fi
+
+# Replace the default TCP-based pgsql_servers with socket-based ones.
+# Same hostgroups (0/1) and same comment so the rest of the suite sees
+# an identical-looking pgsql_servers table; the only difference is the
+# hostname/port pair, which is exactly what this test exercises.
+docker exec -i -e PGPASSWORD="${PROXY_ADMIN_PASS}" "${PROXY_CTNR}" \
+    psql -X -h"${PROXY_HOST}" -p"${PROXY_ADMIN_PORT}" -U"${PROXY_ADMIN_USER}" <<'SQL'
+DELETE FROM pgsql_servers;
+INSERT INTO pgsql_servers (hostgroup_id, hostname, port, max_replication_lag, max_connections, comment)
+    VALUES (0, '/var/run/postgresql-shared', 0, 0, 50, 'pgsql1-unix-socket'),
+           (1, '/var/run/postgresql-shared', 0, 0, 50, 'pgsql1-unix-socket');
+LOAD PGSQL SERVERS TO RUNTIME;
+SAVE PGSQL SERVERS TO DISK;
+SQL
+
+echo ">>> [pgsql-socket/setup-infras] Switched pgsql_servers to Unix-socket mode"

--- a/test/tap/groups/pgsql-socket/setup-infras.bash
+++ b/test/tap/groups/pgsql-socket/setup-infras.bash
@@ -26,7 +26,7 @@ PROXY_ADMIN_PASS="radmin"
 # Wait for ProxySQL admin to be reachable; the previous infra start
 # (legacy-g1 or pgsql-socket-g1) just brought it up but DNS may not have
 # settled in the host network namespace yet.
-for i in $(seq 1 30); do
+for _ in $(seq 1 30); do
     if docker exec -e PGPASSWORD="${PROXY_ADMIN_PASS}" \
         "$(docker ps --filter "name=proxysql.${INFRA_ID}" --format '{{.Names}}' | head -1)" \
         psql -X -h"${PROXY_HOST}" -p"${PROXY_ADMIN_PORT}" -U"${PROXY_ADMIN_USER}" -c "select 1;" >/dev/null 2>&1; then

--- a/test/tap/groups/pgsql-socket/setup-infras.bash
+++ b/test/tap/groups/pgsql-socket/setup-infras.bash
@@ -18,8 +18,11 @@ if [ -z "${INFRA_ID}" ]; then
 fi
 
 # Locate the ProxySQL container (docker-pgsql16-single already started it).
+# ProxySQL exposes BOTH admins: port 6032 is the MySQL admin, 6132 is the
+# PgSQL admin. The PgSQL admin speaks the wire protocol that psql can
+# drive, which is what we need here to issue pgsql_servers DDL.
 PROXY_HOST="proxysql"
-PROXY_ADMIN_PORT="6032"
+PROXY_ADMIN_PORT="6132"
 PROXY_ADMIN_USER="radmin"
 PROXY_ADMIN_PASS="radmin"
 
@@ -45,14 +48,41 @@ fi
 # Same hostgroups (0/1) and same comment so the rest of the suite sees
 # an identical-looking pgsql_servers table; the only difference is the
 # hostname/port pair, which is exactly what this test exercises.
+#
+# We also add a 'monitor' pgsql_user (the default pgsql-monitor_username
+# in ProxySQL is 'monitor'; without it the monitor logs
+# 'role "monitor" does not exist' and never gets a successful
+# connect_check_OK) and shorten pgsql-monitor_connect_interval so the
+# test only needs to wait a few seconds to see a counter tick. The DELETE
+# -then-INSERT dance is the same idempotent pattern the legacy config.sql
+# uses for postgres/testuser.
+#
+# Note: SET statements are sent as separate docker exec calls because
+# the pgsql admin parser mis-handles `value; <next-stmt>` by treating
+# the literal text after the semicolon as a value for the next
+# variable. Splitting avoids that footgun.
 docker exec -i -e PGPASSWORD="${PROXY_ADMIN_PASS}" "${PROXY_CTNR}" \
     psql -X -h"${PROXY_HOST}" -p"${PROXY_ADMIN_PORT}" -U"${PROXY_ADMIN_USER}" <<'SQL'
 DELETE FROM pgsql_servers;
 INSERT INTO pgsql_servers (hostgroup_id, hostname, port, max_replication_lag, max_connections, comment)
     VALUES (0, '/var/run/postgresql-shared', 0, 0, 50, 'pgsql1-unix-socket'),
            (1, '/var/run/postgresql-shared', 0, 0, 50, 'pgsql1-unix-socket');
+DELETE FROM pgsql_users WHERE username='monitor';
+INSERT INTO pgsql_users (username, password, active) VALUES ('monitor', 'monitor', 1);
 LOAD PGSQL SERVERS TO RUNTIME;
+LOAD PGSQL USERS TO RUNTIME;
 SAVE PGSQL SERVERS TO DISK;
+SAVE PGSQL USERS TO DISK;
 SQL
+
+docker exec -e PGPASSWORD="${PROXY_ADMIN_PASS}" "${PROXY_CTNR}" \
+    psql -X -h"${PROXY_HOST}" -p"${PROXY_ADMIN_PORT}" -U"${PROXY_ADMIN_USER}" \
+    -c "SET pgsql-monitor_connect_interval=1000"
+docker exec -e PGPASSWORD="${PROXY_ADMIN_PASS}" "${PROXY_CTNR}" \
+    psql -X -h"${PROXY_HOST}" -p"${PROXY_ADMIN_PORT}" -U"${PROXY_ADMIN_USER}" \
+    -c "LOAD PGSQL VARIABLES TO RUNTIME"
+docker exec -e PGPASSWORD="${PROXY_ADMIN_PASS}" "${PROXY_CTNR}" \
+    psql -X -h"${PROXY_HOST}" -p"${PROXY_ADMIN_PORT}" -U"${PROXY_ADMIN_USER}" \
+    -c "SAVE PGSQL VARIABLES TO DISK"
 
 echo ">>> [pgsql-socket/setup-infras] Switched pgsql_servers to Unix-socket mode"

--- a/test/tap/tests/pgsql-unix_socket-t.cpp
+++ b/test/tap/tests/pgsql-unix_socket-t.cpp
@@ -1,0 +1,193 @@
+/**
+ * @file pgsql-unix_socket-t.cpp
+ * @brief Regression test for sysown/proxysql#5837.
+ *
+ * Validates that when pgsql_servers has port=0 (meaning "hostname is a
+ * Unix-domain socket path"), ProxySQL's client-side connect path AND
+ * the pgsql monitor both build a libpq conninfo string that omits
+ * `port=`. libpq would otherwise reject "port=0" with the error
+ *
+ *     invalid port number: "0"
+ *
+ * seen in the original issue. The test runs in the dedicated
+ * `pgsql-socket` TAP group, whose setup-infras.bash replaces the
+ * default TCP pgsql_servers rows with socket-path rows, and whose
+ * env.sh mounts the pgdb1 socket directory into the ProxySQL
+ * container at /var/run/postgresql-shared.
+ */
+
+#include <unistd.h>
+#include <memory>
+#include <string>
+#include <sstream>
+#include <vector>
+#include "libpq-fe.h"
+#include "command_line.h"
+#include "tap.h"
+
+CommandLine cl;
+
+using PGConnPtr = std::unique_ptr<PGconn, decltype(&PQfinish)>;
+
+enum ConnType { ADMIN, BACKEND };
+
+static PGConnPtr createNewConnection(ConnType t, const std::string& extra = "") {
+	const char* host = (t == BACKEND) ? cl.pgsql_host : cl.pgsql_admin_host;
+	int port = (t == BACKEND) ? cl.pgsql_port : cl.pgsql_admin_port;
+	const char* user = (t == BACKEND) ? cl.pgsql_username : cl.admin_username;
+	const char* pass = (t == BACKEND) ? cl.pgsql_password : cl.admin_password;
+
+	std::stringstream ss;
+	ss << "host=" << host << " port=" << port
+	   << " user=" << user << " password=" << pass
+	   << " sslmode=disable";
+	if (!extra.empty()) {
+		ss << " " << extra;
+	}
+
+	PGconn* conn = PQconnectdb(ss.str().c_str());
+	if (PQstatus(conn) != CONNECTION_OK) {
+		fprintf(stderr, "Connection to %s:%d failed: %s\n",
+			host, port, PQerrorMessage(conn));
+		PQfinish(conn);
+		return PGConnPtr(nullptr, &PQfinish);
+	}
+	return PGConnPtr(conn, &PQfinish);
+}
+
+static long readMonitorCounter(PGConnPtr& admin, const char* var) {
+	std::stringstream q;
+	q << "SELECT Variable_Value FROM stats_pgsql_global "
+	     "WHERE Variable_Name='" << var << "';";
+	PGresult* res = PQexec(admin.get(), q.str().c_str());
+	long v = -1;
+	if (PQresultStatus(res) == PGRES_TUPLES_OK && PQntuples(res) == 1) {
+		v = atol(PQgetvalue(res, 0, 0));
+	}
+	PQclear(res);
+	return v;
+}
+
+static long readGlobalVar(PGConnPtr& admin, const char* var, long fallback) {
+	std::stringstream q;
+	q << "SELECT Variable_Value FROM global_variables "
+	     "WHERE Variable_Name='" << var << "';";
+	PGresult* res = PQexec(admin.get(), q.str().c_str());
+	long v = fallback;
+	if (PQresultStatus(res) == PGRES_TUPLES_OK && PQntuples(res) == 1) {
+		v = atol(PQgetvalue(res, 0, 0));
+	}
+	PQclear(res);
+	return v;
+}
+
+static bool execSql(PGConnPtr& admin, const std::string& sql) {
+	PGresult* res = PQexec(admin.get(), sql.c_str());
+	bool ok = PQresultStatus(res) == PGRES_COMMAND_OK;
+	if (!ok) {
+		fprintf(stderr, "SQL failed: %s | %s\n",
+			sql.c_str(), PQerrorMessage(admin.get()));
+	}
+	PQclear(res);
+	return ok;
+}
+
+int main(int argc, char** argv) {
+	plan(7);
+
+	if (cl.getEnv()) return exit_status();
+
+	auto admin = createNewConnection(ADMIN);
+	ok(admin != nullptr, "ADMIN connection created");
+
+	if (admin == nullptr) {
+		diag("Cannot continue without admin connection");
+		return exit_status();
+	}
+
+	// Speed up monitor cycles so the test finishes quickly.
+	long orig_interval = readGlobalVar(admin,
+		"pgsql-monitor_connect_interval", 2000);
+	if (!execSql(admin, "SET pgsql-monitor_connect_interval=1000; LOAD PGSQL VARIABLES TO RUNTIME;")) {
+		diag("Failed to lower monitor interval, continuing with current value");
+	}
+
+	// -----------------------------------------------------------------
+	// 1. Confirm pgsql_servers is set up the way the group expects:
+	//    hostname='/var/run/postgresql-shared', port=0
+	// -----------------------------------------------------------------
+	{
+		PGresult* res = PQexec(admin.get(),
+			"SELECT hostname, port FROM pgsql_servers "
+			"WHERE hostname='/var/run/postgresql-shared' AND port=0 "
+			"ORDER BY hostgroup_id");
+		bool found = (PQresultStatus(res) == PGRES_TUPLES_OK && PQntuples(res) >= 1);
+		ok(found,
+			"pgsql_servers has at least one row with hostname=/var/run/postgresql-shared, port=0");
+		if (!found) {
+			diag("Run this test via TAP_GROUP=pgsql-socket so setup-infras.bash can configure the socket rows");
+		}
+		PQclear(res);
+	}
+
+	// -----------------------------------------------------------------
+	// 2. Client-side path: a SELECT through the proxy must succeed.
+	//    Before the fix this failed at PQconnectdb with
+	//    "invalid port number: \"0\"".
+	// -----------------------------------------------------------------
+	auto backend = createNewConnection(BACKEND);
+	ok(backend != nullptr, "Client connection through ProxySQL (via Unix-socket backend) succeeds");
+
+	if (backend != nullptr) {
+		PGresult* res = PQexec(backend.get(), "SELECT 1 AS one");
+		bool ok_q = (PQresultStatus(res) == PGRES_TUPLES_OK
+			&& PQntuples(res) == 1
+			&& strcmp(PQgetvalue(res, 0, 0), "1") == 0);
+		ok(ok_q, "SELECT 1 through the proxy returns the expected result");
+		if (!ok_q) {
+			diag("PQresultStatus=%d, ntuples=%d, value=%s, error=%s",
+				PQresultStatus(res), PQntuples(res),
+				PQntuples(res) > 0 ? PQgetvalue(res, 0, 0) : "(none)",
+				PQerrorMessage(backend.get()));
+		}
+		PQclear(res);
+	} else {
+		ok(0, "SELECT 1 through the proxy returns the expected result");
+	}
+
+	// -----------------------------------------------------------------
+	// 3. Monitor path: the pgsql monitor's "Connections_OK" counter
+	//    must increase. Before the fix every monitor attempt logged
+	//    "Monitor connect failed ... invalid port number: \"0\"" and
+	//    "Connections_ERR" increased instead.
+	// -----------------------------------------------------------------
+	long before_ok = readMonitorCounter(admin, "PgSQL_Monitor_Connections_OK");
+	long before_err = readMonitorCounter(admin, "PgSQL_Monitor_Connections_ERR");
+	diag("Baseline: Connections_OK=%ld Connections_ERR=%ld", before_ok, before_err);
+
+	// Wait for at least one full monitor cycle. With
+	// pgsql-monitor_connect_interval=1000 this is ~2.5s.
+	usleep(2500 * 1000);
+
+	long after_ok = readMonitorCounter(admin, "PgSQL_Monitor_Connections_OK");
+	long after_err = readMonitorCounter(admin, "PgSQL_Monitor_Connections_ERR");
+	diag("After wait: Connections_OK=%ld Connections_ERR=%ld", after_ok, after_err);
+
+	ok(after_ok > before_ok,
+		"PgSQL_Monitor_Connections_OK increases when port=0 socket path is configured");
+	ok(after_err == before_err,
+		"PgSQL_Monitor_Connections_ERR stays at baseline (no 'invalid port number' errors)");
+
+	// -----------------------------------------------------------------
+	// 4. Restore monitor interval so the next test group in the same
+	//    INFRA_ID starts from a sane state.
+	// -----------------------------------------------------------------
+	{
+		std::stringstream q;
+		q << "SET pgsql-monitor_connect_interval=" << orig_interval << ";";
+		execSql(admin, q.str());
+		execSql(admin, "LOAD PGSQL VARIABLES TO RUNTIME;");
+	}
+
+	return exit_status();
+}

--- a/test/tap/tests/pgsql-unix_socket-t.cpp
+++ b/test/tap/tests/pgsql-unix_socket-t.cpp
@@ -105,13 +105,6 @@ int main(int argc, char** argv) {
 		return exit_status();
 	}
 
-	// Speed up monitor cycles so the test finishes quickly.
-	long orig_interval = readGlobalVar(admin,
-		"pgsql-monitor_connect_interval", 2000);
-	if (!execSql(admin, "SET pgsql-monitor_connect_interval=1000; LOAD PGSQL VARIABLES TO RUNTIME;")) {
-		diag("Failed to lower monitor interval, continuing with current value");
-	}
-
 	// -----------------------------------------------------------------
 	// 1. Confirm pgsql_servers is set up the way the group expects:
 	//    hostname='/var/run/postgresql-shared', port=0
@@ -156,38 +149,29 @@ int main(int argc, char** argv) {
 	}
 
 	// -----------------------------------------------------------------
-	// 3. Monitor path: the pgsql monitor's "Connections_OK" counter
-	//    must increase. Before the fix every monitor attempt logged
+	// 3. Monitor path: pgsql monitor's "connect_check_OK" must
+	//    increase. Before the fix every monitor attempt logged
 	//    "Monitor connect failed ... invalid port number: \"0\"" and
-	//    "Connections_ERR" increased instead.
+	//    "connect_check_ERR" increased instead.
+	//
+	//    The monitor runs at its configured connect_interval (default
+	//    2000ms in this test infra). We sample twice with a 3-second
+	//    gap so the test always sees at least one cycle.
 	// -----------------------------------------------------------------
-	long before_ok = readMonitorCounter(admin, "PgSQL_Monitor_Connections_OK");
-	long before_err = readMonitorCounter(admin, "PgSQL_Monitor_Connections_ERR");
-	diag("Baseline: Connections_OK=%ld Connections_ERR=%ld", before_ok, before_err);
+	long before_ok  = readMonitorCounter(admin, "PgSQL_Monitor_connect_check_OK");
+	long before_err = readMonitorCounter(admin, "PgSQL_Monitor_connect_check_ERR");
+	diag("Baseline: connect_check_OK=%ld connect_check_ERR=%ld", before_ok, before_err);
 
-	// Wait for at least one full monitor cycle. With
-	// pgsql-monitor_connect_interval=1000 this is ~2.5s.
-	usleep(2500 * 1000);
+	usleep(3000 * 1000);
 
-	long after_ok = readMonitorCounter(admin, "PgSQL_Monitor_Connections_OK");
-	long after_err = readMonitorCounter(admin, "PgSQL_Monitor_Connections_ERR");
-	diag("After wait: Connections_OK=%ld Connections_ERR=%ld", after_ok, after_err);
+	long after_ok  = readMonitorCounter(admin, "PgSQL_Monitor_connect_check_OK");
+	long after_err = readMonitorCounter(admin, "PgSQL_Monitor_connect_check_ERR");
+	diag("After wait: connect_check_OK=%ld connect_check_ERR=%ld", after_ok, after_err);
 
 	ok(after_ok > before_ok,
-		"PgSQL_Monitor_Connections_OK increases when port=0 socket path is configured");
+		"PgSQL_Monitor_connect_check_OK increases when port=0 socket path is configured");
 	ok(after_err == before_err,
-		"PgSQL_Monitor_Connections_ERR stays at baseline (no 'invalid port number' errors)");
-
-	// -----------------------------------------------------------------
-	// 4. Restore monitor interval so the next test group in the same
-	//    INFRA_ID starts from a sane state.
-	// -----------------------------------------------------------------
-	{
-		std::stringstream q;
-		q << "SET pgsql-monitor_connect_interval=" << orig_interval << ";";
-		execSql(admin, q.str());
-		execSql(admin, "LOAD PGSQL VARIABLES TO RUNTIME;");
-	}
+		"PgSQL_Monitor_connect_check_ERR stays at baseline (no 'invalid port number' errors)");
 
 	return exit_status();
 }

--- a/test/tap/tests/pgsql-unix_socket-t.cpp
+++ b/test/tap/tests/pgsql-unix_socket-t.cpp
@@ -93,7 +93,7 @@ static bool execSql(PGConnPtr& admin, const std::string& sql) {
 }
 
 int main(int argc, char** argv) {
-	plan(7);
+	plan(6);
 
 	if (cl.getEnv()) return exit_status();
 


### PR DESCRIPTION
Closes #5837.

When \`pgsql_servers.port\` is 0 the hostname is documented to be a
Unix-domain socket path. libpq rejects \`port=0\` with
\`invalid port number: "0"\`, so the field has to be omitted from the
conninfo string. This PR adds an \`if (port != 0)\` guard at the three
call sites that build libpq conninfo (client connect, backend kill,
monitor) instead of creating a new helper header for a 3-line check.

It also adds a regression TAP test (\`pgsql-socket-g1\`) that configures
a \`pgsql_servers\` row with \`hostname='/var/run/postgresql-shared'\` and
\`port=0\`, then exercises both the client connect path and the pgsql
monitor. The infra uses a host-directory bind mount shared between
the pgdb1 container (which creates the socket) and the ProxySQL
container (which reads it), following the same pattern already used
for the SSL cert directory in the same infra.

### Changes
- \`lib/PgSQL_Connection.cpp\`: 2 sites guarded
- \`lib/PgSQL_Monitor.cpp\`: 1 site guarded
- \`test/infra/docker-pgsql16-single/conf/pgsql/pgsql1/postgresql.conf\`:
  add \`unix_socket_directories = '/var/run/postgresql-shared,/var/run/postgresql'\`
- \`test/infra/docker-pgsql16-single/docker-compose.yml\`: mount the socket
  directory into the pgdb1 container
- \`test/infra/control/start-proxysql-isolated.bash\`: when
  \`PROXYSQL_NEEDS_PGSQL_SOCKET=1\`, mount the same directory into the
  ProxySQL container
- \`test/tap/groups/pgsql-socket/{env.sh,infras.lst,setup-infras.bash}\`:
  new TAP group that sets the env var, reuses \`docker-pgsql16-single\`,
  and replaces the default TCP \`pgsql_servers\` rows with socket rows
- \`test/tap/tests/pgsql-unix_socket-t.cpp\`: the regression test —
  confirms a SELECT through the proxy succeeds and the monitor's
  \`Connections_OK\` counter increases
- \`test/tap/groups/groups.json\`: register \`pgsql-unix_socket-t\` under
  \`pgsql-socket-g1\` (alphabetically sorted)

### Verification
- \`libproxysql.a\` rebuilds cleanly with \`-Wall\`
- \`pgsql-unix_socket-t\` TAP test binary builds and links
- \`bash -n\` clean on all modified/added bash scripts
- \`test/tap/groups/lint_groups_json.py\` and \`check_groups.py --source\` pass
- \`groups.json\` is valid JSON, \`docker-compose.yml\` is valid YAML
- clang-tidy on the changed lines produces no new warnings (the one
  \`implicit bool conversion\` warning is identical to dozens of
  pre-existing ones in the same files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for PostgreSQL Unix-domain socket connections; connection handling omits a numeric port when a socket path is used and includes resolved hostaddr when available.

* **Tests**
  * Added a regression test covering Unix-socket pgsql connectivity and monitor counters.
  * Updated test infra: Docker config, setup scripts, environment/groups, and a CI workflow to exercise Unix-socket scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->