### PR TITLE
ci(builds): reclaim workspace ownership around checkout (self-hosted contamination guard)

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -118,6 +118,18 @@ jobs:
         path: |
           proxysql/binaries/
 
+    # Self-hosted runners reuse the working directory between jobs. The
+    # dockerized build below bind-mounts the checkout (./:/opt/proxysql) and
+    # writes files as root, so on the next job the actions/checkout pre-clean
+    # trips over them:
+    #   ##[error]File was unable to be removed Error: EACCES: permission denied,
+    #   unlink '.../proxysql/deps/prometheus-cpp/.../.bazelignore'
+    # and the job fails before it even builds. Reclaim ownership for the runner
+    # user first so checkout can clean. No-op on ephemeral GitHub-hosted runners.
+    - name: Reclaim workspace ownership (self-hosted contamination guard)
+      if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+      run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
+
     - name: Checkout repository
       if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
       uses: actions/checkout@v4
@@ -533,6 +545,14 @@ jobs:
         if-no-files-found: error
         # cache_bin.tar.zst is produced by the "Pack bin cache" step above.
         path: cache_bin.tar.zst
+
+    # Undo the root ownership the dockerized build left behind, so (a) the next
+    # job on this self-hosted runner can clean/checkout without EACCES and (b)
+    # the failure-path artifact upload below can read the whole tree. Runs on
+    # every outcome; no-op on GitHub-hosted runners.
+    - name: Reclaim workspace ownership (leave runner clean)
+      if: always()
+      run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
 
     - name: Archive artifacts
       if: ${{ failure() && !cancelled() }}


### PR DESCRIPTION
## Problem

On the self-hosted `proxysql-ci` pool, `CI-builds` jobs (`debian12-dbg`, `ubuntu22-tap`) fail **at checkout**, before building anything:

```
##[error]File was unable to be removed Error: EACCES: permission denied,
unlink '.../proxysql/deps/prometheus-cpp/prometheus-cpp-1.1.0/.bazelignore'
##[error]File was unable to be removed Error: EACCES: permission denied,
unlink '.../proxysql/deps/libev/libev-4.33/.deps/ev.Plo'
```

The build itself succeeds (`Compiled 74/43 unit test binaries`), but the job is marked failed.

## Root cause

The dockerized build bind-mounts the checkout (`./:/opt/proxysql`) and writes its outputs (`deps/**`, `obj/**`, …) as **root**. GitHub-hosted runners are ephemeral so this never mattered, but the self-hosted runners **reuse the working directory between jobs**. The next job's `actions/checkout` pre-clean can't `unlink` those root-owned files → EACCES → job dies at checkout. The build starts on a contaminated filesystem.

## Fix

Two `sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"` steps:
- **before `actions/checkout`** (cache-miss only) — so the current job can clean a workspace a previous job contaminated;
- **after the build** (`if: always()`) — so this job leaves the runner clean for the next one, and the failure-path `Archive artifacts` upload can read the tree.

Both are `|| true` and a no-op on ephemeral GitHub-hosted runners. `sudo` is already relied on in this workflow (cache-prune, #5605).

## Verification

Self-hosted-only behaviour can't be reproduced locally; the real proof is this change running on the `proxysql-ci` pool. YAML validated; the reclaim is idempotent and side-effect-free on hosted runners.

## Follow-up (recommended, not in this PR)

This covers the **build** jobs (the contamination source) and, via the post-build reclaim, stops builds from leaving root-owned files behind. For complete coverage — protecting every **test** reusable against pre-existing contamination without editing ~20+ workflows — add a runner-level `ACTIONS_RUNNER_HOOK_JOB_STARTED` cleanup hook on the runner hosts (one script, runs before every job). Happy to provide it.

Found while investigating the `mysql90-gr-g1` / genai-gcov CI failures (context: #5884, #5914).

https://claude.ai/code/session_01KMxsXkndgrPiGHkd5rhgrz