### PR TITLE
docs(tarball): document generic Linux .tar.gz builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ wget https://github.com/sysown/proxysql/releases/download/v3.0.4/proxysql_3.0.4-
 dpkg -i proxysql_3.0.4-ubuntu24_amd64.deb
 ```
 
+#### Generic Linux binaries (tarball)
+
+Distribution-agnostic `.tar.gz` builds are also published on the
+[releases page](https://github.com/sysown/proxysql/releases) — handy for hosts
+where a `.deb`/`.rpm` is inconvenient (any glibc 2.34+ / OpenSSL 3 Linux,
+`amd64` or `arm64`). Grab the `proxysql-<version>-linux-<arch>.tar.gz` asset,
+verify its checksum, and extract:
+```bash
+sha256sum -c proxysql-<version>-linux-amd64.tar.gz.sha256
+tar xzf proxysql-<version>-linux-amd64.tar.gz
+```
+The archive contains `bin/proxysql`, a sample `etc/proxysql.cnf`, the `systemd/`
+units, and helper tools. The v4.0 build additionally ships the runtime plugins
+under `lib/proxysql/` (`ProxySQL_MySQLX_Plugin.so`, `ProxySQL_GenAI_Plugin.so`).
+
 Alternatively you can also use the available repositories:
 
 #### Ubuntu / Debian:

--- a/doc/GH-Actions/README.md
+++ b/doc/GH-Actions/README.md
@@ -731,6 +731,8 @@ All chain off `workflow_run[completed]` on `CI-trigger`.
 |---|---|---|---|---|
 | `CI-codeql.yml` | `ci-codeql.yml` | `workflow_run[completed]` on `CI-trigger` | Security analysis | ✅ |
 | `CI-package-build.yml` | `ci-package-build.yml` | `push` | Build `.deb` / `.rpm` / ARM64 packages | ✅ |
+| `CI-package-amd64-tarball.yml` | *(self-contained)* | `workflow_dispatch` | Build generic Linux `.tar.gz` (amd64, all tiers) | ✅ |
+| `CI-package-arm64-tarball.yml` | *(self-contained)* | `workflow_dispatch` | Build generic Linux `.tar.gz` (arm64, all tiers) | ✅ |
 
 ### Third-party integration (`CI-3p-*`)
 
@@ -752,6 +754,55 @@ from GitHub repository variables like
 | `CI-3p-php-pdo-pgsql.yml` | PHP PDO PostgreSQL | PostgreSQL |
 | `CI-3p-postgresql.yml` | libpq (native) | PostgreSQL |
 | `CI-3p-sqlalchemy.yml` | SQLAlchemy ORM | MySQL, PostgreSQL |
+
+### Release tarballs (generic Linux binaries)
+
+`CI-package-amd64-tarball.yml` and `CI-package-arm64-tarball.yml` build
+distribution-agnostic `.tar.gz` bundles — a portable alternative to the
+`.deb`/`.rpm` packages — and attach them to the rolling `<ref>-head` draft
+pre-release. Unlike most CI, these are **`workflow_dispatch`-only** (manual)
+and **self-contained** (no `@GH-Actions` reusable). Trigger them from the
+Actions UI (*Run workflow*) or the CLI, against any ref:
+
+```bash
+gh workflow run CI-package-amd64-tarball.yml --repo sysown/proxysql --ref v3.0
+gh workflow run CI-package-arm64-tarball.yml --repo sysown/proxysql --ref v3.0
+```
+
+> Note: `workflow_dispatch` workflows are only dispatchable once the file
+> exists on the repo's **default branch** (`v3.0`).
+
+Each run's `build` job is a **matrix over the three feature tiers**, so one
+dispatch produces three tarballs per architecture (`CURVER` is bumped per
+tier, so the names never collide):
+
+| Matrix leg | Flag passed to `make` | Artifact |
+|---|---|---|
+| `v3.0` | *(none)* | `proxysql-3.0.x-linux-<arch>.tar.gz` |
+| `v3.1` | `PROXYSQL31=1` | `proxysql-3.1.x-linux-<arch>.tar.gz` |
+| `v4.0` | `PROXYSQL40=1` | `proxysql-4.0.x-linux-<arch>.tar.gz` (bundles the `mysqlx` + `genai` plugin `.so`s under `lib/proxysql/`) |
+
+Mechanics worth knowing:
+
+* A preceding **`init_release`** job finds-or-creates the draft release tagged
+  `<ref>-head` **by tag name** and reuses it, so the tarballs land on the same
+  rolling draft as the `.deb`/`.rpm` packages (on `v3.0` that is `v3.0-head`).
+* The build runs in the `tarball_build` docker-compose service on an
+  **AlmaLinux 9** image (glibc 2.34 / OpenSSL 3), staged and packaged by
+  `docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash`.
+* Each `build` leg deletes-then-uploads its own assets by name (`.tar.gz` +
+  `.sha256`), so re-running refreshes them in place.
+
+To build a tarball locally (the exact command the workflow runs — needs Docker
+and access to the AlmaLinux 9 packaging image; arch is taken from `uname -m`):
+
+```bash
+make tarball-almalinux9                 # Stable (v3.0.x)
+make tarball-almalinux9 PROXYSQL31=1    # v3.1.x (FFTO + TSDB)
+make tarball-almalinux9 PROXYSQL40=1    # v4.0.x (+ mysqlx/genai plugins)
+```
+
+The resulting `.tar.gz` and its `.sha256` are written to `binaries/`.
 
 ---
 


### PR DESCRIPTION
Documentation for the generic Linux tarball release artifacts (shipped in #5881 / #5892 / #5898). Docs only — no code.

### README.md
Adds a **Generic Linux binaries (tarball)** subsection under Installation for end users: download from the releases page, `sha256sum -c`, `tar xzf`, the archive layout, and that the v4.0 build bundles the `mysqlx`/`genai` plugins under `lib/proxysql/`.

### doc/GH-Actions/README.md
- Two rows in the CodeQL/packaging catalogue for `CI-package-{amd64,arm64}-tarball`.
- A **Release tarballs (generic Linux binaries)** section covering: how to dispatch (`workflow_dispatch`-only, self-contained), the per-tier build matrix (v3.0/v3.1/v4.0 → `PROXYSQL31=1`/`PROXYSQL40=1`), the shared `<ref>-head` draft release via the tag-matched `init_release`, the AlmaLinux 9 `tarball_build` path, and the local `make tarball-almalinux9 [PROXYSQL31=1|PROXYSQL40=1]` command.

Base: **v3.0**.

https://claude.ai/code/session_014qhWjonVGoNJhRRu8H3i5J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for generic Linux `.tar.gz` binaries, including download, checksum verification, and extraction steps.
  * Expanded release documentation with details on Linux tarball packaging workflows and how to trigger them.
  * Noted the contents of the tarball and the extra runtime plugins included in newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->