### PR TITLE
Fix comment explaining how to compile without git history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 
 ### NOTES:
 ### version string is fetched from git history
-### when not available, specify GIT_VERSION on commnad line:
+### when not available, specify GIT_VERSION_BASE during make:
 ###
 ### ```
-### export GIT_VERSION=3.x.y-dev
+### make GIT_VERSION_BASE="v3.x.y"
 ### ```
 
 GIT_VERSION_BASE := $(shell git describe --long --abbrev=7 2>/dev/null || git describe --long --abbrev=7 --always)


### PR DESCRIPTION
While compiling the tagged release from the tarball on Gentoo, I I noticed the example comment had drifted out of sync in c5ccb0f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Makefile versioning documentation: when Git-derived version information is unavailable, the docs now instruct providing GIT_VERSION_BASE on the command line. No build logic, variables, or target behavior were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->