### PR TITLE
build: make MAKEOPT overridable from the environment (enables self-hosted -j cap)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,10 @@ ifneq (,$(findstring $(OS),Darwin FreeBSD))
     export CC
     export CXX
 endif
-export MAKEOPT := -j${NPROCS}
+# MAKEOPT is overridable from the environment so shared CI runners can cap
+# parallelism (e.g. MAKEOPT=-j8); unset, it auto-detects the core count.
+MAKEOPT ?= -j${NPROCS}
+export MAKEOPT
 
 ### systemd
 SYSTEMD := 0


### PR DESCRIPTION
Part of the self-hosted CI runner rollout. Changes `export MAKEOPT := -j$(NPROCS)` → `MAKEOPT ?= -j$(NPROCS)` so an environment-provided `MAKEOPT` (e.g. `-j8` on shared `ci-big6` runners) is respected instead of always recomputing `-j$(nproc)`.

Local/GitHub-hosted builds are unchanged (no `MAKEOPT` in env → auto-detect). The value already flows into the build container (docker-compose `- MAKEOPT` passthrough → `entrypoint.bash` `${MAKE} ${MAKEOPT}`), so this single line also caps the in-container compile.

Pairs with a `ci-builds.yml` change (GH-Actions) that sets `MAKEOPT=-j8` only when `runner.environment == self-hosted`.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build parallelism settings can now be overridden from the environment, instead of always using the default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->