### PR TITLE
test: remove stray committed mysqlbinlog symlink (absolute /home path)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,8 @@ test-scripts/deps/
 test/tap/tests/parsersql_digest_test
 test/tap/tests/setparser_parsersql_test
 deps/protobuf/protobuf-*/
+
+# Stray build artifact: run-tests-isolated.bash creates the real mysqlbinlog
+# symlink at runtime under test-scripts/deps/; never commit this one (it was
+# accidentally committed once with an absolute /home path).
+test/scripts/deps/mysqlbinlog

--- a/test/scripts/deps/mysqlbinlog
+++ b/test/scripts/deps/mysqlbinlog
@@ -1,1 +1,0 @@
-/home/rene/proxysql/test/deps/mysql-connector-c-8.4.0/mysql-8.4.0/runtime_output_directory/mysqlbinlog


### PR DESCRIPTION
`test/scripts/deps/mysqlbinlog` is a committed symlink to `/home/rene/proxysql/test/deps/.../mysqlbinlog` — an absolute path into a developer's home dir, committed by accident in `00b87013c`.

It's unused: `run-tests-isolated.bash` locates the real binary via `find -type f` (skips symlinks) and creates its own at runtime under `test-scripts/deps/` (a different path). Dangling/harmless on GitHub-hosted; on a **self-hosted** runner sharing the box with that checkout it resolves to a path the runner user can't read → `EACCES` when a step stats the work tree.

Removes it and gitignores the path. Found while validating self-hosted runners.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to prevent a stray test-generated artifact from being tracked.
  * Removed an accidentally committed leftover file related to test runtime output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->