### PR TITLE
Revert #5901 (MAKEOPT ?=) — it broke the -tap unit-test builds on v3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,10 +172,7 @@ ifneq (,$(findstring $(OS),Darwin FreeBSD))
     export CC
     export CXX
 endif
-# MAKEOPT is overridable from the environment so shared CI runners can cap
-# parallelism (e.g. MAKEOPT=-j8); unset, it auto-detects the core count.
-MAKEOPT ?= -j${NPROCS}
-export MAKEOPT
+export MAKEOPT := -j${NPROCS}
 
 ### systemd
 SYSTEMD := 0


### PR DESCRIPTION
**Urgent revert.** #5901 changed `export MAKEOPT := -j$(NPROCS)` → `MAKEOPT ?= …`. At that merge commit, `ubuntu22-tap` and `ubuntu24-tap-genai-gcov` began failing the "no unit test binaries found" compile-safety check **on GitHub-hosted runners** (verified: 4 runs at `0932b0953` fail, the preceding `693013468` passed; #5901's one-line Makefile change is the only diff).

The `?=` form changes how `MAKEOPT` resolves inside the build container (docker-compose passes it through, and `?=` stops the container re-forcing it), silently breaking `build_tap_test_debug`. Restoring `:=` unblocks all CI-builds on v3.0.

The self-hosted `-j` cap (the reason for #5901) will be redone with a dedicated variable that doesn't touch `MAKEOPT`'s assignment operator. Discovered while validating self-hosted runners — the routing itself works fine.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build behavior so the project’s default parallel job setting now takes precedence during `make` runs.
  * Kept this setting available to child build steps for consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->