### PR TITLE
ci: run repltests/shuntest from vendored test/repl (drop GH_TOKEN_PROXYSQL)

### DIFF
--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -59,6 +59,19 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
+    - name: Checkout repl test suite
+      # The replication/shunning suite is vendored in-repo at test/repl/ (moved
+      # off the private jenkins-build-scripts repo, so no GH_TOKEN_PROXYSQL PAT).
+      # Sparse-checkout just that dir into proxysql/; the proxysql binary arrives
+      # separately via the build handoff below (unpacked into the same proxysql/).
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ env.SHA }}
+        path: 'proxysql'
+        sparse-checkout: |
+          test/repl
+
     - name: Download build handoff
       # Build payload arrives as workflow artifacts, not an Actions cache:
       # GitHub made cache writes read-only for workflow_run/untrusted triggers
@@ -98,32 +111,24 @@ jobs:
         done
         rm -f ../cache_*.tar.zst ../handoff-*.zip
 
-    - name: Checkout jenkins_build_scripts
-      uses: actions/checkout@v4
-      with:
-        repository: 'proxysql/jenkins-build-scripts'
-        ref: 'proxysql_repl_tests'
-        fetch-depth: 0
-        path: 'jenkins-build-scripts'
-        token: ${{ secrets.GH_TOKEN_PROXYSQL }}
-
     - name: Docker-hoster
       run: |
-        cd jenkins-build-scripts/infra-docker-hoster
+        cd proxysql/test/repl/infra-docker-hoster
         sed -i 's|image: .*|image: ghcr.io/mrmohebi/docker-hoster|' docker-compose.yml
         docker compose up -d
 
     - name: Replication-tests
       run: |
         set +e
-        
-        cd jenkins-build-scripts
+
+        # Vendored suite lives at proxysql/test/repl (was jenkins-build-scripts).
+        cd proxysql/test/repl
         grep -rl 'docker-compose ' | xargs -r -n1 sed -i 's/docker-compose /docker compose /g'
         sed -i "s|#!/usr/bin/bash|#!/usr/bin/bash +e|" proxysql_repl_tests/bin/debezium-check.bash
         sed -i "s|#!/usr/bin/bash|#!/usr/bin/bash +e|" proxysql_repl_tests/exec_repl_test.sh
-        sed -i "s|JENKINS_SCRIPTS_PATH=.*|JENKINS_SCRIPTS_PATH=${{ github.workspace }}/jenkins-build-scripts|" env.sh
+        sed -i "s|JENKINS_SCRIPTS_PATH=.*|JENKINS_SCRIPTS_PATH=${{ github.workspace }}/proxysql/test/repl|" env.sh
         sed -i "s|WORKSPACE=.*|WORKSPACE=${{ github.workspace }}/proxysql|" env.sh
-        
+
         cd proxysql_repl_tests
         #./exec_repl_test.sh 5.7 no-ssl debezium
         RCS=0
@@ -132,7 +137,7 @@ jobs:
           RC=$?
           RCS=$(( $RCS + $RC ))
         done
-        
+
         #./docker-compose-destroy.bash
         sudo chmod -R 777 ${{ github.workspace }}/*
         exit $RCS

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -59,6 +59,19 @@ jobs:
 #        done
 #        echo "Cache available '${BLDCACHE}'"
 
+    - name: Checkout repl test suite
+      # The replication/shunning suite is vendored in-repo at test/repl/ (moved
+      # off the private jenkins-build-scripts repo, so no GH_TOKEN_PROXYSQL PAT).
+      # Sparse-checkout just that dir into proxysql/; the proxysql binary arrives
+      # separately via the build handoff below (unpacked into the same proxysql/).
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ env.SHA }}
+        path: 'proxysql'
+        sparse-checkout: |
+          test/repl
+
     - name: Download build handoff
       # Build payload arrives as workflow artifacts, not an Actions cache:
       # GitHub made cache writes read-only for workflow_run/untrusted triggers
@@ -98,18 +111,9 @@ jobs:
         done
         rm -f ../cache_*.tar.zst ../handoff-*.zip
 
-    - name: Checkout jenkins_build_scripts
-      uses: actions/checkout@v4
-      with:
-        repository: 'proxysql/jenkins-build-scripts'
-        ref: 'proxysql_repl_tests'
-        fetch-depth: 0
-        path: 'jenkins-build-scripts'
-        token: ${{ secrets.GH_TOKEN_PROXYSQL }}
-
     - name: Docker-hoster
       run: |
-        cd jenkins-build-scripts/infra-docker-hoster
+        cd proxysql/test/repl/infra-docker-hoster
         sed -i 's|image: .*|image: ghcr.io/mrmohebi/docker-hoster|' docker-compose.yml
         docker compose up -d
 
@@ -117,11 +121,12 @@ jobs:
       run: |
         set +e
         
-        cd jenkins-build-scripts
+        # Vendored suite lives at proxysql/test/repl (was jenkins-build-scripts).
+        cd proxysql/test/repl
         grep -rl 'docker-compose ' | xargs -r -n1 sed -i 's/docker-compose /docker compose /g'
         sed -i "s|#!/usr/bin/bash|#!/usr/bin/bash +e|" proxysql_repl_tests/bin/debezium-check.bash
         sed -i "s|#!/usr/bin/bash|#!/usr/bin/bash +e|" proxysql_repl_tests/exec_shun_test.sh
-        sed -i "s|JENKINS_SCRIPTS_PATH=.*|JENKINS_SCRIPTS_PATH=${{ github.workspace }}/jenkins-build-scripts|" env.sh
+        sed -i "s|JENKINS_SCRIPTS_PATH=.*|JENKINS_SCRIPTS_PATH=${{ github.workspace }}/proxysql/test/repl|" env.sh
         sed -i "s|WORKSPACE=.*|WORKSPACE=${{ github.workspace }}/proxysql|" env.sh
         cat env.sh
         ls -l ${{ github.workspace }}/proxysql/src


### PR DESCRIPTION
Companion to the v3.0 PR that vendors the suite into `test/repl/` (**merge that first**).

Rewrites `ci-repltests.yml` + `ci-shuntest.yml`:
- sparse-checkout `test/repl` into `proxysql/` (binary still via the build-handoff artifact);
- point Docker-hoster + Replication/Shun-tests at `proxysql/test/repl/{infra-docker-hoster,proxysql_repl_tests}`, set `JENKINS_SCRIPTS_PATH` to `proxysql/test/repl`;
- **remove the `Checkout jenkins_build_scripts` step and `GH_TOKEN_PROXYSQL`**.

After this, **no active workflow uses `GH_TOKEN_PROXYSQL`** — only the disabled `ci-3p-*` still reference it, so the PAT is dormant and can be deleted once those are handled (you opted to leave 3p disabled for now).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01C21CuatwQ3CtFr62A6M4gU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to run replication and shunning tests from the repository’s vendored test suite instead of a separate external checkout.
  * Standardized the test execution and Docker host startup commands to use the new in-repo layout.
  * Improved workflow setup to consistently resolve workspace/test paths for scripts and environment variables.
  * Added a 45-minute timeout to the test jobs for more reliable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->