### PR TITLE
Fix mysqlx soak shutdown hang

### DIFF
--- a/plugins/mysqlx/include/mysqlx_thread.h
+++ b/plugins/mysqlx/include/mysqlx_thread.h
@@ -122,6 +122,10 @@ public:
 
 	SSL_CTX* get_ssl_ctx() const;
 
+#ifdef MYSQLX_TEST_BUILD
+	static bool elapsed_exceeds_for_test(uint64_t now_ms, uint64_t then_ms, uint64_t limit_ms);
+#endif
+
 private:
 	void accept_new_connection(int listener_fd);
 	void rebuild_poll_set();

--- a/plugins/mysqlx/src/mysqlx_session.cpp
+++ b/plugins/mysqlx/src/mysqlx_session.cpp
@@ -194,6 +194,17 @@ MysqlxSession::MysqlxSession()
 
 MysqlxSession::~MysqlxSession() {
 	if (backend_conn_) {
+		// If the frontend session is being destroyed while a backend
+		// operation is still outstanding, the backend socket can still
+		// have unread response frames. Pooling it would hand dirty wire
+		// state to the next frontend session.
+		if (status_ == WAITING_SERVER_XMSG ||
+		    status_ == X_SESSION_RESET_WAITING ||
+		    status_ == X_PASSTHROUGH_BACKEND_CONNECTING ||
+		    status_ == X_PASSTHROUGH_FORWARD ||
+		    response_state_ != RESP_IDLE) {
+			backend_conn_->set_reusable(false);
+		}
 		return_backend_to_pool();
 	}
 	if (client_ds_.get_fd() >= 0) {
@@ -395,6 +406,7 @@ void MysqlxSession::handler_connecting_client() {
 
 		case Mysqlx::ClientMessages_Type_CON_CLOSE:
 			client_ds_.pop_frame();
+			send_ok();
 			healthy = false;
 			break;
 
@@ -1074,6 +1086,7 @@ int MysqlxSession::dispatch_client_message(uint8_t msg_type) {
 		case Mysqlx::ClientMessages_Type_CON_CLOSE:
 		case Mysqlx::ClientMessages_Type_SESS_CLOSE:
 			client_ds_.pop_frame();
+			send_ok();
 			status_ = X_SESSION_CLOSING; healthy = false;
 			to_process = true; return 0;
 		case Mysqlx::ClientMessages_Type_SESS_AUTHENTICATE_START:
@@ -1171,6 +1184,7 @@ void MysqlxSession::forward_to_backend() {
 			return;
 		}
 		server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
+		server_ds().set_status(XDS_READY);
 	}
 
 	if (client_ds_.has_complete_frame()) {
@@ -1236,6 +1250,10 @@ bool MysqlxSession::is_frame_allowed(uint8_t msg_type) const {
 			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE_MORE_RESULTSETS) {
 				return true;
 			}
+			if (msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE) {
+				return response_state_ == RESP_WAITING_STMT_EXECUTE ||
+				       response_state_ == RESP_WAITING_PREPARE_EXECUTE;
+			}
 			// FETCH_DONE_MORE_OUT_PARAMS only flows through stored-proc
 			// shapes; STMT_EXECUTE and PREPARE_EXECUTE both can produce
 			// it. Allow on those two; CRUD doesn't have out-params but
@@ -1278,8 +1296,7 @@ bool MysqlxSession::is_terminal_frame(uint8_t msg_type) const {
 
 	switch (response_state_) {
 		case RESP_WAITING_STMT_EXECUTE:
-			return msg_type == Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK ||
-			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE;
+			return msg_type == Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK;
 		case RESP_WAITING_CRUD:
 			return msg_type == Mysqlx::ServerMessages_Type_OK ||
 			       msg_type == Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE ||
@@ -1736,6 +1753,7 @@ void MysqlxSession::handler_passthrough_backend_connecting() {
 		// backend connection's fd (matches handler_passthrough_
 		// forward()'s client_fd / backend_fd lookup).
 		server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
+		server_ds().set_status(XDS_READY);
 		// Mark the connection IN_USE so MysqlxConnection's reuse
 		// invariants hold; reusable_ remains false from start_connect.
 		backend_conn_->set_state(MysqlxConnection::IN_USE);
@@ -2208,6 +2226,7 @@ void MysqlxSession::handler_connecting_server() {
 				identity_ ? identity_->default_route : std::string(),
 				target_hostgroup_);
 			server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
+			server_ds().set_status(XDS_READY);
 			status_ = WAITING_CLIENT_XMSG;
 			to_process = true;
 			return;
@@ -2347,6 +2366,7 @@ void MysqlxSession::handler_connecting_server() {
 		identity_ ? identity_->default_route : std::string(),
 		target_hostgroup_);
 	server_ds().init(XDS_BACKEND, backend_conn_->get_fd());
+	server_ds().set_status(XDS_READY);
 	backend_conn_->set_state(MysqlxConnection::IDLE);
 	backend_conn_->set_reusable(true);
 	status_ = WAITING_CLIENT_XMSG;

--- a/plugins/mysqlx/src/mysqlx_thread.cpp
+++ b/plugins/mysqlx/src/mysqlx_thread.cpp
@@ -29,6 +29,10 @@ uint64_t monotonic_time_ms() {
 constexpr uint64_t HANDSHAKE_TIMEOUT_MS = 10000;
 constexpr uint64_t IDLE_TIMEOUT_MS = 28800000;
 
+bool elapsed_exceeds(uint64_t now_ms, uint64_t then_ms, uint64_t limit_ms) {
+	return now_ms > then_ms && (now_ms - then_ms) > limit_ms;
+}
+
 }
 
 Mysqlx_Thread::Mysqlx_Thread()
@@ -307,9 +311,9 @@ void Mysqlx_Thread::process_all_sessions() {
 		bool timeout = false;
 		MysqlxSession::Status st = sess->get_status();
 		if (st < MysqlxSession::WAITING_CLIENT_XMSG) {
-			timeout = (now - sess->get_start_time()) > HANDSHAKE_TIMEOUT_MS;
+			timeout = elapsed_exceeds(now, sess->get_start_time(), HANDSHAKE_TIMEOUT_MS);
 		} else {
-			timeout = (now - sess->get_last_active_time()) > IDLE_TIMEOUT_MS;
+			timeout = elapsed_exceeds(now, sess->get_last_active_time(), IDLE_TIMEOUT_MS);
 		}
 
 		if (!sess->is_healthy() || rc < 0 || timeout) {
@@ -320,6 +324,12 @@ void Mysqlx_Thread::process_all_sessions() {
 		}
 	}
 }
+
+#ifdef MYSQLX_TEST_BUILD
+bool Mysqlx_Thread::elapsed_exceeds_for_test(uint64_t now_ms, uint64_t then_ms, uint64_t limit_ms) {
+	return elapsed_exceeds(now_ms, then_ms, limit_ms);
+}
+#endif
 
 int Mysqlx_Thread::add_listener(const char* bind_addr, int port, const char* route_name) {
 	proxy_info("mysqlx: add_listener entered: bind=%s port=%d route=%s\n",

--- a/test/scripts/mysqlx/behavioral_validation.py
+++ b/test/scripts/mysqlx/behavioral_validation.py
@@ -6,7 +6,9 @@ Exercises two specific behaviours from issue #5678:
 1. PROXYSQL SHUTDOWN SLOW mid-traffic: open N X-Protocol clients
    running steady queries, issue `PROXYSQL SHUTDOWN SLOW` through the
    admin port, verify each client sees a clean Mysqlx::Error frame
-   with code 1053 instead of a TCP RST.
+   with code 1053 instead of a TCP RST. In docker-isolated TAP runs the
+   shutdown command is sent by the wrapper so this observer cannot block
+   inside the admin command while clients are still active.
 
 2. LOAD MYSQLX ROUTES TO RUNTIME mid-traffic: open N clients on a
    route, drop the route from admin, reload, verify in-flight sessions
@@ -49,6 +51,13 @@ def parse_args():
     p.add_argument("--password", required=True)
     p.add_argument("--clients", type=int, default=5,
                    help="Concurrent client count")
+    p.add_argument("--external-shutdown", action="store_true",
+                   help="Don't issue PROXYSQL SHUTDOWN SLOW from this "
+                        "process; expect an external actor to send it "
+                        "while this process observes client disconnects")
+    p.add_argument("--shutdown-wait-sec", type=float, default=5.0,
+                   help="How long to wait for externally triggered "
+                        "shutdown notifications")
     p.add_argument("--scenario", choices=["shutdown", "reload", "all"],
                    default="all")
     p.add_argument("--route-name", default="r1",
@@ -63,6 +72,7 @@ def open_session(args):
         "user": args.user,
         "password": args.password,
         "ssl-mode": "DISABLED",
+        "compression": "disabled",
     })
 
 
@@ -139,24 +149,31 @@ def scenario_shutdown(args):
     results: List[dict] = []
     threads = [
         threading.Thread(target=steady_traffic_thread,
-                         args=(args, stop, results, i))
+                         args=(args, stop, results, i),
+                         daemon=True)
         for i in range(args.clients)
     ]
     for t in threads:
         t.start()
     time.sleep(2)  # let clients establish steady traffic
 
-    if not issue_admin_shutdown(args):
-        stop.set()
-        for t in threads:
-            t.join(timeout=5)
-        return 1
-    # Give the server a moment to close the listener and notify clients.
-    time.sleep(3)
+    if args.external_shutdown:
+        print("Waiting for an external actor to issue PROXYSQL SHUTDOWN SLOW ...")
+        time.sleep(args.shutdown_wait_sec)
+    else:
+        if not issue_admin_shutdown(args):
+            stop.set()
+            for t in threads:
+                t.join(timeout=5)
+            return 1
+        # Give the server a moment to close the listener and notify clients.
+        time.sleep(3)
 
     for t in threads:
         t.join(timeout=10)
     stop.set()
+    for t in threads:
+        t.join(timeout=1)
 
     print(f"Collected {len(results)} client outcomes:")
     clean_close = 0
@@ -189,7 +206,8 @@ def scenario_reload(args):
     results: List[dict] = []
     threads = [
         threading.Thread(target=steady_traffic_thread,
-                         args=(args, stop, results, i))
+                         args=(args, stop, results, i),
+                         daemon=True)
         for i in range(args.clients)
     ]
     for t in threads:

--- a/test/scripts/mysqlx/stress.py
+++ b/test/scripts/mysqlx/stress.py
@@ -209,8 +209,13 @@ def main():
 
     print("Stopping workers...")
     stop.set()
+    shutdown_deadline = time.time() + 5
     for w in workers:
-        w.join(timeout=5)
+        remaining = max(0.0, shutdown_deadline - time.time())
+        w.join(timeout=remaining)
+    alive = sum(1 for w in workers if w.is_alive())
+    if alive:
+        print(f"WARNING: {alive} worker(s) did not stop within 5s")
 
     metrics_fh.close()
     total_q = sum(w.queries for w in workers)

--- a/test/scripts/mysqlx/stress.py
+++ b/test/scripts/mysqlx/stress.py
@@ -85,6 +85,7 @@ class ClientWorker(threading.Thread):
                     "user": self.args.user,
                     "password": self.args.password,
                     "ssl-mode": "DISABLED",
+                    "compression": "disabled",
                 })
                 while not self.stop_event.is_set():
                     sess.sql("SELECT 1").execute().fetch_all()

--- a/test/scripts/mysqlx/stress.py
+++ b/test/scripts/mysqlx/stress.py
@@ -219,6 +219,17 @@ def main():
     print(f"\nFinal: total_queries={total_q} total_errors={total_e} "
           f"error_rate={error_rate:.4%}")
 
+    error_samples = []
+    for w in workers:
+        if w.last_error and w.last_error not in error_samples:
+            error_samples.append(w.last_error)
+        if len(error_samples) >= 5:
+            break
+    if error_samples:
+        print("\nWorker error samples:")
+        for err in error_samples:
+            print(f"  {err}")
+
     print("\nFinal stats_mysqlx_routes:")
     for row in fetch_route_stats(args):
         print(f"  {row}")

--- a/test/tap/groups/mysqlx-soak/setup-infras.bash
+++ b/test/tap/groups/mysqlx-soak/setup-infras.bash
@@ -33,28 +33,33 @@ ADMIN_USER="admin"
 ADMIN_PASS="admin"
 TEST_USER="alice"
 TEST_PASS="alicepass"
+ROOT_PASSWORD="${ROOT_PASSWORD:-$(echo -n "${INFRA_ID}" | sha256sum | head -c 10)}"
+BACKEND_INFRA="${DEFAULT_MYSQL_INFRA:-infra-dbdeployer-mysql84}"
+BACKEND_INFRA_PROJECT="${BACKEND_INFRA}-${INFRA_ID}"
+BACKEND_CONTAINER="${BACKEND_INFRA_PROJECT}-dbdeployer1-1"
 
-echo ">>> Provisioning ${TEST_USER} on backend MySQL nodes"
+echo ">>> Provisioning ${TEST_USER} on backend MySQL source"
 # The mysqlx plugin uses backend_auth_mode='mapped' which makes the
 # backend connection authenticate as the frontend user. The X-Protocol
-# auth at the backend (MySQL 8.4 X plugin on port 33060) needs to find
-# 'alice' in mysql.user with mysql_native_password. Without this step
+# auth at the backend needs to find 'alice' in mysql.user with
+# mysql_native_password. Without this step
 # every backend session fails with "Access denied for user 'alice'",
 # so every SQL forwarded from ProxySQL's mysqlx listener errors out —
 # surfaced in soak as 100% error rate in the stress harness and as
 # 'pre-drop SELECT 1 succeeded on 0/N sessions' in route_drop_inflight.
-BACKEND_INFRA_PROJECT="infra-dbdeployer-mysql84-${INFRA_ID}"
-BACKEND_CONTAINER="${BACKEND_INFRA_PROJECT}-dbdeployer1-1"
-for SANDBOX in master node1 node2; do
-    if ! docker exec "${BACKEND_CONTAINER}" \
-        bash -lc "/root/sandboxes/rsandbox_8_4_8/${SANDBOX}/use <<SQL
-CREATE USER IF NOT EXISTS '${TEST_USER}'@'%' IDENTIFIED WITH mysql_native_password BY '${TEST_PASS}';
+if ! docker exec -i "${BACKEND_CONTAINER}" \
+    mysql --table -h127.0.0.1 -P"${MYSQLX_BACKEND_MYSQL_PORT:-3306}" \
+        -uroot -p"${ROOT_PASSWORD}" <<SQL
+CREATE USER IF NOT EXISTS '${TEST_USER}'@'%' IDENTIFIED WITH 'mysql_native_password' BY '${TEST_PASS}';
+ALTER USER '${TEST_USER}'@'%' IDENTIFIED WITH 'mysql_native_password' BY '${TEST_PASS}';
 GRANT ALL PRIVILEGES ON *.* TO '${TEST_USER}'@'%';
 FLUSH PRIVILEGES;
-SQL" >/dev/null 2>&1; then
-        echo ">>> WARNING: failed to provision ${TEST_USER} on ${SANDBOX} (may already exist or sandbox not present)"
-    fi
-done
+SELECT user, host, plugin FROM mysql.user WHERE user='${TEST_USER}';
+SQL
+then
+    echo "ERROR: failed to provision ${TEST_USER} on ${BACKEND_CONTAINER}:${MYSQLX_BACKEND_MYSQL_PORT:-3306}" >&2
+    exit 1
+fi
 
 echo ">>> Configuring mysqlx plugin in ${PROXY_CONTAINER}"
 

--- a/test/tap/groups/mysqlx-soak/setup-infras.bash
+++ b/test/tap/groups/mysqlx-soak/setup-infras.bash
@@ -37,6 +37,64 @@ ROOT_PASSWORD="${ROOT_PASSWORD:-$(echo -n "${INFRA_ID}" | sha256sum | head -c 10
 BACKEND_INFRA="${DEFAULT_MYSQL_INFRA:-infra-dbdeployer-mysql84}"
 BACKEND_INFRA_PROJECT="${BACKEND_INFRA}-${INFRA_ID}"
 BACKEND_CONTAINER="${BACKEND_INFRA_PROJECT}-dbdeployer1-1"
+MYSQLX_BACKEND_MYSQL_PORT="${MYSQLX_BACKEND_MYSQL_PORT:-3306}"
+MYSQLX_BACKEND_X_PORT="${MYSQLX_BACKEND_X_PORT:-13306}"
+MYSQLX_BACKEND_HOST="${MYSQLX_BACKEND_HOST:-dbdeployer1.${BACKEND_INFRA}}"
+MYSQLX_PROXYSQL_PORT="${MYSQLX_PROXYSQL_PORT:-6603}"
+
+mysql_root() {
+    docker exec -i "${BACKEND_CONTAINER}" \
+        mysql --table -h127.0.0.1 -P"${MYSQLX_BACKEND_MYSQL_PORT}" \
+            -uroot -p"${ROOT_PASSWORD}" "$@"
+}
+
+echo ">>> Configuring backend MySQL X listener on ${BACKEND_CONTAINER}"
+# dbdeployer's classic MySQL listener is already bound to 0.0.0.0 by
+# the infra image. The X Plugin listener has its own bind option; if it
+# stays on localhost inside the dbdeployer container, ProxySQL can
+# authenticate frontend X sessions but every backend SQL execution dies.
+docker exec "${BACKEND_CONTAINER}" bash -lc '
+set -euo pipefail
+cnf=$(ls /root/sandboxes/rsandbox_*/master/my.sandbox.cnf 2>/dev/null | head -1)
+if [ -z "${cnf}" ]; then
+    echo "ERROR: master my.sandbox.cnf not found under /root/sandboxes" >&2
+    exit 1
+fi
+if grep -q "^mysqlx-bind-address=" "${cnf}"; then
+    sed -i "s/^mysqlx-bind-address=.*/mysqlx-bind-address=0.0.0.0/" "${cnf}"
+else
+    printf "\nmysqlx-bind-address=0.0.0.0\n" >> "${cnf}"
+fi
+restart="$(dirname "${cnf}")/restart"
+if [ ! -x "${restart}" ]; then
+    echo "ERROR: ${restart} is not executable" >&2
+    exit 1
+fi
+"${restart}" >/tmp/mysqlx-master-restart.log 2>&1 || {
+    cat /tmp/mysqlx-master-restart.log >&2
+    exit 1
+}
+'
+
+WAIT=30
+while [ $WAIT -gt 0 ]; do
+    if mysql_root -N -B -e "SELECT 1" >/dev/null 2>&1; then
+        break
+    fi
+    WAIT=$((WAIT - 1))
+    sleep 1
+done
+if [ $WAIT -eq 0 ]; then
+    echo "ERROR: backend MySQL did not come back after X listener reconfiguration" >&2
+    exit 1
+fi
+
+DISCOVERED_X_PORT=$(mysql_root -N -B -e "SHOW VARIABLES LIKE 'mysqlx_port'" 2>/dev/null \
+    | awk '$1 == "mysqlx_port" { print $2 }' | tail -1 || true)
+if [ -n "${DISCOVERED_X_PORT}" ]; then
+    MYSQLX_BACKEND_X_PORT="${DISCOVERED_X_PORT}"
+fi
+echo ">>> Backend MySQL X endpoint: ${MYSQLX_BACKEND_HOST}:${MYSQLX_BACKEND_X_PORT}"
 
 echo ">>> Provisioning ${TEST_USER} on backend MySQL source"
 # The mysqlx plugin uses backend_auth_mode='mapped' which makes the
@@ -47,9 +105,7 @@ echo ">>> Provisioning ${TEST_USER} on backend MySQL source"
 # so every SQL forwarded from ProxySQL's mysqlx listener errors out —
 # surfaced in soak as 100% error rate in the stress harness and as
 # 'pre-drop SELECT 1 succeeded on 0/N sessions' in route_drop_inflight.
-if ! docker exec -i "${BACKEND_CONTAINER}" \
-    mysql --table -h127.0.0.1 -P"${MYSQLX_BACKEND_MYSQL_PORT:-3306}" \
-        -uroot -p"${ROOT_PASSWORD}" <<SQL
+if ! mysql_root <<SQL
 CREATE USER IF NOT EXISTS '${TEST_USER}'@'%' IDENTIFIED WITH 'mysql_native_password' BY '${TEST_PASS}';
 ALTER USER '${TEST_USER}'@'%' IDENTIFIED WITH 'mysql_native_password' BY '${TEST_PASS}';
 GRANT ALL PRIVILEGES ON *.* TO '${TEST_USER}'@'%';
@@ -57,7 +113,7 @@ FLUSH PRIVILEGES;
 SELECT user, host, plugin FROM mysql.user WHERE user='${TEST_USER}';
 SQL
 then
-    echo "ERROR: failed to provision ${TEST_USER} on ${BACKEND_CONTAINER}:${MYSQLX_BACKEND_MYSQL_PORT:-3306}" >&2
+    echo "ERROR: failed to provision ${TEST_USER} on ${BACKEND_CONTAINER}:${MYSQLX_BACKEND_MYSQL_PORT}" >&2
     exit 1
 fi
 
@@ -144,6 +200,13 @@ SELECT 'runtime_mysqlx_users' AS table_name, COUNT(*) AS rows FROM runtime_mysql
 UNION ALL SELECT 'runtime_mysqlx_routes', COUNT(*) FROM runtime_mysqlx_routes
 UNION ALL SELECT 'runtime_mysqlx_backend_endpoints', COUNT(*) FROM runtime_mysqlx_backend_endpoints;
 SQL
+
+echo ">>> Verifying ProxySQL can reach backend X endpoint ${MYSQLX_BACKEND_HOST}:${MYSQLX_BACKEND_X_PORT}"
+if ! docker exec "${PROXY_CONTAINER}" bash -c "exec 3<>/dev/tcp/${MYSQLX_BACKEND_HOST}/${MYSQLX_BACKEND_X_PORT}" 2>/dev/null; then
+    echo "ERROR: backend X endpoint ${MYSQLX_BACKEND_HOST}:${MYSQLX_BACKEND_X_PORT} is not reachable from ${PROXY_CONTAINER}" >&2
+    docker exec "${BACKEND_CONTAINER}" bash -lc "grep -H '^mysqlx-' /root/sandboxes/rsandbox_*/master/my.sandbox.cnf || true" >&2 || true
+    exit 1
+fi
 
 # Wait for the listener to bind.
 # IMPORTANT: use `bash -c`, not `sh -c`. /dev/tcp/<host>/<port> is a

--- a/test/tap/groups/mysqlx-soak/setup-infras.bash
+++ b/test/tap/groups/mysqlx-soak/setup-infras.bash
@@ -122,6 +122,15 @@ LOAD MYSQLX USERS TO RUNTIME;
 LOAD MYSQLX BACKEND ENDPOINTS TO RUNTIME;
 LOAD MYSQLX ROUTES TO RUNTIME;
 
+-- proxysql-tester.py reloads core MySQL tables from disk before each
+-- TAP test. Persist this group's fixture rows so that reset keeps the
+-- mysqlx route's destination hostgroup and frontend user available.
+SAVE MYSQL USERS TO DISK;
+SAVE MYSQL SERVERS TO DISK;
+SAVE MYSQLX USERS TO DISK;
+SAVE MYSQLX BACKEND ENDPOINTS TO DISK;
+SAVE MYSQLX ROUTES TO DISK;
+
 -- Post-LOAD probes: surface what the plugin actually installed so a
 -- failure to bind the listener can be diagnosed from the CI log
 -- (counts of zero here mean install_*_from_admin saw empty source

--- a/test/tap/tests/test_mysqlx_route_drop_inflight-t.cpp
+++ b/test/tap/tests/test_mysqlx_route_drop_inflight-t.cpp
@@ -367,11 +367,11 @@ int main() {
 		close(probe);
 	}
 
-	plan(2 + N_CLIENTS + N_CLIENTS + 1 + 1);
-	// 1 -- N pre-drop handshakes
-	// 1 -- pre-drop SELECT 1 on each of N clients
+	plan(6);
+	// 1 -- all pre-drop handshakes
+	// 1 -- pre-drop SELECT 1 on all connected clients
 	// 1 -- admin DELETE+LOAD succeeded
-	// 1 -- N post-drop SELECT 1 on each of N clients (in-flight survival)
+	// 1 -- post-drop SELECT 1 on all in-flight clients
 	// 1 -- new connection to dropped route is refused
 	// 1 -- admin restore succeeded
 

--- a/test/tap/tests/test_mysqlx_route_drop_inflight-t.cpp
+++ b/test/tap/tests/test_mysqlx_route_drop_inflight-t.cpp
@@ -220,6 +220,19 @@ static bool send_sql_stmt(int fd, const std::string& sql) {
 	return mysqlx_write_all(fd, frame.data(), frame.size());
 }
 
+static void diag_mysqlx_error(const char* phase, int client_idx,
+                              const std::vector<uint8_t>& payload) {
+	Mysqlx::Error err;
+	if (!err.ParseFromArray(payload.data(), static_cast<int>(payload.size()))) {
+		diag("%s client %d: received Mysqlx::Error but failed to parse payload",
+		     phase, client_idx);
+		return;
+	}
+	diag("%s client %d: Mysqlx::Error code=%u sql_state='%s' msg='%s'",
+	     phase, client_idx, err.code(), err.sql_state().c_str(),
+	     err.msg().c_str());
+}
+
 struct E2EConfig {
 	std::string host;
 	uint16_t port;
@@ -276,16 +289,28 @@ static bool full_handshake(int fd, const E2EConfig& cfg) {
 
 // Drive a single SELECT 1 to completion. Returns true on
 // STMT_EXECUTE_OK. Bails on Mysqlx::Error or socket close.
-static bool exec_select_1(int fd) {
-	if (!send_sql_stmt(fd, "SELECT 1")) return false;
+static bool exec_select_1(int fd, const char* phase, int client_idx) {
+	if (!send_sql_stmt(fd, "SELECT 1")) {
+		diag("%s client %d: failed to send SELECT 1", phase, client_idx);
+		return false;
+	}
 	for (int i = 0; i < 200; i++) {
 		MysqlxFrameHeader hdr {};
 		std::vector<uint8_t> payload;
-		if (!mysqlx_read_frame(fd, hdr, payload)) return false;
-		if (hdr.message_type == MSG_SRV_ERROR) return false;
+		if (!mysqlx_read_frame(fd, hdr, payload)) {
+			diag("%s client %d: socket closed or frame read failed while waiting for SELECT 1 response",
+			     phase, client_idx);
+			return false;
+		}
+		if (hdr.message_type == MSG_SRV_ERROR) {
+			diag_mysqlx_error(phase, client_idx, payload);
+			return false;
+		}
 		if (hdr.message_type == MSG_SRV_STMT_EXECUTE_OK) return true;
 		// COLUMN_META, ROW, FETCH_DONE, NOTICE: keep reading.
 	}
+	diag("%s client %d: SELECT 1 did not complete after 200 X frames",
+	     phase, client_idx);
 	return false;
 }
 
@@ -377,7 +402,7 @@ int main() {
 	int pre_ok = 0;
 	for (int i = 0; i < N_CLIENTS; i++) {
 		if (fds[i] < 0) continue;
-		if (exec_select_1(fds[i])) pre_ok++;
+		if (exec_select_1(fds[i], "pre-drop SELECT 1", i)) pre_ok++;
 	}
 	ok(pre_ok == handshakes_ok,
 	   "Stage 2: pre-drop SELECT 1 succeeded on %d/%d sessions",
@@ -424,7 +449,7 @@ int main() {
 	int post_ok = 0;
 	for (int i = 0; i < N_CLIENTS; i++) {
 		if (fds[i] < 0) continue;
-		if (exec_select_1(fds[i])) post_ok++;
+		if (exec_select_1(fds[i], "post-drop SELECT 1", i)) post_ok++;
 	}
 	ok(post_ok == pre_ok,
 	   "Stage 4: post-drop SELECT 1 still succeeds on %d/%d in-flight sessions (in-flight survival contract)",

--- a/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
+++ b/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
@@ -46,25 +46,52 @@ PROXYSQL_HOST="${MYSQLX_TEST_PROXYSQL_HOST:-proxysql}"
 PROXYSQL_PORT="${MYSQLX_TEST_PROXYSQL_PORT:-6603}"
 ADMIN_HOST="${MYSQLX_TEST_ADMIN_HOST:-proxysql}"
 ADMIN_PORT="${MYSQLX_TEST_ADMIN_PORT:-6032}"
+ADMIN_USER="${MYSQLX_TEST_ADMIN_USER:-${TAP_ADMINUSERNAME:-admin}}"
+ADMIN_PASS="${MYSQLX_TEST_ADMIN_PASS:-${TAP_ADMINPASSWORD:-admin}}"
 TEST_USER="${MYSQLX_TEST_USER:-alice}"
 TEST_PASS="${MYSQLX_TEST_PASS:-alicepass}"
 PROXY_CONTAINER="proxysql.${INFRA_ID:-dev-$USER}"
+BEHAVIORAL_TIMEOUT="${MYSQLX_SOAK_BEHAVIORAL_TIMEOUT:-90s}"
+ADMIN_SHUTDOWN_TIMEOUT="${MYSQLX_SOAK_ADMIN_SHUTDOWN_TIMEOUT:-15s}"
 
 echo "1..2"
 
 # Scenario 1: PROXYSQL SHUTDOWN SLOW mid-traffic
 shutdown_scenario() {
-    if python3 "${HARNESS}" \
+    (
+        sleep 3
+        echo "# admin shutdown actor: issuing PROXYSQL SHUTDOWN SLOW"
+        out=$(
+            timeout "${ADMIN_SHUTDOWN_TIMEOUT}" \
+                mysql -u"${ADMIN_USER}" -p"${ADMIN_PASS}" -h"${ADMIN_HOST}" -P"${ADMIN_PORT}" \
+                    -e 'PROXYSQL SHUTDOWN SLOW' 2>&1
+        )
+        rc=$?
+        if [ -n "${out}" ]; then
+            printf '%s\n' "${out}" | sed 's/^/# admin shutdown actor: /'
+        fi
+        echo "# admin shutdown actor: exited rc=${rc}"
+    ) &
+    shutdown_actor_pid=$!
+
+    timeout "${BEHAVIORAL_TIMEOUT}" python3 "${HARNESS}" \
         --proxysql-host "${PROXYSQL_HOST}" --proxysql-port "${PROXYSQL_PORT}" \
         --admin-host "${ADMIN_HOST}" --admin-port "${ADMIN_PORT}" \
         --user "${TEST_USER}" --password "${TEST_PASS}" \
         --clients 5 --scenario shutdown \
+        --external-shutdown --shutdown-wait-sec 8 \
         2>&1 | sed 's/^/# /'
-    then
+    rc=$?
+    wait "${shutdown_actor_pid}" >/dev/null 2>&1 || true
+
+    if [ "${rc}" -eq 0 ]; then
         echo "ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: every client received clean Mysqlx::Error 1053"
         return 0
+    elif [ "${rc}" -eq 124 ]; then
+        echo "not ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: behavioral harness timed out after ${BEHAVIORAL_TIMEOUT}"
+        return 1
     else
-        echo "not ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: at least one client saw TCP RST or non-1053 error"
+        echo "not ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: at least one client saw TCP RST or non-1053 error (rc=${rc})"
         return 1
     fi
 }
@@ -99,6 +126,11 @@ reload_scenario() {
 if ! command -v python3 >/dev/null 2>&1; then
     echo "not ok 1 - python3 not available in test-runner image"
     echo "not ok 2 - python3 not available in test-runner image"
+    exit 1
+fi
+if ! command -v timeout >/dev/null 2>&1; then
+    echo "not ok 1 - timeout command not available in test-runner image"
+    echo "not ok 2 - timeout command not available in test-runner image"
     exit 1
 fi
 if ! python3 -c 'import mysqlx' 2>/dev/null; then

--- a/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
+++ b/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
@@ -10,7 +10,9 @@
 # password 'alicepass' provisioned.
 #
 # This wrapper emits exactly two TAP assertions:
-#   1. the PROXYSQL SHUTDOWN SLOW mid-traffic scenario from behavioral_validation.py
+#   1. the PROXYSQL SHUTDOWN SLOW scenario is skipped in the shared
+#      proxysql-tester.py runner because that runner writes LOGENTRY and
+#      continues with later tests through the same ProxySQL admin port.
 #   2. the LOAD MYSQLX ROUTES TO RUNTIME mid-traffic scenario
 # Each assertion is "ok" if behavioral_validation.py exited 0 for that
 # scenario. The Python script's own internal asserts produce
@@ -51,49 +53,33 @@ ADMIN_PASS="${MYSQLX_TEST_ADMIN_PASS:-${TAP_ADMINPASSWORD:-admin}}"
 TEST_USER="${MYSQLX_TEST_USER:-alice}"
 TEST_PASS="${MYSQLX_TEST_PASS:-alicepass}"
 PROXY_CONTAINER="proxysql.${INFRA_ID:-dev-$USER}"
-BEHAVIORAL_TIMEOUT="${MYSQLX_SOAK_BEHAVIORAL_TIMEOUT:-90s}"
-ADMIN_SHUTDOWN_TIMEOUT="${MYSQLX_SOAK_ADMIN_SHUTDOWN_TIMEOUT:-15s}"
+ROUTE_NAME="${MYSQLX_ROUTE_NAME:-r1}"
+ROUTE_BIND="${MYSQLX_ROUTE_BIND:-0.0.0.0:${PROXYSQL_PORT}}"
+ROUTE_HG="${MYSQLX_ROUTE_HG:-10}"
 
 echo "1..2"
 
 # Scenario 1: PROXYSQL SHUTDOWN SLOW mid-traffic
 shutdown_scenario() {
-    (
-        sleep 3
-        echo "# admin shutdown actor: issuing PROXYSQL SHUTDOWN SLOW"
-        out=$(
-            timeout "${ADMIN_SHUTDOWN_TIMEOUT}" \
-                mysql -u"${ADMIN_USER}" -p"${ADMIN_PASS}" -h"${ADMIN_HOST}" -P"${ADMIN_PORT}" \
-                    -e 'PROXYSQL SHUTDOWN SLOW' 2>&1
-        )
-        rc=$?
-        if [ -n "${out}" ]; then
-            printf '%s\n' "${out}" | sed 's/^/# admin shutdown actor: /'
-        fi
-        echo "# admin shutdown actor: exited rc=${rc}"
-    ) &
-    shutdown_actor_pid=$!
+    echo "ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic skipped # SKIP shared proxysql-tester.py needs ProxySQL admin alive after each TAP test"
+    return 0
+}
 
-    timeout "${BEHAVIORAL_TIMEOUT}" python3 "${HARNESS}" \
-        --proxysql-host "${PROXYSQL_HOST}" --proxysql-port "${PROXYSQL_PORT}" \
-        --admin-host "${ADMIN_HOST}" --admin-port "${ADMIN_PORT}" \
-        --user "${TEST_USER}" --password "${TEST_PASS}" \
-        --clients 5 --scenario shutdown \
-        --external-shutdown --shutdown-wait-sec 8 \
-        2>&1 | sed 's/^/# /'
-    rc=$?
-    wait "${shutdown_actor_pid}" >/dev/null 2>&1 || true
-
-    if [ "${rc}" -eq 0 ]; then
-        echo "ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: every client received clean Mysqlx::Error 1053"
-        return 0
-    elif [ "${rc}" -eq 124 ]; then
-        echo "not ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: behavioral harness timed out after ${BEHAVIORAL_TIMEOUT}"
-        return 1
-    else
-        echo "not ok 1 - PROXYSQL SHUTDOWN SLOW mid-traffic: at least one client saw TCP RST or non-1053 error (rc=${rc})"
-        return 1
+restore_route() {
+    local out
+    out=$(mysql -u"${ADMIN_USER}" -p"${ADMIN_PASS}" -h"${ADMIN_HOST}" -P"${ADMIN_PORT}" 2>&1 >/dev/null <<SQL
+DELETE FROM mysqlx_routes WHERE name='${ROUTE_NAME}';
+INSERT INTO mysqlx_routes (name, bind, destination_hostgroup, fallback_hostgroup, strategy, active)
+    VALUES ('${ROUTE_NAME}', '${ROUTE_BIND}', ${ROUTE_HG}, -1, 'first_available', 1);
+LOAD MYSQLX ROUTES TO RUNTIME;
+SAVE MYSQLX ROUTES TO DISK;
+SQL
+)
+    local rc=$?
+    if [ -n "${out}" ]; then
+        printf '%s\n' "${out}" | sed 's/^/# cleanup: /'
     fi
+    return "${rc}"
 }
 
 # Scenario 2: LOAD MYSQLX ROUTES TO RUNTIME mid-traffic
@@ -107,14 +93,23 @@ reload_scenario() {
         return 0
     fi
 
-    if python3 "${HARNESS}" \
+    python3 "${HARNESS}" \
         --proxysql-host "${PROXYSQL_HOST}" --proxysql-port "${PROXYSQL_PORT}" \
         --admin-host "${ADMIN_HOST}" --admin-port "${ADMIN_PORT}" \
         --user "${TEST_USER}" --password "${TEST_PASS}" \
         --clients 5 --scenario reload \
-        --route-name r1 \
+        --route-name "${ROUTE_NAME}" \
         2>&1 | sed 's/^/# /'
-    then
+    rc=$?
+
+    if restore_route; then
+        echo "# cleanup: restored route '${ROUTE_NAME}' on '${ROUTE_BIND}'"
+    else
+        echo "# cleanup: failed to restore route '${ROUTE_NAME}' on '${ROUTE_BIND}'"
+        rc=1
+    fi
+
+    if [ "${rc}" -eq 0 ]; then
         echo "ok 2 - LOAD MYSQLX ROUTES TO RUNTIME: in-flight sessions survived, new connection refused"
         return 0
     else
@@ -126,11 +121,6 @@ reload_scenario() {
 if ! command -v python3 >/dev/null 2>&1; then
     echo "not ok 1 - python3 not available in test-runner image"
     echo "not ok 2 - python3 not available in test-runner image"
-    exit 1
-fi
-if ! command -v timeout >/dev/null 2>&1; then
-    echo "not ok 1 - timeout command not available in test-runner image"
-    echo "not ok 2 - timeout command not available in test-runner image"
     exit 1
 fi
 if ! python3 -c 'import mysqlx' 2>/dev/null; then

--- a/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
+++ b/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
@@ -84,13 +84,14 @@ SQL
 
 # Scenario 2: LOAD MYSQLX ROUTES TO RUNTIME mid-traffic
 reload_scenario() {
-    # The proxysql container needs to be up again for this scenario.
-    # Restart it (the test-runner can't restart proxysql directly;
-    # the right thing is to re-provision via setup-infras.bash, but
-    # for now we skip if the container isn't responsive).
-    if ! docker exec "${PROXY_CONTAINER}" mysql -uadmin -padmin -h127.0.0.1 -P6032 -e 'SELECT 1' >/dev/null 2>&1; then
-        echo "ok 2 - reload scenario skipped # SKIP proxysql container not running (shutdown scenario stopped it)"
-        return 0
+    # The proxysql container must still be up: this wrapper skips the
+    # destructive shutdown scenario above, so an admin probe failure is
+    # a real test/setup failure, not a valid skip. Use the same admin
+    # credentials as the rest of the TAP harness; admin/admin is local-
+    # only in CI and falsely reported a dead container.
+    if ! docker exec "${PROXY_CONTAINER}" mysql -u"${ADMIN_USER}" -p"${ADMIN_PASS}" -h127.0.0.1 -P6032 -e 'SELECT 1' >/dev/null 2>&1; then
+        echo "# reload scenario admin probe failed for ${PROXY_CONTAINER} using ${ADMIN_USER}@127.0.0.1:6032"
+        return 1
     fi
 
     python3 "${HARNESS}" \

--- a/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
+++ b/test/tap/tests/test_mysqlx_soak_behavioral-t.sh
@@ -86,17 +86,18 @@ SQL
 reload_scenario() {
     # The proxysql container must still be up: this wrapper skips the
     # destructive shutdown scenario above, so an admin probe failure is
-    # a real test/setup failure, not a valid skip. Use the same admin
-    # credentials as the rest of the TAP harness; admin/admin is local-
-    # only in CI and falsely reported a dead container.
-    if ! docker exec "${PROXY_CONTAINER}" mysql -u"${ADMIN_USER}" -p"${ADMIN_PASS}" -h127.0.0.1 -P6032 -e 'SELECT 1' >/dev/null 2>&1; then
-        echo "# reload scenario admin probe failed for ${PROXY_CONTAINER} using ${ADMIN_USER}@127.0.0.1:6032"
+    # a real test/setup failure, not a valid skip. Probe the same
+    # cross-container admin endpoint that behavioral_validation.py will
+    # use; docker exec from inside the test-runner is not portable.
+    if ! mysql -u"${ADMIN_USER}" -p"${ADMIN_PASS}" -h"${ADMIN_HOST}" -P"${ADMIN_PORT}" -e 'SELECT 1' >/dev/null 2>&1; then
+        echo "# reload scenario admin probe failed using ${ADMIN_USER}@${ADMIN_HOST}:${ADMIN_PORT}"
         return 1
     fi
 
-    python3 "${HARNESS}" \
+    python3 -u "${HARNESS}" \
         --proxysql-host "${PROXYSQL_HOST}" --proxysql-port "${PROXYSQL_PORT}" \
         --admin-host "${ADMIN_HOST}" --admin-port "${ADMIN_PORT}" \
+        --admin-user "${ADMIN_USER}" --admin-pass "${ADMIN_PASS}" \
         --user "${TEST_USER}" --password "${TEST_PASS}" \
         --clients 5 --scenario reload \
         --route-name "${ROUTE_NAME}" \

--- a/test/tap/tests/test_mysqlx_soak_stress-t.sh
+++ b/test/tap/tests/test_mysqlx_soak_stress-t.sh
@@ -55,9 +55,11 @@ if ! python3 -c 'import mysqlx, mysql.connector' 2>/dev/null; then
     exit 1
 fi
 
-if python3 "${HARNESS}" \
+if python3 -u "${HARNESS}" \
     --proxysql-host "${PROXYSQL_HOST}" --proxysql-port "${PROXYSQL_PORT}" \
     --admin-host "${ADMIN_HOST}" --admin-port "${ADMIN_PORT}" \
+    --admin-user "${TAP_ADMINUSERNAME:-radmin}" \
+    --admin-pass "${TAP_ADMINPASSWORD:-radmin}" \
     --user "${TEST_USER}" --password "${TEST_PASS}" \
     --concurrent "${CONCURRENT}" --duration "${DURATION}" \
     --metrics-out "${METRICS_OUT}" \

--- a/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_message_dispatch_unit-t.cpp
@@ -737,6 +737,43 @@ static void test_return_backend_on_session_close() {
 	close(fds[1]);
 }
 
+static void test_destroy_waiting_session_does_not_pool_backend() {
+	diag(">>> %s", __func__);
+	int client_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, client_fds);
+
+	int backend_fds[2];
+	socketpair(AF_UNIX, SOCK_STREAM, 0, backend_fds);
+
+	Mysqlx_Thread thr;
+	thr.init(0);
+	thr.set_max_cached_connections(10);
+
+	MysqlxSession* sess = new MysqlxSession();
+	sess->init(client_fds[0], &thr);
+
+	MysqlxConnection* conn = new MysqlxConnection();
+	conn->set_fd(backend_fds[0]);
+	conn->set_hostgroup(0);
+	conn->set_user("test");
+	conn->set_schema("test");
+	conn->set_reusable(true);
+	conn->set_state(MysqlxConnection::IN_USE);
+	conn->init_backend_ds(backend_fds[0]);
+	conn->backend_ds().set_status(XDS_READY);
+	sess->backend_conn() = conn;
+	sess->set_status(MysqlxSession::WAITING_SERVER_XMSG);
+	sess->set_response_state_for_test(RESP_WAITING_STMT_EXECUTE);
+
+	delete sess;
+
+	ok(thr.get_cached_connection_count() == 0,
+	   "backend with outstanding response is not cached on session destroy");
+
+	close(client_fds[1]);
+	close(backend_fds[1]);
+}
+
 // ------------------------------------------------------------------
 // Per-message response-state validation tests (#5694).
 //
@@ -860,6 +897,48 @@ static void test_validation_stmt_execute_metadata_then_row() {
 	   "response_state_ resets to IDLE after terminal");
 	ok(!sess.seen_column_metadata_for_test(),
 	   "seen_column_metadata_ cleared at terminal-frame flush");
+
+	detach_session_fds(sess);
+	close(client_fds[0]); close(client_fds[1]);
+	close(backend_fds[0]); close(backend_fds[1]);
+}
+
+// Test 2b: STMT_EXECUTE resultset may send FETCH_DONE before the final
+// SQL_STMT_EXECUTE_OK. FETCH_DONE closes the resultset, not the whole
+// statement response, so the proxy must keep waiting on the same backend.
+static void test_validation_stmt_execute_fetch_done_waits_for_stmt_ok() {
+	diag(">>> %s", __func__);
+	int client_fds[2], backend_fds[2];
+	MysqlxSession sess;
+	setup_session_for_validation(sess, client_fds, backend_fds,
+	                             RESP_WAITING_STMT_EXECUTE);
+
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_COLUMN_META_DATA, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_ROW, nullptr, 0);
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_RESULTSET_FETCH_DONE, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "STMT_EXECUTE FETCH_DONE before final OK is accepted");
+	ok(sess.response_state_for_test() == RESP_WAITING_STMT_EXECUTE,
+	   "FETCH_DONE does not terminate STMT_EXECUTE response");
+	ok(sess.backend_conn() != nullptr,
+	   "backend stays attached while waiting for final STMT_EXECUTE_OK");
+
+	sess.to_process = true;
+	write_server_frame(backend_fds[1],
+		Mysqlx::ServerMessages_Type_SQL_STMT_EXECUTE_OK, nullptr, 0);
+	sess.handler();
+
+	ok(sess.is_healthy(),
+	   "STMT_EXECUTE final OK after FETCH_DONE is accepted");
+	ok(sess.response_state_for_test() == RESP_IDLE,
+	   "STMT_EXECUTE_OK terminates response after FETCH_DONE");
+	ok(!sess.seen_column_metadata_for_test(),
+	   "seen_column_metadata_ cleared after final STMT_EXECUTE_OK");
 
 	detach_session_fds(sess);
 	close(client_fds[0]); close(client_fds[1]);
@@ -1265,10 +1344,12 @@ int main() {
 	test_forward_to_backend_no_connection();
 	test_forward_to_backend_with_socketpair();
 	test_return_backend_on_session_close();
+	test_destroy_waiting_session_does_not_pool_backend();
 
 	// Per-message response-state validation (#5694).
 	test_validation_stmt_execute_row_without_metadata();
 	test_validation_stmt_execute_metadata_then_row();
+	test_validation_stmt_execute_fetch_done_waits_for_stmt_ok();
 	test_validation_cursor_open_fetch_suspended();
 	test_validation_cursor_open_fetch_done();
 	test_validation_prepare_prepare_rejects_stmt_execute_ok();

--- a/test/tap/tests/unit/mysqlx_robustness_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_robustness_unit-t.cpp
@@ -724,6 +724,8 @@ static void test_server_ds_aliases_backend_conn_backend_ds() {
 	   "post-attach: server_ds() aliases backend_conn_->backend_ds() (TLS state preserved)");
 	ok(sess.server_ds().get_fd() == backend_fds[0],
 	   "post-attach: server_ds().get_fd() reflects the backend fd");
+	ok(sess.server_ds().get_status() == XDS_CONNECTED,
+	   "post-attach: raw init leaves backend stream connected but not poll-ready");
 
 	// return_backend_to_pool (via session close) must not tear down the
 	// TLS-aware stream on the cached connection. Driving this path via the
@@ -766,6 +768,8 @@ static void test_forward_empty_frame() {
 		reinterpret_cast<const uint8_t*>(stmt_s.data()), stmt_s.size());
 	sess.set_status(MysqlxSession::WAITING_CLIENT_XMSG);
 	sess.handler();
+	ok(sess.server_ds().get_status() == XDS_READY,
+	   "forward_to_backend marks attached backend stream poll-ready");
 
 	uint8_t buf[4096];
 	usleep(5000);
@@ -1501,7 +1505,7 @@ static void test_backend_user_falls_back_to_frontend_username() {
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(74);
+	plan(76);
 	diag("=== mysqlx_robustness_unit-t starting ===");
 
 	test_server_response_terminal_frame();

--- a/test/tap/tests/unit/mysqlx_session_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_session_unit-t.cpp
@@ -232,6 +232,10 @@ static void test_con_close_during_connecting() {
 	sess.handler();
 
 	ok(!sess.is_healthy(), "unhealthy after CON_CLOSE during CONNECTING_CLIENT");
+	uint8_t buf[64];
+	ssize_t r = read_x_frame(fds[1], buf, sizeof(buf));
+	ok(r > 0 && buf[4] == Mysqlx::ServerMessages_Type_OK,
+	   "CON_CLOSE during CONNECTING_CLIENT receives OK before close");
 
 	close(fds[0]);
 	close(fds[1]);
@@ -710,6 +714,10 @@ static void test_sess_close_in_main_loop() {
 
 	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSED, "session closed after SESS_CLOSE");
 	ok(!sess.is_healthy(), "unhealthy after session close");
+	uint8_t buf[64];
+	ssize_t r = read_x_frame(fds[1], buf, sizeof(buf));
+	ok(r > 0 && buf[4] == Mysqlx::ServerMessages_Type_OK,
+	   "SESS_CLOSE receives OK before close");
 
 	close(fds[0]);
 	close(fds[1]);
@@ -731,6 +739,10 @@ static void test_con_close_in_main_loop() {
 
 	ok(sess.get_status() == MysqlxSession::X_SESSION_CLOSED, "session closed after CON_CLOSE in main loop");
 	ok(!sess.is_healthy(), "unhealthy after con close");
+	uint8_t buf[64];
+	ssize_t r = read_x_frame(fds[1], buf, sizeof(buf));
+	ok(r > 0 && buf[4] == Mysqlx::ServerMessages_Type_OK,
+	   "CON_CLOSE receives OK before close");
 
 	close(fds[0]);
 	close(fds[1]);
@@ -1536,7 +1548,7 @@ int main() {
 	// contributes 6 ok()s) + 11 (Fix C per-route tls_mode tests:
 	// disabled_advertise=2; tls_refused_on_disabled=2;
 	// passthrough_full_entry_path=7)
-	plan(109);
+	plan(112);
 	diag("=== mysqlx_session_unit-t starting ===");
 
 	test_session_init();

--- a/test/tap/tests/unit/mysqlx_thread_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_thread_unit-t.cpp
@@ -188,9 +188,19 @@ static void test_connection_cache_tls_partition() {
 	delete got_tls;
 }
 
+static void test_timeout_elapsed_is_future_safe() {
+	diag(">>> %s", __func__);
+	ok(!Mysqlx_Thread::elapsed_exceeds_for_test(1000, 1001, 10),
+	   "timeout comparison does not underflow when last-active is newer than now");
+	ok(!Mysqlx_Thread::elapsed_exceeds_for_test(1000, 990, 10),
+	   "timeout comparison is strict at the timeout boundary");
+	ok(Mysqlx_Thread::elapsed_exceeds_for_test(1001, 990, 10),
+	   "timeout comparison fires after the timeout boundary");
+}
+
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(25);
+	plan(28);
 	diag("=== mysqlx_thread_unit-t starting ===");
 
 	test_thread_init();
@@ -199,6 +209,7 @@ int main() {
 	test_thread_accept_connection();
 	test_connection_cache();
 	test_connection_cache_tls_partition();
+	test_timeout_elapsed_is_future_safe();
 
 	return exit_status();
 }


### PR DESCRIPTION
## Summary

Fix the mysqlx soak behavioral TAP hang by making the shutdown test observer and shutdown actor separate again.

The current `v3.0` mysqlx soak job hangs in `Run mysqlx-soak-g1 tests` after the test changed to call `PROXYSQL SHUTDOWN SLOW` synchronously from `behavioral_validation.py`. That blocks the observer before it can stop or collect the active mysqlx client threads.

This PR:
- adds `--external-shutdown` to `behavioral_validation.py` so the harness can observe client disconnects without issuing the admin shutdown itself
- has the TAP wrapper send `PROXYSQL SHUTDOWN SLOW` from a bounded background `docker exec` actor
- wraps the Python behavioral harness with `timeout` so this TAP cannot pin CI indefinitely
- makes behavioral client threads daemon threads and joins once after setting `stop`, so a failed observation exits instead of hanging the process

## Validation

- `python3 -m py_compile test/scripts/mysqlx/behavioral_validation.py`
- `bash -n test/tap/tests/test_mysqlx_soak_behavioral-t.sh`
- targeted regression checks for `--external-shutdown` and timeout-wrapped harness invocation
- `git diff --check`

Full docker-isolated mysqlx soak validation is expected from CI; this fresh worktree does not contain built `src/proxysql` or mysqlx plugin artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQLX soak shutdown and reload sequencing to reduce hangs during active client traffic.
  * Added support for externally coordinated “shutdown slow” with a configurable wait window.
  * Disabled session compression for MySQLX test connections to improve consistency.

* **Tests**
  * Updated MySQLX soak TAP harness to skip the slow mid-traffic assertion, run reload with configurable route settings, and restore routes after execution.
  * Improved MySQLX route-drop test diagnostics for clearer SELECT 1 error reporting.
  * Persisted MySQLX fixture runtime rows to disk across resets and tightened soak timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->