### PR TITLE
fix(ci): use ubuntu24-tap-genai-gcov cache key in pgsql-socket-g1

### DIFF
--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         infradb: [ 'pgsql16socket' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap_src
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
       MATRIX: '(${{ matrix.infradb }},tap)'
 
     steps:
@@ -73,7 +73,7 @@ jobs:
       id: cache-test
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap_test
+        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
         fail-on-cache-miss: true
         path: cache_test.tar.zst
 


### PR DESCRIPTION
## Summary

\`ci-pgsql-socket-g1.yml\` has been failing on every run since it was introduced in d32ca0172 — but it wasn't flakiness, it was a cache-key typo.

The workflow restores a build cache keyed \`\${SHA}_ubuntu24-tap_src\`, but CI-builds' matrix only produces the \`ubuntu24-tap-genai-gcov\` variant:

| job | cache key suffix | exists? |
|---|---|---|
| ci-mysql84-g1 | \`ubuntu24-tap-genai-gcov_src\` | ✅ |
| ci-legacy-g1 | \`ubuntu24-tap-genai-gcov_src\` | ✅ |
| ci-mariadb10-galera-g1 | \`ubuntu24-tap-genai-gcov_src\` | ✅ |
| ci-pgsql-socket-g1 | \`ubuntu24-tap_src\` | ❌ |

With \`fail-on-cache-miss: true\` the job aborts at the restore step and never executes a single test — surfacing as a \"tests failure\" on every PR.

Patch: 2-character edit, just adds \`-genai-gcov\` in two places to match the sibling workflows.

## Test plan

- [ ] CI on this PR shows ci-pgsql-socket-g1 passing the cache-restore step (and either green tests or a genuine test failure, instead of the silent restore-abort)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration cache configuration for optimized build and test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->