### PR TITLE
fix(ci/infra): set report_host on mysql90/93/95-gr so ProxySQL GR monitor can reach members

### DIFF
--- a/test/infra/infra-dbdeployer-mysql90-gr/docker/entrypoint.sh
+++ b/test/infra/infra-dbdeployer-mysql90-gr/docker/entrypoint.sh
@@ -30,7 +30,8 @@ dbdeployer deploy replication "${MYSQL_VERSION}" \
     -c innodb_flush_log_at_trx_commit=2 \
     -c sync_binlog=0 \
     -c binlog_checksum=NONE \
-    -c innodb_use_native_aio=0
+    -c innodb_use_native_aio=0 \
+    -c report_host=dbdeployer1.${INFRA}
 
 echo "Group Replication deployed. Waiting for all nodes to be ready..."
 

--- a/test/infra/infra-dbdeployer-mysql93-gr/docker/entrypoint.sh
+++ b/test/infra/infra-dbdeployer-mysql93-gr/docker/entrypoint.sh
@@ -30,7 +30,8 @@ dbdeployer deploy replication "${MYSQL_VERSION}" \
     -c innodb_flush_log_at_trx_commit=2 \
     -c sync_binlog=0 \
     -c binlog_checksum=NONE \
-    -c innodb_use_native_aio=0
+    -c innodb_use_native_aio=0 \
+    -c report_host=dbdeployer1.${INFRA}
 
 echo "Group Replication deployed. Waiting for all nodes to be ready..."
 

--- a/test/infra/infra-dbdeployer-mysql95-gr/docker/entrypoint.sh
+++ b/test/infra/infra-dbdeployer-mysql95-gr/docker/entrypoint.sh
@@ -30,7 +30,8 @@ dbdeployer deploy replication "${MYSQL_VERSION}" \
     -c innodb_flush_log_at_trx_commit=2 \
     -c sync_binlog=0 \
     -c binlog_checksum=NONE \
-    -c innodb_use_native_aio=0
+    -c innodb_use_native_aio=0 \
+    -c report_host=dbdeployer1.${INFRA}
 
 echo "Group Replication deployed. Waiting for all nodes to be ready..."
 


### PR DESCRIPTION
## Problem
`CI-mysql93-gr-g1` and `CI-mysql95-gr-g1` fail systematically on `v3.0` (reproduced across multiple unrelated branches). The failing test varies run-to-run — `mysql-last_insert_id-t`, `kill_connection3-t`, `mysql-init_connect-1-t` — always with:

```
Error on Group Replication check for 127.0.0.1:3306/3307/3308 after 0ms.
  Unable to create a connection ... Can't connect to server on '127.0.0.1' (115)
... missed 3 heartbeats, shunning it ... Hostgroup 3500 has no servers available!
Max connect timeout reached while reaching hostgroup 3500 after 10000ms
```

## Root cause
The dbdeployer GR sandboxes default to `report_host=127.0.0.1`, so each GR member advertises `MEMBER_HOST=127.0.0.1` in `performance_schema.replication_group_members`. ProxySQL's GR monitor discovers members at their advertised address and health-checks them **there** — but ProxySQL runs in a separate container/network namespace where `127.0.0.1` does not reach the backend (connection refused). After 3 missed checks ProxySQL shuns all members, the writer hostgroup empties, and whatever query runs next times out.

`infra-dbdeployer-mysql84-gr` already overrides this with `-c report_host=dbdeployer1.${INFRA}` (a reachable address) and is unaffected; `mysql90/93/95-gr` omitted it. It is an intermittent race, worse under the slower gcov CI: 9.3/9.5 fail systematically there, 9.0 shares the same latent flaw.

**mysqld itself is healthy throughout** — clean error logs, 2–5% CPU, no OOM. This is purely a member-address advertisement problem, not a backend crash/overload and not a ProxySQL code bug.

## Fix
Set `report_host` to the reachable docker hostname on all three GR entrypoints, matching `mysql84-gr`:

```diff
     -c innodb_use_native_aio=0
+    -c innodb_use_native_aio=0 \
+    -c report_host=dbdeployer1.${INFRA}
```

`INFRA` is already provided to the container via docker-compose (`- INFRA=${INFRA}`), so it resolves at deploy time exactly as in mysql84-gr.

## Verification
Reproduced locally (debug build): the `mysql93-gr-g1` group failed ~1/3 runs before. After the change (report_host → reachable hostname, GR re-bootstrapped): **5/5 group runs pass (16/16)**. The GR members now advertise `MEMBER_HOST=dbdeployer1.infra-dbdeployer-mysql93-gr` and the monitor reaches them.

## Rollout note
`entrypoint.sh` is baked into `proxysql/ci-infra:dbdeployer-mysql{90,93,95}-gr` (see `docker/Dockerfile`). The three images have been rebuilt (`docker/build.sh`) and pushed; this PR is the source-of-truth change. Once merged, no further action is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database replication setup to include a host reporting setting during deployment.
  * Improved consistency in deployment configuration across supported MySQL versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->