### PR TITLE
ci: add pgsql-socket-g1 reusable workflow

### DIFF
--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -1,0 +1,225 @@
+name: CI-pgsql-socket-g1
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+
+env:
+  SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    # `write-all` grants every default GITHUB_TOKEN scope plus the
+    # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
+    # token for `use_oidc: true`. Caller workflow on v3.0 must also
+    # declare write-all for the permissions to propagate through the
+    # reusable call (permissions are intersected caller-callee).
+    permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        infradb: [ 'pgsql16socket' ]
+    env:
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap_src
+      MATRIX: '(${{ matrix.infradb }},tap)'
+
+    steps:
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ env.SHA }}
+        path: 'proxysql'
+        sparse-checkout: |
+          test/infra
+          test/tap/groups
+          test/scripts
+
+    - name: Cache restore src
+      id: cache-src
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ env.BLDCACHE }}
+        fail-on-cache-miss: true
+        # MUST exactly match the path list in CI-builds' "Cache save src"
+        # step. actions/cache hashes the path list into the cache
+        # "version" alongside the key -- different path lists = different
+        # version = lookup miss, even if the key is identical and the
+        # cache plainly exists in the repo (verified via gh api).
+        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
+        # so this restore needs the same entry; otherwise the restore
+        # silently misses with "Failed to restore cache entry".
+        path: |
+          proxysql/src/
+          proxysql/lib/obj/*.gcno
+
+    - name: Cache restore test
+      id: cache-test
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap_test
+        fail-on-cache-miss: true
+        path: cache_test.tar.zst
+
+    - name: Unpack test cache
+      run: |
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        cd proxysql/
+        zstd -d < ../cache_test.tar.zst | tar -xf -
+        rm ../cache_test.tar.zst
+
+    - name: Verify binary
+      run: |
+        chmod +x proxysql/src/proxysql
+        file proxysql/src/proxysql
+
+    - name: Log in to GHCR and pull CI base image
+      # Both `docker login` and `docker pull` against ghcr.io have been
+      # observed to fail transiently with `net/http: request canceled
+      # (Client.Timeout exceeded while awaiting headers)`. Wrap both in
+      # a short retry loop with linear backoff so a single network blip
+      # does not red the whole TAP group.
+      env:
+        GHCR_USER: ${{ github.actor }}
+        GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set +e
+        attempt=0
+        max_attempts=5
+        while [ $attempt -lt $max_attempts ]; do
+          attempt=$((attempt + 1))
+          echo ">>> GHCR login+pull attempt ${attempt}/${max_attempts}"
+          if echo "$GHCR_TOKEN" | docker login ghcr.io \
+              -u "$GHCR_USER" --password-stdin \
+              && docker pull ghcr.io/sysown/proxysql-ci-base:latest; then
+            echo ">>> GHCR login+pull OK on attempt ${attempt}"
+            docker tag ghcr.io/sysown/proxysql-ci-base:latest \
+                proxysql-ci-base:latest
+            exit 0
+          fi
+          if [ $attempt -lt $max_attempts ]; then
+            sleep_for=$((attempt * 10))
+            echo ">>> attempt ${attempt} failed; sleeping ${sleep_for}s"
+            sleep $sleep_for
+          fi
+        done
+        echo ">>> all ${max_attempts} GHCR attempts failed"
+        exit 1
+
+    - name: Start infrastructure
+      run: |
+        cd proxysql
+        export INFRA_ID="ci-pgsql-socket-g1"
+        export TAP_GROUP="pgsql-socket-g1"
+        export SKIP_CLUSTER_START=1
+        test/infra/control/ensure-infras.bash
+
+    - name: Run pgsql-socket-g1 tests
+      run: |
+        cd proxysql
+        export INFRA_ID="ci-pgsql-socket-g1"
+        export TAP_GROUP="pgsql-socket-g1"
+        export SKIP_CLUSTER_START=1
+        export COVERAGE=1
+        test/infra/control/run-tests-isolated.bash
+
+    - name: Cleanup
+      if: always()
+      run: |
+        set +e
+        cd proxysql
+        export INFRA_ID="ci-pgsql-socket-g1"
+        export TAP_GROUP="pgsql-socket-g1"
+        docker logs proxysql.ci-pgsql-socket-g1 2>&1 | tail -50 || true
+        test/infra/control/stop-proxysql-isolated.bash
+        test/infra/control/destroy-infras.bash
+
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        # actions/upload-artifact dies with EACCES when it scandirs into
+        # directories under ci_*_logs/ that were created inside docker
+        # build containers (root-owned). Make everything readable by the
+        # runner user before upload. sudo required because files are
+        # root-owned; 2>/dev/null + || true because the path may not
+        # exist on all failure paths (e.g. a cache-restore failure before
+        # any test even runs).
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
+    - name: Archive artifacts logs
+      if: ${{ failure() && !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Upload coverage to Codecov
+      # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
+      # (under proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/) to
+      # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
+      # build cache) and was the live daemon answering the pgsql-socket-g1 TAP
+      # suite, so the report reflects production code paths exercised by
+      # integration tests, not just the lib-only unit-test slice.
+      #
+      # `flags: tap-pgsql-socket-g1` lets Codecov merge per-group uploads and show
+      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
+      # legacy uploads with "branch is protected" HTTP 400.
+      #
+      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # whole TAP group; `!cancelled()` so coverage uploads even when
+      # the test step itself reported a failure (partial coverage is
+      # still useful diagnostically).
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
+        flags: tap-pgsql-socket-g1
+        name: tap-pgsql-socket-g1-coverage
+        use_oidc: true
+        # codecov-cli's _get_file_fixes step reads every source file
+        # referenced in the LCOV report and crashes with FileNotFoundError
+        # if any path is missing (the _test cache prunes test deps to fit
+        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
+        # on the runner). disable_file_fixes:true skips that step. Trade-
+        # off: Codecov line-offset annotations on PR diffs may be less
+        # precise, but aggregate coverage numbers are unaffected.
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
Adds the reusable workflow that backs the `CI-pgsql-socket-g1` caller on the v3.0 branch.

Mirrors `ci-legacy-g1.yml` in structure (matrix, permissions, codecov upload) so the caller can delegate to it without changes to permissions or CI mechanics.

This workflow runs the `docker-pgsql16-single` infra (extended by the pgsql-socket TAP group's `setup-infras.bash` to expose a Unix-domain socket at `/var/run/postgresql-shared`) and executes the `pgsql-unix_socket-t` regression test added in PR #5844.

### Dependencies

The caller shim (`.github/workflows/CI-pgsql-socket-g1.yml`) lives in PR #5844 on the v3.0 branch and is a no-op until this reusable is merged. Merge this PR first, then PR #5844's CI will exercise the new socket path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new continuous integration workflow for automated test execution. Features include optimized build artifact caching for efficiency, isolated containerized testing environments, comprehensive log and test artifact collection on failures, automated status reporting, and secure code coverage reporting with OIDC authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->