### PR TITLE
test(deps): robust MySQL tarball download (retry + integrity + atomic)

### DIFF
--- a/test/deps/Makefile
+++ b/test/deps/Makefile
@@ -36,8 +36,21 @@ endif
 
 mariadb_client: mariadb-connector-c/mariadb-connector-c/libmariadb/libmariadbclient.a
 
+# Robust tarball fetch: retry a clean download up to 5x (portable -- no curl
+# --retry-all-errors, which needs curl >= 7.71 and breaks on e.g. EL8), abort a
+# stalled transfer (--speed-limit/--speed-time), verify gzip integrity, and only
+# then atomically rename into place so a partial never satisfies the target.
+# $(1)=dir  $(2)=tarball  $(3)=url
+define fetch_tarball
+	cd $(1) && ( for i in 1 2 3 4 5; do \
+		rm -f $(2).part; \
+		curl -fL --connect-timeout 30 --speed-limit 1024 --speed-time 30 -o $(2).part $(3) && gzip -t $(2).part && mv $(2).part $(2) && exit 0; \
+		echo "download of $(2) failed (attempt $$i/5), retrying in 5s..." >&2; sleep 5; \
+	done; echo "ERROR: could not download $(2) after 5 attempts" >&2; exit 1 )
+endef
+
 mysql-connector-c/mysql-boost-5.7.44.tar.gz:
-	cd mysql-connector-c && rm -f mysql-boost-5.7.44.tar.gz.part && curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 -o mysql-boost-5.7.44.tar.gz.part https://cdn.mysql.com//Downloads/MySQL-5.7/mysql-boost-5.7.44.tar.gz && gzip -t mysql-boost-5.7.44.tar.gz.part && mv mysql-boost-5.7.44.tar.gz.part mysql-boost-5.7.44.tar.gz
+	$(call fetch_tarball,mysql-connector-c,mysql-boost-5.7.44.tar.gz,https://cdn.mysql.com//Downloads/MySQL-5.7/mysql-boost-5.7.44.tar.gz)
 
 mysql-connector-c/mysql-connector-c/libmysql/libmysqlclient.a: mysql-connector-c/mysql-boost-5.7.44.tar.gz
 	cd mysql-connector-c && rm -rf mysql-*/ || true
@@ -72,7 +85,7 @@ endif
 mysql_client: mysql-connector-c/mysql-connector-c/libmysql/libmysqlclient.a
 
 mysql-connector-c-8.4.0/mysql-8.4.0.tar.gz:
-	cd mysql-connector-c-8.4.0 && rm -f mysql-8.4.0.tar.gz.part && curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 -o mysql-8.4.0.tar.gz.part https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.0.tar.gz && gzip -t mysql-8.4.0.tar.gz.part && mv mysql-8.4.0.tar.gz.part mysql-8.4.0.tar.gz
+	$(call fetch_tarball,mysql-connector-c-8.4.0,mysql-8.4.0.tar.gz,https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.0.tar.gz)
 
 mysql-connector-c-8.4.0/mysql-connector-c/libmysql/libmysqlclient.a: mysql-connector-c-8.4.0/mysql-8.4.0.tar.gz
 	cd mysql-connector-c-8.4.0 && rm -rf mysql-*/ || true

--- a/test/deps/Makefile
+++ b/test/deps/Makefile
@@ -37,7 +37,7 @@ endif
 mariadb_client: mariadb-connector-c/mariadb-connector-c/libmariadb/libmariadbclient.a
 
 mysql-connector-c/mysql-boost-5.7.44.tar.gz:
-	cd mysql-connector-c && curl -C - -O -s https://cdn.mysql.com//Downloads/MySQL-5.7/mysql-boost-5.7.44.tar.gz || wget -nc -q https://cdn.mysql.com//Downloads/MySQL-5.7/mysql-boost-5.7.44.tar.gz
+	cd mysql-connector-c && rm -f mysql-boost-5.7.44.tar.gz.part && curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 -o mysql-boost-5.7.44.tar.gz.part https://cdn.mysql.com//Downloads/MySQL-5.7/mysql-boost-5.7.44.tar.gz && gzip -t mysql-boost-5.7.44.tar.gz.part && mv mysql-boost-5.7.44.tar.gz.part mysql-boost-5.7.44.tar.gz
 
 mysql-connector-c/mysql-connector-c/libmysql/libmysqlclient.a: mysql-connector-c/mysql-boost-5.7.44.tar.gz
 	cd mysql-connector-c && rm -rf mysql-*/ || true
@@ -72,7 +72,7 @@ endif
 mysql_client: mysql-connector-c/mysql-connector-c/libmysql/libmysqlclient.a
 
 mysql-connector-c-8.4.0/mysql-8.4.0.tar.gz:
-	cd mysql-connector-c-8.4.0 && curl -C - -O -s https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.0.tar.gz || wget -nc -q https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.0.tar.gz
+	cd mysql-connector-c-8.4.0 && rm -f mysql-8.4.0.tar.gz.part && curl -fL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 -o mysql-8.4.0.tar.gz.part https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.0.tar.gz && gzip -t mysql-8.4.0.tar.gz.part && mv mysql-8.4.0.tar.gz.part mysql-8.4.0.tar.gz
 
 mysql-connector-c-8.4.0/mysql-connector-c/libmysql/libmysqlclient.a: mysql-connector-c-8.4.0/mysql-8.4.0.tar.gz
 	cd mysql-connector-c-8.4.0 && rm -rf mysql-*/ || true


### PR DESCRIPTION
**Root cause of the intermittent `ubuntu22-tap`/`test_deps` failures — reproduced, not guessed.**

`test_deps` fetches large MySQL source tarballs (`mysql-8.4.0.tar.gz` = **413 MB**) with `curl -C - -O -s || wget -nc -q`, which has **zero resilience** to a transient interruption:
- `-s`/`-q` hide the error;
- if curl's transfer breaks, **`wget -nc` sees the partial, refuses to re-fetch it, exits 0** → leaves a **truncated** tarball (reproduced: `wget -nc` on a 141 MB partial exits 0, file stays 141 MB);
- no retry → one blip fails the build.

Since it's a plain internet fetch of a 413 MB file, this hits **everyone** — `ubuntu22-tap` fails intermittently on **GitHub-hosted** at the identical commit (`28958381854` pass, `28960054460` fail on `73ed635d0`). Verified it's *not* network-unreachability, MTU, rate-limiting, OOM, CPU-load, or missing tools — the fetch is robust in isolation (completes even under full CPU load); the recipe just can't survive a normal transient.

**Fix:** download to `.part` with `curl --retry 5 --retry-all-errors`, verify with `gzip -t`, then atomically `mv` to the target. Transient → retries; truncation → caught and never becomes the target; errors visible.

Note: a bigger cleanup worth considering separately — building `mysqlbinlog` from 413 MB of MySQL *source* is the fragile part; a packaged `mysqlbinlog` would remove the download entirely.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of MySQL Connector downloads by adding stronger validation and bounded retry handling.
  * Prevents incomplete or corrupted archive files by downloading to a temporary file, verifying archive integrity, and only then finalizing the download.
* **Chores**
  * Centralized tarball download logic to make setup more consistent across supported MySQL Connector versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->