### PR TITLE
ci(builds): self-hosted proxysql-ci routing (author+allowlist gated) + -j cap

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -42,7 +42,10 @@ jobs:
 #        fi
 
   builds:
-    runs-on: ubuntu-24.04
+    # Route to the self-hosted proxysql-ci pool only when: the actor is renecannao
+    # (trusted) AND this workflow is listed in the SELFHOSTED_WORKFLOWS repo variable.
+    # Otherwise fall back to GitHub-hosted ubuntu-24.04. Empty/absent variable = no routing.
+    runs-on: ${{ (github.actor == 'renecannao' || (inputs.trigger && fromJson(inputs.trigger).event.workflow_run.actor.login == 'renecannao')) && vars.SELFHOSTED_WORKFLOWS && contains(fromJson(vars.SELFHOSTED_WORKFLOWS), github.workflow) && fromJson('["self-hosted","proxysql-ci"]') || 'ubuntu-24.04' }}
 #    needs: [ lock ]
 #    outputs:
 #      matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -182,6 +185,10 @@ jobs:
           # matching \-test|\-tap and selects build_tap_test_debug; -dbg takes the else
           # branch which only builds src/proxysql, leaving test/tap/tests/**/*-t unbuilt
           # (silent false-green — see v3.0 doc/GH-Actions/README.md debugging section).
+          # On shared self-hosted runners, cap build parallelism so concurrent
+          # jobs don't oversubscribe the box (Makefile honours MAKEOPT ?=, and it
+          # propagates into the build container via docker-compose + entrypoint.bash).
+          if [ "${{ runner.environment }}" = "self-hosted" ]; then export MAKEOPT="-j8"; fi
           make ${{ matrix.dist }}-tap | tee ci_build_log/build-tap.log
           
           # create matrix of all test folders containing *-t


### PR DESCRIPTION
Pilot of the self-hosted runner routing on the heaviest workflow (`CI-builds`).

**runs-on routing** — resolves to `[self-hosted, proxysql-ci]` only when **both**: actor is `renecannao` (trusted) **and** `github.workflow` is in the `SELFHOSTED_WORKFLOWS` repo variable. Otherwise `ubuntu-24.04` (today's default). The variable is currently `[]`, so **merging this is a no-op** until `CI-builds` is added to it — safe to land, flip on deliberately.

**-j cap** — on self-hosted, sets `MAKEOPT=-j8` so N concurrent builds across the 8-runner pool don't oversubscribe the 32-core box. Relies on the paired **#5901** (`MAKEOPT ?=` in the Makefile); GitHub-hosted unaffected.

Control model: add/remove a workflow name in `SELFHOSTED_WORKFLOWS` to offload/reclaim it — no workflow edits. Next server just joins the `proxysql-ci` pool.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI build stability by limiting parallel build jobs on self-hosted runners, reducing the risk of resource oversubscription.
  * Made build runner selection more reliable by falling back to a standard hosted runner unless specific self-hosted conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->