### PR TITLE
feat(passthrough-auth): gate to Innovative/AI tiers (refuse enable on Stable)

### DIFF
--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1573,6 +1573,40 @@ void MySQL_Threads_Handler::commit() {
 	__sync_add_and_fetch(&__global_MySQL_Thread_Variables_version,1);
 	proxy_debug(PROXY_DEBUG_MYSQL_SERVER, 1, "Increasing version number to %d - all threads will notice this and refresh their variables\n", __global_MySQL_Thread_Variables_version);
 
+#ifndef PROXYSQL31
+	/**
+	 * @brief Tier gate: pass-through authentication is Innovative-tier only.
+	 *
+	 * Pass-through authentication is a feature of the ProxySQL Innovative
+	 * tier (3.1.x) and AI/MCP tier (4.0.x); both define PROXYSQL31 (4.0
+	 * implies 3.1). On the Stable tier (3.0.x, PROXYSQL31 undefined) the
+	 * code still ships, but the feature must not be arm-able.
+	 *
+	 * We enforce that here, at commit() time, because commit() runs once
+	 * per LOAD MYSQL VARIABLES TO RUNTIME and updates the master
+	 * `variables` struct *before* the worker threads refresh their
+	 * per-thread `mysql_thread___passthrough_auth_enabled` copies from it.
+	 * Coercing the master flag to false here therefore guarantees the
+	 * runtime gate is never armed on a Stable build, no matter how the
+	 * value arrived (SET + LOAD, config file, a saved config carried over
+	 * from a 3.1.x/4.0.x install, or a ProxySQL Cluster sync push).
+	 *
+	 * A saved config that has the flag set to 'true' still loads cleanly;
+	 * it is simply forced back to 'false' with a single log line, rather
+	 * than erroring the load. The coercion runs before the unknown_users
+	 * misconfig warning below, so that warning does not spuriously fire on
+	 * a Stable build where the feature is inert anyway.
+	 */
+	if (variables.passthrough_auth_enabled) {
+		proxy_error(
+			"pass-through authentication is not available on the ProxySQL "
+			"Stable tier (3.0.x); mysql-passthrough_auth_enabled has been "
+			"forced to 'false'. Use a 3.1.x (Innovative) or 4.0.x (AI/MCP) "
+			"build to enable it.\n");
+		variables.passthrough_auth_enabled = false;
+	}
+#endif // PROXYSQL31
+
 	/**
 	 * @brief Operator warning on dangerous pass-through configuration.
 	 *


### PR DESCRIPTION
## What

Makes **pass-through authentication an Innovative-tier (3.1.x) / AI-MCP-tier (4.0.x) feature**. The code still ships in all tiers, but on the **Stable tier (3.0.x)** it can no longer be armed: attempting to enable it is refused at runtime and coerced back to `false` with a clear log line.

This is "Option C" — a lightweight runtime gate — chosen over a full compile-time `#ifdef` exclusion because it's minimal, non-invasive, and avoids introducing a new axis of core auth/protocol divergence between tiers.

## How

One guard in `MySQL_Threads_Handler::commit()`:

```cpp
#ifndef PROXYSQL31
    if (variables.passthrough_auth_enabled) {
        proxy_error("pass-through authentication is not available on the ProxySQL "
                    "Stable tier (3.0.x); mysql-passthrough_auth_enabled has been "
                    "forced to 'false'. Use a 3.1.x (Innovative) or 4.0.x (AI/MCP) "
                    "build to enable it.\n");
        variables.passthrough_auth_enabled = false;
    }
#endif
```

`commit()` runs once per `LOAD MYSQL VARIABLES TO RUNTIME` and updates the master `variables` struct **before** worker threads refresh their per-thread `mysql_thread___passthrough_auth_enabled` copies from it. Coercing the master flag here therefore guarantees the runtime gate is never armed on a Stable build — no matter how the value arrived: `SET`+`LOAD`, config file, a saved config carried over from a 3.1.x/4.0.x install, or a ProxySQL Cluster sync push.

`PROXYSQL31` is the right macro: both 3.1 (`PROXYSQL31=1`) and 4.0 (`PROXYSQL40=1` ⇒ `PROXYSQL31`) define it, so the guard blocks **Stable only**.

## Design choices

- **Coerce, don't error the load.** A saved config with the flag `true` (e.g. a downgrade from 3.1.x) still loads cleanly and is simply forced to `false` with one log line, rather than failing the whole `LOAD`.
- **Runs before the `unknown_users` misconfig warning**, so that warning does not spuriously fire on a Stable build where the feature is inert anyway.
- No `SET`-time hard reject: that would break loading a persisted `true` value on Stable. The `commit()` backstop is the robust, graceful choke point.

## Verification

- ⚠️ **CI never builds the bare-Stable path** (every CI build sets `PROXYSQL31=1` or `PROXYSQL40=1`), so the `#ifndef PROXYSQL31` branch is not exercised by CI. It was **compile-checked locally both ways**: `lib/MySQL_Thread.cpp` compiles with and without `-DPROXYSQL31`.
- No behavioral change on 3.1.x / 4.0.x builds (guard compiled out).
- The pass-through TAP suite runs under `PROXYSQL40` (genai) in CI, so it continues to exercise the feature normally.

## Follow-up (not in this PR)

The pass-through user/reference manuals and the 3.0.10/3.1.10/4.0.10 release-note drafts need retargeting to reflect that pass-through is 3.1.x+ only; that lives with the docs and will be updated separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled pass-through authentication on Stable-tier builds.
  * Added an error message when pass-through authentication is enabled in an unsupported build, preventing the configuration from taking effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->