### PR TITLE
fix(tarball): v4.0 build — protobuf-devel (CRB) + plugin-link ordering (follow-up to #5881)

### DIFF
--- a/.github/workflows/CI-package-amd64-tarball.yml
+++ b/.github/workflows/CI-package-amd64-tarball.yml
@@ -97,6 +97,7 @@ jobs:
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
       if: always()
+      continue-on-error: true
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
@@ -148,6 +149,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()
+      continue-on-error: true
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/.github/workflows/CI-package-arm64-tarball.yml
+++ b/.github/workflows/CI-package-arm64-tarball.yml
@@ -97,6 +97,7 @@ jobs:
     - uses: LouisBrunner/checks-action@v2.0.0
       id: checks
       if: always()
+      continue-on-error: true
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
@@ -148,6 +149,7 @@ jobs:
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()
+      continue-on-error: true
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         check_id: ${{ steps.checks.outputs.check_id }}

--- a/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
@@ -32,14 +32,24 @@ EXTRA=""
 # The v4.0 chassis tier builds plugins/mysqlx/ which dynamically links the
 # system libprotobuf (3.x). Some v4.0.0 packaging images predate the plugin
 # and do not ship protobuf-devel; install it on demand for RHEL-family.
+# protobuf-devel lives in the CRB repo on AlmaLinux/RHEL 9 (PowerTools on
+# EL8), which is disabled by default, so try enabling those before a plain
+# install.
 if [[ "${PROXYSQL40:-}" == "1" ]] && ! pkg-config --exists protobuf 2>/dev/null; then
     echo "==> Installing protobuf-devel (required for PROXYSQL40=1 mysqlx plugin build)"
     if command -v dnf >/dev/null 2>&1; then
-        dnf install -y protobuf-devel
+        dnf install -y --enablerepo=crb protobuf-devel \
+            || dnf install -y --enablerepo=powertools protobuf-devel \
+            || dnf install -y protobuf-devel
     elif command -v yum >/dev/null 2>&1; then
-        yum install -y protobuf-devel
+        yum install -y --enablerepo=powertools protobuf-devel \
+            || yum install -y protobuf-devel
     else
         echo "ERROR: cannot install protobuf-devel (neither dnf nor yum present)" >&2
+        exit 1
+    fi
+    if ! pkg-config --exists protobuf 2>/dev/null; then
+        echo "ERROR: protobuf-devel install did not provide a usable protobuf pkg-config" >&2
         exit 1
     fi
 fi

--- a/plugins/mysqlx/Makefile
+++ b/plugins/mysqlx/Makefile
@@ -92,6 +92,17 @@ CXXFLAGS += -fstack-protector-strong
 
 .DEFAULT_GOAL := all
 
+# Serialize this plugin's build. The vendored protobuf target (deps/Makefile)
+# is a recursive sub-make whose recipe first `rm -rf`s deps/protobuf and then
+# runs a slow cmake build+install. The plugin's .o, .pb.o and the final .so
+# all list $(PROTOBUF_LIB) as a prereq, but under the parent build's -j that
+# destructive rebuild has been observed to race the link -- the .so link
+# fires while protobuf is only partway rebuilt and libprotobuf.a is absent:
+#   /usr/bin/ld: cannot find .../protobuf-3.21.12/install/lib/libprotobuf.a
+# .NOTPARALLEL forces protobuf to finish before any plugin object or link.
+# The plugin build is small, so the lost parallelism is negligible.
+.NOTPARALLEL:
+
 SRCS := $(PLUGIN_DIR)/src/mysqlx_plugin.cpp \
 	$(PLUGIN_DIR)/src/mysqlx_admin_schema.cpp \
 	$(PLUGIN_DIR)/src/mysqlx_config_store.cpp \
@@ -111,6 +122,7 @@ $(ODIR):
 
 $(PROTOBUF_LIB):
 	$(MAKE) -C $(PROXYSQL_PATH)/deps PROXYSQL40=1 protobuf
+	@test -f $@ || { echo "ERROR: deps protobuf build did not produce $@" >&2; exit 1; }
 
 # Several plugin sources transitively include <google/protobuf/...> via
 # the .pb.h files under plugins/mysqlx/proto/ (e.g. mysqlx_protocol.cpp,


### PR DESCRIPTION
Follow-up to #5881 (merged). The generic-tarball feature landed, but validation by dispatching the tarball workflows surfaced two v4.0-only breaks that are **not** in `v3.0` yet. This PR carries the two fixes (the diff is exactly these two commits; the feature commit `e4376e7` is already merged).

### 1. `a5ccb8629` — protobuf-devel + checks-action
- v4.0 build failed with `No match for argument: protobuf-devel`. On AlmaLinux/RHEL 9 `protobuf-devel` is in the **CRB** repo (PowerTools on EL8), disabled by default. Enable it (`dnf --enablerepo=crb` → `powertools` → plain) and verify `pkg-config` finds protobuf after.
- A transient `Connect Timeout` in the trailing `checks-action` red'd an otherwise-successful v3.1 build+upload → mark those steps `continue-on-error`.

### 2. `3a8cdd7a0` — mysqlx plugin link race
After the protobuf-devel fix, the plugin **compiled** but failed at link: `ld: cannot find .../protobuf-3.21.12/install/lib/libprotobuf.a`. The vendored-protobuf rule (`deps/Makefile`) starts with a destructive `rm -rf protobuf-*/` before a slow cmake rebuild; the mysqlx plugin is built from both `build_deps_default` and `build_src_default`, and under `-j` that rebuild raced the `.so` link. Fix: `.NOTPARALLEL` in `plugins/mysqlx/Makefile` so protobuf finishes before any plugin object/link, plus a fail-fast if the archive is missing.

### Validation
- v3.0 + v3.1 tarballs already built + uploaded end-to-end (both arches) on the pre-fix run.
- v4.0 verdict pending: amd64 dispatch on `3a8cdd7a0` is running now; will confirm `proxysql-4.0.9-linux-amd64.tar.gz` (with bundled mysqlx/genai .so) builds + uploads before merge.

https://claude.ai/code/session_014qhWjonVGoNJhRRu8H3i5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability for ARM64 and AMD64 tarball packaging by preventing transient check-step failures from breaking the overall workflow.
  * Strengthened package setup on supported Linux systems so required protobuf tooling is installed and validated before continuing.
* **Chores**
  * Made the MySQLX plugin build more deterministic by avoiding parallel build races and failing fast when required build artifacts are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->