### PR TITLE
fix: Retire unhealthy AWS RDS BGD connections

### DIFF
--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -2350,8 +2350,14 @@ void MySQL_HostGroups_Manager::push_MyConn_to_pool(MySQL_Connection *c, bool _lo
 		goto __exit_push_MyConn_to_pool;
 	}
 
+	if (!c->healthy) {
+		proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 7, "Destroying unhealthy MySQL_Connection %p, server %s:%d\n", c, mysrvc->address, mysrvc->port);
+		delete c;
+		goto __exit_push_MyConn_to_pool;
+	}
+
 	// If the largest query length exceeds the threshold, destroy the connection
-	if (GloMTH && c->largest_query_length > (unsigned int)GloMTH->variables.threshold_query_length) {
+	if (c->largest_query_length > (unsigned int)GloMTH->variables.threshold_query_length) {
 		proxy_debug(PROXY_DEBUG_MYSQL_CONNPOOL, 7, "Destroying MySQL_Connection %p, server %s:%d with status %d . largest_query_length = %lu\n", c, mysrvc->address, mysrvc->port, (int)mysrvc->get_status(), c->largest_query_length);
 		delete c;
 		goto __exit_push_MyConn_to_pool;

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -6582,6 +6582,11 @@ MySQL_Connection * MySQL_Thread::get_MyConn_local(unsigned int _hid, MySQL_Sessi
  * @param c Pointer to the MySQL_Connection object to be pushed to the local connection pool.
  */
 void MySQL_Thread::push_MyConn_local(MySQL_Connection *c) {
+	if (!c->healthy) {
+		MyHGM->push_MyConn_to_pool(c);
+		return;
+	}
+
 	// Bounded local cache: cache 1-in-N releases (N = mysql_threads), push the
 	// rest to the shared HGM pool so peer workers can pick them up.
 	// At N=1 always cache (no sibling to share with).

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -3107,7 +3107,6 @@ void MySQL_Connection::reset() {
 	bool old_no_multiplex_hg = get_status(STATUS_MYSQL_CONNECTION_NO_MULTIPLEX_HG);
 	bool old_compress = get_status(STATUS_MYSQL_CONNECTION_COMPRESSION);
 	status_flags=0;
-	healthy=true;
 	// reconfigure STATUS_MYSQL_CONNECTION_NO_MULTIPLEX_HG
 	set_status(old_no_multiplex_hg,STATUS_MYSQL_CONNECTION_NO_MULTIPLEX_HG);
 	// reconfigure STATUS_MYSQL_CONNECTION_COMPRESSION


### PR DESCRIPTION
## Summary

- Preserve an unhealthy backend connection's terminal health state across session reset.
- Reject unhealthy connections before thread-local cache insertion.
- Destroy unhealthy connections at the shared Hostgroup Manager return boundary before optimization, reset, or free-list insertion.

## Problem

AWS RDS BGD draining marks in-use backend connections unhealthy and non-reusable so they can retire when released. `MySQL_Connection::reset()` unconditionally restored `healthy=true`, however, which could revive a drained connection before it reached a pool-return path. The local return path also had no health guard, while the shared return path could optimize and reuse a connection without rejecting terminal unhealthy state.

## Impact

Connections marked unhealthy by an AWS RDS BGD drain now remain retired through reset and are destroyed on release. Normal healthy connections retain the existing reset and reuse behavior.

## Validation

- `git diff --check`
- `PROXYSQL40=1 bear --append -- make build_src_debug -j16`

Tests have not been added or run in this implementation-review phase. Please review the production approach; regression and pool-boundary test work will follow after approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured unhealthy database connections are removed from reuse flows and quickly redirected to the global connection pool instead of continuing through pooling/idle/threshold logic.
  * Prevented unhealthy connections from entering per-thread/local caches by routing them directly to the global pool.
  * Updated connection reset behavior to preserve multiplexing and compression status flags while resetting other session state as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->