### PR TITLE
test(repl): add vendored proxysql.cnf dropped by .gitignore in #5876

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ core
 
 #config
 proxysql.cnf*
+# ...but keep the vendored repl-suite config (global rule above would drop it):
+!test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf
 proxysql.db*
 
 jeprof*heap

--- a/test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf
+++ b/test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf
@@ -1,0 +1,34 @@
+admin_variables=
+{
+	admin_credentials="admin:admin;radmin:radmin"
+	mysql_ifaces="0.0.0.0:6032"
+}
+
+mysql_variables=
+{
+	threads=8
+	max_connections=2048
+	default_query_delay=0
+	default_query_timeout=36000000
+	have_compress=true
+	poll_timeout=2000
+	interfaces="0.0.0.0:6033"
+	default_schema="information_schema"
+	stacksize=1048576
+	server_version="5.5.30"
+	connect_timeout_server=3000
+	monitor_username="monitor"
+	monitor_password="monitor"
+	monitor_history=600000
+	monitor_connect_interval=10000
+	monitor_connect_timeout=1000
+	monitor_ping_interval=10000
+	monitor_read_only_interval=1500
+	monitor_read_only_timeout=500
+	ping_interval_server_msec=120000
+	ping_timeout_server=500
+	commands_stats=true
+	sessions_sort=true
+	connect_retries_on_failure=10
+	session_idle_ms=1
+}


### PR DESCRIPTION
**Bug in #5876 (found while setting up CI verification for the repl/shun suite).**

#5876 re-vendored the suite but **`test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf` never got committed** — the global `proxysql.cnf*` rule in `.gitignore` (line 106) matches it, so `git add -A` silently skipped it. The `.sql` templates beside it committed fine; the ProxySQL config didn't.

**Impact:** in CI, `exec_repl_test.sh`/`exec_shun_test.sh` run `./proxysql -c …/conf/proxysql/proxysql.cnf` against a **missing file** → ProxySQL never starts → the suite hangs. That's the *exact* original bug #5876 was meant to fix. My earlier local verification passed only because the file existed as an **untracked** file in my worktree — it was never in git.

**Fix:** add the file (`git add -f`) + a `.gitignore` negation so the global rule can't drop it again. Confirmed via `git status --ignored` that `proxysql.cnf` was the *only* vendored file the rule dropped.

⚠️ This should merge **before** re-enabling the auto-triggers (#5888) — otherwise the suite hangs in CI.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01C21CuatwQ3CtFr62A6M4gU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored a bundled ProxySQL configuration so test environments can load the expected settings.
  * Ensured the configuration file is included despite broader ignore rules, preventing it from being skipped during packaging or checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->