### PR TITLE
feat: release generic Linux binaries in tarball format (.tar.gz) (#569)

### DIFF
--- a/.github/workflows/CI-package-amd64-tarball.yml
+++ b/.github/workflows/CI-package-amd64-tarball.yml
@@ -1,0 +1,144 @@
+name: CI-package-amd64-tarball
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04
+    env:
+      ARCH: amd64
+      DIST: tarball
+      MAKE_TARGET: tarball-almalinux9
+      MATRIX: '(amd64,tarball)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/proxysql-*.tar.gz binaries/proxysql-*.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/proxysql-*.tar.gz or binaries/proxysql-*.tar.gz.sha256" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-amd64-tarball.yml
+++ b/.github/workflows/CI-package-amd64-tarball.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,8 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -25,6 +23,7 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Find or create draft release
       id: release
@@ -73,11 +72,24 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tier: v3.0
+            flags: ''
+          - tier: v3.1
+            flags: 'PROXYSQL31=1'
+          - tier: v4.0
+            flags: 'PROXYSQL40=1'
     env:
       ARCH: amd64
       DIST: tarball
       MAKE_TARGET: tarball-almalinux9
-      MATRIX: '(amd64,tarball)'
+      MATRIX: '(amd64,tarball,${{ matrix.tier }})'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
@@ -99,10 +111,11 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
         fetch-depth: 0
+        persist-credentials: false
 
-    - name: Build package
+    - name: Build package (${{ matrix.tier }})
       run: |
-        make ${{ env.MAKE_TARGET }}
+        make ${{ env.MAKE_TARGET }} ${{ matrix.flags }}
 
     - name: Upload to release
       env:

--- a/.github/workflows/CI-package-arm64-tarball.yml
+++ b/.github/workflows/CI-package-arm64-tarball.yml
@@ -1,0 +1,144 @@
+name: CI-package-arm64-tarball
+run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  init_release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+      release_name: ${{ steps.release.outputs.release_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Find or create draft release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        GIT_DESC=$(git describe --long --abbrev=7 --tags)
+        TAG_NAME="${{ github.ref_name }}-head"
+        RELEASE_NAME="${TAG_NAME} - ${GIT_DESC}"
+        REPO="${{ github.repository }}"
+        SHA="${{ github.sha }}"
+        echo "Target: $RELEASE_NAME (sha $SHA)"
+
+        # Stagger start to reduce the thundering-herd on first create
+        sleep $(( RANDOM % 10 ))
+
+        RELEASE_ID=""
+        for attempt in 1 2 3 4 5 6; do
+          IDS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq ".[] | select(.draft==true and .target_commitish==\"${SHA}\" and .tag_name==\"${TAG_NAME}\") | .id" \
+            | sort -n)
+          if [ -n "$IDS" ]; then
+            RELEASE_ID=$(echo "$IDS" | head -1)
+            NDUPES=$(echo "$IDS" | wc -l)
+            echo "attempt ${attempt}: found ${NDUPES} draft(s); using lowest id=${RELEASE_ID}"
+            break
+          fi
+          echo "attempt ${attempt}: no matching draft; creating"
+          gh api -X POST "repos/${REPO}/releases" \
+            -f tag_name="${TAG_NAME}" \
+            -f name="${RELEASE_NAME}" \
+            -f target_commitish="${SHA}" \
+            -F draft=true -F prerelease=true >/dev/null 2>&1 || true
+          sleep $(( (RANDOM % 4) + 2 ))
+        done
+
+        if [ -z "$RELEASE_ID" ]; then
+          echo "ERROR: could not find or create draft release after retries" >&2
+          exit 1
+        fi
+
+        echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+        echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: init_release
+    runs-on: ubuntu-24.04-arm
+    env:
+      ARCH: arm64
+      DIST: tarball
+      MAKE_TARGET: tarball-almalinux9
+      MATRIX: '(arm64,tarball)'
+      BRANCH: ${{ github.ref_name }}
+      RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
+
+    steps:
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Build package
+      run: |
+        make ${{ env.MAKE_TARGET }}
+
+    - name: Upload to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        uploaded=0
+        for f in binaries/proxysql-*.tar.gz binaries/proxysql-*.tar.gz.sha256; do
+          FNAME=$(basename "$f")
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+            --jq ".[] | select(.name==\"${FNAME}\") | .id" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Replacing existing asset ${FNAME} (id=${EXISTING})"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING}"
+          fi
+          echo "Uploading ${FNAME}"
+          gh api --method POST \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=${FNAME}" \
+            --header "Content-Type: application/octet-stream" \
+            --input "$f"
+          uploaded=$((uploaded+1))
+        done
+        if [ "$uploaded" -eq 0 ]; then
+          echo "ERROR: no package files matched binaries/proxysql-*.tar.gz or binaries/proxysql-*.tar.gz.sha256" >&2
+          ls -la binaries/ || true
+          exit 1
+        fi
+        echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ github.sha }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/CI-package-arm64-tarball.yml
+++ b/.github/workflows/CI-package-arm64-tarball.yml
@@ -4,10 +4,6 @@ run-name: '${{ github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -15,6 +11,8 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_name: ${{ steps.release.outputs.release_name }}
@@ -25,6 +23,7 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Find or create draft release
       id: release
@@ -73,11 +72,24 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tier: v3.0
+            flags: ''
+          - tier: v3.1
+            flags: 'PROXYSQL31=1'
+          - tier: v4.0
+            flags: 'PROXYSQL40=1'
     env:
       ARCH: arm64
       DIST: tarball
       MAKE_TARGET: tarball-almalinux9
-      MATRIX: '(arm64,tarball)'
+      MATRIX: '(arm64,tarball,${{ matrix.tier }})'
       BRANCH: ${{ github.ref_name }}
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
@@ -99,10 +111,11 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
         fetch-depth: 0
+        persist-credentials: false
 
-    - name: Build package
+    - name: Build package (${{ matrix.tier }})
       run: |
-        make ${{ env.MAKE_TARGET }}
+        make ${{ env.MAKE_TARGET }} ${{ matrix.flags }}
 
     - name: Upload to release
       env:

--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ build-%: PKG_NAME=$(firstword $(subst -, ,$(BLD_NAME)))
 build-%: PKG_COMP=$(if $(filter $(shell echo $(BLD_NAME) | grep -Eo '\-clang'),-clang),-clang,)
 build-%: PKG_ARCH=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),$(DEB_ARCH),$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarball')),-$(REL_ARCH),$(RPM_ARCH)))
 build-%: PKG_KIND=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),deb,$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarball')),tar.gz,rpm))
-build-%: PKG_FILE=$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarball')),binaries/proxysql-$(REL_VERS)$(PKG_TYPE)-linux$(PKG_ARCH).$(PKG_KIND),binaries/proxysql$(PKG_VERS)$(PKG_TYPE)-$(PKG_NAME)$(PKG_COMP)$(PKG_ARCH).$(PKG_KIND))
+build-%: PKG_FILE=$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarball')),binaries/proxysql-$(CURVER)$(PKG_TYPE)-linux$(PKG_ARCH).$(PKG_KIND),binaries/proxysql$(PKG_VERS)$(PKG_TYPE)-$(PKG_NAME)$(PKG_COMP)$(PKG_ARCH).$(PKG_KIND))
 build-%:
 	@echo 'building $@'
 	@IMG_NAME=$(PKG_NAME) IMG_TYPE=$(subst -,_,$(PKG_TYPE)) IMG_COMP=$(subst -,_,$(PKG_COMP)) BLD_NAME=$(BLD_NAME) $(MAKE) $(PKG_FILE)

--- a/Makefile
+++ b/Makefile
@@ -439,27 +439,30 @@ debian: $(REL_ARCH)-debian ;
 fedora: $(REL_ARCH)-fedora ;
 opensuse: $(REL_ARCH)-opensuse ;
 ubuntu: $(REL_ARCH)-ubuntu ;
+tarball: $(REL_ARCH)-tarball ;
 pkglist: $(REL_ARCH)-pkglist
 
 amd64-%: SYS_ARCH := x86_64
-amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensuse amd64-almalinux
+amd64-packages: amd64-centos amd64-ubuntu amd64-debian amd64-fedora amd64-opensuse amd64-almalinux amd64-tarball
 amd64-almalinux: almalinux8 almalinux8-clang almalinux8-dbg almalinux9 almalinux9-clang almalinux9-dbg almalinux10 almalinux10-clang almalinux10-dbg
 amd64-centos: centos9 centos9-clang centos9-dbg centos10 centos10-clang centos10-dbg
 amd64-debian: debian12 debian12-clang debian12-dbg debian13 debian13-clang debian13-dbg
 amd64-fedora: fedora42 fedora42-clang fedora42-dbg fedora43 fedora43-clang fedora43-dbg fedora44 fedora44-clang fedora44-dbg
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg opensuse16 opensuse16-clang opensuse16-dbg
 amd64-ubuntu: ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
+amd64-tarball: tarball-almalinux9
 amd64-pkglist:
 	@${MAKE} -nk amd64-packages 2>/dev/null | grep -Eo 'binaries/proxysql[^ ]*' | sed 's,^binaries/,,'
 
 arm64-%: SYS_ARCH := aarch64
-arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux
+arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux arm64-tarball
 arm64-almalinux: almalinux8 almalinux9 almalinux10
 arm64-centos: centos9 centos10
 arm64-debian: debian12 debian13
 arm64-fedora: fedora42 fedora43 fedora44
 arm64-opensuse: opensuse15 opensuse16
 arm64-ubuntu: ubuntu22 ubuntu24
+arm64-tarball: tarball-almalinux9
 arm64-pkglist:
 	@${MAKE} -nk arm64-packages 2>/dev/null | grep -Eo 'binaries/proxysql[^ ]*' | sed 's,^binaries/,,'
 
@@ -469,6 +472,7 @@ debian%: build-debian% ;
 fedora%: build-fedora% ;
 opensuse%: build-opensuse% ;
 ubuntu%: build-ubuntu% ;
+tarball%: build-tarball% ;
 
 
 .PHONY: build-%
@@ -478,9 +482,9 @@ build-%: PKG_VERS=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),de
 build-%: PKG_TYPE=$(if $(filter $(shell echo $(BLD_NAME) | grep -Eo '\-de?bu?g|\-test|\-tap'),-dbg -debug -test -tap),-dbg,)
 build-%: PKG_NAME=$(firstword $(subst -, ,$(BLD_NAME)))
 build-%: PKG_COMP=$(if $(filter $(shell echo $(BLD_NAME) | grep -Eo '\-clang'),-clang),-clang,)
-build-%: PKG_ARCH=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),$(DEB_ARCH),$(RPM_ARCH))
-build-%: PKG_KIND=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),deb,rpm)
-build-%: PKG_FILE=binaries/proxysql$(PKG_VERS)$(PKG_TYPE)-$(PKG_NAME)$(PKG_COMP)$(PKG_ARCH).$(PKG_KIND)
+build-%: PKG_ARCH=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),$(DEB_ARCH),$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarball')),-$(REL_ARCH),$(RPM_ARCH)))
+build-%: PKG_KIND=$(if $(filter $(shell echo ${BLD_NAME} | grep -Eo '[a-z]+'),debian ubuntu),deb,$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarball')),tar.gz,rpm))
+build-%: PKG_FILE=$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarball')),binaries/proxysql-$(REL_VERS)$(PKG_TYPE)-linux$(PKG_ARCH).$(PKG_KIND),binaries/proxysql$(PKG_VERS)$(PKG_TYPE)-$(PKG_NAME)$(PKG_COMP)$(PKG_ARCH).$(PKG_KIND))
 build-%:
 	@echo 'building $@'
 	@IMG_NAME=$(PKG_NAME) IMG_TYPE=$(subst -,_,$(PKG_TYPE)) IMG_COMP=$(subst -,_,$(PKG_COMP)) BLD_NAME=$(BLD_NAME) $(MAKE) $(PKG_FILE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -419,4 +419,17 @@ services:
       - PROXYSQL_BUILD_TYPE=debug
 
 ####################################################################################################
+  tarball_build:
+    extends:
+      service: _build
+    image: proxysql/packaging:build-almalinux9-v4.0.0
+    volumes:
+      - ./docker/images/proxysql/tarball-compliant/entrypoint/:/opt/entrypoint/
+      - ./:/opt/proxysql/
+    environment:
+      - PKG_RELEASE=tarball
+      - PROXYSQL_BUILD_TYPE=clickhouse
+
 ####################################################################################################
+####################################################################################################
+

--- a/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
@@ -1,10 +1,17 @@
 #!/bin/bash
 set -eu
 
+# CURVER, MAKE, MAKEOPT, PROXYSQL31/PROXYSQL40 are passed in from the outer
+# `make` via the docker-compose `_build` environment passthrough. CURVER
+# already reflects the tier (Stable 3.0.x, PROXYSQL31 -> 3.1.x, PROXYSQL40
+# -> 4.0.x), so the three tier tarballs get distinct, self-describing names.
 ARCH=$(uname -m)
 REL_ARCH=$(echo "${ARCH}" | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 DIR_NAME="proxysql-${CURVER}-linux-${REL_ARCH}"
 TARBALL_FILE="proxysql-${CURVER}-linux-${REL_ARCH}.tar.gz"
+
+echo "==> Build environment (tier-relevant):"
+env | grep -E '^(CURVER|PROXYSQL(31|40|FFTO|TSDB|_BUILD_TYPE)|MAKE|MAKEOPT)=' || true
 
 echo "==> Cleaning staging directories"
 rm -rf "/opt/proxysql/binaries/${TARBALL_FILE}" "/opt/proxysql/pkgroot" || true
@@ -12,13 +19,36 @@ rm -rf "/opt/proxysql/binaries/${TARBALL_FILE}" "/opt/proxysql/pkgroot" || true
 echo "==> Building ProxySQL"
 cd /opt/proxysql
 git config --system --add safe.directory '/opt/proxysql'
+echo "==> ProxySQL '$(git describe --long --abbrev=7 --tags)'  (tier CURVER=${CURVER})"
+export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
 
-# Determine targets
+# Pass the chassis tier flag explicitly on the make command line (matches
+# the deb/rpm entrypoints and is override-safe). CURVER above is computed
+# by the outer make with the same flag, so the artifact name stays in sync.
+EXTRA=""
+[[ "${PROXYSQL40:-}" == "1" ]] && EXTRA="${EXTRA} PROXYSQL40=1"
+[[ "${PROXYSQL31:-}" == "1" ]] && EXTRA="${EXTRA} PROXYSQL31=1"
+
+# The v4.0 chassis tier builds plugins/mysqlx/ which dynamically links the
+# system libprotobuf (3.x). Some v4.0.0 packaging images predate the plugin
+# and do not ship protobuf-devel; install it on demand for RHEL-family.
+if [[ "${PROXYSQL40:-}" == "1" ]] && ! pkg-config --exists protobuf 2>/dev/null; then
+    echo "==> Installing protobuf-devel (required for PROXYSQL40=1 mysqlx plugin build)"
+    if command -v dnf >/dev/null 2>&1; then
+        dnf install -y protobuf-devel
+    elif command -v yum >/dev/null 2>&1; then
+        yum install -y protobuf-devel
+    else
+        echo "ERROR: cannot install protobuf-devel (neither dnf nor yum present)" >&2
+        exit 1
+    fi
+fi
+
 deps_target="build_deps_clickhouse"
 build_target="clickhouse"
 
-${MAKE} ${MAKEOPT} ${deps_target}
-${MAKE} ${MAKEOPT} ${build_target}
+${MAKE} ${MAKEOPT} ${EXTRA} ${deps_target}
+${MAKE} ${MAKEOPT} ${EXTRA} ${build_target}
 
 echo "==> Staging Tarball Files"
 mkdir -p "pkgroot/${DIR_NAME}/bin"
@@ -33,14 +63,23 @@ cp tools/proxysql_galera_checker.sh tools/proxysql_galera_writer.pl "pkgroot/${D
 cp systemd/system/proxysql.service systemd/system/proxysql-initial.service "pkgroot/${DIR_NAME}/systemd/system/"
 cp LICENSE README.md "pkgroot/${DIR_NAME}/"
 
-# Add plugins for v4.0+
+# v4.0 chassis: bundle the plugin .so artefacts. The proxysql binary is the
+# loader; runtime features (mysqlx, genai/MCP) ship as separate .so files.
+# Under PROXYSQL40=1 the Makefile builds them, so fail-fast if any is missing
+# rather than ship an incomplete tarball.
 if [[ "${PROXYSQL40:-}" == "1" ]]; then
     mkdir -p "pkgroot/${DIR_NAME}/lib/proxysql"
-    [[ -f plugins/mysqlx/ProxySQL_MySQLX_Plugin.so ]] && cp plugins/mysqlx/ProxySQL_MySQLX_Plugin.so "pkgroot/${DIR_NAME}/lib/proxysql/"
-    [[ -f plugins/genai/ProxySQL_GenAI_Plugin.so ]] && cp plugins/genai/ProxySQL_GenAI_Plugin.so "pkgroot/${DIR_NAME}/lib/proxysql/"
+    for plugin in plugins/mysqlx/ProxySQL_MySQLX_Plugin.so plugins/genai/ProxySQL_GenAI_Plugin.so; do
+        if [[ ! -f "${plugin}" ]]; then
+            echo "ERROR: PROXYSQL40=1 build but '${plugin}' is missing" >&2
+            exit 1
+        fi
+        cp "${plugin}" "pkgroot/${DIR_NAME}/lib/proxysql/"
+    done
 fi
 
 echo "==> Compressing Tarball"
+mkdir -p /opt/proxysql/binaries
 cd pkgroot
 tar -czf "../binaries/${TARBALL_FILE}" "${DIR_NAME}"
 
@@ -48,4 +87,8 @@ tar -czf "../binaries/${TARBALL_FILE}" "${DIR_NAME}"
 cd ../binaries
 sha256sum "${TARBALL_FILE}" > "${TARBALL_FILE}.sha256"
 
-echo "==> Tarball build successfully completed!"
+# Clean up staging (the repo root is bind-mounted, so leftover root-owned
+# pkgroot/ would pollute the host git working tree).
+rm -rf /opt/proxysql/pkgroot || true
+
+echo "==> Tarball build successfully completed: ${TARBALL_FILE}"

--- a/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -eu
+
+ARCH=$(uname -m)
+REL_ARCH=$(echo "${ARCH}" | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+DIR_NAME="proxysql-${CURVER}-linux-${REL_ARCH}"
+TARBALL_FILE="proxysql-${CURVER}-linux-${REL_ARCH}.tar.gz"
+
+echo "==> Cleaning staging directories"
+rm -rf "/opt/proxysql/binaries/${TARBALL_FILE}" "/opt/proxysql/pkgroot" || true
+
+echo "==> Building ProxySQL"
+cd /opt/proxysql
+git config --system --add safe.directory '/opt/proxysql'
+
+# Determine targets
+deps_target="build_deps_clickhouse"
+build_target="clickhouse"
+
+${MAKE} ${MAKEOPT} ${deps_target}
+${MAKE} ${MAKEOPT} ${build_target}
+
+echo "==> Staging Tarball Files"
+mkdir -p "pkgroot/${DIR_NAME}/bin"
+mkdir -p "pkgroot/${DIR_NAME}/etc/logrotate.d"
+mkdir -p "pkgroot/${DIR_NAME}/share/proxysql/tools"
+mkdir -p "pkgroot/${DIR_NAME}/systemd/system"
+
+cp src/proxysql "pkgroot/${DIR_NAME}/bin/"
+cp etc/proxysql.cnf "pkgroot/${DIR_NAME}/etc/"
+cp etc/logrotate.d/proxysql "pkgroot/${DIR_NAME}/etc/logrotate.d/"
+cp tools/proxysql_galera_checker.sh tools/proxysql_galera_writer.pl "pkgroot/${DIR_NAME}/share/proxysql/tools/"
+cp systemd/system/proxysql.service systemd/system/proxysql-initial.service "pkgroot/${DIR_NAME}/systemd/system/"
+cp LICENSE README.md "pkgroot/${DIR_NAME}/"
+
+# Add plugins for v4.0+
+if [[ "${PROXYSQL40:-}" == "1" ]]; then
+    mkdir -p "pkgroot/${DIR_NAME}/lib/proxysql"
+    [[ -f plugins/mysqlx/ProxySQL_MySQLX_Plugin.so ]] && cp plugins/mysqlx/ProxySQL_MySQLX_Plugin.so "pkgroot/${DIR_NAME}/lib/proxysql/"
+    [[ -f plugins/genai/ProxySQL_GenAI_Plugin.so ]] && cp plugins/genai/ProxySQL_GenAI_Plugin.so "pkgroot/${DIR_NAME}/lib/proxysql/"
+fi
+
+echo "==> Compressing Tarball"
+cd pkgroot
+tar -czf "../binaries/${TARBALL_FILE}" "${DIR_NAME}"
+
+# Generate SHA256 sum file
+cd ../binaries
+sha256sum "${TARBALL_FILE}" > "${TARBALL_FILE}.sha256"
+
+echo "==> Tarball build successfully completed!"


### PR DESCRIPTION
This PR implements generic Linux binary packaging in tarball format (.tar.gz) as requested in issue #569.

    ### Changes:
    1. **Makefile**: Added `tarball` targets (`amd64-tarball`, `arm64-tarball`, `tarball-almalinux9`) and configured variable matching to support `.tar.gz` output.
    2. **docker-compose.yml**: Registered the `tarball_build` service using an **AlmaLinux 9** base build image (supporting OpenSSL 3 and glibc 2.34 compatibility).
    3. **Staging & Packaging Entrypoint Script**: Created `docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash` to bundle the compiled binary, configurations, tools, systemd
  units, and plugins.
    4. **GitHub Action Workflows**: Created workflows for amd64 and arm64 manual/dispatch tarball builds.

    Addresses: #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tarball packaging support for both amd64 and arm64 builds.
  * Added manual workflows to build and publish amd64/arm64 tarball packages as draft prereleases tied to the current commit.
  * Introduced container-based tarball artifact building and staging.
* **Bug Fixes**
  * Release assets with the same filename are now replaced automatically when publishing new tarballs.
  * Builds now fail when no matching tarball artifacts are produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->