### PR TITLE
fix(pgsql): classify backend error severity from non-localized field

### DIFF
--- a/lib/PgSQL_Error_Helper.cpp
+++ b/lib/PgSQL_Error_Helper.cpp
@@ -367,6 +367,7 @@ void PgSQL_Error_Helper::fill_extended_error_info(PgSQL_ErrorInfo& err_info, con
 
 	if (ext_fields & PGSQL_ERROR_FIELD_TEXT) {
 		val = PQresultErrorField(result, PG_DIAG_SEVERITY_NONLOCALIZED);
+		if (val == nullptr) val = PQresultErrorField(result, PG_DIAG_SEVERITY);
 		err_info.ext_info->text = identify_error_severity(val ? val : "");
 	}
 

--- a/lib/PgSQL_Error_Helper.cpp
+++ b/lib/PgSQL_Error_Helper.cpp
@@ -447,7 +447,8 @@ void PgSQL_Error_Helper::fill_error_info(PgSQL_ErrorInfo& err_info, const PGresu
 	}
 	const char* sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
 	const char* message = PQresultErrorField(result, PG_DIAG_MESSAGE_PRIMARY);
-	const char* severity = PQresultErrorField(result, PG_DIAG_SEVERITY);
+	const char* severity = PQresultErrorField(result, PG_DIAG_SEVERITY_NONLOCALIZED);
+	if (severity == nullptr) severity = PQresultErrorField(result, PG_DIAG_SEVERITY);
 	fill_error_info(err_info, sqlstate ? sqlstate : "00000", message ? message : "", severity ? severity : "");
 	fill_extended_error_info(err_info, result, ext_fields);
 }


### PR DESCRIPTION
When a PostgreSQL backend is configured with a non-English `lc_messages`
(e.g. `lc_messages = 'ko_KR.UTF-8'`), **every erroring query aborts the
entire ProxySQL process.** This is not limited to debug builds: the
standard build does not define `NDEBUG`, so the `assert()` is compiled in
and fires (SIGABRT) on production release binaries as well.

The blast radius is the whole proxy, not the single failing query: a
single client running e.g. `SELECT 1/0` tears down ProxySQL and drops
**all** client connections. Under Docker (or any supervisor with a restart
policy) the container then restarts on every such query, turning any
ordinary SQL error into a repeated full-proxy outage / crash loop.

## Root cause

`PgSQL_Error_Helper::fill_error_info()` read the error severity from
`PG_DIAG_SEVERITY`. That field is **localized** by the backend through
`lc_messages`, so on a non-English server its value is a translated string
rather than `ERROR` / `FATAL` / `PANIC` / `WARNING` / ...

As a result:

1. `identify_error_severity()` does nreturns
## Root cause

`PgSQL_Error_Helper::fill_error_info()` read the error severity from
`PG_DIAG_SEVERITY`. That field is **localized** by the backend through
`lc_messages`, so on a non-English server its value is a translated string
rather than `ERROR` / `FATAL` / `PANIC` / `WARNING` / ...

As a result:

1. `identify_error_severity()` does not match any known token and returns
   `ERRSEVERITY_UNKNOWN_SEVERITY`.
2. `is_error_present()` consequently
3. `assert(is_error_present())` in `PgSQL_Connection.cpp` then aborts the
   process — on every erroring query.

## Fix

Read the severity from `PG_DIAG_SEVERITY_NONLOCALIZED`, which always
carries the untranslated token regardless of `lc_messages`, falling back
to `PG_DIAG_SEVERITY` for servers older than 9.6 (where the non-localized
field is unavailable).

This matches how the non-localized field is already used elsewhere in the
codebase — `fill_extended_error_info()` (`ext_info->text`) and the wire
`V` field in `PgSQL_Protocol.cpp`. The localized `PG_DIAG_SEVERITY` is
still forwarded to the client unchanged in the `S` field, so client-facing
messages keep the backend's localization.

```diff
-     const char* severity = PQresultErrorField(result, PG_DIAG_SEVERITY);
+     const char* severity = PQresultVERITY_NONLOCALIZED);
+     if (severity == nullptr) severity = PQresultErrorField(result, PG_DIAG_SEVERITY);

Testing

Reproduced against a PostgreSQL 17 backend with lc_messages set to
ko_KR.UTF-8 at the role level:

- Before: an erroring query (e.g. SELECT 1/0,
CREATE DATABASE <existing>) through ProxySQL aborts the process; the
Docker container restarts and all connections are dropped.
- After: the same queries return the (still Korean-localized) error to
the client normally, with severity correctly classified internally:
오류:  0으로는 나눌수 없습니다.

Impact

- Affects any deployment whose PostgreSQL backend uses a non-English
lc_messages (role-, database-, or cluy
SQL error from any client takes down the whole proxy.
- Present in standard release builds, not just debug (NDEBUG is not set).
- No behavior change for English (C / en_*) backends.
- Client-visible error text is unchanged (localized severity still
forwarded in the S field).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database error reporting so severity messages are more consistent and accurate, including cases where a non-localized severity value is available.
  * Error details continue to use the same existing severity levels, but now fall back more reliably when certain message fields are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->