### PR TITLE
ci: finish artifact-handoff rollout (taptests*) + fix mysqlx e2e apt-404

### DIFF
--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -290,6 +290,12 @@ jobs:
         # by default; install explicitly so we never silently depend on
         # whatever the runner happens to ship.
         run: |
+          # The runner image ships a pre-baked apt index that pins point-
+          # releases which get superseded and pulled from the mirror, so a
+          # bare install 404s (e.g. libtinfo5/libncurses5 6.3-2ubuntu0.1 ->
+          # "404 Not Found"). Refresh the index first so we resolve to the
+          # currently-published version.
+          sudo apt-get update -y
           sudo apt-get install -y -qq --no-install-recommends \
             libaio1 libnuma1 libncurses5 libtinfo5
 

--- a/.github/workflows/ci-taptests-asan.yml
+++ b/.github/workflows/ci-taptests-asan.yml
@@ -45,14 +45,42 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
-    - name: Cache restore
-      id: cache-matrix
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/tap-matrix*
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: matrix
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Set matrix
       id: set-matrix
@@ -134,30 +162,42 @@ jobs:
         sudo apt-cache policy libmysqlclient-dev
         sudo apt-get install -y --allow-downgrades libmysqlclient-dev=5.7*
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_src
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4

--- a/.github/workflows/ci-taptests-groups.yml
+++ b/.github/workflows/ci-taptests-groups.yml
@@ -45,14 +45,42 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
-    - name: Cache restore
-      id: cache-matrix
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/tap-matrix*
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: matrix
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Set matrix
       id: set-matrix
@@ -149,30 +177,42 @@ jobs:
         sudo apt-cache policy libmysqlclient-dev
         sudo apt-get install -y --allow-downgrades libmysqlclient-dev=5.7*
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_src
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4

--- a/.github/workflows/ci-taptests-ssl.yml
+++ b/.github/workflows/ci-taptests-ssl.yml
@@ -44,14 +44,42 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
-    - name: Cache restore
-      id: cache-matrix
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/tap-matrix*
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: matrix
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Set matrix
       id: set-matrix
@@ -112,39 +140,42 @@ jobs:
         sudo apt-cache policy libmysqlclient-dev
         sudo apt-get install -y --allow-downgrades libmysqlclient-dev=5.7*
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_src
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src test matrix
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
-
-    - name: Cache restore tap-matrix
-      id: cache-matrix
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_matrix
-        fail-on-cache-miss: true
-        path: |
-          proxysql/tap-matrix*
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4

--- a/.github/workflows/ci-taptests.yml
+++ b/.github/workflows/ci-taptests.yml
@@ -46,14 +46,42 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
-    - name: Cache restore
-      id: cache-matrix
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}
-        fail-on-cache-miss: true
-        path: |
-          proxysql/tap-matrix*
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: matrix
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Set matrix
       id: set-matrix
@@ -131,30 +159,42 @@ jobs:
         sudo apt-cache policy libmysqlclient-dev
         sudo apt-get install -y --allow-downgrades libmysqlclient-dev=5.7*
 
-    - name: Cache restore src
-      id: cache-src
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_src
-        fail-on-cache-miss: true
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Cache restore test
-      id: cache-test
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ env.BLDCACHE }}_test
-        fail-on-cache-miss: true
-        path: cache_test.tar.zst
-
-    - name: Unpack test cache
+    - name: Download build handoff
+      # Build payload arrives as workflow artifacts, not an Actions cache:
+      # GitHub made cache writes read-only for workflow_run/untrusted triggers
+      # (changelog 2026-06-26). Download the per-type handoff artifacts and
+      # unpack into proxysql/. SHA is the real head SHA, so names line up.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src test
       run: |
+        set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in 1 2 3 4 5 6; do
+            aid=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>/dev/null || true)
+            [ -n "$aid" ] && break
+            echo ">>> ${name} not visible yet (${attempt}/6); sleeping 10s"; sleep 10
+          done
+          if [ -z "$aid" ]; then echo "ERROR: handoff artifact ${name} not found -- did CI-builds succeed for ${SHA}?" >&2; exit 1; fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
         cd proxysql/
-        zstd -d < ../cache_test.tar.zst | tar -xf -
-        rm ../cache_test.tar.zst
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
 
     - name: Checkout jenkins_build_scripts
       uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #5868, covering the two items deferred there. Two independent commits.

## A — migrate `taptests*` to the artifact handoff (4 files)

The `taptests*` reusables were deferred from #5868 because of their two-job shape:
a **`select`** job that restored the `_matrix` cache to build the dynamic test
matrix, and a **`tests`** job that restored `_src`/`_test` (+`_matrix` for `-ssl`),
both keyed on dynamic `${{ matrix.testdist }}`. Both jobs now use the same
`Download build handoff` step as the rest of the rollout, against the per-type
artifacts `CI-builds` publishes (`testdist` → `ubuntu22-tap`).

Verified the `ubuntu22-tap-matrix` handoff artifact carries `tap-matrix-tests.json`
so the `select` job's Set-matrix sed still works.

## B — fix `ci-mysqlx` e2e-tests apt 404 (pre-existing, revealed by #5868)

`e2e-tests` failed at `Install MySQL 8.4 runtime libs`:

```
E: Failed to fetch .../libtinfo5_6.3-2ubuntu0.1_amd64.deb   404  Not Found
E: Failed to fetch .../libncurses5_6.3-2ubuntu0.1_amd64.deb 404  Not Found
```

The runner ships a pre-baked apt index pinning point-releases that get superseded
and pulled from the mirror. Add `apt-get update` before the install so packages
resolve to the currently-published version. This failure pre-dates #5868 (baseline
`CI-mysqlx` died earlier at the cache restore and never reached this step); the
handoff migration merely let e2e-tests progress far enough to surface it.

## Validation (live, `workflow_dispatch` on a v3.0 test branch)

Producer rebuilt to publish the artifacts, then:

**A — `CI-taptests-groups`** (the one active `taptests*`; the other three are `disabled_manually`):
- `select` job: `Download build handoff` ✅ + `Set matrix` ✅ → matrix-artifact download and dynamic matrix generation work.
- `tests` jobs: `Download build handoff` ✅; the TAP suites run as before.

**B — `CI-mysqlx`**: `e2e-tests` went **failure → success** — `Install MySQL 8.4 runtime libs` ✅ and `Run mysqlx e2e tests` ✅. unit-tests green.

## Notes / remaining
- Of the 4 `taptests*`, only `CI-taptests-groups` is enabled; the other three (`taptests`, `-asan`, `-ssl`) are `disabled_manually` — converted for correctness-when-re-enabled, riding the same validated mechanism.
- Still open from the rollout: drop the now-dead `Cache save`/`Cache check` path in `ci-builds.yml`, and convert the 10 `disabled_manually` `ci-3p-*` workflows when they're re-enabled.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01C21CuatwQ3CtFr62A6M4gU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test workflow reliability by updating package indices before installing MySQL runtime libraries.
  * Switched several test jobs to fetch prebuilt handoff artifacts more reliably, with retries and stricter failure handling.
  * Reduced dependency on cache restores by unpacking downloaded artifacts directly into the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->