### PR TITLE
fix: Isolate AWS RDS BGD worker configuration refresh

### DIFF
--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -1214,12 +1214,10 @@ class MySQL_HostGroups_Manager : public Base_HostGroups_Manager<MyHGC> {
 	/**
 	 * @brief Rebuilds the AWS RDS BGD monitor's host resultset.
 	 *
-	 * @details Rebuilds `GloMyMon->AWS_RDS_Blue_Hosts_resultset` and publishes a checksum combining
-	 *   the blue hosts with the green hosts.
-	 *
-	 * @param lock When true, the monitor's `aws_rds_bgd_mutex` is taken internally.
+	 * @details Rebuilds `GloMyMon->AWS_RDS_BGD_Hosts_resultset` and publishes both the full BGD hosts
+	 *   checksum and one checksum per writer hostgroup.
 	 */
-	void update_aws_rds_bgd_hosts_monitor_resultset(bool lock=false);
+	void update_aws_rds_bgd_hosts_monitor_resultset();
 	/**
 	 * @brief Auto-generate a runtime `mysql_aws_rds_bgd_hostgroups` entry for a server's writer hostgroup.
 	 *

--- a/include/MySQL_Monitor.hpp
+++ b/include/MySQL_Monitor.hpp
@@ -403,46 +403,30 @@ struct srv_addr_t {
 };
 
 /**
- * @brief A single node (row) of a 'SELECT * FROM mysql.rds_topology' result.
- */
-struct AWS_RDS_Topology_Node {
-	std::string id;
-	std::string endpoint;
-	int port = 0;
-	std::string role;    ///< empty when the column is absent or NULL
-	std::string status;  ///< empty when the column is absent or NULL
+* @brief State of the per-host RDS topology probe.
+*/
+enum RDS_BGD_Topology_Monitor_State {
+	TOPOLOGY_TABLE_CHECK,    ///< verify mysql.rds_topology exists
+	TOPOLOGY_METADATA_FETCH  ///< table confirmed present; fetch and branch on its metadata
 };
 
 /**
- * @brief Parsed representation of a 'SELECT * FROM mysql.rds_topology' result,
- *        shared by the read_only monitor's discovery path and the AWS RDS BGD
- *        monitor thread.
+ * @brief Column positions in `AWS_RDS_BGD_Hosts_resultset`.
  */
-struct AWS_RDS_Topology_Result {
-	bool blue_green = false;  ///< 'role' and 'status' present AND non-NULL
-	std::vector<AWS_RDS_Topology_Node> nodes;
-};
-
-/**
- * @brief Mapping between one blue host and its name-matched green counterpart.
- *
- * @details The RDS BGD worker builds these pairs from the current blue
- *   writer/reader hostgroups and the discovered green topology. Each entry
- *   carries the blue server attributes needed to move the matching green
- *   server during switchover handling.
- */
-struct AWS_RDS_BlueGreenPair {
-	std::string blue_host;                ///< Blue hostname from the writer or reader hostgroup.
-	std::string green_host;               ///< Matched green hostname using the RDS "-green-<random>" naming pattern.
-	int port = 0;                         ///< Shared blue/green port; hostgroup manager keys servers by host and port.
-	int64_t blue_weight = 1;              ///< Blue server weight mirrored onto the green server when it is added.
-	int64_t blue_max_conns = 1000;        ///< Blue server max_connections mirrored onto the green server when it is added.
-	int32_t blue_use_ssl = 0;             ///< Blue server SSL setting mirrored onto the green server when it is added.
-	int32_t green_use_ssl = -1;           ///< Green server SSL; -1 means unset (use blue_use_ssl).
-	std::string green_ip;                 ///< Green host IP resolved at SWITCHOVER_INITIATED and held warm.
-	unsigned long long green_ip_ttl = 0;  ///< Expiry for green_ip when resolved by the BGD thread; 0 means DNS_Cache-sourced.
-	bool green_ip_pinned = false;         ///< True after green_ip has been pinned and blue_host connections drained/purged.
-	bool is_writer = false;               ///< True when this pair maps the blue writer.
+enum AWS_RDS_BGD_Hosts_Column {
+	AWS_RDS_BGD_HOSTNAME = 0,
+	AWS_RDS_BGD_PORT,
+	AWS_RDS_BGD_USE_SSL,
+	AWS_RDS_BGD_WRITER_HOSTGROUP,
+	AWS_RDS_BGD_READER_HOSTGROUP,
+	AWS_RDS_BGD_GREEN_WRITER_HOSTGROUP,
+	AWS_RDS_BGD_GREEN_READER_HOSTGROUP,
+	AWS_RDS_BGD_CHECK_INTERVAL_MS,
+	AWS_RDS_BGD_CHECK_TIMEOUT_MS,
+	AWS_RDS_BGD_WRITER_IS_ALSO_READER,
+	AWS_RDS_BGD_SRV_TYPE,
+	AWS_RDS_BGD_IS_WRITER,
+	AWS_RDS_BGD_HOSTS_COLUMNS
 };
 
 /**
@@ -481,47 +465,6 @@ enum class AWS_RDS_BGD_Server_Status {
 	IN_PROGRESS = 1
 };
 
-// Maps a switchover status enum to its stored/display string.
-const char* aws_rds_bgd_status_str(AWS_RDS_BGD_Status s);
-
-/**
- * @brief Switchover state carried by RDS BGD worker thread.
- *
- * @details One worker (monitor_RDS_BGD_thread_HG) owns one writer hostgroup ==
- *   one blue/green deployment, so this struct lives on the worker's stack and is
- *   single-owner (no locking on the struct itself). It is passed by reference to
- *   handle_aws_rds_bgd, which runs the status-driven switchover FSM and mutates it
- *   across poll cycles. Config-derived fields are loaded once from the resultset;
- *   the rest carries topology, resolved IPs, and one-shot enforcement bookkeeping.
- */
-struct AWS_RDS_BGD_State {
-	unsigned int writer_hg = 0;               ///< blue/current writer hostgroup
-	unsigned int reader_hg = 0;               ///< blue/current reader hostgroup
-	int green_writer_hg = -1;                 ///< -1 when NULL (auto-discovery path)
-	int green_reader_hg = -1;                 ///< -1 when NULL
-	int writer_is_also_reader = 0;            ///< drives post-switchover writer cleanup
-
-	std::string last_topology_status;                 ///< raw mysql.rds_topology TARGET status from the previous poll (verbatim)
-	std::vector<AWS_RDS_BlueGreenPair> bg_map;        ///< [writer] always; [readers] only when green_reader_hg is configured
-	std::vector<srv_addr_t> shunned_readers;                  ///< readers we shunned
-	AWS_RDS_BGD_Status bgd_status = AWS_RDS_BGD_Status::NONE;  ///< drives the FSM and the deferred cleanup
-
-	bool bgd_in_progress_set = false;             ///< deployment's servers flagged in aws_rds_bgd_server_status
-
-	unsigned int next_check_interval_ms = 0;    ///< FSM-controlled interval; 0 => baseline
-	std::string next_check_host;                ///< FSM-pinned probe host; when set (the green IP), the worker
-	                                            ///< polls it directly instead of selecting among the blue hosts
-	unsigned int next_check_host_failures = 0;  ///< consecutive failures polling next_check_host; clears it after 3
-};
-
-/**
-* @brief State of the per-host RDS topology probe.
-*/
-enum RDS_BGD_Topology_Monitor_State {
-	TOPOLOGY_TABLE_CHECK,    ///< verify mysql.rds_topology exists
-	TOPOLOGY_METADATA_FETCH  ///< table confirmed present; fetch and branch on its metadata
-};
-
 // AWS RDS blue/green role and switchover-status column values (mysql.rds_topology).
 inline const char* const BGD_ROLE_SOURCE         = "BLUE_GREEN_DEPLOYMENT_SOURCE";  // blue
 inline const char* const BGD_ROLE_TARGET         = "BLUE_GREEN_DEPLOYMENT_TARGET";  // green
@@ -530,6 +473,120 @@ inline const char* const BGD_STATUS_INITIATED    = "SWITCHOVER_INITIATED";
 inline const char* const BGD_STATUS_IN_PROGRESS  = "SWITCHOVER_IN_PROGRESS";
 inline const char* const BGD_STATUS_POST_PROC    = "SWITCHOVER_IN_POST_PROCESSING";
 inline const char* const BGD_STATUS_COMPLETED    = "SWITCHOVER_COMPLETED";
+
+/**
+* @brief BGD Monitor state for one AWS RDS BGD worker.
+*/
+struct AWS_RDS_BGD_Worker {
+	int writer_hg = 0;
+	pthread_t thread {};
+	std::atomic_bool worker_stop {false};
+	std::atomic<uint64_t> current_checksum {0};
+};
+
+/**
+ * @brief A single node (row) of a 'SELECT * FROM mysql.rds_topology' result.
+ */
+struct AWS_RDS_Topology_Node {
+	std::string id;
+	std::string endpoint;
+	int port = 0;
+	std::string role;    ///< empty when the column is absent or NULL
+	std::string status;  ///< empty when the column is absent or NULL
+};
+
+/**
+ * @brief Parsed representation of a 'SELECT * FROM mysql.rds_topology' result,
+ *        shared by the read_only monitor's discovery path and the AWS RDS BGD
+ *        monitor thread.
+ */
+class AWS_RDS_Topology_Result {
+public:
+	bool blue_green = false;  ///< 'role' and 'status' present AND non-NULL
+	std::vector<AWS_RDS_Topology_Node> nodes;
+
+	/**
+	* @brief Find the blue/green deployment TARGET node.
+	*
+	* @return The TARGET node, or nullptr when it is not present.
+	*/
+	AWS_RDS_Topology_Node* target() {
+		for (AWS_RDS_Topology_Node& node : nodes) {
+			if (strcasecmp(node.role.c_str(), BGD_ROLE_TARGET) == 0) {
+				return &node;
+			}
+		}
+		return nullptr;
+	}
+};
+
+/**
+ * @brief Mapping between one blue host and its name-matched green counterpart.
+ *
+ * @details The RDS BGD worker builds these pairs from the current blue
+ *   writer/reader hostgroups and the discovered green topology. Each entry
+ *   carries the blue server attributes needed to move the matching green
+ *   server during switchover handling.
+ */
+struct AWS_RDS_BlueGreenPair {
+	std::string blue_host;                ///< Blue hostname from the writer or reader hostgroup.
+	std::string green_host;               ///< Matched green hostname using the RDS "-green-<random>" naming pattern.
+	int port = 0;                         ///< Shared blue/green port; hostgroup manager keys servers by host and port.
+	int64_t blue_weight = 1;              ///< Blue server weight mirrored onto the green server when it is added.
+	int64_t blue_max_conns = 1000;        ///< Blue server max_connections mirrored onto the green server when it is added.
+	int32_t blue_use_ssl = 0;             ///< Blue server SSL setting mirrored onto the green server when it is added.
+	int32_t green_use_ssl = -1;           ///< Green server SSL; -1 means unset (use blue_use_ssl).
+	std::string green_ip;                 ///< Green host IP resolved at SWITCHOVER_INITIATED and held warm.
+	unsigned long long green_ip_ttl = 0;  ///< Expiry for green_ip when resolved by the BGD thread; 0 means DNS_Cache-sourced.
+	bool green_ip_pinned = false;         ///< True after green_ip has been pinned and blue_host connections drained/purged.
+	bool is_writer = false;               ///< True when this pair maps the blue writer.
+};
+
+/**
+ * @brief Host used by a BGD worker to probe `mysql.rds_topology`.
+ */
+struct AWS_RDS_BGD_Probe_Host {
+	std::string hostname;
+	int port = 0;
+	int use_ssl = 0;
+};
+
+/**
+ * @brief Switchover state carried by RDS BGD worker thread.
+ *
+ * @details One worker (monitor_RDS_BGD_thread_HG) owns one writer hostgroup ==
+ *   one blue/green deployment, so this struct lives on the worker's stack and is
+ *   single-owner (no locking on the struct itself). It is passed by reference to
+ *   handle_aws_rds_bgd, which runs the status-driven switchover FSM and mutates it
+ *   across poll cycles. Config-derived fields can be refreshed in place; the rest
+ *   carries resolved IPs and state for switchover actions and cleanup.
+ */
+struct AWS_RDS_BGD_State {
+	unsigned int writer_hg = 0;               ///< blue/current writer hostgroup
+	unsigned int reader_hg = 0;               ///< blue/current reader hostgroup
+	int green_writer_hg = -1;                 ///< -1 when NULL (auto-discovery path)
+	int green_reader_hg = -1;                 ///< -1 when NULL
+	int writer_is_also_reader = 0;            ///< drives post-switchover writer cleanup
+	unsigned int check_interval_ms = 0;       ///< configured baseline check interval
+	unsigned int check_timeout_ms = 0;        ///< configured topology-check timeout
+
+	std::vector<AWS_RDS_BlueGreenPair> bg_map;        ///< [writer] always; [readers] only when green_reader_hg is configured
+	std::vector<AWS_RDS_BGD_Probe_Host> probe_hosts;  ///< hosts eligible for topology probes
+
+	std::vector<srv_addr_t> shunned_readers;                  ///< readers we shunned
+	AWS_RDS_BGD_Status bgd_status = AWS_RDS_BGD_Status::NONE;  ///< drives the FSM and the deferred cleanup
+
+	bool bgd_in_progress_set = false;             ///< deployment's servers flagged in aws_rds_bgd_server_status
+	bool config_refresh_pending = false;          ///< bg_map must be rebuilt from the next topology result
+
+	unsigned int next_check_interval_ms = 0;    ///< FSM-controlled interval; 0 => baseline
+	std::string next_check_host;                ///< FSM-pinned probe host; when set (the green IP), the worker
+	                                            ///< polls it directly instead of selecting among the blue hosts
+	unsigned int next_check_host_failures = 0;  ///< consecutive failures polling next_check_host; clears it after 3
+};
+
+// Maps a switchover status enum to its stored/display string.
+const char* aws_rds_bgd_status_str(AWS_RDS_BGD_Status s);
 
 // read_only monitor server-enumeration query.
 // Every server that belongs to a replication hostgroup and status NOT IN (OFFLINE_SOFT, OFFLINE_HARD)
@@ -590,6 +647,7 @@ class MySQL_Monitor {
 	pthread_mutex_t galera_mutex; // for simplicity, a mutex instead of a rwlock
 	pthread_mutex_t aws_aurora_mutex; // for simplicity, a mutex instead of a rwlock
 	pthread_mutex_t aws_rds_bgd_mutex;
+	pthread_mutex_t aws_rds_bgd_hosts_mutex;
 	pthread_mutex_t mysql_servers_mutex; // for simplicity, a mutex instead of a rwlock
 	pthread_mutex_t proxysql_servers_mutex; 
 	//std::map<char *, MyGR_monitor_node *, cmp_str> Group_Replication_Hosts_Map;
@@ -601,8 +659,9 @@ class MySQL_Monitor {
 	SQLite3_result *AWS_Aurora_Hosts_resultset;
 	uint64_t AWS_Aurora_Hosts_resultset_checksum;
 	std::unordered_map<std::string, AWS_RDS_BGD_Server_Status> aws_rds_bgd_server_status;
-	SQLite3_result *AWS_RDS_Blue_Hosts_resultset;
+	std::shared_ptr<SQLite3_result> AWS_RDS_BGD_Hosts_resultset;
 	uint64_t AWS_RDS_BGD_Hosts_checksum;
+	std::unordered_map<int, uint64_t> AWS_RDS_BGD_Cluster_checksum;
 	unsigned int num_threads;
 	unsigned int aux_threads;
 	unsigned int started_threads;
@@ -653,11 +712,39 @@ class MySQL_Monitor {
 	/**
 	* @brief AWS RDS BGD monitor thread entry point.
 	*
-	* @details Spawns one worker (monitor_RDS_BGD_thread_HG) per writer hostgroup; each worker picks a pingable writer,
-	*   probes 'mysql.rds_topology' and dispatches based on the detected topology shape.
-	*   Workers are (re)spawned whenever the AWS_RDS_BGD_Hosts_checksum changes.
+	* @details Maintains one worker (monitor_RDS_BGD_thread_HG) per active writer hostgroup. The parent starts
+	*   and stops workers and signals configuration changes. Each worker selects a pingable probe host,
+	*   probes 'mysql.rds_topology', and runs the switchover state machine.
 	*/
 	void * monitor_aws_rds_bgd();
+	/**
+	* @brief Run an asynchronous query and store its result on a BGD monitor connection.
+	*
+	* @param mmsd        Monitor state data holding the connection, timing, and result.
+	* @param query       SQL text to execute.
+	* @param worker_stop Per-worker shutdown signal.
+	*
+	* @return 0 on success, 1 on timeout or query error, and 2 when shutdown is requested.
+	*/
+	int aws_rds_bgd_async_query(
+		MySQL_Monitor_State_Data* mmsd, const char* query, std::atomic_bool& worker_stop);
+	/**
+	* @brief Apply changed configuration to one running BGD worker.
+	*
+	* @details Before writer post-processing, applies the configuration and schedules mapping
+	*   reconciliation after the next topology poll. At or after post-processing, rolls back the
+	*   deployment and restarts its topology state machine.
+	*
+	* @param st               Worker-owned BGD state.
+	* @param current_checksum Per-cluster checksum captured for this refresh.
+	* @param topology_state   Current topology query state.
+	* @param next_loop_at     Next scheduled worker iteration.
+	*
+	* @return true when the configuration was applied; false when it must be retried.
+	*/
+	bool aws_rds_bgd_refresh_worker_config(
+		AWS_RDS_BGD_State& st, uint64_t current_checksum,
+		RDS_BGD_Topology_Monitor_State& topology_state, unsigned long long& next_loop_at);
 	/**
 	* @brief Run the status-driven blue/green switchover FSM for one deployment.
 	*
@@ -672,7 +759,7 @@ class MySQL_Monitor {
 	* @param st        BGD switchover state.
 	* @param topology  Parsed mysql.rds_topology result for this cycle.
 	*/
-	void handle_aws_rds_bgd(AWS_RDS_BGD_State& st, const AWS_RDS_Topology_Result& topology);
+	void handle_aws_rds_bgd(AWS_RDS_BGD_State& st, AWS_RDS_Topology_Result& topology);
 	/**
 	* @brief Pin green IPs and drain existing blue-host connections.
 	*
@@ -786,6 +873,64 @@ class MySQL_Monitor {
 	void monitor_gr_async_actions_handler(const vector<unique_ptr<MySQL_Monitor_State_Data>>& mmsds);
 
 private:
+	/**
+	* @brief Load one BGD worker's configuration from the published host rows.
+	*
+	* @details Copies the cluster rows, verifies their checksum, copies configuration fields from
+	*   the first row, and builds the probe host list.
+	*
+	* @param writer_hg        Writer hostgroup identifying the deployment.
+	* @param current_checksum Per-cluster checksum captured for this refresh.
+	* @param candidate        State populated from the published rows.
+	*
+	* @return true when the checksum matches and the rows contain a probe host.
+	*/
+	bool aws_rds_bgd_load_worker_config(int writer_hg, uint64_t current_checksum, AWS_RDS_BGD_State& candidate);
+	/**
+	* @brief Replace the configuration-derived fields in a live BGD worker state.
+	*
+	* @param st        Live worker state.
+	* @param candidate Parsed configuration to apply.
+	*/
+	void aws_rds_bgd_apply_cluster_config(AWS_RDS_BGD_State& st, AWS_RDS_BGD_State& candidate);
+	/**
+	* @brief Rebuild the mapping and reconcile writer state after a configuration refresh.
+	*
+	* @details Called only when config_refresh_pending is set.
+	*
+	* @param st       Worker-owned BGD state.
+	* @param topology Fresh topology used to rebuild the mapping.
+	*/
+	void aws_rds_bgd_config_refresh_action(AWS_RDS_BGD_State& st, AWS_RDS_Topology_Result& topology);
+	/**
+	* @brief Build the blue-to-green host mapping for a BGD worker.
+	*
+	* @param st       Worker-owned BGD state.
+	* @param topology Parsed topology used to identify the green target.
+	*/
+	void aws_rds_bgd_build_map(AWS_RDS_BGD_State& st, AWS_RDS_Topology_Result& topology);
+	/**
+	* @brief Resolve green host IPs and select the next topology probe host.
+	*
+	* @param st Worker-owned BGD state.
+	*/
+	void aws_rds_bgd_resolve_green_ips(AWS_RDS_BGD_State& st);
+	/**
+	* @brief Add the green writer to its configured hostgroup.
+	*
+	* @param st Worker-owned BGD state.
+	*/
+	void aws_rds_bgd_add_green_writer_in_hg(AWS_RDS_BGD_State& st);
+	/**
+	* @brief Find the writer pair in a blue-to-green host mapping.
+	*
+	* @param bg_map Host mapping to inspect.
+	* @param writer Writer address populated when a pair is found.
+	*
+	* @return true when the map contains a writer pair.
+	*/
+	bool aws_rds_bgd_find_writer(std::vector<AWS_RDS_BlueGreenPair>& bg_map, srv_addr_t& writer);
+
 	/**
 	 * @brief Handling of monitor tasks asyncronously
 	 * @details Basic workflow is same for all monitor_*_async methods:

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1617,7 +1617,7 @@ bool MySQL_HostGroups_Manager::commit(
 	// calls to 'generate_mysql_servers'.
 	update_table_mysql_servers_for_monitor(false);
 	// Refresh BGD monitoring after all runtime server changes are applied.
-	update_aws_rds_bgd_hosts_monitor_resultset(true);
+	update_aws_rds_bgd_hosts_monitor_resultset();
 
 	wrunlock();
 	unsigned long long curtime2=monotonic_time();
@@ -7139,105 +7139,78 @@ void MySQL_HostGroups_Manager::update_aws_aurora_hosts_monitor_resultset(bool lo
 	}
 }
 
-const char SELECT_AWS_RDS_BGD_BLUE_SERVERS_FOR_MONITOR[] {
-	"SELECT writer_hostgroup, reader_hostgroup, hostname, port, MAX(use_ssl) use_ssl, green_writer_hostgroup,"
-		" green_reader_hostgroup, check_interval_ms, check_timeout_ms, writer_is_also_reader,"
-		" MAX(hostgroup_id=writer_hostgroup) is_writer"
-		" FROM mysql_servers"
-		" JOIN mysql_aws_rds_bgd_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=reader_hostgroup"
-		" WHERE active=1 AND mysql_servers.status NOT IN (2,3)"
-		" GROUP BY writer_hostgroup, hostname, port"
-};
-
-const char SELECT_AWS_RDS_BGD_GREEN_SERVERS_FOR_MONITOR[] {
-	"SELECT bgd.writer_hostgroup, srv.hostgroup_id, srv.hostname, srv.port, srv.use_ssl FROM mysql_servers AS srv"
-		" JOIN mysql_aws_rds_bgd_hostgroups AS bgd ON srv.hostgroup_id=bgd.green_writer_hostgroup"
-		" OR srv.hostgroup_id=bgd.green_reader_hostgroup"
-		" WHERE bgd.active=1 AND srv.status NOT IN (2,3)"
-		" ORDER BY bgd.writer_hostgroup, srv.hostgroup_id, srv.hostname, srv.port"
+const char SELECT_AWS_RDS_BGD_SERVERS_FOR_MONITOR[] {
+	"SELECT srv.hostname, srv.port, MAX(srv.use_ssl) AS use_ssl, "
+		"bgd.writer_hostgroup, bgd.reader_hostgroup, bgd.green_writer_hostgroup, bgd.green_reader_hostgroup, "
+		"bgd.check_interval_ms, bgd.check_timeout_ms, bgd.writer_is_also_reader, "
+		"'B' AS srv_type, MAX(srv.hostgroup_id=bgd.writer_hostgroup) AS is_writer "
+	"FROM mysql_servers AS srv "
+	"JOIN mysql_aws_rds_bgd_hostgroups AS bgd "
+		"ON srv.hostgroup_id=bgd.writer_hostgroup OR srv.hostgroup_id=bgd.reader_hostgroup "
+	"WHERE bgd.active=1 AND srv.status NOT IN (2,3) "
+	"GROUP BY bgd.writer_hostgroup, srv.hostname, srv.port "
+	"UNION ALL "
+	"SELECT srv.hostname, srv.port, srv.use_ssl, "
+		"bgd.writer_hostgroup, bgd.reader_hostgroup, bgd.green_writer_hostgroup, bgd.green_reader_hostgroup, "
+		"bgd.check_interval_ms, bgd.check_timeout_ms, bgd.writer_is_also_reader, "
+		"'G' AS srv_type, srv.hostgroup_id=bgd.green_writer_hostgroup AS is_writer "
+	"FROM mysql_servers AS srv "
+	"JOIN mysql_aws_rds_bgd_hostgroups AS bgd "
+		"ON srv.hostgroup_id=bgd.green_writer_hostgroup OR srv.hostgroup_id=bgd.green_reader_hostgroup "
+	"WHERE bgd.active=1 AND srv.status NOT IN (2,3) "
+	"ORDER BY writer_hostgroup, srv_type, is_writer DESC, hostname, port"
 };
 
 /**
  * @brief Rebuilds the AWS RDS BGD monitor's host resultset.
  *
- * @details Rebuilds `GloMyMon->AWS_RDS_Blue_Hosts_resultset` and publishes a checksum combining
- *   the blue hosts with the green hosts.
- *
- * @param lock When true, the monitor's `aws_rds_bgd_mutex` is taken internally.
+ * @details Rebuilds `GloMyMon->AWS_RDS_BGD_Hosts_resultset` and publishes both the full BGD hosts
+ *   checksum and one checksum per writer hostgroup. The previous result remains active when the
+ *   query fails.
  */
-void MySQL_HostGroups_Manager::update_aws_rds_bgd_hosts_monitor_resultset(bool lock) {
+void MySQL_HostGroups_Manager::update_aws_rds_bgd_hosts_monitor_resultset() {
 	if (!GloMyMon) {
 		return;
 	}
 
-	if (lock) {
-		pthread_mutex_lock(&GloMyMon->aws_rds_bgd_mutex);
-	}
+	SQLite3_result* resultset = nullptr;
+	char* error = nullptr;
+	int cols = 0;
+	int affected_rows = 0;
+	mydb->execute_statement(SELECT_AWS_RDS_BGD_SERVERS_FOR_MONITOR, &error, &cols, &affected_rows, &resultset);
 
-	// Unlike other monitor resultset/checksum pairs, BGD intentionally tracks different data in each.
-	//
-	// AWS_RDS_Blue_Hosts_resultset contains only blue hosts. The BGD monitor dispatcher uses it to start
-	// workers, and each worker uses it to select its `mysql.rds_topology` probe candidates.
-	//
-	// AWS_RDS_BGD_Hosts_checksum combines the blue and green resultset checksums. Workers and the dispatcher
-	// use it as a generation signal: relevant changes in mysql_servers or mysql_aws_rds_bgd_hostgroups
-	// stop the old workers so replacements rebuild the blue/green map from the current runtime configuration.
-
-	SQLite3_result* blue_resultset = nullptr;
-	SQLite3_result* green_resultset = nullptr;
-	char* blue_error = nullptr;
-	char* green_error = nullptr;
-	int blue_cols = 0;
-	int green_cols = 0;
-	int blue_affected_rows = 0;
-	int green_affected_rows = 0;
-
-	mydb->execute_statement(
-		SELECT_AWS_RDS_BGD_BLUE_SERVERS_FOR_MONITOR,
-		&blue_error, &blue_cols, &blue_affected_rows, &blue_resultset);
-	mydb->execute_statement(
-		SELECT_AWS_RDS_BGD_GREEN_SERVERS_FOR_MONITOR,
-		&green_error, &green_cols, &green_affected_rows, &green_resultset);
-
-	if (blue_error || green_error || !blue_resultset || !green_resultset) {
-		if (blue_error) {
-			proxy_error("Error refreshing AWS RDS BGD blue hosts: %s\n", blue_error);
-		}
-		if (green_error) {
-			proxy_error("Error refreshing AWS RDS BGD green hosts: %s\n", green_error);
-		}
-		free(blue_error);
-		free(green_error);
-		delete blue_resultset;
-		delete green_resultset;
-
-		if (lock) {
-			pthread_mutex_unlock(&GloMyMon->aws_rds_bgd_mutex);
-		}
+	if (error || !resultset) {
+		proxy_error("Error refreshing AWS RDS BGD hosts: %s\n", error ? error : "empty resultset");
+		free(error);
+		delete resultset;
 		return;
 	}
+	free(error);
 
-	const uint64_t blue_checksum = blue_resultset->raw_checksum();
-	const uint64_t green_checksum = green_resultset->raw_checksum();
-	SpookyHash hash;
-	hash.Init(19, 3);
-	hash.Update(&blue_checksum, sizeof(blue_checksum));
-	hash.Update(&green_checksum, sizeof(green_checksum));
-
-	uint64_t combined_checksum = 0;
-	uint64_t ignored = 0;
-	hash.Final(&combined_checksum, &ignored);
-
-	if (GloMyMon->AWS_RDS_Blue_Hosts_resultset) {
-		delete GloMyMon->AWS_RDS_Blue_Hosts_resultset;
+	std::unordered_map<int, uint64_t> cluster_checksums;
+	std::unordered_map<int, SQLite3_result*> cluster_resultsets;
+	for (SQLite3_row* row : resultset->rows) {
+		const int writer_hg = atoi(row->fields[AWS_RDS_BGD_WRITER_HOSTGROUP]);
+		auto cluster_it = cluster_resultsets.find(writer_hg);
+		if (cluster_it == cluster_resultsets.end()) {
+			cluster_it = cluster_resultsets.emplace(
+				writer_hg, new SQLite3_result(resultset->columns)).first;
+		}
+		cluster_it->second->add_row(row);
 	}
-	GloMyMon->AWS_RDS_Blue_Hosts_resultset = blue_resultset;
-	GloMyMon->AWS_RDS_BGD_Hosts_checksum = combined_checksum;
-	delete green_resultset;
-
-	if (lock) {
-		pthread_mutex_unlock(&GloMyMon->aws_rds_bgd_mutex);
+	for (const auto& [writer_hg, cluster_resultset] : cluster_resultsets) {
+		cluster_checksums[writer_hg] = cluster_resultset->raw_checksum();
+		delete cluster_resultset;
 	}
+
+	const uint64_t hosts_checksum = resultset->raw_checksum();
+	std::shared_ptr<SQLite3_result> hosts_resultset { resultset };
+
+	pthread_mutex_lock(&GloMyMon->aws_rds_bgd_hosts_mutex);
+	GloMyMon->AWS_RDS_BGD_Hosts_resultset.swap(hosts_resultset);
+	GloMyMon->AWS_RDS_BGD_Hosts_checksum = hosts_checksum;
+	GloMyMon->AWS_RDS_BGD_Cluster_checksum.swap(cluster_checksums);
+	pthread_mutex_unlock(&GloMyMon->aws_rds_bgd_hosts_mutex);
 }
 
 /**
@@ -7306,7 +7279,7 @@ bool MySQL_HostGroups_Manager::add_aws_rds_bgd_hostgroup_entry(const std::string
 
 	if (added) {
 		// publish the refreshed host list to the BGD monitor thread
-		update_aws_rds_bgd_hosts_monitor_resultset(true);
+		update_aws_rds_bgd_hosts_monitor_resultset();
 	}
 
 	wrunlock();

--- a/lib/MySQL_Monitor.cpp
+++ b/lib/MySQL_Monitor.cpp
@@ -1141,12 +1141,14 @@ MySQL_Monitor::MySQL_Monitor() {
 
 	pthread_mutex_init(&aws_aurora_mutex,NULL);
 	pthread_mutex_init(&aws_rds_bgd_mutex,NULL);
+	pthread_mutex_init(&aws_rds_bgd_hosts_mutex,NULL);
 	pthread_mutex_init(&mysql_servers_mutex,NULL);
 	pthread_mutex_init(&proxysql_servers_mutex, NULL);
 	AWS_Aurora_Hosts_resultset=NULL;
 	AWS_Aurora_Hosts_resultset_checksum = 0;
-	AWS_RDS_Blue_Hosts_resultset=NULL;
+	AWS_RDS_BGD_Hosts_resultset.reset();
 	AWS_RDS_BGD_Hosts_checksum = 0;
+	AWS_RDS_BGD_Cluster_checksum.clear();
 	shutdown=false;
 	monitor_enabled=true;	// default
 	// create new SQLite datatabase
@@ -1247,10 +1249,9 @@ MySQL_Monitor::~MySQL_Monitor() {
 		delete AWS_Aurora_Hosts_resultset;
 		AWS_Aurora_Hosts_resultset=NULL;
 	}
-	if (AWS_RDS_Blue_Hosts_resultset) {
-		delete AWS_RDS_Blue_Hosts_resultset;
-		AWS_RDS_Blue_Hosts_resultset=NULL;
-	}
+	AWS_RDS_BGD_Hosts_resultset.reset();
+	AWS_RDS_BGD_Cluster_checksum.clear();
+	pthread_mutex_destroy(&aws_rds_bgd_hosts_mutex);
 	std::map<std::string, AWS_Aurora_monitor_node *>::iterator it2;
 	AWS_Aurora_monitor_node *node=NULL;
 	for (it2 = AWS_Aurora_Hosts_Map.begin(); it2 != AWS_Aurora_Hosts_Map.end(); ++it2) {
@@ -6622,12 +6623,13 @@ void * MySQL_Monitor::monitor_aws_aurora() {
 /**
 * @brief Runs an async query + store_result on the monitor connection.
 *
-* @param mmsd  Monitor state data holding the connection, timing, and result.
-* @param query SQL text to execute.
+* @param mmsd        Monitor state data holding the connection, timing, and result.
+* @param query       SQL text to execute.
+* @param worker_stop Per-worker shutdown signal.
 *
-* @return 0 on success, 1 on timeout/query-error, 2 if shutdown was requested.
+* @return 0 on success, 1 on timeout/query-error, 2 if global or worker shutdown was requested.
 */
-static int aws_rds_bgd_async_query(MySQL_Monitor_State_Data *mmsd, const char *query) {
+int MySQL_Monitor::aws_rds_bgd_async_query(MySQL_Monitor_State_Data *mmsd, const char *query, std::atomic_bool& worker_stop) {
 	mmsd->t1 = monotonic_time();
 	mmsd->interr = 0;
 	mmsd->async_exit_status = mysql_query_start(&mmsd->interr, mmsd->mysql, query);
@@ -6638,7 +6640,7 @@ static int aws_rds_bgd_async_query(MySQL_Monitor_State_Data *mmsd, const char *q
 			mmsd->mysql_error_msg = strdup("timeout check");
 			return 1;
 		}
-		if (GloMyMon->shutdown == true) {
+		if (shutdown == true || worker_stop.load()) {
 			return 2;
 		}
 		if ((mmsd->async_exit_status & MYSQL_WAIT_TIMEOUT) == 0) {
@@ -6653,7 +6655,7 @@ static int aws_rds_bgd_async_query(MySQL_Monitor_State_Data *mmsd, const char *q
 			mmsd->mysql_error_msg = strdup("timeout check");
 			return 1;
 		}
-		if (GloMyMon->shutdown == true) {
+		if (shutdown == true || worker_stop.load()) {
 			return 2;
 		}
 		if ((mmsd->async_exit_status & MYSQL_WAIT_TIMEOUT) == 0) {
@@ -6715,12 +6717,108 @@ static void aws_rds_bgd_set_status(AWS_RDS_BGD_State& st, AWS_RDS_BGD_Status sta
 	}
 }
 
-void * monitor_RDS_BGD_thread_HG(void *arg) {
-	unsigned int wHG = *(unsigned int *)arg;
-	unsigned int num_hosts = 0;
+/**
+* @brief Load one BGD worker's configuration from the published host rows.
+*
+* @details Copies the cluster rows, verifies their checksum, copies configuration fields from
+*   the first row, and builds the probe host list. FSM fields retain their defaults and must not
+*   replace the corresponding fields in the live state.
+*
+* @param writer_hg        Writer hostgroup identifying the deployment.
+* @param current_checksum Per-cluster checksum captured for this refresh.
+* @param candidate        State populated from the published rows.
+*
+* @return true when the checksum matches and the rows contain a blue writer; false otherwise.
+*/
+bool MySQL_Monitor::aws_rds_bgd_load_worker_config(int writer_hg, uint64_t current_checksum, AWS_RDS_BGD_State& candidate) {
+	SQLite3_result result(AWS_RDS_BGD_HOSTS_COLUMNS);
+	std::shared_ptr<SQLite3_result> hosts_resultset;
+
+	pthread_mutex_lock(&aws_rds_bgd_hosts_mutex);
+	hosts_resultset = AWS_RDS_BGD_Hosts_resultset;
+	pthread_mutex_unlock(&aws_rds_bgd_hosts_mutex);
+
+	if (hosts_resultset) {
+		for (SQLite3_row* row : hosts_resultset->rows) {
+			if (atoi(row->fields[AWS_RDS_BGD_WRITER_HOSTGROUP]) == writer_hg) {
+				result.add_row(row);
+			}
+		}
+	}
+	if (result.raw_checksum() != current_checksum) {
+		return false;
+	}
+
+	candidate.writer_hg = writer_hg;
+	bool first_row = true;
+
+	for (SQLite3_row* row : result.rows) {
+		unsigned int reader_hg = atoi(row->fields[AWS_RDS_BGD_READER_HOSTGROUP]);
+		int green_writer_hg = row->fields[AWS_RDS_BGD_GREEN_WRITER_HOSTGROUP]
+			&& row->fields[AWS_RDS_BGD_GREEN_WRITER_HOSTGROUP][0]
+			? atoi(row->fields[AWS_RDS_BGD_GREEN_WRITER_HOSTGROUP]) : -1;
+		int green_reader_hg = row->fields[AWS_RDS_BGD_GREEN_READER_HOSTGROUP]
+			&& row->fields[AWS_RDS_BGD_GREEN_READER_HOSTGROUP][0]
+			? atoi(row->fields[AWS_RDS_BGD_GREEN_READER_HOSTGROUP]) : -1;
+		unsigned int check_interval_ms = atoi(row->fields[AWS_RDS_BGD_CHECK_INTERVAL_MS]);
+		unsigned int check_timeout_ms = atoi(row->fields[AWS_RDS_BGD_CHECK_TIMEOUT_MS]);
+		int writer_is_also_reader = atoi(row->fields[AWS_RDS_BGD_WRITER_IS_ALSO_READER]);
+
+		if (first_row) {
+			candidate.reader_hg = reader_hg;
+			candidate.green_writer_hg = green_writer_hg;
+			candidate.green_reader_hg = green_reader_hg;
+			candidate.check_interval_ms = check_interval_ms;
+			candidate.check_timeout_ms = check_timeout_ms;
+			candidate.writer_is_also_reader = writer_is_also_reader;
+			first_row = false;
+		}
+
+		char* srv_type = row->fields[AWS_RDS_BGD_SRV_TYPE];
+		if (srv_type[0] == 'B' && atoi(row->fields[AWS_RDS_BGD_IS_WRITER]) != 0) {
+			candidate.probe_hosts.push_back(AWS_RDS_BGD_Probe_Host {
+				row->fields[AWS_RDS_BGD_HOSTNAME],
+				atoi(row->fields[AWS_RDS_BGD_PORT]),
+				atoi(row->fields[AWS_RDS_BGD_USE_SSL])
+			});
+		}
+	}
+
+	if (first_row || candidate.probe_hosts.empty()) {
+		proxy_error("AWS RDS BGD [wHG=%d]: no blue writer available for topology checks\n", writer_hg);
+		return false;
+	}
+
+	return true;
+}
+
+/**
+* @brief Replace only configuration-derived fields in a live BGD worker state.
+*
+* @param st        Live worker state.
+* @param candidate Parsed configuration to apply.
+*/
+void MySQL_Monitor::aws_rds_bgd_apply_cluster_config(AWS_RDS_BGD_State& st, AWS_RDS_BGD_State& candidate) {
+	st.reader_hg = candidate.reader_hg;
+	st.green_writer_hg = candidate.green_writer_hg;
+	st.green_reader_hg = candidate.green_reader_hg;
+	st.writer_is_also_reader = candidate.writer_is_also_reader;
+	st.check_interval_ms = candidate.check_interval_ms;
+	st.check_timeout_ms = candidate.check_timeout_ms;
+	st.probe_hosts = candidate.probe_hosts;
+}
+
+/**
+* @brief Run the monitor loop for one AWS RDS BGD writer hostgroup.
+*
+* @param arg Pointer to the worker state owned by the parent monitor thread.
+*
+* @return nullptr when the worker exits.
+*/
+void* monitor_RDS_BGD_thread_HG(void* arg) {
+	AWS_RDS_BGD_Worker* worker = static_cast<AWS_RDS_BGD_Worker*>(arg);
+	unsigned int wHG = worker->writer_hg;
 	unsigned int cur_host_idx = 0;
-	unsigned int check_interval_ms = 0;
-	unsigned int check_timeout_ms = 0;
 	set_thread_name("MonitorRdsBgdHG", GloVars.set_thread_name);
 	proxy_info("Started Monitor thread for AWS RDS writer HG %u\n", wHG);
 
@@ -6739,70 +6837,19 @@ void * monitor_RDS_BGD_thread_HG(void *arg) {
 	MySQL_Monitor__thread_MySQL_Thread_Variables_version = GloMTH->get_global_version();
 	mysql_thr->refresh_variables();
 
-	uint64_t initial_checksum = 0;
-
-	// initial data load from the monitor resultset
-	// Columns:
-	// 0 writer_hostgroup, 1 reader_hostgroup, 2 hostname, 3 port, 4 use_ssl,
-	// 5 green_writer_hostgroup, 6 green_reader_hostgroup, 7 check_interval_ms,
-	// 8 check_timeout_ms, 9 writer_is_also_reader, 10 is_writer
-	pthread_mutex_lock(&GloMyMon->aws_rds_bgd_mutex);
-	initial_checksum = GloMyMon->AWS_RDS_BGD_Hosts_checksum;
-	for (SQLite3_row *r : GloMyMon->AWS_RDS_Blue_Hosts_resultset->rows) {
-		if (atoi(r->fields[0]) == (int)wHG) {
-			if (atoi(r->fields[10]) != 0) {
-				num_hosts++;
-			}
-			if (st.reader_hg == 0) {
-				st.reader_hg = atoi(r->fields[1]);
-			}
-			if (st.green_writer_hg < 0 && r->fields[5] && r->fields[5][0]) {
-				st.green_writer_hg = atoi(r->fields[5]);
-			}
-			if (st.green_reader_hg < 0 && r->fields[6] && r->fields[6][0]) {
-				st.green_reader_hg = atoi(r->fields[6]);
-			}
-			if (check_interval_ms == 0) {
-				check_interval_ms = atoi(r->fields[7]);
-			}
-			if (check_timeout_ms == 0) {
-				check_timeout_ms = atoi(r->fields[8]);
-			}
-			if (r->fields[9] && r->fields[9][0]) {
-				st.writer_is_also_reader = atoi(r->fields[9]);
-			}
-		}
-	}
-
-	host_def_t *hpa = (host_def_t *)malloc(sizeof(host_def_t)*(num_hosts ? num_hosts : 1));
-	for (SQLite3_row *r : GloMyMon->AWS_RDS_Blue_Hosts_resultset->rows) {
-		// r->writer_hostgroup == wHG && r->is_writer != 0
-		if (atoi(r->fields[0]) == (int)wHG && atoi(r->fields[10]) != 0) {
-			hpa[cur_host_idx].host = strdup(r->fields[2]);
-			hpa[cur_host_idx].port = atoi(r->fields[3]);
-			hpa[cur_host_idx].use_ssl = atoi(r->fields[4]);
-			cur_host_idx++;
-		}
-	}
-	if (num_hosts && cur_host_idx >= num_hosts) {
-		cur_host_idx = num_hosts - 1;
-	}
-	pthread_mutex_unlock(&GloMyMon->aws_rds_bgd_mutex);
-
-	bool exit_now = false;
 	unsigned long long t1 = 0;
 	unsigned long long next_loop_at = 0;
 	bool crc = false;
-	uint64_t current_checksum = 0;
+	uint64_t last_checksum = 0;
 	size_t rnd;
 	bool found_pingable_host = false;
-	bool rc_ping = false;
 	MySQL_Monitor_State_Data *mmsd = NULL;
 	RDS_BGD_Topology_Monitor_State topology_state = TOPOLOGY_TABLE_CHECK;
 
 	t1 = monotonic_time();
 
-	while (GloMyMon->shutdown==false && mysql_thread___monitor_enabled==true && exit_now==false) {
+	while (GloMyMon->shutdown==false && mysql_thread___monitor_enabled==true
+		&& worker->worker_stop.load()==false) {
 		unsigned int glover;
 		t1 = monotonic_time();
 		bool poll_success = false;
@@ -6818,17 +6865,20 @@ void * monitor_RDS_BGD_thread_HG(void *arg) {
 			next_loop_at = 0;
 		}
 
-		// if the host list/definition changed, terminate so the dispatcher respawns
-		pthread_mutex_lock(&GloMyMon->aws_rds_bgd_mutex);
-		current_checksum = GloMyMon->AWS_RDS_BGD_Hosts_checksum;
-		pthread_mutex_unlock(&GloMyMon->aws_rds_bgd_mutex);
-		if (current_checksum != initial_checksum) {
-			exit_now = true;
-			break;
+		uint64_t current_checksum = worker->current_checksum.load();
+		if (current_checksum != last_checksum) {
+			if (!GloMyMon->aws_rds_bgd_refresh_worker_config(st, current_checksum, topology_state, next_loop_at)) {
+				usleep(50000);
+				continue;
+			}
+			last_checksum = current_checksum;
+			if (cur_host_idx >= st.probe_hosts.size()) {
+				cur_host_idx = 0;
+			}
 		}
 
-		if (num_hosts == 0) {
-			next_loop_at = t1 + (check_interval_ms ? check_interval_ms : 1000) * 1000;
+		if (st.probe_hosts.empty()) {
+			next_loop_at = t1 + (st.check_interval_ms ? st.check_interval_ms : 1000) * 1000;
 			usleep(50000);
 			continue;
 		}
@@ -6844,7 +6894,7 @@ void * monitor_RDS_BGD_thread_HG(void *arg) {
 
 		// Determine the host to probe. If the FSM pinned a host (the green IP, during a
 		// switchover), poll it directly and skip ping/random selection; otherwise pick a
-		// pingable host (random first, then shuffle and scan).
+		// pingable host, starting at a random position.
 		const char* poll_host;
 		int poll_port;
 		bool poll_use_ssl;
@@ -6870,43 +6920,35 @@ void * monitor_RDS_BGD_thread_HG(void *arg) {
 		if (st.next_check_host.empty()) {
 			found_pingable_host = false;
 			rnd = (size_t) rand();
-			rnd %= num_hosts;
-			rc_ping = GloMyMon->server_responds_to_ping(hpa[rnd].host, hpa[rnd].port);
-			if (rc_ping) {
-				found_pingable_host = true;
-				cur_host_idx = rnd;
-			} else {
-				MyHGM->p_update_mysql_error_counter(
-					p_mysql_error_type::proxysql, wHG, hpa[rnd].host, hpa[rnd].port, ER_PROXYSQL_AWS_NO_PINGABLE_SRV
-				);
-				shuffle_hosts(hpa, num_hosts);
-				for (unsigned int i=0; (found_pingable_host == false && i<num_hosts); i++) {
-					rc_ping = GloMyMon->server_responds_to_ping(hpa[i].host, hpa[i].port);
-					if (rc_ping) {
-						found_pingable_host = true;
-						cur_host_idx = i;
-					} else {
-						MyHGM->p_update_mysql_error_counter(
-							p_mysql_error_type::proxysql, wHG, hpa[i].host, hpa[i].port, ER_PROXYSQL_AWS_NO_PINGABLE_SRV
-						);
-					}
+			rnd %= st.probe_hosts.size();
+			for (size_t i = 0; found_pingable_host == false && i < st.probe_hosts.size(); i++) {
+				size_t host_idx = (rnd + i) % st.probe_hosts.size();
+				AWS_RDS_BGD_Probe_Host& host = st.probe_hosts[host_idx];
+				if (GloMyMon->server_responds_to_ping(host.hostname.data(), host.port)) {
+					found_pingable_host = true;
+					cur_host_idx = host_idx;
+				} else {
+					MyHGM->p_update_mysql_error_counter(
+						p_mysql_error_type::proxysql, wHG, host.hostname.data(), host.port,
+						ER_PROXYSQL_AWS_NO_PINGABLE_SRV
+					);
 				}
 			}
 			if (found_pingable_host == false) {
 				proxy_error("No node is pingable for AWS RDS cluster with writer HG %u\n", wHG);
-				next_loop_at = t1 + check_interval_ms * 1000;
+				next_loop_at = t1 + st.check_interval_ms * 1000;
 				continue;
 			}
-			poll_host = hpa[cur_host_idx].host;
-			poll_port = hpa[cur_host_idx].port;
-			poll_use_ssl = hpa[cur_host_idx].use_ssl;
+			poll_host = st.probe_hosts[cur_host_idx].hostname.c_str();
+			poll_port = st.probe_hosts[cur_host_idx].port;
+			poll_use_ssl = st.probe_hosts[cur_host_idx].use_ssl;
 		}
 
 		mmsd = new MySQL_Monitor_State_Data(
 			MON_AWS_RDS_BGD, (char*)poll_host, poll_port, poll_use_ssl
 		);
 		mmsd->writer_hostgroup = wHG;
-		mmsd->aws_aurora_check_timeout_ms = check_timeout_ms;
+		mmsd->aws_aurora_check_timeout_ms = st.check_timeout_ms;
 		mmsd->mysql = GloMyMon->My_Conn_Pool->get_connection(mmsd->hostname, mmsd->port, mmsd);
 		mmsd->t1 = t1;
 
@@ -6932,7 +6974,7 @@ void * monitor_RDS_BGD_thread_HG(void *arg) {
 			// we advance to TOPOLOGY_METADATA_FETCH and skip this check on subsequent
 			// iterations, until a fetch reports the table is gone.
 
-			int qrc = aws_rds_bgd_async_query(mmsd, QUERY_AWS_RDS_TOPOLOGY_TABLE_CHECK);
+			int qrc = GloMyMon->aws_rds_bgd_async_query(mmsd, QUERY_AWS_RDS_TOPOLOGY_TABLE_CHECK, worker->worker_stop);
 			if (qrc == 2) {
 				goto __exit_monitor_RDS_BGD_thread_HG_now;
 			}
@@ -6963,7 +7005,7 @@ void * monitor_RDS_BGD_thread_HG(void *arg) {
 			// differs by RDS type (the Multi-AZ Cluster topology table may not expose
 			// 'role'/'status' at all), so dump all columns and detect what is present.
 
-			int qrc = aws_rds_bgd_async_query(mmsd, QUERY_AWS_RDS_TOPOLOGY_DISCOVERY);
+			int qrc = GloMyMon->aws_rds_bgd_async_query(mmsd, QUERY_AWS_RDS_TOPOLOGY_DISCOVERY, worker->worker_stop);
 			if (qrc == 2) {
 				goto __exit_monitor_RDS_BGD_thread_HG_now;
 			}
@@ -7032,7 +7074,7 @@ __end_of_loop:
 		mmsd->t2 = monotonic_time();
 		// the FSM tightens the interval to 100ms while a switchover is in flight
 		// (st.next_check_interval_ms); otherwise fall back to the configured baseline.
-		unsigned int eff = st.next_check_interval_ms ? st.next_check_interval_ms : check_interval_ms;
+		unsigned int eff = st.next_check_interval_ms ? st.next_check_interval_ms : st.check_interval_ms;
 		next_loop_at = t1 + (eff * 1000);
 		if (mmsd->t2 > t1) {
 			next_loop_at -= (mmsd->t2 - t1);
@@ -7063,11 +7105,6 @@ __exit_monitor_RDS_BGD_thread_HG_now:
 		delete mmsd;
 		mmsd = NULL;
 	}
-
-	for (unsigned int i=0; i<num_hosts; i++) {
-		free(hpa[i].host);
-	}
-	free(hpa);
 
 	if (mysql_thr) {
 		delete mysql_thr;
@@ -7113,25 +7150,26 @@ static bool aws_rds_bgd_match_host(const std::string& blue_hostname, const std::
 	return g_host_stripped == b_host && g_domain == b_domain;
 }
 
-// Build the blue<->green map once (refreshed only after a switchover completes and
-// clears it, which also covers a worker that starts mid-switchover). The topology
-// exposes only primaries, so the writer pair is always present; reader pairs exist
-// only when green_reader_hostgroup is configured (the user populated it).
-static void aws_rds_bgd_build_map(AWS_RDS_BGD_State& st, const AWS_RDS_Topology_Result& topo) {
+/**
+* @brief Build the blue-to-green host mapping for a BGD worker.
+*
+* @details Builds the map only when it is empty. The topology exposes only primaries, so the
+*   writer pair is always present; reader pairs are added when green_reader_hostgroup is configured.
+*
+* @param st   Worker-owned BGD state.
+* @param topo Parsed topology used to identify the green target.
+*/
+void MySQL_Monitor::aws_rds_bgd_build_map(AWS_RDS_BGD_State& st, AWS_RDS_Topology_Result& topo) {
 	if (!st.bg_map.empty()) {
 		return;
 	}
 
-	std::string green_writer_host;
-	for (const AWS_RDS_Topology_Node& n : topo.nodes) {
-		if (strcasecmp(n.role.c_str(), BGD_ROLE_TARGET) == 0) {
-			green_writer_host = n.endpoint;
-			break;
-		}
-	}
-	if (green_writer_host.empty()) {
+	AWS_RDS_Topology_Node* target = topo.target();
+	if (!target || target->endpoint.empty()) {
 		return;
 	}
+
+	std::string green_writer_host = target->endpoint;
 
 	MyHGM->wrlock();
 
@@ -7236,8 +7274,10 @@ static void aws_rds_bgd_build_map(AWS_RDS_BGD_State& st, const AWS_RDS_Topology_
 *   green primary BY IP: green stays reachable through the entire cutover (blue has a connectivity
 *   gap), and the green IP survives the post-COMPLETED name swap (it becomes the promoted primary),
 *   whereas the green DNS name is retired. 'next_check_host' is cleared at COMPLETED.
+*
+* @param st Worker-owned BGD state.
 */
-static void aws_rds_bgd_resolve_green_ips(AWS_RDS_BGD_State& st) {
+void MySQL_Monitor::aws_rds_bgd_resolve_green_ips(AWS_RDS_BGD_State& st) {
 	int ai_family = mysql_resolution_family_to_ai_family(mysql_thread___resolution_family);
 	for (auto &p : st.bg_map) {
 		// Always check the cache first: a green host that is a monitored server may be there.
@@ -7281,8 +7321,10 @@ static void aws_rds_bgd_resolve_green_ips(AWS_RDS_BGD_State& st) {
 
 /**
 * @brief Add the green writer to green_writer_hostgroup, when that hostgroup is configured.
+*
+* @param st Worker-owned BGD state.
 */
-static void aws_rds_bgd_add_green_writer_in_hg(AWS_RDS_BGD_State& st) {
+void MySQL_Monitor::aws_rds_bgd_add_green_writer_in_hg(AWS_RDS_BGD_State& st) {
 	if (st.green_writer_hg < 0) {
 		return;
 	}
@@ -7304,6 +7346,126 @@ static void aws_rds_bgd_add_green_writer_in_hg(AWS_RDS_BGD_State& st) {
 		}
 		MyHGM->wrunlock();
 		break;
+	}
+}
+
+/**
+* @brief Find the writer pair in a blue/green map.
+*
+* @param bg_map Blue/green host mapping.
+* @param writer Writer address populated when a pair is found.
+*
+* @return true when the map contains a writer pair; false otherwise.
+*/
+bool MySQL_Monitor::aws_rds_bgd_find_writer(std::vector<AWS_RDS_BlueGreenPair>& bg_map, srv_addr_t& writer) {
+	for (AWS_RDS_BlueGreenPair& p : bg_map) {
+		if (p.is_writer) {
+			writer = srv_addr_t { p.blue_host, p.port };
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+* @brief Apply a changed configuration to one running BGD worker.
+*
+* @details Before writer post-processing, applies the configuration and schedules mapping
+*   reconciliation after the next topology poll. At or after post-processing, rolls back the
+*   deployment and restarts its topology FSM without replacing the worker thread.
+*
+* @param st               Worker-owned BGD state.
+* @param current_checksum Per-cluster checksum captured for this refresh.
+* @param topology_state   Current topology query state.
+* @param next_loop_at     Next scheduled worker iteration.
+*
+* @return true when the captured configuration was applied; false when it must be retried.
+*/
+bool MySQL_Monitor::aws_rds_bgd_refresh_worker_config(
+	AWS_RDS_BGD_State& st, uint64_t current_checksum,
+	RDS_BGD_Topology_Monitor_State& topology_state, unsigned long long& next_loop_at
+) {
+	AWS_RDS_BGD_State candidate;
+	if (!aws_rds_bgd_load_worker_config(st.writer_hg, current_checksum, candidate)) {
+		return false;
+	}
+
+	// Changes at or after writer post-processing require a full rollback and FSM restart.
+	if (st.bgd_status >= AWS_RDS_BGD_Status::WRITER_SWITCHOVER_POST_PROCESSING) {
+		AWS_RDS_BGD_Status old_status = st.bgd_status;
+		handle_aws_rds_bgd_post_switchover(st, true);
+		aws_rds_bgd_apply_cluster_config(st, candidate);
+		topology_state = TOPOLOGY_TABLE_CHECK;
+		next_loop_at = 0;
+		proxy_info(
+			"AWS RDS BGD [wHG=%u rHG=%u]: applied checksum %llu with full rollback from %s\n",
+			st.writer_hg, st.reader_hg, (unsigned long long)current_checksum,
+			aws_rds_bgd_status_str(old_status));
+		return true;
+	}
+
+	AWS_RDS_BGD_Status status = st.bgd_status;
+	unsigned int old_reader_hg = st.reader_hg;
+	bool refresh_in_progress = st.bgd_in_progress_set;
+	bool hostgroups_changed = old_reader_hg != candidate.reader_hg;
+
+	// Clear the in-progress marker from the old reader hostgroup before applying the new configuration.
+	if (refresh_in_progress && hostgroups_changed) {
+		aws_rds_bgd_clear_bgd_in_progress(st);
+	}
+
+	// Apply the new configuration.
+	aws_rds_bgd_apply_cluster_config(st, candidate);
+	st.next_check_host.clear();
+	st.next_check_host_failures = 0;
+	next_loop_at = 0;
+	// Rebuild bg_map from the next topology probe result.
+	st.config_refresh_pending = true;
+
+	// Apply the in-progress marker to the new reader hostgroup after the refresh.
+	if (refresh_in_progress && hostgroups_changed) {
+		aws_rds_bgd_set_bgd_in_progress(st);
+	}
+
+	proxy_info(
+		"AWS RDS BGD [wHG=%u rHG=%u]: applied checksum %llu with in-place refresh at %s\n",
+		st.writer_hg, st.reader_hg, (unsigned long long)current_checksum,
+		aws_rds_bgd_status_str(status));
+	return true;
+}
+
+/**
+* @brief Rebuild the mapping and reconcile writer state after a configuration refresh.
+*
+* @details Called only when config_refresh_pending is set.
+*
+* @param st       Worker-owned BGD state.
+* @param topology Fresh topology used to rebuild the mapping.
+*/
+void MySQL_Monitor::aws_rds_bgd_config_refresh_action(AWS_RDS_BGD_State& st, AWS_RDS_Topology_Result& topology) {
+	srv_addr_t old_writer;
+	bool had_old_writer = aws_rds_bgd_find_writer(st.bg_map, old_writer);
+	st.bg_map.clear();
+	aws_rds_bgd_build_map(st, topology);
+
+	srv_addr_t new_writer;
+	bool has_new_writer = aws_rds_bgd_find_writer(st.bg_map, new_writer);
+	aws_rds_bgd_add_green_writer_in_hg(st);
+
+	// Transfer the writer demotion when the refreshed configuration maps a different writer.
+	if (st.bgd_status == AWS_RDS_BGD_Status::WRITER_SWITCHOVER_IN_PROGRESS
+		&& (had_old_writer != has_new_writer
+			|| (had_old_writer && (old_writer.host != new_writer.host || old_writer.port != new_writer.port)))) {
+		if (had_old_writer) {
+			MyHGM->read_only_action_v2(std::list<read_only_server_t> {
+				read_only_server_t { old_writer.host, (port_t)old_writer.port, 0 }
+			});
+		}
+		if (has_new_writer) {
+			MyHGM->read_only_action_v2(std::list<read_only_server_t> {
+				read_only_server_t { new_writer.host, (port_t)new_writer.port, 1 }
+			});
+		}
 	}
 }
 
@@ -7361,28 +7523,21 @@ const char* aws_rds_bgd_status_str(AWS_RDS_BGD_Status s) {
 * @param st        BGD switchover state (worker-owned, mutated here).
 * @param topology  Parsed mysql.rds_topology result for this cycle.
 */
-void MySQL_Monitor::handle_aws_rds_bgd(AWS_RDS_BGD_State& st, const AWS_RDS_Topology_Result& topology) {
+void MySQL_Monitor::handle_aws_rds_bgd(AWS_RDS_BGD_State& st, AWS_RDS_Topology_Result& topology) {
 	if (!topology.blue_green) {
 		st.next_check_interval_ms = 0;
 		aws_rds_bgd_set_status(st, AWS_RDS_BGD_Status::NONE);
 		return;
 	}
 
-	std::string status;
-	for (const AWS_RDS_Topology_Node& n : topology.nodes) {
-		if (strcasecmp(n.role.c_str(), BGD_ROLE_TARGET) == 0) {
-			status = n.status;
-			break;
-		}
-	}
-	if (status.empty()) {
+	AWS_RDS_Topology_Node* target = topology.target();
+	if (!target || target->status.empty()) {
 		st.next_check_interval_ms = 0;
 		aws_rds_bgd_set_status(st, AWS_RDS_BGD_Status::NONE);
 		return;
 	}
-	st.last_topology_status = status;
 
-	AWS_RDS_BGD_Status topology_status = aws_rds_bgd_status_from_topology(status);
+	AWS_RDS_BGD_Status topology_status = aws_rds_bgd_status_from_topology(target->status);
 
 	// Once we advance to READER_SWITCHOVER_IN_PROGRESS phase, AWS keeps reporting
 	// WRITER_SWITCHOVER_COMPLETED (a single green row) until mysql.rds_topology drains. Ignore
@@ -7408,6 +7563,12 @@ void MySQL_Monitor::handle_aws_rds_bgd(AWS_RDS_BGD_State& st, const AWS_RDS_Topo
 			aws_rds_bgd_add_green_writer_in_hg(st);
 		}
 		return;
+	}
+
+	// Rebuild a refreshed worker's mapping only after receiving this current topology result.
+	if (st.config_refresh_pending) {
+		aws_rds_bgd_config_refresh_action(st, topology);
+		st.config_refresh_pending = false;
 	}
 
 	if (topology_status == st.bgd_status) {
@@ -7706,7 +7867,7 @@ void MySQL_Monitor::handle_aws_rds_bgd_post_switchover(AWS_RDS_BGD_State& st, bo
 
 	// state cleanup
 	st.bg_map.clear();
-	st.last_topology_status.clear();
+	st.config_refresh_pending = false;
 	st.next_check_host.clear();
 	st.next_check_interval_ms = 0;
 	aws_rds_bgd_set_status(st, AWS_RDS_BGD_Status::NONE);
@@ -7851,9 +8012,9 @@ void MySQL_Monitor::set_aws_rds_bgd_server_in_progress(unsigned int writer_hg, u
 /**
 * @brief AWS RDS BGD monitor thread entry point.
 *
-* @details Spawns one worker (monitor_RDS_BGD_thread_HG) per writer hostgroup; each worker picks a pingable
-*   writer, probes 'mysql.rds_topology' and dispatches based on the detected topology shape.
-*   Workers are (re)spawned whenever the AWS_RDS_BGD_Hosts_checksum changes.
+* @details Maintains one worker (monitor_RDS_BGD_thread_HG) per active writer hostgroup. The parent starts
+*   and stops workers and signals configuration changes. Each worker selects a pingable probe host,
+*   probes 'mysql.rds_topology', and runs the switchover state machine.
 */
 void * MySQL_Monitor::monitor_aws_rds_bgd() {
 	// Wait for GloMTH to be initialized
@@ -7867,14 +8028,12 @@ void * MySQL_Monitor::monitor_aws_rds_bgd() {
 	mysql_thr->refresh_variables();
 
 	uint64_t last_checksum = 0;
-	unsigned int *hgs_array = NULL;
-	pthread_t *pthreads_array = NULL;
-	unsigned int hgs_num = 0;
+	std::unordered_map<int, std::unique_ptr<AWS_RDS_BGD_Worker>> workers;
 
 	while (GloMyMon->shutdown==false && mysql_thread___monitor_enabled==true) {
 		unsigned int glover;
 		if (!GloMTH)
-			return NULL;
+			break;
 
 		glover = GloMTH->get_global_version();
 		if (MySQL_Monitor__thread_MySQL_Thread_Variables_version < glover) {
@@ -7882,70 +8041,99 @@ void * MySQL_Monitor::monitor_aws_rds_bgd() {
 			mysql_thr->refresh_variables();
 		}
 
-		// respawn the per-writer-HG workers when the host list/definition changes
-		pthread_mutex_lock(&aws_rds_bgd_mutex);
-		uint64_t new_checksum = AWS_RDS_BGD_Hosts_checksum;
-		pthread_mutex_unlock(&aws_rds_bgd_mutex);
-		if (new_checksum != last_checksum) {
-			proxy_info("Detected new/changed definition for AWS RDS monitoring\n");
-			last_checksum = new_checksum;
-			if (pthreads_array) {
-				for (unsigned int i=0; i < hgs_num; i++) {
-					pthread_join(pthreads_array[i], NULL);
-					proxy_info("Stopped Monitor thread for AWS RDS writer HG %u\n", hgs_array[i]);
+		uint64_t new_checksum = 0;
+		std::shared_ptr<SQLite3_result> hosts_resultset;
+		std::unordered_map<int, uint64_t> cluster_checksums;
+
+		pthread_mutex_lock(&aws_rds_bgd_hosts_mutex);
+		new_checksum = AWS_RDS_BGD_Hosts_checksum;
+		if (new_checksum != last_checksum && AWS_RDS_BGD_Hosts_resultset) {
+			hosts_resultset = AWS_RDS_BGD_Hosts_resultset;
+			cluster_checksums = AWS_RDS_BGD_Cluster_checksum;
+		}
+		pthread_mutex_unlock(&aws_rds_bgd_hosts_mutex);
+
+		std::unordered_map<int, uint64_t> active_cluster_checksums;
+		if (hosts_resultset) {
+			for (SQLite3_row* row : hosts_resultset->rows) {
+				char* srv_type = row->fields[AWS_RDS_BGD_SRV_TYPE];
+				if (srv_type && srv_type[0] == 'B'
+					&& atoi(row->fields[AWS_RDS_BGD_IS_WRITER]) != 0) {
+					int writer_hg = atoi(row->fields[AWS_RDS_BGD_WRITER_HOSTGROUP]);
+					auto checksum_it = cluster_checksums.find(writer_hg);
+					if (checksum_it != cluster_checksums.end()) {
+						active_cluster_checksums[writer_hg] = checksum_it->second;
+					}
 				}
-				free(pthreads_array);
-				free(hgs_array);
-				pthreads_array = NULL;
-				hgs_array = NULL;
+			}
+		}
+
+		if (new_checksum != last_checksum) {
+			proxy_info("Detected changed definition for AWS RDS Blue Green monitoring\n");
+			last_checksum = new_checksum;
+			std::vector<int> stopped_workers;
+
+			for (auto& [writer_hg, worker] : workers) {
+				auto cluster_it = active_cluster_checksums.find(writer_hg);
+				if (cluster_it == active_cluster_checksums.end()) {
+					worker->worker_stop.store(true);
+					stopped_workers.push_back(writer_hg);
+					proxy_info(
+						"AWS RDS BGD [wHG=%d]: stopping worker; deployment is inactive, removed, or has no blue writer\n",
+						writer_hg);
+					continue;
+				}
+
+				uint64_t old_cluster_checksum = worker->current_checksum.load();
+				if (old_cluster_checksum != cluster_it->second) {
+					worker->current_checksum.store(cluster_it->second);
+					proxy_info(
+						"AWS RDS BGD [wHG=%d]: signaling config refresh, checksum %llu -> %llu\n",
+						writer_hg, (unsigned long long)old_cluster_checksum,
+						(unsigned long long)cluster_it->second);
+				}
 			}
 
-			hgs_num = 0;
-			pthread_mutex_lock(&aws_rds_bgd_mutex);
-			unsigned int num_rows = AWS_RDS_Blue_Hosts_resultset->rows_count;
-			if (num_rows) {
-				unsigned int *tmp_hgs_array = (unsigned int *)malloc(sizeof(unsigned int)*num_rows);
-				for (SQLite3_row *r : AWS_RDS_Blue_Hosts_resultset->rows) {
-					int wHG = atoi(r->fields[0]);
-					bool found = false;
-					for (unsigned int i=0; i < hgs_num; i++) {
-						if (tmp_hgs_array[i] == (unsigned int)wHG) {
-							found = true;
-						}
-					}
-					if (found == false) {
-						tmp_hgs_array[hgs_num] = wHG;
-						hgs_num++;
-					}
+			for (auto& [writer_hg, checksum] : active_cluster_checksums) {
+				if (workers.find(writer_hg) != workers.end()) {
+					continue;
 				}
-				proxy_info("Activating Monitoring of %u AWS RDS clusters\n", hgs_num);
-				hgs_array = (unsigned int *)malloc(sizeof(unsigned int)*hgs_num);
-				pthreads_array = (pthread_t *)malloc(sizeof(pthread_t)*hgs_num);
-				for (unsigned int i=0; i < hgs_num; i++) {
-					hgs_array[i] = tmp_hgs_array[i];
-					proxy_info("Starting Monitor thread for AWS RDS writer HG %u\n", hgs_array[i]);
-					if (pthread_create(&pthreads_array[i], NULL, monitor_RDS_BGD_thread_HG, &hgs_array[i]) != 0) {
-						// LCOV_EXCL_START
-						proxy_error("Thread creation\n");
-						assert(0);
-						// LCOV_EXCL_STOP
-					}
+
+				std::unique_ptr<AWS_RDS_BGD_Worker> worker(new AWS_RDS_BGD_Worker);
+				worker->writer_hg = writer_hg;
+				worker->current_checksum.store(checksum);
+				AWS_RDS_BGD_Worker* worker_arg = worker.get();
+				workers.emplace(writer_hg, std::move(worker));
+				proxy_info("Starting Monitor thread for AWS RDS writer HG %d\n", writer_hg);
+				if (pthread_create(&worker_arg->thread, NULL, monitor_RDS_BGD_thread_HG, worker_arg) != 0) {
+					// LCOV_EXCL_START
+					proxy_error("Thread creation\n");
+					assert(0);
+					// LCOV_EXCL_STOP
 				}
-				free(tmp_hgs_array);
 			}
-			pthread_mutex_unlock(&aws_rds_bgd_mutex);
+
+			for (int writer_hg : stopped_workers) {
+				auto worker_it = workers.find(writer_hg);
+				if (worker_it == workers.end()) {
+					continue;
+				}
+				pthread_join(worker_it->second->thread, NULL);
+				proxy_info("Stopped Monitor thread for AWS RDS writer HG %d\n", writer_hg);
+				workers.erase(worker_it);
+			}
 		}
 
 		usleep(10000);
 	}
-	// on shutdown, join any running per-HG workers
-	if (pthreads_array) {
-		for (unsigned int i=0; i < hgs_num; i++) {
-			pthread_join(pthreads_array[i], NULL);
-		}
-		free(pthreads_array);
-		free(hgs_array);
+	for (auto& [writer_hg, worker] : workers) {
+		worker->worker_stop.store(true);
 	}
+	for (auto& [writer_hg, worker] : workers) {
+		pthread_join(worker->thread, NULL);
+		proxy_info("Stopped Monitor thread for AWS RDS writer HG %d\n", writer_hg);
+	}
+	workers.clear();
 	if (mysql_thr) {
 		delete mysql_thr;
 		mysql_thr = NULL;


### PR DESCRIPTION
## Summary

- publish one ordered blue and green host snapshot with a global checksum and per-writer-hostgroup checksums
- keep a stable parent-owned worker registry and signal only affected workers to refresh or stop
- preserve the worker thread and FSM before writer post-processing, while using full rollback from post-processing onward
- track worker-added green writers so an in-place refresh can replace only the affected placement

## Why

A change to any AWS RDS BGD deployment previously changed one global generation checksum. The parent then joined and recreated every BGD worker, causing unrelated deployments to lose worker-local progress and roll back an in-flight switchover.

The parent now uses the global checksum only as a reconciliation trigger. It derives per-cluster checksums from the same resultset and updates only the worker whose effective configuration changed.

## Behavior

- added deployments start one worker and removed or inactive deployments stop only their own worker
- changes before WRITER_SWITCHOVER_POST_PROCESSING rebuild the map, resolve the green writer, and reconcile writer placement in place
- changes at or after WRITER_SWITCHOVER_POST_PROCESSING run the existing full rollback and restart the same worker FSM from the beginning
- shared snapshot publication and row copies use a dedicated short-held hosts mutex

## Validation

- PROXYSQL40=1 bear --append -- make build_src_debug -j16
- Tests not run; implementation review is requested before separate test work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded AWS RDS Blue/Green Deployment monitoring to use combined blue/green host tracking and per-writer topology awareness.
  - Enhanced worker-based monitoring with checksum-driven configuration refresh that applies changes without full worker restarts.
- **Bug Fixes**
  - Improved background monitoring responsiveness during shutdown and configuration refresh interruptions.
  - More robust handling of topology state updates and cleanup when deployments change or become inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->