### PR TITLE
MySrvC::connect_error(): skip ER_MUST_CHANGE_PASSWORD_LOGIN (1862)

### DIFF
--- a/lib/MySrvC.cpp
+++ b/lib/MySrvC.cpp
@@ -77,6 +77,7 @@ void MySrvC::connect_error(int err_num, bool get_mutex) {
 		case 1120:
 		case 1203: // User %s already has more than 'max_user_connections' active connections
 		case 1226: // User '%s' has exceeded the '%s' resource (current value: %ld)
+		case 1862: // Your password has expired. To log in you must change it using a client that supports expired passwords.
 		case 3118: // Access denied for user '%s'. Account is locked..
 			return;
 			break;


### PR DESCRIPTION
Adds `case 1862:` to the per-user-error skip-list in `MySrvC::connect_error()`. Without it, a backend connection failure due to `password_expired = Y` on the user counts toward `mysql-shun_on_failures` and can mark the backend `SHUNNED` — degrading or failing connections for unrelated clients on the same backend.

`1862` is the errno MySQL 8.0 / Aurora returns at `mysql_real_connect()` time when the user has an expired password. It's per-user state, not backend health — by definition the backend is responsive enough to evaluate credentials and report the expiry. This matches the intent of the existing entries (`1044`, `1045`, `1203`, `1226`, `3118`, etc.).

Verified on `v3.0.9` and `v4.0` head — `1862` is not in the current skip-list. Reproduction and damage measurement in #5846.

Happy to add a regression test under `test/tap/` if the maintainers indicate the preferred location. The existing entries in this switch don't appear to have dedicated tests, so I followed that precedent for the initial submission.