### PR TITLE
ci: harden TAP coverage uploads

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -150,12 +151,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-clickhouse-g1"
         export TAP_GROUP="legacy-clickhouse-g1"
         docker logs proxysql.ci-legacy-clickhouse-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -186,6 +191,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/) to
@@ -203,7 +213,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
@@ -222,7 +232,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g1"
         export TAP_GROUP="legacy-g1"
         docker logs proxysql.ci-legacy-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -44,6 +44,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -163,12 +164,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g2-genai"
         export TAP_GROUP="legacy-g2"
         docker logs proxysql.ci-legacy-g2-genai 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -199,6 +204,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/)
@@ -218,7 +228,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/ci-legacy-g2-genai.info
@@ -241,7 +251,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g3"
         export TAP_GROUP="legacy-g3"
         docker logs proxysql.ci-legacy-g3 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -150,12 +151,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g4"
         export TAP_GROUP="legacy-g4"
         docker logs proxysql.ci-legacy-g4 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -186,6 +191,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/) to
@@ -203,7 +213,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
@@ -222,7 +232,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,12 +148,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g5"
         export TAP_GROUP="legacy-g5"
         docker logs proxysql.ci-legacy-g5 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -183,6 +188,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/) to
@@ -200,7 +210,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
@@ -219,7 +229,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g6"
         export TAP_GROUP="legacy-g6"
         docker logs proxysql.ci-legacy-g6 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g7"
         export TAP_GROUP="legacy-g7"
         docker logs proxysql.ci-legacy-g7 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g8"
         export TAP_GROUP="legacy-g8"
         docker logs proxysql.ci-legacy-g8 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-legacy-g9"
         export TAP_GROUP="legacy-g9"
         docker logs proxysql.ci-legacy-g9 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g1"
         export TAP_GROUP="mariadb10-galera-g1"
         docker logs proxysql.ci-mariadb10-galera-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g2"
         export TAP_GROUP="mariadb10-galera-g2"
         docker logs proxysql.ci-mariadb10-galera-g2 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g3"
         export TAP_GROUP="mariadb10-galera-g3"
         docker logs proxysql.ci-mariadb10-galera-g3 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g4"
         export TAP_GROUP="mariadb10-galera-g4"
         docker logs proxysql.ci-mariadb10-galera-g4 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,12 +148,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g5"
         export TAP_GROUP="mariadb10-galera-g5"
         docker logs proxysql.ci-mariadb10-galera-g5 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -176,6 +181,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/) to
@@ -193,7 +203,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
@@ -212,7 +222,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g6"
         export TAP_GROUP="mariadb10-galera-g6"
         docker logs proxysql.ci-mariadb10-galera-g6 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g7"
         export TAP_GROUP="mariadb10-galera-g7"
         docker logs proxysql.ci-mariadb10-galera-g7 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g8"
         export TAP_GROUP="mariadb10-galera-g8"
         docker logs proxysql.ci-mariadb10-galera-g8 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g9"
         export TAP_GROUP="mariadb10-galera-g9"
         docker logs proxysql.ci-mariadb10-galera-g9 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -37,6 +37,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -155,12 +156,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql56-single-g1"
         export TAP_GROUP="mysql56-single-g1"
         docker logs proxysql.ci-mysql56-single-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -191,6 +196,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/) to
@@ -208,7 +218,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
@@ -227,7 +237,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g1"
         export TAP_GROUP="mysql84-g1"
         docker logs proxysql.ci-mysql84-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g2"
         export TAP_GROUP="mysql84-g2"
         docker logs proxysql.ci-mysql84-g2 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g3"
         export TAP_GROUP="mysql84-g3"
         docker logs proxysql.ci-mysql84-g3 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g4"
         export TAP_GROUP="mysql84-g4"
         docker logs proxysql.ci-mysql84-g4 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,12 +148,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g5"
         export TAP_GROUP="mysql84-g5"
         docker logs proxysql.ci-mysql84-g5 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -183,6 +188,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/) to
@@ -200,7 +210,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
@@ -219,7 +229,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g6"
         export TAP_GROUP="mysql84-g6"
         docker logs proxysql.ci-mysql84-g6 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g7"
         export TAP_GROUP="mysql84-g7"
         docker logs proxysql.ci-mysql84-g7 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g8"
         export TAP_GROUP="mysql84-g8"
         docker logs proxysql.ci-mysql84-g8 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-g9"
         export TAP_GROUP="mysql84-g9"
         docker logs proxysql.ci-mysql84-g9 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g1"
         export TAP_GROUP="mysql84-gr-g1"
         docker logs proxysql.ci-mysql84-gr-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g2"
         export TAP_GROUP="mysql84-gr-g2"
         docker logs proxysql.ci-mysql84-gr-g2 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g3"
         export TAP_GROUP="mysql84-gr-g3"
         docker logs proxysql.ci-mysql84-gr-g3 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g4"
         export TAP_GROUP="mysql84-gr-g4"
         docker logs proxysql.ci-mysql84-gr-g4 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,12 +148,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g5"
         export TAP_GROUP="mysql84-gr-g5"
         docker logs proxysql.ci-mysql84-gr-g5 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -176,6 +181,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/) to
@@ -193,7 +203,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
@@ -212,7 +222,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g6"
         export TAP_GROUP="mysql84-gr-g6"
         docker logs proxysql.ci-mysql84-gr-g6 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g7"
         export TAP_GROUP="mysql84-gr-g7"
         docker logs proxysql.ci-mysql84-gr-g7 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g8"
         export TAP_GROUP="mysql84-gr-g8"
         docker logs proxysql.ci-mysql84-gr-g8 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g9"
         export TAP_GROUP="mysql84-gr-g9"
         docker logs proxysql.ci-mysql84-gr-g9 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql90-gr-g1"
         export TAP_GROUP="mysql90-gr-g1"
         docker logs proxysql.ci-mysql90-gr-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/ci-mysql90-gr-g1.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql93-gr-g1"
         export TAP_GROUP="mysql93-gr-g1"
         docker logs proxysql.ci-mysql93-gr-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/ci-mysql93-gr-g1.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-mysql95-gr-g1"
         export TAP_GROUP="mysql95-gr-g1"
         docker logs proxysql.ci-mysql95-gr-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -178,6 +183,11 @@ jobs:
           proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/) to
@@ -195,7 +205,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/ci-mysql95-gr-g1.info
@@ -214,7 +224,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-pgsql-socket-g1"
         export TAP_GROUP="pgsql-socket-g1"
         docker logs proxysql.ci-pgsql-socket-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,12 +150,16 @@ jobs:
       if: always()
       run: |
         set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
         cd proxysql
         export INFRA_ID="ci-set-parser-algorithm-3-g1"
         export TAP_GROUP="set_parser_algorithm_3-g1"
         docker logs proxysql.ci-set-parser-algorithm-3-g1 2>&1 | tail -50 || true
-        test/infra/control/stop-proxysql-isolated.bash
-        test/infra/control/destroy-infras.bash
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}
@@ -185,6 +190,11 @@ jobs:
           proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/
         if-no-files-found: ignore
 
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
     - name: Upload coverage to Codecov
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/) to
@@ -202,7 +212,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
@@ -221,7 +231,8 @@ jobs:
         verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
-      if: always()
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}


### PR DESCRIPTION
## Summary

Hardens the reusable TAP workflows that upload coverage to Codecov.

- makes the custom `LouisBrunner/checks-action` status publishing non-blocking
- skips final custom-check updates when the initial check creation did not return a `check_id`
- makes cleanup tolerate failures before checkout creates `proxysql/`
- skips Codecov upload when no LCOV report exists and emits an explicit diagnostic instead

## Root cause

A recent TAP coverage run failed before checkout because custom check creation hit a GitHub installation API rate limit. Since checkout and tests were skipped, cleanup failed on the missing `proxysql/` directory and Codecov was invoked with a missing `.info` file.

## Validation

- `git diff --check`
- PyYAML parse of all 65 workflow files
- `actionlint` via `go run github.com/rhysd/actionlint/cmd/actionlint@latest` on the modified workflow files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI jobs are now more resilient when optional cleanup files or directories are missing.
  * Coverage upload is skipped when no coverage report is generated, with a clear message instead of a failed upload.
  * Check-status reporting is now less likely to fail jobs, helping pipelines complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->