### PR TITLE
test(repl): recover relayed replica IO thread killed by backend blips on CI runners

### DIFF
--- a/test/repl/proxysql_repl_tests/bin/mysql-data-checksum.bash
+++ b/test/repl/proxysql_repl_tests/bin/mysql-data-checksum.bash
@@ -71,4 +71,24 @@ else
 fi
 echo "================================================================================"
 
+# On non-convergence, dump enough state to distinguish "mysql3 is behind" (SQL
+# thread lagging/stuck -> fewer rows / lower gtid_executed) from "mysql3 has
+# diverged" (same gtid_executed but different content -> a real relay/apply
+# correctness bug). Captured for mysql1/2/3 plus mysql3's replica status.
+if [[ ${res} -ne 0 ]]; then
+    echo ">>> DIAGNOSTIC: replicas did not converge within ${CHECKSUM_SYNC_TIMEOUT}s -- capturing state"
+    for node in "MYSQL1 ${MYSQL1_HOST} ${MYSQL1_PORT}" "MYSQL2 ${MYSQL2_HOST} ${MYSQL2_PORT}" "MYSQL3 ${MYSQL3_HOST} ${MYSQL3_PORT}"; do
+        set -- $node; nname=$1; nhost=$2; nport=$3
+        echo "--- ${nname} (${nhost}${INFRA}:${nport}) ---"
+        mysql -h${nhost}${INFRA} -P${nport} -uroot -proot --skip-column-names -e "\
+          SELECT CONCAT('gtid_executed=', @@GLOBAL.gtid_executed); \
+          SELECT CONCAT('rows[1..5]= ',(SELECT COUNT(*) FROM sysbench.sbtest1),' ',(SELECT COUNT(*) FROM sysbench.sbtest2),' ',(SELECT COUNT(*) FROM sysbench.sbtest3),' ',(SELECT COUNT(*) FROM sysbench.sbtest4),' ',(SELECT COUNT(*) FROM sysbench.sbtest5)); \
+          CHECKSUM TABLE sysbench.sbtest1, sysbench.sbtest2, sysbench.sbtest3, sysbench.sbtest4, sysbench.sbtest5;" 2>&1 | grep -vP "mysql: .?Warning"
+    done
+    echo "--- MYSQL3 replica status (IO/SQL running, lag, GTID positions, errors) ---"
+    mysql -h${MYSQL3_HOST}${INFRA} -P${MYSQL3_PORT} -uroot -proot -e "SHOW SLAVE STATUS\G" 2>&1 | grep -vP "mysql: .?Warning" \
+      | grep -iE "Slave_IO_Running|Slave_SQL_Running|Seconds_Behind|Retrieved_Gtid_Set|Executed_Gtid_Set|Read_Master_Log_Pos|Exec_Master_Log_Pos|Last_IO_Error|Last_SQL_Error|Auto_Position"
+    echo "================================================================================"
+fi
+
 exit $res

--- a/test/repl/proxysql_repl_tests/bin/mysql-data-checksum.bash
+++ b/test/repl/proxysql_repl_tests/bin/mysql-data-checksum.bash
@@ -55,6 +55,20 @@ while :; do
     if (( SECONDS >= CHECKSUM_SYNC_TIMEOUT )); then
         break
     fi
+    # A transient backend-unreachability (e.g. an overloaded CI runner) can make
+    # ProxySQL exceed connect_timeout_server_max (10s) reaching the source
+    # hostgroup, which makes a replica's IO thread hit a FATAL error and stop for
+    # good -- MySQL never auto-restarts it, so the replica is frozen and no amount
+    # of waiting converges. Detect a stopped IO thread on the replicas and restart
+    # it so it reconnects and catches up once the backend is reachable again.
+    for rep in "${MYSQL2_HOST} ${MYSQL2_PORT}" "${MYSQL3_HOST} ${MYSQL3_PORT}"; do
+        set -- $rep; rhost=$1; rport=$2
+        io=$(mysql -h${rhost}${INFRA} -P${rport} -uroot -proot -e "SHOW SLAVE STATUS\G" 2>/dev/null | grep -i "Slave_IO_Running:" | awk '{print $2}')
+        if [ "${io}" = "No" ]; then
+            echo "  ${rhost}${INFRA}: replica IO thread stopped -- restarting (STOP SLAVE; START SLAVE)"
+            mysql -h${rhost}${INFRA} -P${rport} -uroot -proot -e "STOP SLAVE; START SLAVE;" 2>/dev/null
+        fi
+    done
     sleep 1
 done
 

--- a/test/repl/proxysql_repl_tests/bin/mysql-data-checksum.bash
+++ b/test/repl/proxysql_repl_tests/bin/mysql-data-checksum.bash
@@ -34,21 +34,38 @@ mysql -h${MYSQL1_HOST}${INFRA} -P${MYSQL1_PORT} -uroot -proot sysbench --skip-co
 CHECKSUM TABLE sbtest1, sbtest2, sbtest3, sbtest4, sbtest5; \
 " 2>&1 | grep -vP "mysql: .?Warning"
 
-echo "Comparing sysbench data between primary and replicas ..."
-chk1=$(mysql -h${MYSQL1_HOST}${INFRA} -P${MYSQL1_PORT} -uroot -proot sysbench --skip-column-names -e "CHECKSUM TABLE sbtest1, sbtest2, sbtest3, sbtest4, sbtest5;" 2>&1 | grep -vP "mysql: .?Warning" | md5sum)
-chk2=$(mysql -h${MYSQL2_HOST}${INFRA} -P${MYSQL2_PORT}  -uroot -proot sysbench --skip-column-names -e "CHECKSUM TABLE sbtest1, sbtest2, sbtest3, sbtest4, sbtest5;" 2>&1 | grep -vP "mysql: .?Warning" | md5sum)
-chk3=$(mysql -h${MYSQL3_HOST}${INFRA} -P${MYSQL3_PORT}  -uroot -proot sysbench --skip-column-names -e "CHECKSUM TABLE sbtest1, sbtest2, sbtest3, sbtest4, sbtest5;" 2>&1 | grep -vP "mysql: .?Warning" | md5sum)
-
+# Replication through ProxySQL can lag briefly under load, so comparing the
+# checksums a single time (after only a fixed sleep in the caller) is racy and
+# yields spurious "data is different" failures. Poll the checksums until the
+# replicas converge with the primary, bounded by CHECKSUM_SYNC_TIMEOUT seconds
+# (default 30). Succeed as soon as they match; report a mismatch only if they
+# never converge within the budget -- which then reflects a genuine replication
+# break rather than lag.
+: "${CHECKSUM_SYNC_TIMEOUT:=30}"
+echo "Comparing sysbench data between primary and replicas (waiting up to ${CHECKSUM_SYNC_TIMEOUT}s for replicas to sync) ..."
+SECONDS=0
+while :; do
+    chk1=$(mysql -h${MYSQL1_HOST}${INFRA} -P${MYSQL1_PORT} -uroot -proot sysbench --skip-column-names -e "CHECKSUM TABLE sbtest1, sbtest2, sbtest3, sbtest4, sbtest5;" 2>&1 | grep -vP "mysql: .?Warning" | md5sum)
+    chk2=$(mysql -h${MYSQL2_HOST}${INFRA} -P${MYSQL2_PORT}  -uroot -proot sysbench --skip-column-names -e "CHECKSUM TABLE sbtest1, sbtest2, sbtest3, sbtest4, sbtest5;" 2>&1 | grep -vP "mysql: .?Warning" | md5sum)
+    chk3=$(mysql -h${MYSQL3_HOST}${INFRA} -P${MYSQL3_PORT}  -uroot -proot sysbench --skip-column-names -e "CHECKSUM TABLE sbtest1, sbtest2, sbtest3, sbtest4, sbtest5;" 2>&1 | grep -vP "mysql: .?Warning" | md5sum)
+    if [[ "${chk1}" == "${chk2}" ]] && [[ "${chk1}" == "${chk3}" ]]; then
+        res=0
+        break
+    fi
+    if (( SECONDS >= CHECKSUM_SYNC_TIMEOUT )); then
+        break
+    fi
+    sleep 1
+done
 
 echo "================================================================================"
 echo "[`date '+%Y-%m-%d %H:%M:%S'`]"
-if [[ "${chk1}" == "${chk2}" ]] && [[ "${chk1}" == "${chk3}" ]]; then
+if [[ ${res} -eq 0 ]]; then
     echo "TEST PASSED: generated data is identical on all replicas"
-    res=0
 elif [[ "${chk1}" != "${chk3}" ]]; then
-    echo "TEST FAILED: generated data is different on" ${MYSQL3_HOST}${INFRA}
+    echo "TEST FAILED: generated data is different on" ${MYSQL3_HOST}${INFRA} "(did not sync within ${CHECKSUM_SYNC_TIMEOUT}s)"
 elif [[ "${chk1}" != "${chk2}" ]]; then
-    echo "TEST FAILED: generated data is different on" ${MYSQL2_HOST}${INFRA}
+    echo "TEST FAILED: generated data is different on" ${MYSQL2_HOST}${INFRA} "(did not sync within ${CHECKSUM_SYNC_TIMEOUT}s)"
 else
     echo "TEST FAILED"
 fi

--- a/test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf
+++ b/test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf
@@ -17,12 +17,6 @@ mysql_variables=
 	stacksize=1048576
 	server_version="5.5.30"
 	connect_timeout_server=3000
-	# On an overloaded CI runner the source backend can be transiently
-	# unreachable for several seconds; the default 10000ms cap makes ProxySQL
-	# return a fatal "Max connect timeout reached while reaching hostgroup N"
-	# to the relayed replica IO thread, which then stops for good. Give the
-	# backend more room to recover before that happens.
-	connect_timeout_server_max=30000
 	monitor_username="monitor"
 	monitor_password="monitor"
 	monitor_history=600000

--- a/test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf
+++ b/test/repl/proxysql_repl_tests/conf/proxysql/proxysql.cnf
@@ -17,6 +17,12 @@ mysql_variables=
 	stacksize=1048576
 	server_version="5.5.30"
 	connect_timeout_server=3000
+	# On an overloaded CI runner the source backend can be transiently
+	# unreachable for several seconds; the default 10000ms cap makes ProxySQL
+	# return a fatal "Max connect timeout reached while reaching hostgroup N"
+	# to the relayed replica IO thread, which then stops for good. Give the
+	# backend more room to recover before that happens.
+	connect_timeout_server_max=30000
 	monitor_username="monitor"
 	monitor_password="monitor"
 	monitor_history=600000


### PR DESCRIPTION
## Root cause (captured, not guessed)
The intermittent `generated data is different on mysql3` in `CI-repltests` is **not lag and not a relay-correctness bug**. Diagnostics added here captured it in CI:

```
MYSQL1/MYSQL2: gtid 1-1247, 1000 rows/table
MYSQL3:        gtid 1-5    ← frozen at initial setup
   Slave_IO_Running: No
   Last_IO_Error: ...Max connect timeout reached while reaching hostgroup 2 after 10000ms
```

In the `mysql1=>proxysql=>mysql3` chain, mysql3 replicates **through** ProxySQL. On the resource-starved CI runner the source backend (hostgroup 2 / mysql1) goes transiently unreachable for >10s (proxysql monitor log: `Can't connect to server ... (110)`, `Lost connection during query`). ProxySQL hits `connect_timeout_server_max` (default 10000ms) reaching hostgroup 2 and returns a **fatal** error to mysql3's replica IO thread, which **stops for good** — MySQL never auto-restarts it. mysql3 freezes → checksum never matches. A checksum retry alone can never fix a dead IO thread. (Doesn't reproduce on a fast box — 31 clean local runs incl. 100× load — because the backend never stays unreachable that long there.)

## Fix (two parts)
1. **proxysql.cnf**: `connect_timeout_server_max=30000` — give the overloaded backend room to recover before ProxySQL declares the fatal timeout, so the IO thread stalls-and-resumes instead of dying.
2. **mysql-data-checksum.bash**: during the bounded sync-wait, detect a stopped IO thread (`Slave_IO_Running=No`) and restart it (`STOP SLAVE; START SLAVE`) so it reconnects and catches up once the backend is reachable. Plus a diagnostic dump (gtid/rows/replica-status) on non-convergence so any future failure is self-explaining. Still fails loudly if it truly can't converge.

Supersedes the earlier naive checksum-retry framing.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum validation by polling until the primary and all replicas converge, instead of using a single comparison.
  * Added a configurable synchronization timeout (default 30s) and clearer timeout messaging.
  * Enhanced failure diagnostics with the replica that diverged plus replication/table state details to speed troubleshooting.
  * Updated ProxySQL connection timeout behavior for more resilient backend recovery in CI scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->