### PR TITLE
ci: re-enable workflow_run auto-trigger for repltests/shuntest

### DIFF
--- a/.github/workflows/CI-repltests.yml
+++ b/.github/workflows/CI-repltests.yml
@@ -2,13 +2,10 @@ name: CI-repltests
 run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
-  # Auto-triggering disabled: jenkins-build-scripts repo access currently
-  # returns HTTP 403 from this workflow. Re-enable by restoring the
-  # workflow_run trigger once jenkins-build-scripts access is fixed.
   workflow_dispatch:
-  # workflow_run:
-  #   workflows: [ CI-trigger ]
-  #   types: [ completed ]
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}

--- a/.github/workflows/CI-shuntest.yml
+++ b/.github/workflows/CI-shuntest.yml
@@ -2,13 +2,10 @@ name: CI-shuntest
 run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
 
 on:
-  # Auto-triggering disabled: jenkins-build-scripts repo access currently
-  # returns HTTP 403 from this workflow. Re-enable by restoring the
-  # workflow_run trigger once jenkins-build-scripts access is fixed.
   workflow_dispatch:
-  # workflow_run:
-  #   workflows: [ CI-trigger ]
-  #   types: [ completed ]
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ completed ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}


### PR DESCRIPTION
Follow-up to #5876. Re-enables the `workflow_run` auto-trigger on `CI-repltests.yml` and `CI-shuntest.yml` so they run on every push/PR again (currently `workflow_dispatch`-only).

**Why they were disabled:** the callers carry the note *"Auto-triggering disabled: jenkins-build-scripts repo access currently returns HTTP 403 ... Re-enable once jenkins-build-scripts access is fixed."* That precondition is now met — #5872/#5876 vendored the suite into `test/repl/` and removed the cross-org `jenkins-build-scripts` checkout + `GH_TOKEN_PROXYSQL` PAT (no more 403). #5876 also fixed the suite itself (missing `proxysql.cnf`, obsolete `admin-hash_passwords`, and bounded all 19 polling loops).

**Verified locally** against a freshly-built branch proxysql (`3.0.9-710`, the `-tap` debug build CI produces): repl (no-ssl), repl (SSL), repl (Debezium/CDC — GTID match), and shun all pass (`EXIT=0`).

The only change is uncommenting the `on: workflow_run:` block; the job `if:`, `permissions: write-all`, and `uses: …@GH-Actions` were already correct.

⚠️ **Caveat before merge:** my verification was *local*. These haven't yet run green on a real CI runner (they were disabled). Recommend one manual `workflow_dispatch` of each on v3.0 first to confirm CI-green, so merging doesn't add two red checks to every PR. Happy to run that.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01C21CuatwQ3CtFr62A6M4gU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled automated workflow triggers so two CI-related checks now start automatically after the upstream pipeline completes.
  * Manual run options remain available for both workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->