### PR TITLE
fix(ci): grant permissions: write-all to workflow_run caller workflows

### DIFF
--- a/.github/workflows/CI-3p-aiomysql.yml
+++ b/.github/workflows/CI-3p-aiomysql.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-aiomysql.yml@GH-Actions
     secrets: inherit
     with:
@@ -28,6 +36,14 @@ jobs:
 
   run-mariadb:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-aiomysql.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-django-framework.yml
+++ b/.github/workflows/CI-3p-django-framework.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
     secrets: inherit
     with:
@@ -28,6 +36,14 @@ jobs:
 
   run-mariadb:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
     secrets: inherit
     with:
@@ -39,6 +55,14 @@ jobs:
     if: |
       (github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run) &&
       ! startsWith((github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name), 'v2.')
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-django-framework.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-laravel-framework.yml
+++ b/.github/workflows/CI-3p-laravel-framework.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
     secrets: inherit
     with:
@@ -28,6 +36,14 @@ jobs:
 
   run-mariadb:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
     secrets: inherit
     with:
@@ -39,6 +55,14 @@ jobs:
     if: |
       (github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run) &&
       ! startsWith((github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name), 'v2.')
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-laravel-framework.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-mariadb-connector-c.yml
+++ b/.github/workflows/CI-3p-mariadb-connector-c.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-mariadb-connector-c.yml@GH-Actions
     secrets: inherit
     with:
@@ -28,6 +36,14 @@ jobs:
 
   run-mariadb:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-mariadb-connector-c.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-mysql-connector-j.yml
+++ b/.github/workflows/CI-3p-mysql-connector-j.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-mysql-connector-j.yml@GH-Actions
     secrets: inherit
     with:
@@ -28,6 +36,14 @@ jobs:
 
   run-mariadb:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-mysql-connector-j.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-pgjdbc.yml
+++ b/.github/workflows/CI-3p-pgjdbc.yml
@@ -21,6 +21,14 @@ jobs:
     if: |
       (github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run) &&
       ! startsWith((github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name), 'v2.')
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-pgjdbc.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-php-pdo-mysql.yml
+++ b/.github/workflows/CI-3p-php-pdo-mysql.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-php-pdo-mysql.yml@GH-Actions
     secrets: inherit
     with:
@@ -28,6 +36,14 @@ jobs:
 
   run-mariadb:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-php-pdo-mysql.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/CI-3p-php-pdo-pgsql.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-pgsql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-php-pdo-pgsql.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-postgresql.yml
+++ b/.github/workflows/CI-3p-postgresql.yml
@@ -21,6 +21,14 @@ jobs:
     if: |
       (github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run) &&
       ! startsWith((github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name), 'v2.')
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-postgresql.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-3p-sqlalchemy.yml
+++ b/.github/workflows/CI-3p-sqlalchemy.yml
@@ -19,6 +19,14 @@ concurrency:
 jobs:
   run-mysql:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
     secrets: inherit
     with:
@@ -28,6 +36,14 @@ jobs:
 
   run-mariadb:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
     secrets: inherit
     with:
@@ -39,6 +55,14 @@ jobs:
     if: |
       (github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run) &&
       ! startsWith((github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name), 'v2.')
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-3p-sqlalchemy.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-basictests.yml
+++ b/.github/workflows/CI-basictests.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-basictests.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-builds.yml
+++ b/.github/workflows/CI-builds.yml
@@ -13,6 +13,14 @@ concurrency:
 
 jobs:
   run:
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-codeql.yml
+++ b/.github/workflows/CI-codeql.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-codeql.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-legacy-g2.yml
+++ b/.github/workflows/CI-legacy-g2.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-legacy-g2.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-maketest.yml
+++ b/.github/workflows/CI-maketest.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-maketest.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-repltests.yml
+++ b/.github/workflows/CI-repltests.yml
@@ -17,6 +17,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-repltests.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-selftests.yml
+++ b/.github/workflows/CI-selftests.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-selftests.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-shuntest.yml
+++ b/.github/workflows/CI-shuntest.yml
@@ -17,6 +17,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-shuntest.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests-asan.yml
+++ b/.github/workflows/CI-taptests-asan.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-taptests-asan.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests-groups.yml
+++ b/.github/workflows/CI-taptests-groups.yml
@@ -18,6 +18,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-taptests-groups.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests-pgsql-cluster.yml
+++ b/.github/workflows/CI-taptests-pgsql-cluster.yml
@@ -17,6 +17,11 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    # `write-all` is required so the workflow_run event's GITHUB_TOKEN has
+    # the cache-writable scope (GitHub started enforcing this for workflow_run
+    # in early July 2026). Without it actions/cache/save@v4 fails with
+    # 'cache write denied: token has no writable scopes'.
+    permissions: write-all
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI-taptests-ssl.yml
+++ b/.github/workflows/CI-taptests-ssl.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-taptests-ssl.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-taptests.yml
+++ b/.github/workflows/CI-taptests.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-taptests.yml@GH-Actions
     secrets: inherit
     with:

--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -60,6 +60,11 @@ env:
 jobs:
   unit-tests-tsan:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required so the workflow_run event's GITHUB_TOKEN has
+    # the cache-writable scope (GitHub started enforcing this for workflow_run
+    # in early July 2026). Without it actions/cache/save@v4 fails with
+    # 'cache write denied: token has no writable scopes'.
+    permissions: write-all
     runs-on: ubuntu-24.04
     timeout-minutes: 90
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -43,6 +43,14 @@ concurrency:
 jobs:
   run:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required because reusable-workflow permissions are the
+    # intersection of caller + callee. Without it the workflow_run event's
+    # GITHUB_TOKEN has no cache-writable scope, so the callee's
+    # actions/cache/save@v4 fails with 'cache write denied: token has no
+    # writable scopes' (GitHub started enforcing this for workflow_run in
+    # early July 2026 alongside the Node.js 20 -> 24 actions deprecation).
+    # The callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
     uses: sysown/proxysql/.github/workflows/ci-unittests.yml@GH-Actions
     secrets: inherit
     with:


### PR DESCRIPTION
## Problem

Since early July 2026, CI has been broken across the entire test matrix. Build jobs compile successfully but fail to save their caches:

```
Cache reservation failed: cache write denied: token has no writable scopes
Cache save failed.
```

Every downstream test group then fails at `Cache restore src` in 12-19 seconds with `fail-on-cache-miss` — **no tests actually run**. This correlates with GitHub's Node.js 20 -> 24 actions deprecation that landed in this window.

## Root cause

`workflow_run`-triggered reusable-workflow callers now receive a `GITHUB_TOKEN` with **no cache-writable scope** unless they explicitly declare `permissions: write-all`.

Reusable-workflow permissions are the **intersection of caller + callee**: the callee at `ci-<group>.yml@GH-Actions` already declares `write-all`, but that cannot elevate a token the caller's `workflow_run` context never granted. So `actions/cache/save@v4` in the build is denied.

Most caller workflows (e.g. `CI-mysql84-g4.yml`) **already** declared `permissions: write-all` for their Codecov OIDC upload step -- those were unaffected. **25 callers were missing it**, including the critical `CI-builds.yml` (which writes the _src/_bin/_test caches every test group reads).

Verified: not a config change on our side. `CI-builds.yml` is byte-identical to the 2026-06-29 version where the cache worked (0 write-denied errors then vs. consistent denials now). It is a GitHub platform-side enforcement change.

## Fix

Add `permissions: write-all` (job-level, same placement and comment style as the already-correct callers) to the 25 callers that were missing it, including CI-builds.yml (the one currently failing). The 2 inline (non-reusable) callers (CI-taptests-pgsql-cluster, CI-unit-tests-tsan) get a job-level declaration for the same reason.

## Validation

- All 245 CI-*.yml files parse as valid YAML.
- After this lands, build jobs should save caches again and the full test matrix should run (~30 min per group instead of 12-19s fast-exits).

## Impact

Blocks all PRs that rely on the TAP/unit test matrix -- e.g. #5810 (pass-through auth), whose test results have been unreadable because every group fails at cache-restore before running a single test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated multiple CI workflows to grant broader GitHub Actions permissions, preventing cache-save failures in reusable test and build jobs.
  * Improved reliability for workflows triggered automatically after other runs, especially when saving build caches.

* **Documentation**
  * Added explanatory comments in workflows clarifying why the expanded permissions are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->