### PR TITLE
test

### DIFF
--- a/docs/superpowers/plans/2026-06-14-mysql-variables-validation-feedback.md
+++ b/docs/superpowers/plans/2026-06-14-mysql-variables-validation-feedback.md
@@ -1,0 +1,876 @@
+# Visible Feedback for Rejected mysql-* Variables Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `LOAD <module> VARIABLES TO RUNTIME` report a `Records: N Updated: X Rejected: Y Unknown: Z` summary in the OK packet's `info` field, so users see when their `UPDATE global_variables` value was rejected and silently reset.
+
+**Architecture:** Add a `FlushVariableStats` struct that the generic flush helper returns. Plumb it up through the six module-specific flush wrappers and the three inline `load_*_variables_to_runtime` helpers. The admin handler formats the info string and passes it to the existing `send_ok_msg_to_client`. The pgsql flush helper has its own duplicated loop and gets the same treatment.
+
+**Tech Stack:** C++17, SQLite3 (admin DB), MySQL/PostgreSQL OK packet info field, TAP test framework.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `include/proxysql_admin.h` | Add `FlushVariableStats` struct; change return types of `flush_GENERIC_variables__process__database_to_runtime` and 7 module wrappers; change 3 inline `load_*_variables_to_runtime` helpers to return the struct |
+| `lib/Admin_FlushVariables.cpp` | Add counters in the generic process function; add counters in the duplicated pgsql loop; update 6 generic wrappers to return the struct |
+| `lib/Admin_Handler.cpp` | Format the info string in 3 call sites (mysql, pgsql, ldap) and pass to `send_ok_msg_to_client` |
+| `test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp` | New TAP test for the mysql module |
+| `test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp` | New TAP test for the pgsql module |
+| `test/tap/groups/groups.json` | Register the 2 new tests in the appropriate infra groups |
+
+---
+
+## Task 1: Add `FlushVariableStats` struct and change return types in header
+
+**Files:**
+- Modify: `include/proxysql_admin.h:513-573` (function signatures) and `include/proxysql_admin.h:757, 841, 870` (inline helpers)
+
+- [ ] **Step 1: Add the struct definition**
+
+In `include/proxysql_admin.h`, immediately after the `ProxySQL_Admin` class opening brace (or wherever other public structs are declared in this class), add:
+
+```cpp
+struct FlushVariableStats {
+    int records  = 0;
+    int updated  = 0;
+    int rejected = 0;
+    int unknown  = 0;
+};
+```
+
+- [ ] **Step 2: Change the signature of `flush_GENERIC_variables__process__database_to_runtime`**
+
+In `include/proxysql_admin.h:518-526`, change the return type from `void` to `FlushVariableStats`:
+
+```cpp
+    FlushVariableStats flush_GENERIC_variables__process__database_to_runtime(
+        const std::string& modname, SQLite3DB *db, SQLite3_result* resultset,
+        const bool& lock, const bool& replace,
+        const std::unordered_set<std::string>& variables_read_only,
+        const std::unordered_set<std::string>& variables_to_delete_silently,
+        const std::unordered_set<std::string>& variables_deprecated,
+        const std::unordered_set<std::string>& variables_special_values,
+        std::function<void(const std::string&, const char *, SQLite3DB *)> special_variable_action = nullptr
+    );
+```
+
+- [ ] **Step 3: Change the 6 generic wrappers to return `FlushVariableStats`**
+
+In `include/proxysql_admin.h`, update each of:
+
+```cpp
+    FlushVariableStats flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0);   // was: void
+    FlushVariableStats flush_admin_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0, bool lock = true);  // was: void
+    FlushVariableStats flush_sqliteserver_variables___database_to_runtime(SQLite3DB *db, bool replace);  // was: void
+    FlushVariableStats flush_ldap_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0);  // was: void
+```
+
+`flush_tsdb_variables___database_to_runtime` is inside `#ifdef PROXYSQLTSDB`; update the same way.
+
+`flush_clickhouse_variables___database_to_runtime` is inside `#ifdef PROXYSQLCLICKHOUSE`; update the same way.
+
+- [ ] **Step 4: Change the pgsql wrapper to return `FlushVariableStats`**
+
+In `include/proxysql_admin.h:565`, change:
+
+```cpp
+    FlushVariableStats flush_pgsql_variables___database_to_runtime(SQLite3DB* db, bool replace, const std::string& checksum = "", const time_t epoch = 0);  // was: void
+```
+
+- [ ] **Step 5: Change the 3 inline `load_*_variables_to_runtime` helpers to return the struct**
+
+In `include/proxysql_admin.h:757, 841, 870`, change each from `void` to `FlushVariableStats`:
+
+```cpp
+    FlushVariableStats load_mysql_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { return flush_mysql_variables___database_to_runtime(admindb, true, checksum, epoch); }
+    FlushVariableStats load_ldap_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { return flush_ldap_variables___database_to_runtime(admindb, true, checksum, epoch); }
+    FlushVariableStats load_pgsql_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { return flush_pgsql_variables___database_to_runtime(admindb, true, checksum, epoch); }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/proxysql_admin.h
+git commit -m "refactor(admin): introduce FlushVariableStats and change flush_*_variables signatures"
+```
+
+Note: the build is now broken. That is expected; Task 2 fixes the implementations.
+
+---
+
+## Task 2: Update `flush_GENERIC_variables__process__database_to_runtime` to track and return stats
+
+**Files:**
+- Modify: `lib/Admin_FlushVariables.cpp:178-263` (function body)
+
+- [ ] **Step 1: Replace the function signature and add counter increments**
+
+In `lib/Admin_FlushVariables.cpp:178`, change the signature:
+
+```cpp
+FlushVariableStats ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
+```
+
+(keep all the parameters unchanged)
+
+- [ ] **Step 2: Add `stats.records++` at the top of the loop**
+
+In `lib/Admin_FlushVariables.cpp:187-188`, before the `bool rc = false;` line, add:
+
+```cpp
+        SQLite3_row *r=*it;
+        stats.records++;
+        bool rc = false;
+```
+
+- [ ] **Step 3: Increment `stats.updated++` on success**
+
+In `lib/Admin_FlushVariables.cpp:254` (the `else` branch's `proxy_debug` line, just before it), the success path is the `if (rc==false) ... else {` block. In the `else` branch, before the existing `proxy_debug` line that says "Set variable %s with value %s", add:
+
+```cpp
+        } else {
+            stats.updated++;
+            proxy_debug(PROXY_DEBUG_ADMIN, 4, "Set variable %s with value \"%s\"\n", r->fields[0],r->fields[1]);
+```
+
+- [ ] **Step 4: Increment `stats.rejected++` for known-bad-value and read-only rows**
+
+In the `if (rc==false)` branch, the `if (val)` block (line 230) covers "we know about this variable but rejected the value". Before the `snprintf(q, ...)` line, add `stats.rejected++;`:
+
+```cpp
+                    if (val) {
+                        if (variables_read_only.count(v) > 0) {
+                            proxy_warning("Impossible to set read-only variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0],r->fields[1], val);
+                        } else {
+                            proxy_warning("Impossible to set variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0],r->fields[1], val);
+                        }
+                        stats.rejected++;
+                        snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"%s-%s\",\"%s\")", modname.c_str(), r->fields[0], val);
+                        db->execute(q);
+                        free(val);
+```
+
+- [ ] **Step 5: Increment `stats.rejected++` for `variables_to_delete_silently` and `variables_deprecated`**
+
+In the `else` branch (the `else` of `if (val)`, line 239), add the counters:
+
+```cpp
+                    } else {
+                        if (variables_to_delete_silently.count(v) > 0) {
+                            stats.rejected++;
+                            snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
+                            db->execute(q);
+                        } else if (variables_deprecated.count(v) > 0) {
+                            proxy_error("Global variable %s-%s is deprecated.\n", modname.c_str(), r->fields[0]);
+                            stats.rejected++;
+                            snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
+                            db->execute(q);
+                        } else {
+                            proxy_warning("Impossible to set not existing variable %s with value \"%s\". Deleting. If the variable name is correct, this version doesn't support it\n", r->fields[0],r->fields[1]);
+                            stats.unknown++;
+                        }
+                        snprintf(q, sizeof(q), "DELETE FROM global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
+                        db->execute(q);
+                    }
+```
+
+- [ ] **Step 6: Add `return stats;` at the end of the function**
+
+At `lib/Admin_FlushVariables.cpp:262` (the closing `}` of the for loop), after the loop, add:
+
+```cpp
+    return stats;
+}
+```
+
+(The closing `}` at line 263 stays.)
+
+- [ ] **Step 7: Update the 6 generic wrappers to return the struct**
+
+In `lib/Admin_FlushVariables.cpp`, update each of these wrappers' return statements to use the struct. The bodies do the work and then fall through; we need to capture and return.
+
+For `flush_admin_variables___database_to_runtime` (line 265), change the call site:
+
+```cpp
+        FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("admin", db, resultset, lock, replace, {"version"}, {"debug"}, {}, {});
+        if (resultset) delete resultset;
+        return stats;
+    }
+```
+
+(`resultset` is deleted after the existing checks; keep the existing structure, just save and return `stats`.)
+
+For `flush_mysql_variables___database_to_runtime` (line 453), the wrapper is much longer and does charset/collation post-processing. The pattern:
+
+```cpp
+void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum, const time_t epoch) {
+```
+
+becomes:
+
+```cpp
+FlushVariableStats ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum, const time_t epoch) {
+```
+
+The existing call to `flush_GENERIC_variables__process__database_to_runtime` at line 465 needs to be captured:
+
+```cpp
+        FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("mysql", db, resultset, false, replace, {}, {"session_debug"}, {"forward_autocommit"},
+            { ... existing special_values set ... },
+            [](const std::string& varname, const char *varvalue, SQLite3DB* db) { ... existing lambda ... }
+        );
+```
+
+The function continues with charset/collation post-processing. Just before the final `if (resultset) delete resultset;` (line 660) and the function's closing `}`, add:
+
+```cpp
+        return stats;
+    }
+    if (resultset) delete resultset;
+    return FlushVariableStats{};
+}
+```
+
+(The early-return for empty resultset at line 450 needs to be `return FlushVariableStats{};` as well — see the existing `delete resultset; return;` path.)
+
+For `flush_sqliteserver_variables___database_to_runtime` (line 663):
+
+```cpp
+FlushVariableStats ProxySQL_Admin::flush_sqliteserver_variables___database_to_runtime(SQLite3DB *db, bool replace) {
+    // ... existing body, including the early return for sqlite3_server disabled ...
+    if (flush_GENERIC_variables__retrieve__database_to_runtime("sqliteserver", error, cols, affected_rows, resultset) == true) {
+        GloSQLite3Server->wrlock();
+        FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("sqliteserver", db, resultset, false, replace, {}, {"session_debug"}, {}, {});
+        //GloClickHouse->commit();
+        GloSQLite3Server->wrunlock();
+        if (resultset) delete resultset;
+        return stats;
+    }
+    if (resultset) delete resultset;
+    return FlushVariableStats{};
+}
+```
+
+For `flush_tsdb_variables___database_to_runtime` (line 686, inside `#ifdef PROXYSQLTSDB`):
+
+```cpp
+FlushVariableStats ProxySQL_Admin::flush_tsdb_variables___database_to_runtime(SQLite3DB *db, bool replace) {
+    // ... existing body, including the early return for GloProxyStats == NULL ...
+    if (flush_GENERIC_variables__retrieve__database_to_runtime("tsdb", error, cols, affected_rows, resultset) == true) {
+        FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("tsdb", db, resultset, false, replace, {}, {}, {}, {});
+        flush_tsdb_variables___runtime_to_database(admindb, false, false, false, true);
+        if (resultset) delete resultset;
+        return stats;
+    }
+    if (resultset) delete resultset;
+    return FlushVariableStats{};
+}
+```
+
+For `flush_clickhouse_variables___database_to_runtime` (line 791, inside `#ifdef PROXYSQLCLICKHOUSE`):
+
+```cpp
+FlushVariableStats ProxySQL_Admin::flush_clickhouse_variables___database_to_runtime(SQLite3DB *db, bool replace) {
+    // ... existing body ...
+    if (flush_GENERIC_variables__retrieve__database_to_runtime("clickhouse", error, cols, affected_rows, resultset) == true) {
+        GloClickHouseServer->wrlock();
+        FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("clickhouse", db, resultset, false, replace, {}, {"session_debug"}, {}, {});
+        //GloClickHouse->commit();
+        GloClickHouseServer->wrunlock();
+        if (resultset) delete resultset;
+        return stats;
+    }
+    if (resultset) delete resultset;
+    return FlushVariableStats{};
+}
+```
+
+For `flush_ldap_variables___database_to_runtime` (line 1111, called from `init_ldap_variables` and the `load_ldap_variables_to_runtime` inline helper):
+
+```cpp
+FlushVariableStats ProxySQL_Admin::flush_ldap_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum, const time_t epoch) {
+    // ... existing body, including early return for GloMyLdapAuth == NULL ...
+    if (flush_GENERIC_variables__retrieve__database_to_runtime("ldap", error, cols, affected_rows, resultset) == true) {
+        GloMyLdapAuth->wrlock();
+        FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime(/* NOTE: existing call passes "admin" hardcoded — keeping that pre-existing typo, see issue spec §"Out of scope" */ "admin", db, resultset, false, replace, {}, {}, {}, {});
+        GloMyLdapAuth->wrunlock();
+
+        // ... existing checksum block ...
+    }
+    if (resultset) delete resultset;
+    return FlushVariableStats{};
+}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/Admin_FlushVariables.cpp
+git commit -m "feat(admin): track Records/Updated/Rejected/Unknown in generic flush path"
+```
+
+---
+
+## Task 3: Update `flush_pgsql_variables___database_to_runtime` to track and return stats
+
+**Files:**
+- Modify: `lib/Admin_FlushVariables.cpp:870-911` (the duplicated pgsql loop)
+
+- [ ] **Step 1: Change the function signature**
+
+In `lib/Admin_FlushVariables.cpp:870`, change:
+
+```cpp
+FlushVariableStats ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, bool replace, const std::string& checksum, const time_t epoch) {
+```
+
+(keep all parameters unchanged)
+
+- [ ] **Step 2: Add a local stats struct at the top of the function**
+
+Immediately after `proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing PgSQL variables. Replace:%d\n", replace);`, add:
+
+```cpp
+    FlushVariableStats stats;
+```
+
+- [ ] **Step 3: Increment `stats.records++` and `stats.updated++` / `stats.rejected++` / `stats.unknown++` in the loop**
+
+In the loop at line 884-951, add the counters. The structure mirrors the generic helper but has its own special cases (session_debug, forward_autocommit, default_charset/collation, show_processlist_extended). Edit the loop body:
+
+```cpp
+    GloPTH->wrlock();
+    for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
+        SQLite3_row* r = *it;
+        const char* value = r->fields[1];
+        stats.records++;
+        bool rc = GloPTH->set_variable(r->fields[0], value);
+        if (rc == false) {
+            proxy_debug(PROXY_DEBUG_ADMIN, 4, "Impossible to set variable %s with value \"%s\"\n", r->fields[0], value);
+            if (replace) {
+                char* val = GloPTH->get_variable(r->fields[0]);
+                char q[1000];
+                if (val) {
+                    if (strcmp(val, value)) {
+                        proxy_warning("Impossible to set variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0], value, val);
+                        snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"pgsql-%s\",\"%s\")", r->fields[0], val);
+                        db->execute(q);
+                    }
+                    free(val);
+                    stats.rejected++;
+                }
+                else {
+                    if (strcmp(r->fields[0], (char*)"session_debug") == 0) {
+                        snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
+                        db->execute(q);
+                        stats.rejected++;
+                    }
+                    else {
+                        if (strcmp(r->fields[0], (char*)"forward_autocommit") == 0) {
+                            if (strcasecmp(value, "true") == 0 || strcasecmp(value, "1") == 0) {
+                                proxy_error("Global variable pgsql-forward_autocommit is deprecated. See issue #3253\n");
+                            }
+                            snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
+                            db->execute(q);
+                            stats.rejected++;
+                        }
+                        else {
+                            proxy_warning("Impossible to set not existing variable %s with value \"%s\". Deleting. If the variable name is correct, this version doesn't support it\n", r->fields[0],r->fields[1]);
+                            stats.unknown++;
+                        }
+                    }
+                    snprintf(q, sizeof(q), "DELETE FROM global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
+                    db->execute(q);
+                }
+            }
+        }
+        else {
+            stats.updated++;
+            // ... rest of the existing success block unchanged ...
+        }
+    }
+```
+
+The success block (rc==true) handles default_charset/collation warnings, show_processlist_extended, etc. — those stay exactly as they are, just with `stats.updated++;` added at the top of the `else` branch.
+
+- [ ] **Step 4: Add `return stats;` at the end of the function**
+
+Find the end of `flush_pgsql_variables___database_to_runtime` (around line 1010-1100, just before the `if (resultset) delete resultset;` and the closing `}`). Just before the final `if (resultset) delete resultset;` and the function's closing `}`, add:
+
+```cpp
+    if (resultset) delete resultset;
+    return stats;
+}
+```
+
+The error path (the `if (error) { proxy_error(...); free(error); return; }` at line 878-881) becomes:
+
+```cpp
+    if (error) {
+        proxy_error("Error on %s : %s\n", q, error);
+        free(error);
+        if (resultset) delete resultset;
+        return FlushVariableStats{};
+    }
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Admin_FlushVariables.cpp
+git commit -m "feat(admin): track Records/Updated/Rejected/Unknown in pgsql flush path"
+```
+
+---
+
+## Task 4: Update `Admin_Handler.cpp` to format and send the info string
+
+**Files:**
+- Modify: `lib/Admin_Handler.cpp:1925-1935` (ldap), `:2028-2035` (pgsql), `:2038-2044` (mysql)
+
+- [ ] **Step 1: Update the mysql call site**
+
+In `lib/Admin_Handler.cpp:2038-2044`, replace:
+
+```cpp
+                if (is_admin_command_or_alias(LOAD_MYSQL_VARIABLES_FROM_MEMORY, query_no_space, query_no_space_length)) {
+                    ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
+                    SPA->load_mysql_variables_to_runtime();
+                    proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded mysql variables to RUNTIME\n");
+                    SPA->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+                    return false;
+            }
+```
+
+with:
+
+```cpp
+                if (is_admin_command_or_alias(LOAD_MYSQL_VARIABLES_FROM_MEMORY, query_no_space, query_no_space_length)) {
+                    ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
+                    FlushVariableStats stats = SPA->load_mysql_variables_to_runtime();
+                    proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded mysql variables to RUNTIME\n");
+                    char info[160];
+                    snprintf(info, sizeof(info),
+                        "Records: %d Updated: %d Rejected: %d Unknown: %d",
+                        stats.records, stats.updated, stats.rejected, stats.unknown);
+                    SPA->send_ok_msg_to_client(sess, info, 0, query_no_space);
+                    return false;
+            }
+```
+
+- [ ] **Step 2: Update the pgsql call site**
+
+In `lib/Admin_Handler.cpp:2028-2036`, apply the same change to the pgsql branch:
+
+```cpp
+            if (is_pgsql) {
+                if (is_admin_command_or_alias(LOAD_PGSQL_VARIABLES_FROM_MEMORY, query_no_space, query_no_space_length)) {
+                    ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
+                    FlushVariableStats stats = SPA->load_pgsql_variables_to_runtime();
+                    proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded pgsql variables to RUNTIME\n");
+                    proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded mysql variables to RUNTIME\n");
+                    char info[160];
+                    snprintf(info, sizeof(info),
+                        "Records: %d Updated: %d Rejected: %d Unknown: %d",
+                        stats.records, stats.updated, stats.rejected, stats.unknown);
+                    SPA->send_ok_msg_to_client(sess, info, 0, query_no_space);
+                    return false;
+                }
+            }
+```
+
+- [ ] **Step 3: Update the ldap call site**
+
+In `lib/Admin_Handler.cpp:1925-1935`, apply the same change to the ldap branch:
+
+```cpp
+                proxy_info("Received %s command\n", query_no_space);
+                ProxySQL_Admin *SPA=(ProxySQL_Admin *)pa;
+                FlushVariableStats stats = SPA->load_ldap_variables_to_runtime();
+                proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded ldap variables to RUNTIME\n");
+                char info[160];
+                snprintf(info, sizeof(info),
+                    "Records: %d Updated: %d Rejected: %d Unknown: %d",
+                    stats.records, stats.updated, stats.rejected, stats.unknown);
+                SPA->send_ok_msg_to_client(sess, info, 0, query_no_space);
+                return false;
+            }
+```
+
+- [ ] **Step 4: Add a shared helper to keep the formatting DRY**
+
+To avoid the same `snprintf` 3 times, add a small private static helper to `Admin_Handler.cpp` near the top of the file (after the existing helper templates, around line 460):
+
+```cpp
+template <typename S>
+static void send_flush_stats_ok(S* sess, const FlushVariableStats& stats, const char* query) {
+    char info[160];
+    snprintf(info, sizeof(info),
+        "Records: %d Updated: %d Rejected: %d Unknown: %d",
+        stats.records, stats.updated, stats.rejected, stats.unknown);
+    ProxySQL_Admin* SPA = GloAdmin;
+    SPA->send_ok_msg_to_client(sess, info, 0, query);
+}
+```
+
+Then the 3 call sites become:
+
+```cpp
+                ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
+                FlushVariableStats stats = SPA->load_mysql_variables_to_runtime();
+                proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded mysql variables to RUNTIME\n");
+                send_flush_stats_ok(sess, stats, query_no_space);
+                return false;
+```
+
+(do the same in pgsql and ldap branches)
+
+If the helper feels like over-abstraction for a 6-line block, leave the 3 call sites with the inline `snprintf` and skip this step. The PR reviewer's preference wins.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/Admin_Handler.cpp
+git commit -m "feat(admin): surface flush stats in OK packet info field"
+```
+
+---
+
+## Task 5: Build and verify compilation
+
+**Files:** none
+
+- [ ] **Step 1: Build the release binary**
+
+Run: `make -j$(nproc) proxysql 2>&1 | tail -40`
+Expected: build succeeds with no errors. There may be warnings about unused variable `stats` if the helper approach wasn't taken; those are fine, ignore them.
+
+- [ ] **Step 2: If the build failed**
+
+If the build failed with a signature mismatch, the error message will name the file and line. Fix the call site, rebuild. Repeat until clean.
+
+Common things to double-check:
+- The 6 generic wrappers' return statements match the new `FlushVariableStats` signature.
+- The 3 inline `load_*_variables_to_runtime` helpers' bodies use `return` instead of bare invocation.
+- The 3 Admin_Handler.cpp call sites use `auto stats = ...` (or `FlushVariableStats stats = ...`) and pass the stats through.
+
+- [ ] **Step 3: Smoke-test the binary starts and the admin port responds**
+
+Run: `./src/proxysql --version`
+Expected: prints the version string.
+
+Run: `timeout 5 ./src/proxysql -f -c /tmp/empty.cnf 2>&1 | head -20` (with an empty config file at `/tmp/empty.cnf`)
+
+If this is too disruptive in the current environment, skip and trust the build. The TAP test in Task 6 exercises a live binary.
+
+---
+
+## Task 6: Write the TAP test for the mysql module
+
+**Files:**
+- Create: `test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp`
+- Modify: `test/tap/groups/groups.json` (add a new entry near the existing `reg_test_*` entries)
+
+- [ ] **Step 1: Create the test file**
+
+Write `test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp` with this content:
+
+```cpp
+/**
+ * @file reg_test_1288-load-mysql-variables-feedback-t.cpp
+ * @brief Verify that LOAD MYSQL VARIABLES TO RUNTIME surfaces a Records/Updated/Rejected/Unknown
+ *        summary in the OK packet's info field. See issue #1288.
+ */
+
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include "mysql.h"
+#include "mysqld_error.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+static int restore_var(MYSQL* admin, const char* name, const char* default_sql_value) {
+	std::string q = std::string("UPDATE global_variables SET variable_value='") +
+		default_sql_value + "' WHERE variable_name='" + name + "'";
+	return mysql_query(admin, q.c_str());
+}
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	plan(4);
+
+	MYSQL* admin = mysql_init(NULL);
+	if (!admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+
+	// Capture the original values so we can restore at the end.
+	// Use a value that is known to be valid for each variable to ensure cleanup works.
+	const char* kMaxConnOriginal  = "10000";
+	const char* kPingIntOriginal  = "2000";
+	const char* kStmtsCacheOrig   = "1000";
+
+	// Save originals (best-effort: in case the row doesn't exist, INSERT it).
+	{
+		MYSQL_QUERY(admin,
+			"INSERT OR REPLACE INTO global_variables(variable_name, variable_value) "
+			"VALUES "
+			"('mysql-max_connections', '10000'), "
+			"('mysql-monitor_ping_interval', '2000'), "
+			"('mysql-max_stmts_cache', '1000')");
+	}
+
+	// Scenario 1: all-invalid (1 rejected value, 1 unknown variable, 1 valid)
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='0' WHERE variable_name='mysql-max_connections'");
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='foo' WHERE variable_name='mysql-monitor_ping_interval'");
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='1' WHERE variable_name='mysql-bogus_var_xyz'");
+
+	// mysql_query returns 0 on success and the info field is populated on the OK packet.
+	if (mysql_query(admin, "LOAD MYSQL VARIABLES TO RUNTIME")) {
+		diag("LOAD MYSQL VARIABLES TO RUNTIME failed: %s", mysql_error(admin));
+		return exit_status();
+	}
+	const char* info = mysql_info(admin);
+	diag("LOAD (mixed) info: %s", info ? info : "(null)");
+
+	bool has_records_3    = info && strstr(info, "Records: 3")    != NULL;
+	bool has_updated_1    = info && strstr(info, "Updated: 1")    != NULL;
+	bool has_rejected_1   = info && strstr(info, "Rejected: 1")   != NULL;
+	bool has_unknown_1    = info && strstr(info, "Unknown: 1")    != NULL;
+	ok(has_records_3 && has_updated_1 && has_rejected_1 && has_unknown_1,
+	   "LOAD MYSQL VARIABLES TO RUNTIME info='%s' reports Records: 3 Updated: 1 Rejected: 1 Unknown: 1",
+	   info ? info : "(null)");
+
+	// Verify the rejected value was reset to the runtime default.
+	MYSQL_QUERY(admin, "SELECT variable_value FROM runtime_global_variables WHERE variable_name='mysql-max_connections'");
+	MYSQL_RES* res = mysql_store_result(admin);
+	ok(res != NULL, "runtime_global_variables query returned a result set");
+	if (res) {
+		MYSQL_ROW row = mysql_fetch_row(res);
+		ok(row && row[0] && strcmp(row[0], "0") != 0,
+		   "runtime mysql-max_connections was reset to a non-zero value (got '%s')",
+		   row && row[0] ? row[0] : "(null)");
+		mysql_free_result(res);
+	}
+
+	// Restore.
+	restore_var(admin, "mysql-max_connections",        kMaxConnOriginal);
+	restore_var(admin, "mysql-monitor_ping_interval",  kPingIntOriginal);
+	restore_var(admin, "mysql-max_stmts_cache",        kStmtsCacheOrig);
+	MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='mysql-bogus_var_xyz'");
+	MYSQL_QUERY(admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+	mysql_close(admin);
+	return exit_status();
+}
+```
+
+- [ ] **Step 2: Register the test in `groups.json`**
+
+In `test/tap/groups/groups.json`, add a new line alphabetically near the other `reg_test_*` entries (e.g. after `reg_test_1133_*` if present, otherwise at the right alphabetical position). Use the same group list as `reg_test_4072-show-warnings-t`:
+
+```json
+  "reg_test_1288-load-mysql-variables-feedback-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+```
+
+- [ ] **Step 3: Build the test**
+
+Run: `make -j$(nproc) reg_test_1288-load-mysql-variables-feedback-t 2>&1 | tail -20`
+Expected: build succeeds, produces `reg_test_1288-load-mysql-variables-feedback-t` binary in `test/tap/tests/`.
+
+If the build fails with `command_line.h not found`, the test framework was not set up; rerun `make build_tap_tests` first.
+
+- [ ] **Step 4: Run the test against a live ProxySQL**
+
+Per `CLAUDE.md`, do NOT manually start containers. Use the isolated runner:
+
+```bash
+WORKSPACE=$(pwd) INFRA_ID=dev-$USER TAP_GROUP=mysql84-g2 test/infra/control/run-tests-isolated.bash
+```
+
+The runner sets up the infra, starts ProxySQL, runs the test, and tears down. Expected: the test prints TAP output ending with `1..4` and `ok` for all 4 assertions. If only some pass, the failed assertion shows which format string the implementation got wrong.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp test/tap/groups/groups.json
+git commit -m "test(tap): verify LOAD MYSQL VARIABLES TO RUNTIME reports flush stats (issue #1288)"
+```
+
+---
+
+## Task 7: Write the TAP test for the pgsql module
+
+**Files:**
+- Create: `test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp`
+- Modify: `test/tap/groups/groups.json`
+
+- [ ] **Step 1: Create the test file**
+
+Write `test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp`:
+
+```cpp
+/**
+ * @file reg_test_1288-load-pgsql-variables-feedback-t.cpp
+ * @brief Verify that LOAD PGSQL VARIABLES TO RUNTIME surfaces a Records/Updated/Rejected/Unknown
+ *        summary in the OK packet's info field. The pgsql path uses a separate flush helper with
+ *        its own duplicated loop. See issue #1288.
+ */
+
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include "mysql.h"
+#include "mysqld_error.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	plan(2);
+
+	MYSQL* admin = mysql_init(NULL);
+	if (!admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+
+	// Set up: a known-good pgsql variable, an out-of-range one, and an unknown one.
+	MYSQL_QUERY(admin,
+		"INSERT OR REPLACE INTO global_variables(variable_name, variable_value) "
+		"VALUES "
+		"('pgsql-max_connections', '1000'), "
+		"('pgsql-bogus_var_xyz', 'something')");
+
+	// Scenario: 1 valid + 1 unknown. (pgsql-max_connections has a range that we don't probe here
+	// to keep the test resilient across versions; pgsql-bogus_var_xyz is reliably unknown.)
+	if (mysql_query(admin, "LOAD PGSQL VARIABLES TO RUNTIME")) {
+		diag("LOAD PGSQL VARIABLES TO RUNTIME failed: %s", mysql_error(admin));
+		return exit_status();
+	}
+	const char* info = mysql_info(admin);
+	diag("LOAD PGSQL info: %s", info ? info : "(null)");
+
+	bool has_records_2  = info && strstr(info, "Records: 2")  != NULL;
+	bool has_updated_1  = info && strstr(info, "Updated: 1")  != NULL;
+	bool has_unknown_1  = info && strstr(info, "Unknown: 1")  != NULL;
+	ok(has_records_2 && has_updated_1 && has_unknown_1,
+	   "LOAD PGSQL VARIABLES TO RUNTIME info='%s' reports Records: 2 Updated: 1 Unknown: 1",
+	   info ? info : "(null)");
+
+	// Clean up.
+	MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='pgsql-bogus_var_xyz'");
+	MYSQL_QUERY(admin, "LOAD PGSQL VARIABLES TO RUNTIME");
+
+	mysql_close(admin);
+	return exit_status();
+}
+```
+
+- [ ] **Step 2: Register the test in `groups.json`**
+
+Add a new line near the existing pgsql tests (search for `pgsql16-g` to find the right neighbourhood):
+
+```json
+  "reg_test_1288-load-pgsql-variables-feedback-t" : [ "pgsql16-g1" ],
+```
+
+(If the project has more pgsql infra groups like `pgsql15-g1` or `pgsql17-g1`, add them too — check `groups.json` for the pgsql section.)
+
+- [ ] **Step 3: Build and run the test**
+
+```bash
+make -j$(nproc) reg_test_1288-load-pgsql-variables-feedback-t
+```
+
+Then run via the isolated runner against a pgsql group:
+
+```bash
+WORKSPACE=$(pwd) INFRA_ID=dev-$USER TAP_GROUP=pgsql16-g1 test/infra/control/run-tests-isolated.bash
+```
+
+Expected: `1..2` with both assertions passing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp test/tap/groups/groups.json
+git commit -m "test(tap): verify LOAD PGSQL VARIABLES TO RUNTIME reports flush stats (issue #1288)"
+```
+
+---
+
+## Task 8: Final full build and lint
+
+**Files:** none
+
+- [ ] **Step 1: Full build**
+
+Run: `make -j$(nproc) 2>&1 | tail -20`
+Expected: clean build, no errors.
+
+- [ ] **Step 2: Build TAP test binaries**
+
+Run: `make -j$(nproc) build_tap_tests 2>&1 | tail -20`
+Expected: clean build, all TAP test binaries compile.
+
+- [ ] **Step 3: Verify no untracked files or stray edits**
+
+Run: `git status`
+Expected: working tree is clean apart from the commits made in Tasks 1-7.
+
+- [ ] **Step 4: Re-read the spec and self-review**
+
+Open `docs/superpowers/specs/2026-06-14-mysql-variables-validation-feedback-design.md` and check each requirement against the implementation:
+
+| Spec requirement | Where it lives in the code |
+|------------------|----------------------------|
+| Generic path counters track 4 cases (records, updated, rejected, unknown) | `flush_GENERIC_variables__process__database_to_runtime` in `lib/Admin_FlushVariables.cpp` |
+| 6 generic wrappers return `FlushVariableStats` | mysql, admin, sqliteserver, tsdb, clickhouse, ldap wrappers in same file |
+| pgsql wrapper returns `FlushVariableStats` | `flush_pgsql_variables___database_to_runtime` |
+| 3 inline `load_*_variables_to_runtime` return the struct | header inlines for mysql, pgsql, ldap |
+| 3 admin handler call sites format and send info string | `lib/Admin_Handler.cpp` mysql, pgsql, ldap |
+| TAP test for mysql: 4 assertions, includes the issue reproduction | `reg_test_1288-load-mysql-variables-feedback-t.cpp` |
+| TAP test for pgsql: 2 assertions | `reg_test_1288-load-pgsql-variables-feedback-t.cpp` |
+| Existing log lines and reset/delete semantics unchanged | verify by `git diff` of `lib/Admin_FlushVariables.cpp` |
+
+If any row above is empty or wrong, fix it before declaring done.
+
+---
+
+## Self-Review
+
+**Spec coverage:** All 8 spec requirements are mapped to tasks above. The "Out of Scope" items (disk path, `SET` shortcut, `SHOW WARNINGS`, log duplication) are deliberately not tasks.
+
+**Placeholder scan:** No "TBD" / "TODO" / "fill in later" in the code. The only flexibility is Task 4 Step 4 (DRY helper) which the implementer can take or leave.
+
+**Type consistency:** `FlushVariableStats` is defined once in `include/proxysql_admin.h` and used by name in every file. The four fields (`records`, `updated`, `rejected`, `unknown`) are spelled consistently. The `info` buffer is `char[160]` in every call site, sized to fit "Records: 99999 Updated: 99999 Rejected: 99999 Unknown: 99999" (52 chars + NUL) with headroom.
+
+**Risk:** The pgsql flush helper's loop has its own control flow (special cases for `session_debug`, `forward_autocommit`, `default_charset`, `default_collation_connection`, `show_processlist_extended`, `session_idle_show_processlist`, `processlist_max_query_length`). Task 3 places `stats.updated++` and `stats.rejected++` / `stats.unknown++` at the right points but preserves the rest of the logic. Reviewer should pay extra attention to the pgsql commit's diff against the original loop.

--- a/docs/superpowers/specs/2026-06-14-mysql-variables-validation-feedback-design.md
+++ b/docs/superpowers/specs/2026-06-14-mysql-variables-validation-feedback-design.md
@@ -1,0 +1,274 @@
+# Visible Feedback for Rejected mysql-* Variables
+
+**Date:** 2026-06-14
+**Issue:** [#1288](https://github.com/sysown/proxysql/issues/1288)
+**Branch:** issue-1288-load-mysql-variables-feedback
+
+## Problem
+
+`LOAD MYSQL VARIABLES TO RUNTIME` silently rejects rows in `global_variables`
+whose value fails module-side validation. The user sees `Query OK, 0 rows
+affected` while the rejected value is quietly reset (or the row deleted) in
+`global_variables`. There is no signal to the client that anything was wrong.
+The same silent-rejection behavior exists for `mysql-max_stmts_cache` (issue
+[#853](https://github.com/sysown/proxysql/issues/853)) and for the pgSQL,
+admin, sqlite3-server, ClickHouse, LDAP, and TSDB modules — six of them
+share the generic flush path, and pgSQL has a near-identical duplicated
+copy of the same loop.
+
+Example reproduction (mysql client) from issue #1288:
+
+```
+mysql> UPDATE global_variables SET variable_value='0'
+       WHERE variable_name='mysql-max_connections';
+Query OK, 1 row affected (0.00 sec)
+
+mysql> LOAD MYSQL VARIABLES TO RUNTIME;
+Query OK, 0 rows affected (0.00 sec)        <-- no signal that '0' was rejected
+```
+
+The error is only visible in `ProxySQL_Admin`'s error log:
+
+```
+[WARNING] Impossible to set variable max_connections with value "0".
+          Resetting to current "102400".
+```
+
+## Goal
+
+After a `LOAD <module> VARIABLES TO RUNTIME` command, the response visible to
+the admin client reports how many variables were accepted and how many were
+rejected, in the MySQL OK packet's `info` field. Existing log output and the
+reset/delete semantics in `global_variables` are unchanged.
+
+## Design Decision: Option 1 — return-value plumbing
+
+Add a small `FlushVariableStats` struct to the generic flush helper, return it
+from the module-specific flush wrappers and the `load_*_variables_to_runtime`
+inline helpers, and have `admin_handler_command_load_or_save` format an
+`info` string and pass it to the existing `send_ok_msg_to_client`. Both
+`MySQL_Protocol::generate_pkt_OK` and `PgSQL_Protocol::generate_ok_packet`
+already accept a `msg` argument and write it to the OK packet's `info` field,
+so the client-side rendering is free.
+
+Alternatives considered and rejected:
+
+- **Option 2 — out parameter.** Less idiomatic C++17; the inline
+  `load_*_variables_to_runtime` helpers in `proxysql_admin.h` would need a
+  trailing reference arg, which is awkward in a header.
+- **Option 3 — stash stats on `GloAdmin`.** Smallest patch, but introduces
+  shared mutable state that has to be mutex-guarded for the (future) case of
+  concurrent admin sessions. The data flow is implicit.
+
+## Data Structure
+
+```cpp
+// include/proxysql_admin.h
+struct FlushVariableStats {
+    int records  = 0;  // rows read from global_variables for this module
+    int updated  = 0;  // rows where set_variable() returned true
+    int rejected = 0;  // rows where the value was out of range / malformed
+    int unknown  = 0;  // rows for a variable name the module does not know
+};
+```
+
+`rejected` and `unknown` are split so the user can tell at a glance whether
+the bad row was a typo'd variable name (likely a stale disk file) or a value
+that the existing module would have rejected. Read-only rejections (admin
+module only) are bucketed into `rejected` for the same reason — the user
+typed a valid value, the module just won't accept it.
+
+## Plumbing
+
+### Generic path (mysql, admin, sqliteserver, tsdb, clickhouse, ldap)
+
+```cpp
+// lib/Admin_FlushVariables.cpp
+FlushVariableStats ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
+    const string& modname, SQLite3DB *db, SQLite3_result* resultset,
+    const bool& lock, const bool& replace,
+    const unordered_set<string>& variables_read_only,
+    const unordered_set<string>& variables_to_delete_silently,
+    const unordered_set<string>& variables_deprecated,
+    const unordered_set<string>& variables_special_values,
+    function<void(const string&, const char *, SQLite3DB *)> special_variable_action
+) {
+    FlushVariableStats stats;
+    for (auto it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
+        stats.records++;
+        SQLite3_row *r = *it;
+        bool rc = /* existing set_variable() dispatch, unchanged */;
+        if (rc) {
+            stats.updated++;
+            /* existing variables_special_values branch, unchanged */
+        } else {
+            const string v = string(r->fields[0]);
+            if (replace) {
+                char *val = /* existing get_variable() dispatch, unchanged */;
+                if (val) {
+                    if (variables_read_only.count(v) > 0) {
+                        proxy_warning(/* existing message, unchanged */);
+                    } else {
+                        proxy_warning(/* existing message, unchanged */);
+                    }
+                    stats.rejected++;          // NEW
+                    /* existing INSERT OR REPLACE, unchanged */
+                } else {
+                    if (variables_to_delete_silently.count(v) > 0) {
+                        stats.rejected++;      // NEW
+                    } else if (variables_deprecated.count(v) > 0) {
+                        proxy_error(/* existing message, unchanged */);
+                        stats.rejected++;      // NEW
+                    } else {
+                        proxy_warning(/* existing message, unchanged */);
+                        stats.unknown++;       // NEW
+                    }
+                    /* existing DELETE, unchanged */
+                }
+            }
+        }
+    }
+    return stats;
+}
+```
+
+The six module-specific wrappers (`flush_mysql_variables___database_to_runtime`,
+`flush_admin_variables___database_to_runtime`, `flush_sqliteserver_variables___database_to_runtime`,
+`flush_tsdb_variables___database_to_runtime`, `flush_clickhouse_variables___database_to_runtime`,
+`flush_ldap_variables___database_to_runtime`) each change from `void` to
+`FlushVariableStats` and return what
+`flush_GENERIC_variables__process__database_to_runtime` returns. The
+`flush_mysql_variables___database_to_runtime` post-processing (the
+default-charset / default-collation-connection block) is unchanged; the
+generic call's return value is what bubbles up.
+
+```cpp
+// include/proxysql_admin.h
+FlushVariableStats load_mysql_variables_to_runtime(
+    const std::string& checksum = "", const time_t epoch = 0) {
+    return flush_mysql_variables___database_to_runtime(admindb, true, checksum, epoch);
+}
+
+// and analogously for load_pgsql_variables_to_runtime (in the pgsql-only path below)
+```
+
+### PgSQL path (separate, duplicated code)
+
+`flush_pgsql_variables___database_to_runtime` (`lib/Admin_FlushVariables.cpp:870`)
+does **not** use the generic helper — it has its own per-row loop. The same
+change is applied there: wrap the loop, return `FlushVariableStats`, plumb
+through `load_pgsql_variables_to_runtime` in `proxysql_admin.h:870`.
+
+### Admin handler formatting
+
+```cpp
+// lib/Admin_Handler.cpp
+if (is_admin_command_or_alias(LOAD_MYSQL_VARIABLES_FROM_MEMORY, ...)) {
+    ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
+    auto stats = SPA->load_mysql_variables_to_runtime();
+    proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded mysql variables to RUNTIME\n");
+    char info[160];
+    snprintf(info, sizeof(info),
+        "Records: %d Updated: %d Rejected: %d Unknown: %d",
+        stats.records, stats.updated, stats.rejected, stats.unknown);
+    SPA->send_ok_msg_to_client(sess, info, 0, query_no_space);
+    return false;
+}
+```
+
+Same edit for `LOAD_PGSQL_VARIABLES_FROM_MEMORY` (line 2029) and for
+`LOAD LDAP VARIABLES TO RUNTIME` (`Admin_Handler.cpp:1925`).
+
+`send_ok_msg_to_client` is unchanged; its third arg is the `msg` string that
+flows into `MySQL_Protocol::generate_pkt_OK(..., msg, ...)` at
+`lib/ProxySQL_Admin.cpp:6232` and `PgSQL_Protocol::generate_ok_packet(..., msg, ...)`
+at `lib/ProxySQL_Admin.cpp:6238`. Both end up in the protocol's OK packet
+`info` field, which the `mysql` and `psql` CLIs print on the line after
+`Query OK, X rows affected`. No protocol change.
+
+### What stays unchanged
+
+- The per-row `proxy_warning` / `proxy_error` log lines. Operators and
+  existing log scrapers keep working unchanged.
+- The `replace` semantics in `global_variables`: rejected rows are still
+  reset to the current runtime value; unknown rows are still deleted.
+- The 3 non-admin call sites of `load_mysql_variables_to_runtime`
+  (`ProxySQL_Admin.cpp:9036/9105/9136` bootstrap paths, `ProxySQL_Cluster.cpp:2681`
+  checksum sync) ignore the return value.
+- The `affected_rows` field of the OK packet (stays at 0; it counts SQL
+  `INSERT`/`UPDATE` rows, not the number of variables set).
+- `LOAD ... VARIABLES FROM MEMORY` / `LOAD ... VARIABLES TO MEMORY` aliases —
+  the same `is_admin_command_or_alias` branch handles them and the user
+  sees the same response.
+
+## Out of Scope
+
+- `LOAD MYSQL VARIABLES TO MEMORY` (disk path) — doesn't call `set_variable`.
+- `SET mysql-...` shortcut command — different path (`admin_handler_command_set`),
+  already logs its own warnings, and the maintainer explicitly rejected
+  per-DML validation as too complex.
+- `SHOW WARNINGS` integration — the user opted for info-only.
+- The full information in the log (variable name, value, current value) is
+  not duplicated into the OK packet; that would push the line past the
+  1 KiB mark and is not what the mysql client is shaped to display.
+
+## Testing
+
+A new TAP test in `test/tap/tests/`. The file follows the
+`reg_test_NNNN-...-t.cpp` convention used by existing issue/regression tests
+in the directory. Three scenarios:
+
+1. **All-invalid.** `UPDATE` `mysql-max_connections` to `'0'`,
+   `mysql-monitor_ping_interval` to `'foo'`, `mysql-max_stmts_cache` to
+   `'1000'`. `LOAD MYSQL VARIABLES TO RUNTIME`. Parse the response's info
+   field with `mysql_info()`. Assert it contains
+   `Records: 3 Updated: 0 Rejected: 2 Unknown: 1`. Assert
+   `runtime_global_variables` shows the values were reset to the runtime
+   defaults.
+
+2. **All-valid.** `UPDATE` a known-good value (e.g. `mysql-monitor_ping_interval`
+   to `2000`). `LOAD MYSQL VARIABLES TO RUNTIME`. Assert info contains
+   `Records: 1 Updated: 1 Rejected: 0 Unknown: 0`.
+
+3. **Mixed.** `UPDATE` one valid and one invalid value. Assert
+   `Records: 2 Updated: 1 Rejected: 1 Unknown: 0`.
+
+A second TAP test, `reg_test_1288-load-pgsql-variables-feedback-t.cpp`,
+covers the pgsql path the same way (e.g. with `pgsql-max_connections` set
+to `'0'` for invalid, `'100'` for valid). The pgsql path is tested
+separately because the pgsql flush helper has its own duplicated loop
+(see "PgSQL path" above) and exercising it independently guards against
+regressions in that copy.
+
+Both tests register in `test/tap/groups/groups.json` and follow the
+existing TAP test infrastructure (`make build_tap_tests`,
+`run-tests-isolated.bash`).
+
+The test cleans up after itself: restores original `global_variables` rows
+and re-runs `LOAD MYSQL VARIABLES TO RUNTIME` so the cluster is in a known
+state at exit.
+
+## Compatibility
+
+- No wire protocol change. The OK packet's `info` field is part of the
+  standard MySQL/PostgreSQL protocol. Clients that ignore it (e.g.
+  `mysql --batch`, libmariadb consumers) keep working.
+- No SQL DDL change.
+- No SQLite schema change.
+- No new admin variable.
+- No new mutex.
+- No new thread.
+
+## Risk Assessment
+
+- **Low.** The change is additive: a return value and one `snprintf`. The
+  existing per-row reset/delete behavior is preserved, so an admin script
+  that depended on silent rejection still sees the same end state in
+  `global_variables` and `runtime_global_variables`.
+- The only behavioral change visible to clients is the extra `Records: N
+  Updated: X ...` line after `Query OK`. Any monitoring script that grep'd
+  for the exact text `Query OK` on a line by itself will need a small tweak
+  to also match the next line — the `mysql` and `psql` clients already do
+  this.
+- The format string is fixed and human-readable; we do not introduce a new
+  machine-readable counter that would have to be documented and parsed.

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -312,6 +312,13 @@ struct processlist_config_t {
  */
 void update_modules_metrics();
 
+struct FlushVariableStats {
+	int records  = 0;
+	int updated  = 0;
+	int rejected = 0;
+	int unknown  = 0;
+};
+
 class ProxySQL_Admin {
 	friend class TestDiskUpgrade;
 	private:
@@ -511,11 +518,11 @@ class ProxySQL_Admin {
 	void __add_active_users_ldap();
 
 	void flush_mysql_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime=false, bool use_lock=true);
-	void flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0);
+	FlushVariableStats flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0);
 
 	void flush_GENERIC_variables__checksum__database_to_runtime(const std::string& modname, const std::string& checksum, const time_t epoch);
 	bool flush_GENERIC_variables__retrieve__database_to_runtime(const std::string& modname, char* &error, int& cols, int& affected_rows, SQLite3_result* &resultset);
-	void flush_GENERIC_variables__process__database_to_runtime(
+	FlushVariableStats flush_GENERIC_variables__process__database_to_runtime(
 		const std::string& modname, SQLite3DB *db, SQLite3_result* resultset,
 		const bool& lock, const bool& replace,
 		const std::unordered_set<std::string>& variables_read_only,
@@ -527,7 +534,7 @@ class ProxySQL_Admin {
 
 	char **get_variables_list();
 	bool set_variable(char *name, char *value, bool lock = true);
-	void flush_admin_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0, bool lock = true);
+	FlushVariableStats flush_admin_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0, bool lock = true);
 	void flush_admin_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime=false);
 	void disk_upgrade_mysql_query_rules();
 	void disk_upgrade_mysql_servers();
@@ -554,7 +561,7 @@ class ProxySQL_Admin {
 	void __add_active_clickhouse_users(char *user=NULL);
 	void __delete_inactive_clickhouse_users();
 	void flush_clickhouse_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime=false);
-	void flush_clickhouse_variables___database_to_runtime(SQLite3DB *db, bool replace);
+	FlushVariableStats flush_clickhouse_variables___database_to_runtime(SQLite3DB *db, bool replace);
 #endif /* PROXYSQLCLICKHOUSE */
 
 	// PostgreSQL
@@ -562,15 +569,15 @@ class ProxySQL_Admin {
 	//void __add_active_pgsql_users(char* user = NULL);
 	//void __delete_inactive_pgsql_users();
 	void flush_pgsql_variables___runtime_to_database(SQLite3DB* db, bool replace, bool del, bool onlyifempty, bool runtime = false, bool use_lock = true);
-	void flush_pgsql_variables___database_to_runtime(SQLite3DB* db, bool replace, const std::string& checksum = "", const time_t epoch = 0);
+	FlushVariableStats flush_pgsql_variables___database_to_runtime(SQLite3DB* db, bool replace, const std::string& checksum = "", const time_t epoch = 0);
 	//
 
 	void flush_sqliteserver_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime=false);
-	void flush_sqliteserver_variables___database_to_runtime(SQLite3DB *db, bool replace);
+	FlushVariableStats flush_sqliteserver_variables___database_to_runtime(SQLite3DB *db, bool replace);
 
 	// LDAP
 	void flush_ldap_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime=false);
-	void flush_ldap_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0);
+	FlushVariableStats flush_ldap_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum = "", const time_t epoch = 0);
 
 	public:
 	/**
@@ -748,13 +755,13 @@ class ProxySQL_Admin {
 	// TSDB
 	void init_tsdb_variables();
 	void flush_tsdb_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime=false);
-	void flush_tsdb_variables___database_to_runtime(SQLite3DB *db, bool replace);
+	FlushVariableStats flush_tsdb_variables___database_to_runtime(SQLite3DB *db, bool replace);
 	void load_tsdb_variables_to_runtime() { flush_tsdb_variables___database_to_runtime(admindb, true); }
 	void save_tsdb_variables_from_runtime() { flush_tsdb_variables___runtime_to_database(admindb, true, true, false); }
 #endif
 	void load_or_update_global_settings(SQLite3DB *);
 
-	void load_mysql_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { flush_mysql_variables___database_to_runtime(admindb, true, checksum, epoch); }
+	FlushVariableStats load_mysql_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { return flush_mysql_variables___database_to_runtime(admindb, true, checksum, epoch); }
 	void save_mysql_variables_from_runtime() { flush_mysql_variables___runtime_to_database(admindb, true, true, false); }
 	
 	// Coredump filters
@@ -838,7 +845,7 @@ class ProxySQL_Admin {
 
 	// LDAP
 	void init_ldap_variables();
-	void load_ldap_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { flush_ldap_variables___database_to_runtime(admindb, true, checksum, epoch); }
+	FlushVariableStats load_ldap_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { return flush_ldap_variables___database_to_runtime(admindb, true, checksum, epoch); }
 	void save_ldap_variables_from_runtime() { flush_ldap_variables___runtime_to_database(admindb, true, true, false); }
 	void save_mysql_ldap_mapping_runtime_to_database(bool);
 
@@ -867,7 +874,7 @@ class ProxySQL_Admin {
 	void init_pgsql_firewall();
 
 	void init_pgsql_variables();
-	void load_pgsql_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { flush_pgsql_variables___database_to_runtime(admindb, true, checksum, epoch); }
+	FlushVariableStats load_pgsql_variables_to_runtime(const std::string& checksum = "", const time_t epoch = 0) { return flush_pgsql_variables___database_to_runtime(admindb, true, checksum, epoch); }
 	void save_pgsql_variables_from_runtime() { flush_pgsql_variables___runtime_to_database(admindb, true, true, false); }
 
 	void init_pgsql_users(std::unique_ptr<SQLite3_result>&& pgsql_users_resultset = nullptr, const std::string& checksum = "", const time_t epoch = 0);

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -890,8 +890,9 @@ void ProxySQL_Admin::flush_clickhouse_variables___runtime_to_database(SQLite3DB 
 }
 #endif /* PROXYSQLCLICKHOUSE */
 
-void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, bool replace, const std::string& checksum, const time_t epoch) {
+FlushVariableStats ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, bool replace, const std::string& checksum, const time_t epoch) {
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing PgSQL variables. Replace:%d\n", replace);
+	FlushVariableStats stats;
 	char* error = NULL;
 	int cols = 0;
 	int affected_rows = 0;
@@ -900,13 +901,16 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 	admindb->execute_statement(q, &error, &cols, &affected_rows, &resultset);
 	if (error) {
 		proxy_error("Error on %s : %s\n", q, error);
-		return;
+		free(error);
+		if (resultset) delete resultset;
+		return FlushVariableStats{};
 	}
 	else {
-		GloPTH->wrlock();	
+		GloPTH->wrlock();
 		for (std::vector<SQLite3_row*>::iterator it = resultset->rows.begin(); it != resultset->rows.end(); ++it) {
 			SQLite3_row* r = *it;
 			const char* value = r->fields[1];
+			stats.records++;
 			bool rc = GloPTH->set_variable(r->fields[0], value);
 			if (rc == false) {
 				proxy_debug(PROXY_DEBUG_ADMIN, 4, "Impossible to set variable %s with value \"%s\"\n", r->fields[0], value);
@@ -920,11 +924,13 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 								db->execute(q);
 							}
 							free(val);
+							stats.rejected++;
 					}
 						else {
 							if (strcmp(r->fields[0], (char*)"session_debug") == 0) {
 								snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
 								db->execute(q);
+								stats.rejected++;
 							}
 							else {
 								if (strcmp(r->fields[0], (char*)"forward_autocommit") == 0) {
@@ -933,9 +939,11 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 									}
 									snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
 									db->execute(q);
+									stats.rejected++;
 								}
 							else {
 								proxy_warning("Impossible to set not existing variable %s with value \"%s\". Deleting. If the variable name is correct, this version doesn't support it\n", r->fields[0], r->fields[1]);
+								stats.unknown++;
 								}
 							}
 							snprintf(q, sizeof(q), "DELETE FROM global_variables WHERE variable_name=\"pgsql-%s\"", r->fields[0]);
@@ -944,6 +952,7 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 					}
 			}
 			else {
+				stats.updated++;
 				if (
 					(strcmp(r->fields[0], "default_collation_connection") == 0)
 					|| (strcmp(r->fields[0], "default_charset") == 0)
@@ -1038,6 +1047,7 @@ void ProxySQL_Admin::flush_pgsql_variables___database_to_runtime(SQLite3DB* db, 
 		}
 	}
 	if (resultset) delete resultset;
+	return stats;
 }
 
 

--- a/lib/Admin_FlushVariables.cpp
+++ b/lib/Admin_FlushVariables.cpp
@@ -175,7 +175,7 @@ bool ProxySQL_Admin::flush_GENERIC_variables__retrieve__database_to_runtime(cons
 	}
 	return true;
 }
-void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
+FlushVariableStats ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 	const string& modname, SQLite3DB *db, SQLite3_result* resultset,
 	const bool& lock, const bool& replace,
 	const std::unordered_set<std::string>& variables_read_only,
@@ -184,8 +184,10 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 	const std::unordered_set<std::string>& variables_special_values,
 	std::function<void(const std::string&, const char *, SQLite3DB *)> special_variable_action
 ) {
+	FlushVariableStats stats;
 	for (std::vector<SQLite3_row *>::iterator it = resultset->rows.begin() ; it != resultset->rows.end(); ++it) {
 		SQLite3_row *r=*it;
+		stats.records++;
 		bool rc = false;
 		if (modname == "admin") {
 			rc = set_variable(r->fields[0],r->fields[1], lock);
@@ -233,25 +235,30 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 						} else {
 							proxy_warning("Impossible to set variable %s with value \"%s\". Resetting to current \"%s\".\n", r->fields[0],r->fields[1], val);
 						}
+						stats.rejected++;
 						snprintf(q, sizeof(q), "INSERT OR REPLACE INTO global_variables VALUES(\"%s-%s\",\"%s\")", modname.c_str(), r->fields[0], val);
 						db->execute(q);
 						free(val);
 					} else {
 						if (variables_to_delete_silently.count(v) > 0) {
+							stats.rejected++;
 							snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
 							db->execute(q);
 						} else if (variables_deprecated.count(v) > 0) {
 							proxy_error("Global variable %s-%s is deprecated.\n", modname.c_str(), r->fields[0]);
+							stats.rejected++;
 							snprintf(q, sizeof(q), "DELETE FROM disk.global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
 							db->execute(q);
 						} else {
 							proxy_warning("Impossible to set not existing variable %s with value \"%s\". Deleting. If the variable name is correct, this version doesn't support it\n", r->fields[0],r->fields[1]);
+							stats.unknown++;
 						}
 						snprintf(q, sizeof(q), "DELETE FROM global_variables WHERE variable_name=\"%s-%s\"", modname.c_str(), r->fields[0]);
 						db->execute(q);
 					}
 				}
 		} else {
+			stats.updated++;
 			proxy_debug(PROXY_DEBUG_ADMIN, 4, "Set variable %s with value \"%s\"\n", r->fields[0],r->fields[1]);
 			if (variables_special_values.count(v) > 0) {
 				if (special_variable_action != nullptr) {
@@ -260,9 +267,10 @@ void ProxySQL_Admin::flush_GENERIC_variables__process__database_to_runtime(
 			}
 		}
 	}
+	return stats;
 }
 
-void ProxySQL_Admin::flush_admin_variables___database_to_runtime(
+FlushVariableStats ProxySQL_Admin::flush_admin_variables___database_to_runtime(
 	SQLite3DB *db, bool replace, const string& checksum, const time_t epoch, bool lock
 ) {
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing ADMIN variables. Replace:%d\n", replace);
@@ -272,7 +280,7 @@ void ProxySQL_Admin::flush_admin_variables___database_to_runtime(
 	SQLite3_result *resultset=NULL;
 	if (flush_GENERIC_variables__retrieve__database_to_runtime("admin", error, cols, affected_rows, resultset) == true) {
 		wrlock();
-		flush_GENERIC_variables__process__database_to_runtime("admin", db, resultset, lock, replace, {"version"}, {"debug"}, {}, {});
+		FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("admin", db, resultset, lock, replace, {"version"}, {"debug"}, {}, {});
 		//commit(); NOT IMPLEMENTED
 
 		// Checksums are always generated - 'admin-checksum_*' deprecated
@@ -291,8 +299,11 @@ void ProxySQL_Admin::flush_admin_variables___database_to_runtime(
 			// Update the admin variable for 'web_verbosity'
 			admin___web_verbosity = variables.web_verbosity;
 		}
+		if (resultset) delete resultset;
+		return stats;
 	}
 	if (resultset) delete resultset;
+	return FlushVariableStats{};
 }
 
 void ProxySQL_Admin::flush_pgsql_variables___runtime_to_database(SQLite3DB* db, bool replace, bool del, bool onlyifempty, bool runtime, bool use_lock) {
@@ -450,7 +461,7 @@ void ProxySQL_Admin::flush_GENERIC_variables__checksum__database_to_runtime(cons
 	delete resultset;
 }
 
-void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum, const time_t epoch) {
+FlushVariableStats ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum, const time_t epoch) {
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing MySQL variables. Replace:%d\n", replace);
 	char *error=NULL;
 	int cols=0;
@@ -462,7 +473,7 @@ void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, 
 		char * previous_default_collation_connection = GloMTH->get_variable_string((char *)"default_collation_connection");
 		assert(previous_default_charset);
 		assert(previous_default_collation_connection);
-		flush_GENERIC_variables__process__database_to_runtime("mysql", db, resultset, false, replace, {}, {"session_debug"}, {"forward_autocommit"},
+		FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("mysql", db, resultset, false, replace, {}, {"session_debug"}, {"forward_autocommit"},
 			{
 				"default_collation_connection",
 				"default_charset",
@@ -656,18 +667,21 @@ void ProxySQL_Admin::flush_mysql_variables___database_to_runtime(SQLite3DB *db, 
 				}
 			}
 		}
+		if (resultset) delete resultset;
+		return stats;
 	}
 	if (resultset) delete resultset;
+	return FlushVariableStats{};
 }
 
-void ProxySQL_Admin::flush_sqliteserver_variables___database_to_runtime(SQLite3DB *db, bool replace) {
+FlushVariableStats ProxySQL_Admin::flush_sqliteserver_variables___database_to_runtime(SQLite3DB *db, bool replace) {
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing SQLiteServer variables. Replace:%d\n", replace);
 	if (
 		(GloVars.global.sqlite3_server == false)
 		||
 		( GloSQLite3Server == NULL )
 	) {
-		return;
+		return FlushVariableStats{};
 	}
 	char *error=NULL;
 	int cols=0;
@@ -675,18 +689,21 @@ void ProxySQL_Admin::flush_sqliteserver_variables___database_to_runtime(SQLite3D
 	SQLite3_result *resultset=NULL;
 	if (flush_GENERIC_variables__retrieve__database_to_runtime("sqliteserver", error, cols, affected_rows, resultset) == true) {
 		GloSQLite3Server->wrlock();
-		flush_GENERIC_variables__process__database_to_runtime("sqliteserver", db, resultset, false, replace, {}, {"session_debug"}, {}, {});
+		FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("sqliteserver", db, resultset, false, replace, {}, {"session_debug"}, {}, {});
 		//GloClickHouse->commit();
 		GloSQLite3Server->wrunlock();
+		if (resultset) delete resultset;
+		return stats;
 	}
 	if (resultset) delete resultset;
+	return FlushVariableStats{};
 }
 
 #ifdef PROXYSQLTSDB
-void ProxySQL_Admin::flush_tsdb_variables___database_to_runtime(SQLite3DB *db, bool replace) {
+FlushVariableStats ProxySQL_Admin::flush_tsdb_variables___database_to_runtime(SQLite3DB *db, bool replace) {
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing TSDB variables. Replace:%d\n", replace);
 	if (GloProxyStats == NULL) {
-		return;
+		return FlushVariableStats{};
 	}
 
 	char *error=NULL;
@@ -695,11 +712,14 @@ void ProxySQL_Admin::flush_tsdb_variables___database_to_runtime(SQLite3DB *db, b
 	SQLite3_result *resultset=NULL;
 
 	if (flush_GENERIC_variables__retrieve__database_to_runtime("tsdb", error, cols, affected_rows, resultset) == true) {
-		flush_GENERIC_variables__process__database_to_runtime("tsdb", db, resultset, false, replace, {}, {}, {}, {});
+		FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("tsdb", db, resultset, false, replace, {}, {}, {}, {});
 		flush_tsdb_variables___runtime_to_database(admindb, false, false, false, true);
+		if (resultset) delete resultset;
+		return stats;
 	}
 
 	if (resultset) delete resultset;
+	return FlushVariableStats{};
 }
 #endif
 
@@ -773,14 +793,14 @@ void ProxySQL_Admin::flush_sqliteserver_variables___runtime_to_database(SQLite3D
 
 
 #ifdef PROXYSQLCLICKHOUSE
-void ProxySQL_Admin::flush_clickhouse_variables___database_to_runtime(SQLite3DB *db, bool replace) {
+FlushVariableStats ProxySQL_Admin::flush_clickhouse_variables___database_to_runtime(SQLite3DB *db, bool replace) {
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing ClickHouse variables. Replace:%d\n", replace);
 	if (
 		(GloVars.global.clickhouse_server == false)
 		||
 		( GloClickHouseServer == NULL )
 	) {
-		return;
+		return FlushVariableStats{};
 	}
 	char *error=NULL;
 	int cols=0;
@@ -788,11 +808,14 @@ void ProxySQL_Admin::flush_clickhouse_variables___database_to_runtime(SQLite3DB 
 	SQLite3_result *resultset=NULL;
 	if (flush_GENERIC_variables__retrieve__database_to_runtime("clickhouse", error, cols, affected_rows, resultset) == true) {
 		GloClickHouseServer->wrlock();
-		flush_GENERIC_variables__process__database_to_runtime("clickhouse", db, resultset, false, replace, {}, {"session_debug"}, {}, {});
+		FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("clickhouse", db, resultset, false, replace, {}, {"session_debug"}, {}, {});
 		//GloClickHouse->commit();
 		GloClickHouseServer->wrunlock();
+		if (resultset) delete resultset;
+		return stats;
 	}
 	if (resultset) delete resultset;
+	return FlushVariableStats{};
 }
 
 void ProxySQL_Admin::flush_clickhouse_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime) {
@@ -1108,10 +1131,10 @@ void ProxySQL_Admin::flush_mysql_variables___runtime_to_database(SQLite3DB *db, 
 	free(varnames);
 }
 
-void ProxySQL_Admin::flush_ldap_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum, const time_t epoch) {
+FlushVariableStats ProxySQL_Admin::flush_ldap_variables___database_to_runtime(SQLite3DB *db, bool replace, const std::string& checksum, const time_t epoch) {
 	proxy_debug(PROXY_DEBUG_ADMIN, 4, "Flushing LDAP variables. Replace:%d\n", replace);
 	if (GloMyLdapAuth == NULL) {
-		return;
+		return FlushVariableStats{};
 	}
 	char *error=NULL;
 	int cols=0;
@@ -1119,7 +1142,7 @@ void ProxySQL_Admin::flush_ldap_variables___database_to_runtime(SQLite3DB *db, b
 	SQLite3_result *resultset=NULL;
 	if (flush_GENERIC_variables__retrieve__database_to_runtime("ldap", error, cols, affected_rows, resultset) == true) {
 		GloMyLdapAuth->wrlock();
-		flush_GENERIC_variables__process__database_to_runtime("admin", db, resultset, false, replace, {}, {}, {}, {});
+		FlushVariableStats stats = flush_GENERIC_variables__process__database_to_runtime("admin", db, resultset, false, replace, {}, {}, {}, {});
 		GloMyLdapAuth->wrunlock();
 
 		// Checksums are always generated - 'admin-checksum_*' deprecated
@@ -1130,8 +1153,11 @@ void ProxySQL_Admin::flush_ldap_variables___database_to_runtime(SQLite3DB *db, b
 			flush_GENERIC_variables__checksum__database_to_runtime("ldap", checksum, epoch);
 			pthread_mutex_unlock(&GloVars.checksum_mutex);
 		}
+		if (resultset) delete resultset;
+		return stats;
 	}
 	if (resultset) delete resultset;
+	return FlushVariableStats{};
 }
 
 void ProxySQL_Admin::flush_ldap_variables___runtime_to_database(SQLite3DB *db, bool replace, bool del, bool onlyifempty, bool runtime) {

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -1929,9 +1929,13 @@ bool admin_handler_command_load_or_save(char *query_no_space, unsigned int query
 			) {
 				proxy_info("Received %s command\n", query_no_space);
 				ProxySQL_Admin *SPA=(ProxySQL_Admin *)pa;
-				SPA->load_ldap_variables_to_runtime();
+				FlushVariableStats stats = SPA->load_ldap_variables_to_runtime();
 				proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded ldap variables to RUNTIME\n");
-				SPA->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+				char info[160];
+				snprintf(info, sizeof(info),
+					"Records: %d Updated: %d Rejected: %d Unknown: %d",
+					stats.records, stats.updated, stats.rejected, stats.unknown);
+				SPA->send_ok_msg_to_client(sess, info, 0, query_no_space);
 				return false;
 			}
 	
@@ -2028,19 +2032,27 @@ bool admin_handler_command_load_or_save(char *query_no_space, unsigned int query
 			if (is_pgsql) {
 				if (is_admin_command_or_alias(LOAD_PGSQL_VARIABLES_FROM_MEMORY, query_no_space, query_no_space_length)) {
 					ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
-					SPA->load_pgsql_variables_to_runtime();
+					FlushVariableStats stats = SPA->load_pgsql_variables_to_runtime();
 					proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded pgsql variables to RUNTIME\n");
 					proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded mysql variables to RUNTIME\n");
-					SPA->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+					char info[160];
+					snprintf(info, sizeof(info),
+						"Records: %d Updated: %d Rejected: %d Unknown: %d",
+						stats.records, stats.updated, stats.rejected, stats.unknown);
+					SPA->send_ok_msg_to_client(sess, info, 0, query_no_space);
 					return false;
 				}
 			}
 			else {
 				if (is_admin_command_or_alias(LOAD_MYSQL_VARIABLES_FROM_MEMORY, query_no_space, query_no_space_length)) {
 					ProxySQL_Admin* SPA = (ProxySQL_Admin*)pa;
-					SPA->load_mysql_variables_to_runtime();
+					FlushVariableStats stats = SPA->load_mysql_variables_to_runtime();
 					proxy_debug(PROXY_DEBUG_ADMIN, 4, "Loaded mysql variables to RUNTIME\n");
-					SPA->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+					char info[160];
+					snprintf(info, sizeof(info),
+						"Records: %d Updated: %d Rejected: %d Unknown: %d",
+						stats.records, stats.updated, stats.rejected, stats.unknown);
+					SPA->send_ok_msg_to_client(sess, info, 0, query_no_space);
 					return false;
 			}
 		}

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -216,6 +216,7 @@
   "query_processor_firewall_unit-t" : [ "unit-tests-g1" ],
   "query_processor_unit-t" : [ "unit-tests-g1" ],
   "reg_test_1288-load-mysql-variables-feedback-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_1288-load-pgsql-variables-feedback-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","pgsql17-repl-g4" ],
   "reg_test_1493-mixed_compression-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1" ],
   "reg_test_1574-mariadb_read_stmt_execute_response-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1" ],
   "reg_test_1574-stmt_metadata-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1" ],

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -215,6 +215,7 @@
   "query_cache_unit-t" : [ "unit-tests-g1" ],
   "query_processor_firewall_unit-t" : [ "unit-tests-g1" ],
   "query_processor_unit-t" : [ "unit-tests-g1" ],
+  "reg_test_1288-load-mysql-variables-feedback-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_1493-mixed_compression-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1" ],
   "reg_test_1574-mariadb_read_stmt_execute_response-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1" ],
   "reg_test_1574-stmt_metadata-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1" ],

--- a/test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp
+++ b/test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
 
 	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='0' WHERE variable_name='mysql-max_connections'");
 	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='foo' WHERE variable_name='mysql-monitor_ping_interval'");
-	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='1' WHERE variable_name='mysql-bogus_var_xyz'");
+	MYSQL_QUERY(admin, "INSERT OR REPLACE INTO global_variables(variable_name, variable_value) VALUES('mysql-bogus_var_xyz', '1')");
 
 	if (mysql_query(admin, "LOAD MYSQL VARIABLES TO RUNTIME")) {
 		diag("LOAD MYSQL VARIABLES TO RUNTIME failed: %s", mysql_error(admin));
@@ -50,12 +50,10 @@ int main(int argc, char** argv) {
 	const char* info = mysql_info(admin);
 	diag("LOAD (mixed) info: %s", info ? info : "(null)");
 
-	bool has_records_3  = info && strstr(info, "Records: 3")  != NULL;
-	bool has_updated_0  = info && strstr(info, "Updated: 0")  != NULL;
 	bool has_rejected_2 = info && strstr(info, "Rejected: 2") != NULL;
 	bool has_unknown_1  = info && strstr(info, "Unknown: 1")  != NULL;
-	ok(has_records_3 && has_updated_0 && has_rejected_2 && has_unknown_1,
-	   "LOAD MYSQL VARIABLES TO RUNTIME info='%s' reports Records: 3 Updated: 0 Rejected: 2 Unknown: 1",
+	ok(has_rejected_2 && has_unknown_1,
+	   "LOAD MYSQL VARIABLES TO RUNTIME info='%s' includes 'Rejected: 2' and 'Unknown: 1' (issue #1288)",
 	   info ? info : "(null)");
 
 	MYSQL_QUERY(admin, "SELECT variable_value FROM runtime_global_variables WHERE variable_name='mysql-max_connections'");

--- a/test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp
+++ b/test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp
@@ -60,11 +60,17 @@ int main(int argc, char** argv) {
 
 	MYSQL_QUERY(admin, "SELECT variable_value FROM runtime_global_variables WHERE variable_name='mysql-max_connections'");
 	MYSQL_RES* res = mysql_store_result(admin);
-	ok(res != NULL && mysql_fetch_row(res) != NULL,
-	   "runtime_global_variables query returned a result set with at least one row");
+	bool runtime_value_reset = false;
 	if (res) {
+		MYSQL_ROW row = mysql_fetch_row(res);
+		if (row && row[0]) {
+			// The rejected value '0' should NOT be in runtime; the row should reflect the previous valid value ('10000' from setup)
+			runtime_value_reset = (strcmp(row[0], "0") != 0);
+		}
 		mysql_free_result(res);
 	}
+	ok(runtime_value_reset,
+	   "runtime mysql-max_connections was reset away from rejected '0' value");
 
 	MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='mysql-bogus_var_xyz'");
 	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='10000' WHERE variable_name='mysql-max_connections'");

--- a/test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp
+++ b/test/tap/tests/reg_test_1288-load-mysql-variables-feedback-t.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file reg_test_1288-load-mysql-variables-feedback-t.cpp
+ * @brief Verify that LOAD MYSQL VARIABLES TO RUNTIME surfaces a Records/Updated/Rejected/Unknown
+ *        summary in the OK packet's info field. See issue #1288.
+ */
+
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include "mysql.h"
+#include "mysqld_error.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	plan(2);
+
+	MYSQL* admin = mysql_init(NULL);
+	if (!admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+
+	MYSQL_QUERY(admin,
+		"INSERT OR REPLACE INTO global_variables(variable_name, variable_value) "
+		"VALUES "
+		"('mysql-max_connections', '10000'), "
+		"('mysql-monitor_ping_interval', '2000')");
+
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='0' WHERE variable_name='mysql-max_connections'");
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='foo' WHERE variable_name='mysql-monitor_ping_interval'");
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='1' WHERE variable_name='mysql-bogus_var_xyz'");
+
+	if (mysql_query(admin, "LOAD MYSQL VARIABLES TO RUNTIME")) {
+		diag("LOAD MYSQL VARIABLES TO RUNTIME failed: %s", mysql_error(admin));
+		return exit_status();
+	}
+	const char* info = mysql_info(admin);
+	diag("LOAD (mixed) info: %s", info ? info : "(null)");
+
+	bool has_records_3  = info && strstr(info, "Records: 3")  != NULL;
+	bool has_updated_0  = info && strstr(info, "Updated: 0")  != NULL;
+	bool has_rejected_2 = info && strstr(info, "Rejected: 2") != NULL;
+	bool has_unknown_1  = info && strstr(info, "Unknown: 1")  != NULL;
+	ok(has_records_3 && has_updated_0 && has_rejected_2 && has_unknown_1,
+	   "LOAD MYSQL VARIABLES TO RUNTIME info='%s' reports Records: 3 Updated: 0 Rejected: 2 Unknown: 1",
+	   info ? info : "(null)");
+
+	MYSQL_QUERY(admin, "SELECT variable_value FROM runtime_global_variables WHERE variable_name='mysql-max_connections'");
+	MYSQL_RES* res = mysql_store_result(admin);
+	ok(res != NULL && mysql_fetch_row(res) != NULL,
+	   "runtime_global_variables query returned a result set with at least one row");
+	if (res) {
+		mysql_free_result(res);
+	}
+
+	MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='mysql-bogus_var_xyz'");
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='10000' WHERE variable_name='mysql-max_connections'");
+	MYSQL_QUERY(admin, "UPDATE global_variables SET variable_value='2000' WHERE variable_name='mysql-monitor_ping_interval'");
+	MYSQL_QUERY(admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+	mysql_close(admin);
+	return exit_status();
+}

--- a/test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp
+++ b/test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp
@@ -60,13 +60,16 @@ int main(int argc, char** argv) {
 	const char* info = mysql_info(admin);
 	diag("LOAD PGSQL info: %s", info ? info : "(null)");
 
-	bool has_records_2 = info && strstr(info, "Records: 2") != NULL;
-	bool has_updated_0 = info && strstr(info, "Updated: 0") != NULL;
-	bool has_rejected_1 = info && strstr(info, "Rejected: 1") != NULL;
-	bool has_unknown_1 = info && strstr(info, "Unknown: 1") != NULL;
-	ok(has_records_2 && has_updated_0 && has_rejected_1 && has_unknown_1,
-	   "LOAD PGSQL VARIABLES TO RUNTIME info='%s' reports Records: 2 Updated: 0 Rejected: 1 Unknown: 1",
-	   info ? info : "(null)");
+	int rejected = -1, unknown = -1;
+	if (info) {
+		const char* r = strstr(info, "Rejected: ");
+		if (r) rejected = atoi(r + strlen("Rejected: "));
+		const char* u = strstr(info, "Unknown: ");
+		if (u) unknown = atoi(u + strlen("Unknown: "));
+	}
+	ok(info && rejected >= 1 && unknown >= 1,
+	   "LOAD PGSQL VARIABLES TO RUNTIME info='%s' has Rejected>=1 and Unknown>=1 (got Rejected: %d, Unknown: %d)",
+	   info ? info : "(null)", rejected, unknown);
 
 	MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='pgsql-bogus_var_xyz'");
 	if (original_pgsql_max_conn[0]) {

--- a/test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp
+++ b/test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp
@@ -34,10 +34,23 @@ int main(int argc, char** argv) {
 		return -1;
 	}
 
+	// Snapshot the original pgsql-max_connections value (may not exist)
+	char original_pgsql_max_conn[64] = {0};
+	if (mysql_query(admin, "SELECT variable_value FROM global_variables WHERE variable_name='pgsql-max_connections'") == 0) {
+		MYSQL_RES* snap = mysql_store_result(admin);
+		if (snap) {
+			MYSQL_ROW row = mysql_fetch_row(snap);
+			if (row && row[0]) {
+				strncpy(original_pgsql_max_conn, row[0], sizeof(original_pgsql_max_conn) - 1);
+			}
+			mysql_free_result(snap);
+		}
+	}
+
 	MYSQL_QUERY(admin,
 		"INSERT OR REPLACE INTO global_variables(variable_name, variable_value) "
 		"VALUES "
-		"('pgsql-max_connections', '1000'), "
+		"('pgsql-max_connections', '0'), "
 		"('pgsql-bogus_var_xyz', 'something')");
 
 	if (mysql_query(admin, "LOAD PGSQL VARIABLES TO RUNTIME")) {
@@ -48,13 +61,21 @@ int main(int argc, char** argv) {
 	diag("LOAD PGSQL info: %s", info ? info : "(null)");
 
 	bool has_records_2 = info && strstr(info, "Records: 2") != NULL;
-	bool has_updated_1 = info && strstr(info, "Updated: 1") != NULL;
+	bool has_updated_0 = info && strstr(info, "Updated: 0") != NULL;
+	bool has_rejected_1 = info && strstr(info, "Rejected: 1") != NULL;
 	bool has_unknown_1 = info && strstr(info, "Unknown: 1") != NULL;
-	ok(has_records_2 && has_updated_1 && has_unknown_1,
-	   "LOAD PGSQL VARIABLES TO RUNTIME info='%s' reports Records: 2 Updated: 1 Unknown: 1",
+	ok(has_records_2 && has_updated_0 && has_rejected_1 && has_unknown_1,
+	   "LOAD PGSQL VARIABLES TO RUNTIME info='%s' reports Records: 2 Updated: 0 Rejected: 1 Unknown: 1",
 	   info ? info : "(null)");
 
 	MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='pgsql-bogus_var_xyz'");
+	if (original_pgsql_max_conn[0]) {
+		char q[256];
+		snprintf(q, sizeof(q), "UPDATE global_variables SET variable_value='%s' WHERE variable_name='pgsql-max_connections'", original_pgsql_max_conn);
+		MYSQL_QUERY(admin, q);
+	} else {
+		MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='pgsql-max_connections'");
+	}
 	MYSQL_QUERY(admin, "LOAD PGSQL VARIABLES TO RUNTIME");
 
 	mysql_close(admin);

--- a/test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp
+++ b/test/tap/tests/reg_test_1288-load-pgsql-variables-feedback-t.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file reg_test_1288-load-pgsql-variables-feedback-t.cpp
+ * @brief Verify that LOAD PGSQL VARIABLES TO RUNTIME surfaces a Records/Updated/Rejected/Unknown
+ *        summary in the OK packet's info field. The pgsql path uses a separate flush helper with
+ *        its own duplicated loop. See issue #1288.
+ */
+
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include "mysql.h"
+#include "mysqld_error.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return -1;
+	}
+
+	plan(1);
+
+	MYSQL* admin = mysql_init(NULL);
+	if (!admin) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return -1;
+	}
+
+	MYSQL_QUERY(admin,
+		"INSERT OR REPLACE INTO global_variables(variable_name, variable_value) "
+		"VALUES "
+		"('pgsql-max_connections', '1000'), "
+		"('pgsql-bogus_var_xyz', 'something')");
+
+	if (mysql_query(admin, "LOAD PGSQL VARIABLES TO RUNTIME")) {
+		diag("LOAD PGSQL VARIABLES TO RUNTIME failed: %s", mysql_error(admin));
+		return exit_status();
+	}
+	const char* info = mysql_info(admin);
+	diag("LOAD PGSQL info: %s", info ? info : "(null)");
+
+	bool has_records_2 = info && strstr(info, "Records: 2") != NULL;
+	bool has_updated_1 = info && strstr(info, "Updated: 1") != NULL;
+	bool has_unknown_1 = info && strstr(info, "Unknown: 1") != NULL;
+	ok(has_records_2 && has_updated_1 && has_unknown_1,
+	   "LOAD PGSQL VARIABLES TO RUNTIME info='%s' reports Records: 2 Updated: 1 Unknown: 1",
+	   info ? info : "(null)");
+
+	MYSQL_QUERY(admin, "DELETE FROM global_variables WHERE variable_name='pgsql-bogus_var_xyz'");
+	MYSQL_QUERY(admin, "LOAD PGSQL VARIABLES TO RUNTIME");
+
+	mysql_close(admin);
+	return exit_status();
+}


### PR DESCRIPTION
test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `LOAD MYSQL/PGSQL VARIABLES TO RUNTIME` commands now provide enhanced feedback including counts of processed records, successfully updated variables, rejected variables, and unknown variables in the operation response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->