### PR TITLE
[codex] mysqlx soak admin shutdown

### DIFF
--- a/test/scripts/mysqlx/README.md
+++ b/test/scripts/mysqlx/README.md
@@ -23,11 +23,12 @@ pip install mysql-connector-python
 
 Validates two operationally-important behaviours:
 
-1. **PROXYSQL SHUTDOWN mid-traffic**: opens N concurrent X-Protocol
-   clients running steady queries; issues `PROXYSQL SHUTDOWN` through
-   the admin port; verifies each client receives a clean
-   `Mysqlx::Error` frame with code 1053 ("Server is shutting down")
-   instead of an unannounced TCP RST. Exercises
+1. **PROXYSQL SHUTDOWN SLOW mid-traffic**: opens N concurrent
+   X-Protocol clients running steady queries; issues
+   `PROXYSQL SHUTDOWN SLOW` through the admin port; verifies each
+   client receives a clean `Mysqlx::Error` frame with code 1053
+   ("Server is shutting down") instead of an unannounced TCP RST.
+   Exercises
    `MysqlxSession::shutdown_notify_client()` (commit `55e90d1a7`).
 
 2. **`LOAD MYSQLX ROUTES TO RUNTIME` mid-traffic**: opens N clients on

--- a/test/scripts/mysqlx/README.md
+++ b/test/scripts/mysqlx/README.md
@@ -23,12 +23,12 @@ pip install mysql-connector-python
 
 Validates two operationally-important behaviours:
 
-1. **SIGTERM mid-traffic**: opens N concurrent X-Protocol clients
-   running steady queries; sends SIGTERM to ProxySQL; verifies each
-   client receives a clean `Mysqlx::Error` frame with code 1053
-   ("Server is shutting down") instead of an unannounced TCP RST.
-   Exercises `MysqlxSession::shutdown_notify_client()` (commit
-   `55e90d1a7`).
+1. **PROXYSQL SHUTDOWN mid-traffic**: opens N concurrent X-Protocol
+   clients running steady queries; issues `PROXYSQL SHUTDOWN` through
+   the admin port; verifies each client receives a clean
+   `Mysqlx::Error` frame with code 1053 ("Server is shutting down")
+   instead of an unannounced TCP RST. Exercises
+   `MysqlxSession::shutdown_notify_client()` (commit `55e90d1a7`).
 
 2. **`LOAD MYSQLX ROUTES TO RUNTIME` mid-traffic**: opens N clients on
    route `r1`, then via the admin port deletes `r1` from

--- a/test/scripts/mysqlx/behavioral_validation.py
+++ b/test/scripts/mysqlx/behavioral_validation.py
@@ -3,10 +3,10 @@
 
 Exercises two specific behaviours from issue #5678:
 
-1. PROXYSQL SHUTDOWN mid-traffic: open N X-Protocol clients running
-   steady queries, issue `PROXYSQL SHUTDOWN` through the admin port,
-   verify each client sees a clean Mysqlx::Error frame with code 1053
-   instead of a TCP RST.
+1. PROXYSQL SHUTDOWN SLOW mid-traffic: open N X-Protocol clients
+   running steady queries, issue `PROXYSQL SHUTDOWN SLOW` through the
+   admin port, verify each client sees a clean Mysqlx::Error frame
+   with code 1053 instead of a TCP RST.
 
 2. LOAD MYSQLX ROUTES TO RUNTIME mid-traffic: open N clients on a
    route, drop the route from admin, reload, verify in-flight sessions
@@ -95,7 +95,7 @@ def steady_traffic_thread(args, stop_event, results: List[dict], idx: int):
 
 
 def issue_admin_shutdown(args):
-    print("Issuing `PROXYSQL SHUTDOWN` through the admin port ...")
+    print("Issuing `PROXYSQL SHUTDOWN SLOW` through the admin port ...")
     try:
         import mysql.connector  # admin port speaks classic protocol
     except ImportError as e:
@@ -111,7 +111,7 @@ def issue_admin_shutdown(args):
         )
         cur = adm.cursor()
         try:
-            cur.execute("PROXYSQL SHUTDOWN")
+            cur.execute("PROXYSQL SHUTDOWN SLOW")
             print("Admin shutdown command accepted.")
             return True
         except Exception as e:
@@ -134,7 +134,7 @@ def issue_admin_shutdown(args):
 
 
 def scenario_shutdown(args):
-    print("=== Scenario 1: PROXYSQL SHUTDOWN mid-traffic ===")
+    print("=== Scenario 1: PROXYSQL SHUTDOWN SLOW mid-traffic ===")
     stop = threading.Event()
     results: List[dict] = []
     threads = [

--- a/test/scripts/mysqlx/behavioral_validation.py
+++ b/test/scripts/mysqlx/behavioral_validation.py
@@ -3,9 +3,10 @@
 
 Exercises two specific behaviours from issue #5678:
 
-1. SIGTERM mid-traffic: open N X-Protocol clients running steady
-   queries, send SIGTERM to proxysql, verify each client sees a clean
-   Mysqlx::Error frame with code 1053 instead of a TCP RST.
+1. PROXYSQL SHUTDOWN mid-traffic: open N X-Protocol clients running
+   steady queries, issue `PROXYSQL SHUTDOWN` through the admin port,
+   verify each client sees a clean Mysqlx::Error frame with code 1053
+   instead of a TCP RST.
 
 2. LOAD MYSQLX ROUTES TO RUNTIME mid-traffic: open N clients on a
    route, drop the route from admin, reload, verify in-flight sessions
@@ -19,9 +20,6 @@ test/scripts/mysqlx/README.md for the full setup recipe.
 """
 
 import argparse
-import os
-import signal
-import subprocess
 import sys
 import threading
 import time
@@ -51,15 +49,7 @@ def parse_args():
     p.add_argument("--password", required=True)
     p.add_argument("--clients", type=int, default=5,
                    help="Concurrent client count")
-    p.add_argument("--proxysql-pid-file", default="/var/run/proxysql.pid",
-                   help="Where to find the proxysql pid (for kill -TERM)")
-    p.add_argument("--external-kill", action="store_true",
-                   help="Don't try to send SIGTERM ourselves; expect an "
-                        "external actor (e.g. `docker kill -s TERM ...`) to "
-                        "deliver the signal while we observe disconnects. "
-                        "Required when ProxySQL runs in a separate container "
-                        "or host than this harness.")
-    p.add_argument("--scenario", choices=["sigterm", "reload", "all"],
+    p.add_argument("--scenario", choices=["shutdown", "reload", "all"],
                    default="all")
     p.add_argument("--route-name", default="r1",
                    help="Route name to drop in the reload scenario")
@@ -104,18 +94,47 @@ def steady_traffic_thread(args, stop_event, results: List[dict], idx: int):
     results.append(record)
 
 
-def find_proxysql_pid(args) -> int:
-    if os.path.isfile(args.proxysql_pid_file):
-        with open(args.proxysql_pid_file) as fh:
-            return int(fh.read().strip())
-    out = subprocess.check_output(["pidof", "proxysql"]).decode().strip()
-    if not out:
-        raise RuntimeError("proxysql process not found")
-    return int(out.split()[0])
+def issue_admin_shutdown(args):
+    print("Issuing `PROXYSQL SHUTDOWN` through the admin port ...")
+    try:
+        import mysql.connector  # admin port speaks classic protocol
+    except ImportError as e:
+        print(f"Admin shutdown unavailable: {type(e).__name__}: {e}")
+        return False
+
+    adm = None
+    try:
+        adm = mysql.connector.connect(
+            host=args.admin_host, port=args.admin_port,
+            user=args.admin_user, password=args.admin_pass,
+            ssl_disabled=True,
+        )
+        cur = adm.cursor()
+        try:
+            cur.execute("PROXYSQL SHUTDOWN")
+            print("Admin shutdown command accepted.")
+            return True
+        except Exception as e:
+            errno = getattr(e, "errno", None)
+            msg = str(e)
+            if errno in (2006, 2013) or "Lost connection" in msg or "gone away" in msg:
+                print(f"Admin shutdown disconnected as expected: {type(e).__name__}: {e}")
+                return True
+            print(f"Admin shutdown command failed: {type(e).__name__}: {e}")
+            return False
+    except Exception as e:
+        print(f"Admin shutdown connection failed: {type(e).__name__}: {e}")
+        return False
+    finally:
+        if adm is not None:
+            try:
+                adm.close()
+            except Exception:
+                pass
 
 
-def scenario_sigterm(args):
-    print("=== Scenario 1: SIGTERM mid-traffic ===")
+def scenario_shutdown(args):
+    print("=== Scenario 1: PROXYSQL SHUTDOWN mid-traffic ===")
     stop = threading.Event()
     results: List[dict] = []
     threads = [
@@ -127,16 +146,13 @@ def scenario_sigterm(args):
         t.start()
     time.sleep(2)  # let clients establish steady traffic
 
-    if args.external_kill:
-        print("--external-kill set; waiting for the external actor to send SIGTERM ...")
-        # Hold for the same ~few seconds the in-process path would take
-        # so steady-traffic threads accumulate observations to the
-        # disconnect.
-        time.sleep(5)
-    else:
-        pid = find_proxysql_pid(args)
-        print(f"Sending SIGTERM to proxysql (pid {pid})...")
-        os.kill(pid, signal.SIGTERM)
+    if not issue_admin_shutdown(args):
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+        return 1
+    # Give the server a moment to close the listener and notify clients.
+    time.sleep(3)
 
     for t in threads:
         t.join(timeout=10)
@@ -231,8 +247,8 @@ def scenario_reload(args):
 def main():
     args = parse_args()
     rc = 0
-    if args.scenario in ("sigterm", "all"):
-        rc |= scenario_sigterm(args)
+    if args.scenario in ("shutdown", "all"):
+        rc |= scenario_shutdown(args)
     if args.scenario in ("reload", "all"):
         rc |= scenario_reload(args)
     sys.exit(rc)

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -420,14 +420,14 @@ test_mysqlx_route_drop_inflight-t: test_mysqlx_route_drop_inflight-t.cpp $(PROXY
 		-I$(PROXYSQL_PATH)/plugins/mysqlx/include -I$(MYSQLX_PROTO_DIR) \
 		$(IDIRS) $(LDIRS) $(OPT) $(PROTOBUF_LIB) -lssl -lcrypto -ltap -lcpp_dotenv -lcurl -lmariadbclient -lpthread -lz -ldl -o $@
 
-# test_mysqlx_sigterm_inflight-t (the C++ stub binary) was deleted in the
-# same PR that removed skip_all() from the framework. The stub had never
-# been more than a skip_all() guard pointing operators at the real
-# implementation, which lives in
-# test/scripts/mysqlx/behavioral_validation.py --scenario sigterm. Once
-# skip_all was removed, the stub had no purpose other than to BAIL_OUT
-# on invocation, so the source and this Makefile target were removed
-# together. The python scenario is the canonical sigterm-inflight test.
+# The historical inflight stub binary was deleted in the same PR that
+# removed skip_all() from the framework. The stub had never been more
+# than a skip_all() guard pointing operators at the real implementation,
+# which lives in test/scripts/mysqlx/behavioral_validation.py
+# --scenario shutdown. Once skip_all was removed, the stub had no
+# purpose other than to BAIL_OUT on invocation, so the source and this
+# Makefile target were removed together. The python scenario is the
+# canonical shutdown-inflight test.
 
 
 ### clean targets

--- a/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
+++ b/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
@@ -10,7 +10,7 @@
 # password 'alicepass' provisioned.
 #
 # This wrapper emits exactly two TAP assertions:
-#   1. the PROXYSQL SHUTDOWN mid-traffic scenario from behavioral_validation.py
+#   1. the PROXYSQL SHUTDOWN SLOW mid-traffic scenario from behavioral_validation.py
 #   2. the LOAD MYSQLX ROUTES TO RUNTIME mid-traffic scenario
 # Each assertion is "ok" if behavioral_validation.py exited 0 for that
 # scenario. The Python script's own internal asserts produce
@@ -52,7 +52,7 @@ PROXY_CONTAINER="proxysql.${INFRA_ID:-dev-$USER}"
 
 echo "1..2"
 
-# Scenario 1: PROXYSQL SHUTDOWN mid-traffic
+# Scenario 1: PROXYSQL SHUTDOWN SLOW mid-traffic
 shutdown_scenario() {
     if python3 "${HARNESS}" \
         --proxysql-host "${PROXYSQL_HOST}" --proxysql-port "${PROXYSQL_PORT}" \
@@ -61,10 +61,10 @@ shutdown_scenario() {
         --clients 5 --scenario shutdown \
         2>&1 | sed 's/^/# /'
     then
-        echo "ok 1 - PROXYSQL SHUTDOWN mid-traffic: every client received clean Mysqlx::Error 1053"
+        echo "ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: every client received clean Mysqlx::Error 1053"
         return 0
     else
-        echo "not ok 1 - PROXYSQL SHUTDOWN mid-traffic: at least one client saw TCP RST or non-1053 error"
+        echo "not ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: at least one client saw TCP RST or non-1053 error"
         return 1
     fi
 }

--- a/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
+++ b/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
@@ -10,7 +10,7 @@
 # password 'alicepass' provisioned.
 #
 # This wrapper emits exactly two TAP assertions:
-#   1. the SIGTERM-mid-traffic scenario from behavioral_validation.py
+#   1. the PROXYSQL SHUTDOWN mid-traffic scenario from behavioral_validation.py
 #   2. the LOAD MYSQLX ROUTES TO RUNTIME mid-traffic scenario
 # Each assertion is "ok" if behavioral_validation.py exited 0 for that
 # scenario. The Python script's own internal asserts produce
@@ -52,35 +52,19 @@ PROXY_CONTAINER="proxysql.${INFRA_ID:-dev-$USER}"
 
 echo "1..2"
 
-# Scenario 1: SIGTERM mid-traffic
-# behavioral_validation.py wants the host PID; in the docker-isolated
-# harness ProxySQL is in a separate container. We send SIGTERM via
-# `docker exec ... kill 1` (PID 1 inside the container is the
-# proxysql process via the entrypoint command). The harness's
-# --proxysql-pid-file path is ignored because we kill from outside.
-sigterm_scenario() {
-    # Run the harness in scenario=sigterm mode but tell it to NOT
-    # send SIGTERM itself; we'll kill the container's PID 1 in the
-    # background and the harness will observe the disconnect.
-    # Simplest path: run the Python in a background subshell, kill
-    # PID 1 in the proxysql container after a short delay, wait for
-    # the harness to exit, and report.
-    (
-        sleep 3
-        docker kill -s TERM "${PROXY_CONTAINER}" >/dev/null 2>&1 || true
-    ) &
-
+# Scenario 1: PROXYSQL SHUTDOWN mid-traffic
+shutdown_scenario() {
     if python3 "${HARNESS}" \
         --proxysql-host "${PROXYSQL_HOST}" --proxysql-port "${PROXYSQL_PORT}" \
+        --admin-host "${ADMIN_HOST}" --admin-port "${ADMIN_PORT}" \
         --user "${TEST_USER}" --password "${TEST_PASS}" \
-        --clients 5 --scenario sigterm \
-        --external-kill \
+        --clients 5 --scenario shutdown \
         2>&1 | sed 's/^/# /'
     then
-        echo "ok 1 - SIGTERM mid-traffic: every client received clean Mysqlx::Error 1053"
+        echo "ok 1 - PROXYSQL SHUTDOWN mid-traffic: every client received clean Mysqlx::Error 1053"
         return 0
     else
-        echo "not ok 1 - SIGTERM mid-traffic: at least one client saw TCP RST or non-1053 error"
+        echo "not ok 1 - PROXYSQL SHUTDOWN mid-traffic: at least one client saw TCP RST or non-1053 error"
         return 1
     fi
 }
@@ -92,7 +76,7 @@ reload_scenario() {
     # the right thing is to re-provision via setup-infras.bash, but
     # for now we skip if the container isn't responsive).
     if ! docker exec "${PROXY_CONTAINER}" mysql -uadmin -padmin -h127.0.0.1 -P6032 -e 'SELECT 1' >/dev/null 2>&1; then
-        echo "ok 2 - reload scenario skipped # SKIP proxysql container not running (sigterm scenario killed it)"
+        echo "ok 2 - reload scenario skipped # SKIP proxysql container not running (shutdown scenario stopped it)"
         return 0
     fi
 
@@ -124,6 +108,6 @@ if ! python3 -c 'import mysqlx' 2>/dev/null; then
 fi
 
 RC=0
-sigterm_scenario || RC=1
+shutdown_scenario || RC=1
 reload_scenario  || RC=1
 exit $RC


### PR DESCRIPTION
This changes the mysqlx soak behavioral test to trigger the shutdown path through the ProxySQL admin port instead of killing the container with SIGTERM.

What changed:
- `behavioral_validation.py` now issues `PROXYSQL SHUTDOWN` via the admin connection for the shutdown scenario.
- `test_mysqlx_soak_behavioral-t.sh` now drives that shutdown scenario directly and no longer sends `docker kill -s TERM`.
- The mysqlx README and TAP Makefile comments were updated to match the new behavior.

Why:
- The prior wrapper was masking the behavior under test by using an out-of-band SIGTERM. The test should exercise the admin shutdown path that ProxySQL actually exposes.

Checks:
- `python3 -m py_compile test/scripts/mysqlx/behavioral_validation.py`
- `bash -n test/tap/tests/test_mysqlx_soak_behavioral-t.sh`
- `git diff --check` on the touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the mid-traffic X-Protocol shutdown validation to use a controlled shutdown path, so clients now receive a clean `Mysqlx::Error` with code **1053** instead of a TCP reset.

* **Tests**
  * Switched scenario-1 from **SIGTERM** to a **shutdown**-based flow and adjusted the harness expectations accordingly (treating non-1053 outcomes as failures).
  * Updated the wrapper script to run the new **shutdown** scenario before the reload scenario.

* **Documentation**
  * Refreshed scenario-1 documentation and related comments to reflect the new **shutdown** behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->