### PR TITLE
fix(ci): codecov — strip 'proxysql/' path prefix so TAP daemon coverage aligns to repo tree

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,49 @@
+# Codecov server-side configuration for ProxySQL.
+#
+# ---------------------------------------------------------------------------
+# Coverage path alignment (the `fixes` block below)
+# ---------------------------------------------------------------------------
+# ProxySQL uploads coverage to Codecov from two independent pipelines that
+# historically disagreed on the *root* of every source path, which left the
+# daemon's lib/ coverage filed under a phantom folder Codecov could not align
+# to the git tree. Symptom: lib/MySQL_Monitor.cpp (and every other daemon-only
+# file) showing a flat 0% on https://app.codecov.io/gh/sysown/proxysql even
+# though the integration suite exercises it heavily.
+#
+# The two pipelines:
+#
+#   1. TAP integration groups (flags `tap-*`)
+#      test/infra/control/run-tests-isolated.bash rewrites every LCOV `SF:`
+#      path to a `proxysql/`-prefixed form (e.g. `proxysql/lib/MySQL_Monitor.cpp`).
+#      The prefix matches the CI checkout layout — the repo is checked out into
+#      a `proxysql/` subdirectory of the runner workspace, and codecov-cli's
+#      network-file listing is rooted one level above it — but it does NOT match
+#      the repository git tree, whose root holds lib/, src/, include/, test/.
+#
+#   2. Unit tests (flag `unit-tests`)
+#      test/infra/control/run-unit-tests-asan-coverage.bash captures with
+#      `lcov --capture --directory lib`, producing repo-root-relative paths
+#      (`lib/MySQL_Monitor.cpp`). A `--initial` baseline seeds every instrumented
+#      line at 0%, so files the unit tests never execute (the monitor thread,
+#      the admin handler, the session loop, ...) sit at 0% in this namespace.
+#
+# Because the TAP coverage landed under `proxysql/lib/...` and the unit-tests
+# baseline owned `lib/...`, the two never merged: browsing the canonical repo
+# path `lib/MySQL_Monitor.cpp` showed only the unit-tests 0% baseline, while the
+# real ~38% from the TAP daemon was orphaned (and ultimately dropped) under the
+# non-existent `proxysql/lib/` tree.
+#
+# `fixes` strips the `proxysql/` prefix from report paths during Codecov's
+# server-side processing, so the TAP namespace collapses onto the git-tree
+# paths (`proxysql/lib/MySQL_Monitor.cpp` -> `lib/MySQL_Monitor.cpp`) and merges
+# with the unit-tests sessions. Verified against a real `tap-legacy-g1` upload:
+# all 210 `SF:` paths resolve to an existing repo file after the strip, with
+# zero misses. The rule only matches paths beginning with `proxysql/`, so the
+# already-correct `unit-tests` paths (`lib/...`, `include/...`) are untouched.
+#
+# If the TAP pipeline is ever changed to emit repo-root-relative paths directly
+# (the cleaner long-term fix, which also needs the codecov-action `root_dir`
+# pointed at the checkout subdir in the reusable ci-*.yml workflows on the
+# GH-Actions branch), this rule becomes a harmless no-op and can be removed.
+fixes:
+  - "proxysql/::"


### PR DESCRIPTION
## Summary

Daemon `lib/` coverage (`MySQL_Monitor.cpp`, `MySQL_Session.cpp`, `Admin_Handler.cpp`, `ProxySQL_Cluster.cpp`, ...) still showed a flat **0%** on Codecov after #5843, e.g. https://app.codecov.io/gh/sysown/proxysql/tree/v3.0/lib. #5843 was not wrong — it fixed coverage **generation**. The remaining breakage is a **path-namespace mismatch on Codecov's side**, not missing data.

Concrete evidence — the `tap-legacy-g1` artifact from a post-#5843 v3.0 run (`27503981411`, commit `6a33b85a`) genuinely contains the daemon coverage:

```
proxysql/lib/MySQL_Monitor.cpp   LH:1812 / LF:4777  (~38%)
proxysql/lib/MySQL_Session.cpp   LH:359  / LF:5122
proxysql/lib/Admin_Handler.cpp   LH:818  / LF:3236
```

…yet Codecov's merged report for that same commit has **zero `proxysql/lib/*` files**, and `lib/MySQL_Monitor.cpp` = **0 hits / 4632 lines**.

## Root cause — two coverage pipelines disagree on the path root

| Pipeline | Flag | Path root it uploads | Matches git tree? |
|---|---|---|---|
| TAP integration groups | `tap-*` | `proxysql/lib/MySQL_Monitor.cpp` | ❌ — repo root has `lib/`, not `proxysql/lib/` |
| Unit tests | `unit-tests` | `lib/MySQL_Monitor.cpp` | ✅ |

* `test/infra/control/run-tests-isolated.bash` rewrites every LCOV `SF:` path to a `proxysql/`-prefixed form. That prefix matches the CI checkout layout (the repo is checked out into a `proxysql/` subdir of the runner workspace, and codecov-cli's network listing is rooted one level above), but **not** the repository git tree, whose root holds `lib/`, `src/`, `include/`, `test/`.
* `test/infra/control/run-unit-tests-asan-coverage.bash` captures with `lcov --capture --directory lib`, producing repo-root-relative paths, plus an `lcov --initial` baseline that seeds every instrumented line at **0%**. Unit tests never exercise the monitor / admin / session paths, so those files sit at 0% in the `lib/` namespace.

The two namespaces never merged. Browsing the canonical repo path `lib/MySQL_Monitor.cpp` showed only the unit-tests 0% baseline, while the real ~38% from the TAP daemon was orphaned (and ultimately dropped) under the non-existent `proxysql/lib/` tree.

Codecov API breakdown for commit `6a33b85a` confirms the split:

```
lib/            101 files   (root-relative — unit-tests; Monitor=0%, Authentication=63.9%)
include/         52 files   (root-relative — unit-tests)
proxysql/test   272 files   (TAP, orphaned under phantom prefix)
proxysql/src      4 files   (TAP, orphaned)
proxysql/lib      0 files   (TAP daemon coverage — gone)
```

## Fix

Add a repo-root `codecov.yml` whose `fixes` rule strips the `proxysql/` prefix during Codecov's **server-side** report processing:

```yaml
fixes:
  - "proxysql/::"
```

This collapses the TAP namespace onto the git-tree paths (`proxysql/lib/MySQL_Monitor.cpp` → `lib/MySQL_Monitor.cpp`) so it merges with the unit-tests sessions and lifts the daemon files off 0%. It fixes **all** TAP groups at once with no per-workflow changes. The rule only matches paths beginning with `proxysql/`, so the already-correct `unit-tests` paths are untouched.

## Verification

- ✅ `curl --data-binary @codecov.yml https://codecov.io/validate` → **"Valid!"**
- ✅ YAML parses to `{'fixes': ['proxysql/::']}`.
- ✅ Applied the strip to a real `tap-legacy-g1` upload: **all 210** `SF:` paths resolve to an existing repo file afterward (`lib/MySQL_Monitor.cpp`, `src/main.cpp`, `test/tap/tests/*-t.cpp`, ...), **0 misses**.

## Notes / follow-ups

- Takes effect for uploads of commits that **contain** this file — coverage corrects on the next `v3.0` run after merge.
- Unrelated to this symptom: the "46 errored" uploads on the commit page are all `REPORT_EMPTY`, one stray empty upload per flag from duplicate/retriggered runs; harmless and out of scope here.
- Cleaner long-term option (not required by this PR): make the TAP pipeline emit repo-root-relative paths directly and set the codecov-action `root_dir` to the checkout subdir in the reusable `ci-*.yml` workflows on the `GH-Actions` branch — at which point this `fixes` rule becomes a no-op. Documented in the file header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code coverage path standardization across different testing pipelines to ensure consistent coverage report tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->