### PR TITLE
fix(ci-builds): genai build must set PROXYSQL40=1, not the dead PROXYSQLGENAI

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -165,7 +165,23 @@ jobs:
           sed -i "/command/i \      - TEST_WITHASAN=1" docker-compose.yml
         fi
         if [[ "${{ matrix.type }}" =~ "-genai" ]]; then
-          sed -i "/command/i \      - PROXYSQLGENAI=1" docker-compose.yml
+          # GenAI / v4.0 chassis tier flag. PROXYSQLGENAI was REMOVED in
+          # #5815 -- the GenAI/MCP/AI/RAG tier is now selected with
+          # PROXYSQL40=1, which the top-level Makefile cascades into
+          # PROXYSQL31 / PROXYSQLFFTO / PROXYSQLTSDB automatically. Injecting
+          # the dead PROXYSQLGENAI flag was a silent no-op, so this build's
+          # core libproxysql compiled as BARE STABLE (GITVERSION 3.0.x, no
+          # tier defines) -- every test group consuming the genai-gcov cache
+          # was exercising a Stable core, with FFTO/TSDB/genai/pass-through
+          # #ifdef'd out. Use PROXYSQL40=1 so the core matches the tier.
+          sed -i "/command/i \      - PROXYSQL40=1" docker-compose.yml
+          # Skip the ~14 genai_*_unit-t binaries. With PROXYSQL40=1 the unit
+          # Makefile's `ifeq ($(PROXYSQL40),1)` block would otherwise add them
+          # to UNIT_TESTS; they statically link 30+ plugins/genai/.cpp at
+          # -O0 -ggdb (~160 MB each, ~2 GB total, larger still under gcov) and
+          # blow the runner's free disk. This build feeds TAP integration
+          # groups, not unit-test groups (which build separately).
+          sed -i "/command/i \      - SKIP_GENAI_UNIT_TESTS=1" docker-compose.yml
         fi
         if [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
           # Chassis tier flag for plugins/mysqlx build. _build.environment


### PR DESCRIPTION
## Summary

The `-tap-genai-gcov` build variant in `ci-builds.yml` — the build cache **restored by the majority of CI test groups** — injects `PROXYSQLGENAI=1` into `docker-compose.yml`. That flag was **removed in #5815**; the GenAI / v4.0 tier is now selected with `PROXYSQL40=1` (which the top-level Makefile cascades into `PROXYSQL31` / `PROXYSQLFFTO` / `PROXYSQLTSDB`).

Injecting the dead flag is a **silent no-op**, so this build's core `libproxysql` compiles as **bare Stable** — `GITVERSION="3.0.x"`, no tier defines. The `-tap-mysqlx` variant already uses `PROXYSQL40=1` correctly; this aligns `-genai` with it.

## Evidence

From the `-tap-genai-gcov` build of commit `9ec4415` — the `MySQL_Thread.cpp` compile line:
```
MySQL_Thread.oo ... -DGITVERSION="3.0.9-918-g9ec4415" -DWITHGCOV --coverage -DPROXYSQLCLICKHOUSE
```
No `-DPROXYSQL40/31/FFTO/TSDB`. Compare `-tap-mysqlx` for the same commit: `GITVERSION="4.0.9..."` with `-DPROXYSQL40 -DPROXYSQL31 -DPROXYSQLFFTO -DPROXYSQLTSDB`.

## Consequence (what this fixes)

Every test group that restores the `genai-gcov` cache has been exercising a **Stable core** — FFTO, TSDB, the genai plugin, and pass-through authentication were all `#ifdef`'d out of the binary under test, despite the `genai` label. This surfaced when a PR (`feat/passthrough-innovative-tier-gate`) added the first core code whose behavior depends on `PROXYSQL31`: its `#ifndef PROXYSQL31` gate fired in the "genai" build and disabled pass-through, failing all pass-through TAP tests in `mysql84-g4`.

## Change

- `-genai` branch: `PROXYSQLGENAI=1` → `PROXYSQL40=1`.
- Add `SKIP_GENAI_UNIT_TESTS=1` to the `-genai` branch (as `-mysqlx` already does): with `PROXYSQL40=1` the unit Makefile would otherwise build ~14 `genai_*_unit-t` binaries (~2 GB, larger under gcov) and blow the runner's free disk. This build feeds TAP **integration** groups, not unit-test groups.

## ⚠️ Blast radius

This flips the **core tier of nearly all CI test groups from Stable to v4.0**. That is the intended behavior — the `genai` build should test a genai core — but groups that have only ever run against a Stable core may surface **pre-existing failures that were previously masked** (FFTO-default-on behavior, TSDB, genai plugin load, etc.). Recommend watching the first full run closely and triaging any new failures as "newly-exposed, not newly-introduced."

## Follow-ups (separate)

- `doc/GH-Actions/README.md` (on `v3.0`) still documents this variant as `PROXYSQLGENAI=1` + "CI-legacy-g2-genai only" — both stale; should be updated.
- PR #5945 (the pass-through tier gate) should go green once this lands, since the genai build will then define `PROXYSQL31` and compile the gate out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GenAI build configuration to select the appropriate ProxySQL tier.
  * Streamlined GenAI build runs by skipping unnecessary unit-test binaries.
  * Clarified build workflow comments for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->