### PR TITLE
ci: migrate build→test handoff from Actions cache to workflow artifacts

### DIFF
--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -48,15 +48,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -447,6 +447,86 @@ jobs:
         path: |
           proxysql/tap-matrix*
 
+    # === Build → test handoff via workflow artifacts ===
+    # GitHub made Actions cache WRITES read-only for untrusted / workflow_run
+    # triggers operating in default-branch context (changelog 2026-06-26): the
+    # `Cache save *` steps above get "cache write denied: token has no writable
+    # scopes" on PR/workflow_run runs even with permissions: write-all, so every
+    # downstream test workflow fails at `fail-on-cache-miss`. Workflow ARTIFACTS
+    # are not subject to that policy, so we publish the same payloads the caches
+    # carried as per-type artifacts named `ci-builds-handoff-<sha>-<variant>-<t>`
+    # (t = src|test|matrix|bin). Each test workflow downloads only the types it
+    # used to restore -- a faithful 1:1 replacement of its cache keys. The
+    # `Cache save *` steps above are now dead weight (they warn-and-noop on PRs);
+    # kept for one release to preserve the fast path on trusted `push` builds,
+    # and slated for removal once every consumer is on artifacts.
+    #
+    # env.SHA is the real head SHA (identical to the value each consumer
+    # computes), NOT the workflow_run default-branch SHA, so names line up
+    # without any run-id correlation.
+    - name: Pack src + matrix for handoff (zstd-15)
+      if: ${{ success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      run: |
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        cd proxysql/
+        shopt -s nullglob
+        # _src payload: src/ (proxysql binary + src gcno) plus the lib gcno the
+        # gcov coverage collector matches against .gcda (gcov build only; the
+        # nullglob array is empty and harmless on non-gcov -tap variants).
+        gcno=(lib/obj/*.gcno)
+        tar -cf - src/ "${gcno[@]}" | zstd -15 -T0 -o ../cache_src.tar.zst
+        # _matrix payload (tap-matrix* json) -- only the taptests* groups consume
+        # it, and only ubuntu22-tap generates it; skip when absent.
+        mtx=(tap-matrix*)
+        if [ ${#mtx[@]} -gt 0 ]; then
+          tar -cf - "${mtx[@]}" | zstd -15 -T0 -o ../cache_matrix.tar.zst
+        fi
+
+    - name: Upload handoff (src)
+      if: ${{ success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-src
+        retention-days: 1
+        compression-level: 0
+        if-no-files-found: error
+        path: cache_src.tar.zst
+
+    - name: Upload handoff (test)
+      if: ${{ success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-test
+        retention-days: 1
+        compression-level: 0
+        if-no-files-found: error
+        # cache_test.tar.zst is produced by the "Pack test cache" step above.
+        path: cache_test.tar.zst
+
+    - name: Upload handoff (matrix)
+      if: ${{ success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-matrix
+        retention-days: 1
+        compression-level: 0
+        # Only ubuntu22-tap generates tap-matrix*; ignore on variants without it.
+        if-no-files-found: ignore
+        path: cache_matrix.tar.zst
+
+    - name: Upload handoff (bin)
+      # Only the debian12-dbg build feeds the 3p suites, and they consume bin
+      # only. bin is large (.git/ + binaries/), so don't ship it for -tap.
+      if: ${{ success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-dbg') }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-bin
+        retention-days: 1
+        compression-level: 0
+        if-no-files-found: error
+        # cache_bin.tar.zst is produced by the "Pack bin cache" step above.
+        path: cache_bin.tar.zst
+
     - name: Archive artifacts
       if: ${{ failure() && !cancelled() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -64,38 +64,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -45,30 +45,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu22-tap
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -57,38 +57,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -60,32 +60,43 @@ jobs:
           # sparse-checkout: a few extra MB is much cheaper than
           # debugging a missing-file failure inside the container.
 
-      - name: Cache restore src
-        uses: actions/cache/restore@v4
-        with:
-          # CI-builds save-src path now includes
-          # proxysql/plugins/mysqlx/ProxySQL_MySQLX_Plugin.so as well
-          # as proxysql/src/, gated on -tap-mysqlx via PROXYSQL40=1 in
-          # the build env. See the analogous block in ci-builds.yml.
-          key: ${{ env.BLDCACHE }}_src
-          fail-on-cache-miss: true
-          path: |
-            proxysql/src/
-            proxysql/lib/obj/*.gcno
-
-      - name: Cache restore test
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ env.BLDCACHE }}_test
-          fail-on-cache-miss: true
-          path: cache_test.tar.zst
-
-      - name: Unpack test cache
+      - name: Download build handoff
+        # Build payload arrives as workflow artifacts, not an Actions cache:
+        # GitHub made cache writes read-only for workflow_run/untrusted triggers
+        # (changelog 2026-06-26). Download the per-type handoff artifacts and
+        # unpack into proxysql/. The following 'Restore plugin .so' step then
+        # copies the mysqlx/genai .so out of the unpacked test tree as before.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+          HANDOFF_VARIANT: ubuntu22-tap-mysqlx
+          HANDOFF_TYPES: src test
         run: |
+          set -uo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd
+          for t in $HANDOFF_TYPES; do
+            name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+            aid=""
+            for attempt in 1 2 3 4 5 6; do
+              aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                      --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+              [ -n "$aid" ] && break
+              echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+            done
+            if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+            echo ">>> downloading ${name} (id=${aid})"
+            gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+            unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+          done
+          mkdir -p proxysql
           cd proxysql/
-          zstd -d < ../cache_test.tar.zst | tar -xf -
-          rm ../cache_test.tar.zst
+          for tb in ../cache_*.tar.zst; do
+            [ -e "$tb" ] || continue
+            echo ">>> unpacking $(basename "$tb")"
+            zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+          done
+          rm -f ../cache_*.tar.zst ../handoff-*.zip
 
       - name: Restore plugin .so files from _runtime_libs
         # CI-builds stages plugins/mysqlx + plugins/genai .so files
@@ -216,28 +227,43 @@ jobs:
           ref: ${{ env.SHA }}
           path: 'proxysql'
 
-      - name: Cache restore src
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ env.BLDCACHE }}_src
-          fail-on-cache-miss: true
-          path: |
-            proxysql/src/
-            proxysql/lib/obj/*.gcno
-
-      - name: Cache restore test
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ env.BLDCACHE }}_test
-          fail-on-cache-miss: true
-          path: cache_test.tar.zst
-
-      - name: Unpack test cache
+      - name: Download build handoff
+        # Build payload arrives as workflow artifacts, not an Actions cache:
+        # GitHub made cache writes read-only for workflow_run/untrusted triggers
+        # (changelog 2026-06-26). Download the per-type handoff artifacts and
+        # unpack into proxysql/. The following 'Restore plugin .so' step then
+        # copies the mysqlx/genai .so out of the unpacked test tree as before.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+          HANDOFF_VARIANT: ubuntu22-tap-mysqlx
+          HANDOFF_TYPES: src test
         run: |
+          set -uo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd
+          for t in $HANDOFF_TYPES; do
+            name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+            aid=""
+            for attempt in 1 2 3 4 5 6; do
+              aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                      --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+              [ -n "$aid" ] && break
+              echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+            done
+            if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+            echo ">>> downloading ${name} (id=${aid})"
+            gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+            unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+          done
+          mkdir -p proxysql
           cd proxysql/
-          zstd -d < ../cache_test.tar.zst | tar -xf -
-          rm ../cache_test.tar.zst
+          for tb in ../cache_*.tar.zst; do
+            [ -e "$tb" ] || continue
+            echo ">>> unpacking $(basename "$tb")"
+            zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+          done
+          rm -f ../cache_*.tar.zst ../handoff-*.zip
 
       - name: Restore plugin .so files from _runtime_libs
         # CI-builds stages plugins/mysqlx + plugins/genai .so files
@@ -444,28 +470,43 @@ jobs:
             test/tap/groups
             test/scripts
 
-      - name: Cache restore src
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ env.BLDCACHE }}_src
-          fail-on-cache-miss: true
-          path: |
-            proxysql/src/
-            proxysql/lib/obj/*.gcno
-
-      - name: Cache restore test
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ env.BLDCACHE }}_test
-          fail-on-cache-miss: true
-          path: cache_test.tar.zst
-
-      - name: Unpack test cache
+      - name: Download build handoff
+        # Build payload arrives as workflow artifacts, not an Actions cache:
+        # GitHub made cache writes read-only for workflow_run/untrusted triggers
+        # (changelog 2026-06-26). Download the per-type handoff artifacts and
+        # unpack into proxysql/. The following 'Restore plugin .so' step then
+        # copies the mysqlx/genai .so out of the unpacked test tree as before.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+          HANDOFF_VARIANT: ubuntu22-tap-mysqlx
+          HANDOFF_TYPES: src test
         run: |
+          set -uo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd
+          for t in $HANDOFF_TYPES; do
+            name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+            aid=""
+            for attempt in 1 2 3 4 5 6; do
+              aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                      --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+              [ -n "$aid" ] && break
+              echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+            done
+            if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+            echo ">>> downloading ${name} (id=${aid})"
+            gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+            unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+          done
+          mkdir -p proxysql
           cd proxysql/
-          zstd -d < ../cache_test.tar.zst | tar -xf -
-          rm ../cache_test.tar.zst
+          for tb in ../cache_*.tar.zst; do
+            [ -e "$tb" ] || continue
+            echo ">>> unpacking $(basename "$tb")"
+            zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+          done
+          rm -f ../cache_*.tar.zst ../handoff-*.zip
 
       - name: Restore plugin .so files from _runtime_libs
         # CI-builds stages plugins/mysqlx + plugins/genai .so files

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -59,15 +59,44 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -54,16 +54,44 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        enableCrossOsArchive: true
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Run proxysql
       run: |

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -51,38 +51,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        # MUST exactly match the path list in CI-builds' "Cache save src"
-        # step. actions/cache hashes the path list into the cache
-        # "version" alongside the key -- different path lists = different
-        # version = lookup miss, even if the key is identical and the
-        # cache plainly exists in the repo (verified via gh api).
-        # CI-builds added proxysql/lib/obj/*.gcno for the -gcov variants
-        # so this restore needs the same entry; otherwise the restore
-        # silently misses with "Failed to restore cache entry".
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -59,15 +59,44 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -41,30 +41,44 @@ jobs:
           test/tap/groups
           test/scripts
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). CI-builds uploads per-type artifacts named
+      # ci-builds-handoff-<sha>-<variant>-<type>; download the types this job
+      # used to restore and unpack them into proxysql/. SHA is the real head
+      # SHA (identical to CI-builds' SHA), so the artifact names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ubuntu22-tap
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Verify binary
       run: |


### PR DESCRIPTION
## Problem

Since **2026-06-26** GitHub makes the Actions **cache read-only for untrusted triggers** in default-branch context ([changelog](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/)). `CI-builds` is `workflow_run`-triggered, so on PR runs its `Cache save *` steps fail with `cache write denied: token has no writable scopes` — verified the token had `Actions: write` yet the cache service still denied it, so `permissions: write-all` (PR #5867) cannot fix it. Result: the `_src`/`_test`/`_matrix`/`_bin` caches are never written and **every downstream `workflow_run` test job dies at `fail-on-cache-miss`**.

**Workflow artifacts are not subject to the cache policy.** This PR moves the build→test handoff from the Actions cache to per-type artifacts.

## What changed (48 files)

**Producer — `ci-builds.yml`:** for each `-tap` variant, publish the payloads as per-type artifacts `ci-builds-handoff-<sha>-<variant>-<type>` (`type` = `src`/`test`/`matrix`; `bin` for `debian12-dbg`). The name embeds the **real head SHA** (identical in every workflow), so consumers resolve it by name with no cross-run id correlation. The old `Cache save *` steps are left in place for now (they warn-and-noop on PRs, still work on trusted `push`) and are slated for removal once every consumer is migrated.

**Consumers — 47 reusables:** each `Cache restore <type>` + unpack becomes one `Download build handoff` step (resolve by name via `gh api`, retried for index lag, expired filtered; download; unpack into `proxysql/`). Covers all active gcov groups (legacy / mysql84 / mysql84-gr / mariadb10-galera / mysql56-single / pgsql-socket / set_parser / legacy-clickhouse / legacy-g2-genai), the ubuntu22-tap groups (legacy-g2, unittests, selftests, basictests, repltests, shuntest), and **`ci-mysqlx`** (all 3 jobs, plugin-`.so` restore preserved).

**Deferred (documented, not part of the red wall):**
- **`taptests*`** (4) — different architecture (a matrix-generation job that restores `_matrix`, plus dynamic `${{ matrix.testdist }}`); needs its own change.
- **`ci-3p-*`** (10) — `disabled_manually`; also carry a `BRANCH != 'none'` guard the uniform transform would drop. Producer already ships the `debian12-dbg-bin` artifact so they convert cleanly when re-enabled.
- **`ci-codeql`** — its cache restore is already commented out (no-op).

## Validation (live, `workflow_dispatch` on a v3.0 test branch)

Producer [run 28781166711](https://github.com/sysown/proxysql/actions/runs/28781166711) generated all per-type artifacts (gcov-src 44 MB / gcov-test 1019 MB, ubuntu22-tap src/test, ubuntu22-tap-mysqlx src/test 2.2 GB, matrix, debian12 bin). A diverse sample then consumed them:

| Group | Variant / shape | Result |
|---|---|---|
| `CI-legacy-g1` | gcov · src+test | ✅ success |
| `CI-legacy-g2` | ubuntu22-tap · src+test | ✅ success |
| `CI-selftests` | ubuntu22-tap · src-only (`mkdir` path) | ✅ success |
| `CI-mysqlx` unit-tests | mysqlx · src+test + plugin restore | ✅ success |

The `Download build handoff` step succeeded in **all** jobs including `ci-mysqlx` e2e + soak.

### Note: `ci-mysqlx` e2e-tests surfaces a pre-existing, unrelated failure

`e2e-tests` fails at **`Install MySQL 8.4 runtime libs`** (three steps *after* a successful handoff, in a step this PR does not touch):

```
E: Failed to fetch .../libtinfo5_6.3-2ubuntu0.1_amd64.deb   404  Not Found
E: Failed to fetch .../libncurses5_6.3-2ubuntu0.1_amd64.deb 404  Not Found
```

Root cause: the deprecated transitional packages `libncurses5`/`libtinfo5` are pinned to a point-release (`6.3-2ubuntu0.1`) that has been pulled from the Ubuntu mirror. This is **not** caused by this PR — the baseline v3.0 `CI-mysqlx` dies earlier at `Cache restore src` (the very bug fixed here) and never reaches this step; the migration merely lets e2e progress far enough to reveal it. Fix belongs in a separate change (`apt-get update` before install / `--fix-missing` / drop the deprecated packages).

## Follow-ups
- Convert `taptests*` (matrix-gen job + dynamic testdist).
- Fix the `ci-mysqlx` e2e apt-404 (separate, pre-existing).
- Once all consumers are on artifacts: drop the dead `Cache save *` / `Cache check` path from `ci-builds.yml`.
- Convert `ci-3p-*` when re-enabled.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01C21CuatwQ3CtFr62A6M4gU