### PR TITLE
ci: Add workflow for cluster simulation groups

### DIFF
--- a/.github/workflows/CI-cluster-simulator.yml
+++ b/.github/workflows/CI-cluster-simulator.yml
@@ -1,0 +1,129 @@
+# Builds ProxySQL once with every cluster simulation flag enabled, then runs
+# each registered cluster_sim_* TAP group as an independent matrix job.
+#
+# Maintenance notes:
+# - Groups and TAP binaries are discovered from test/tap/groups/groups.json.
+# - `testall` is intentional: every matrix job shares one ProxySQL binary built
+#   with all simulation flags.
+# - Registering a new simulation group and TAP binary requires no YAML changes.
+# - The exact-SHA cache contains only the runtime files used by matrix jobs.
+# - Command details and local examples: test/infra/control/cluster-simulator-ci.bash help.
+
+name: CI-cluster-simulator
+run-name: '${{ github.head_ref || github.ref_name }} ${{ github.workflow }} ${{ github.sha }}'
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  BUILD_CACHE_KEY: cluster-simulator-v3-ubuntu22-${{ github.sha }}
+  RUNTIME_CACHE_DIR: .cluster-simulator-runtime
+
+jobs:
+  build:
+    name: Build ProxySQL with simulation support
+    runs-on: ubuntu-22.04
+    outputs:
+      groups: ${{ steps.simulator-groups.outputs.groups }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Discover simulation groups
+      id: simulator-groups
+      run: test/infra/control/cluster-simulator-ci.bash discover
+
+    - name: Restore simulation build
+      id: simulator-build
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ env.BUILD_CACHE_KEY }}
+        path: ${{ env.RUNTIME_CACHE_DIR }}
+
+    - name: Install cached simulation runtime
+      if: steps.simulator-build.outputs.cache-hit == 'true'
+      run: test/infra/control/cluster-simulator-ci.bash install
+
+    - name: Build simulation test runtime
+      if: steps.simulator-build.outputs.cache-hit != 'true'
+      run: test/infra/control/cluster-simulator-ci.bash build
+
+    - name: Verify simulation build
+      run: test/infra/control/cluster-simulator-ci.bash verify
+
+    - name: Stage simulation runtime
+      if: steps.simulator-build.outputs.cache-hit != 'true'
+      run: test/infra/control/cluster-simulator-ci.bash stage
+
+    - name: Save simulation build
+      if: steps.simulator-build.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ env.BUILD_CACHE_KEY }}
+        path: ${{ env.RUNTIME_CACHE_DIR }}
+
+  test:
+    name: ${{ matrix.group }}
+    needs: build
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJSON(needs.build.outputs.groups) }}
+    env:
+      INFRA_ID: ${{ matrix.group }}-${{ github.run_id }}-${{ github.run_attempt }}
+      TAP_GROUP: ${{ matrix.group }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Restore simulation build
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ env.BUILD_CACHE_KEY }}
+        fail-on-cache-miss: true
+        path: ${{ env.RUNTIME_CACHE_DIR }}
+
+    - name: Install simulation runtime
+      run: test/infra/control/cluster-simulator-ci.bash install
+
+    - name: Verify simulation build
+      run: test/infra/control/cluster-simulator-ci.bash verify "${TAP_GROUP}"
+
+    - name: Build CI base image
+      run: docker build --network host -t proxysql-ci-base:latest test/infra/docker-base
+
+    - name: Start infrastructure
+      run: test/infra/control/ensure-infras.bash
+
+    - name: Run simulation tests
+      run: test/infra/control/run-tests-isolated.bash
+
+    - name: Cleanup
+      if: always()
+      run: |
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
+
+    - name: Archive failure logs
+      if: ${{ failure() && !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.group }}-${{ github.sha }}-logs-run${{ github.run_number }}
+        path: ci_infra_logs/

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,8 @@ pkgroot/
 
 #files generated during CI run
 proxysql-save.cfg
+.cluster-simulator-binaries
+.cluster-simulator-runtime/
 test/tap/tests/test_cluster_sync_config/cluster_sync_node_stderr.txt
 test/tap/tests/test_cluster_sync_config/proxysql*.pem
 test/tap/tests/test_cluster_sync_config/test_cluster_sync.cnf

--- a/test/infra/control/cluster-simulator-ci.bash
+++ b/test/infra/control/cluster-simulator-ci.bash
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+#
+# Centralizes cluster simulation workflow operations so build and runtime
+# packaging behavior is readable, reusable locally, and kept out of YAML.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd -P)"
+GROUPS_FILE="${REPO_ROOT}/test/tap/groups/groups.json"
+SIMULATOR_BINARIES_FILE="${REPO_ROOT}/.cluster-simulator-binaries"
+RUNTIME_CACHE_DIR_VALUE="${RUNTIME_CACHE_DIR:-.cluster-simulator-runtime}"
+
+if [[ "${RUNTIME_CACHE_DIR_VALUE}" = /* ]]; then
+    RUNTIME_CACHE_PATH="$(realpath -m -- "${RUNTIME_CACHE_DIR_VALUE}")"
+else
+    RUNTIME_CACHE_PATH="$(realpath -m -- "${REPO_ROOT}/${RUNTIME_CACHE_DIR_VALUE}")"
+fi
+
+case "${RUNTIME_CACHE_PATH}" in
+    "${REPO_ROOT}/"*) ;;
+    *)
+        echo "ERROR: RUNTIME_CACHE_DIR must resolve inside ${REPO_ROOT}." >&2
+        exit 1
+        ;;
+esac
+
+STAGE_TEMP_DIR=""
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+usage_error() {
+    echo "ERROR: $*" >&2
+    echo "Run '$0 help' for usage." >&2
+    exit 2
+}
+
+expect_no_arguments() {
+    local command="${1}"
+    local argument_count="${2}"
+
+    [[ "${argument_count}" -eq 0 ]] ||
+        usage_error "'${command}' does not accept arguments."
+}
+
+require_command() {
+    command -v "${1}" >/dev/null 2>&1 ||
+        die "Required command '${1}' was not found."
+}
+
+require_executable() {
+    [[ -x "${1}" ]] || die "Required executable is missing: ${1}"
+}
+
+require_directory() {
+    [[ -d "${1}" ]] || die "Required directory is missing: ${1}"
+}
+
+discover_groups_json() {
+    jq -ce '
+        [.[] | .[] | select(type == "string" and startswith("cluster_sim_"))]
+        | unique
+        | if length > 0 then . else error("no cluster simulation groups found") end
+    ' "${GROUPS_FILE}"
+}
+
+refresh_binaries_manifest() {
+    local temporary_manifest
+
+    temporary_manifest="$(mktemp "${SIMULATOR_BINARIES_FILE}.tmp.XXXXXX")"
+    if ! jq -er '
+        [
+            to_entries[]
+            | select(any(.value[]; type == "string" and startswith("cluster_sim_")))
+            | .key
+        ]
+        | unique
+        | if length > 0 then .[] else error("no cluster simulation TAP binaries found") end
+    ' "${GROUPS_FILE}" > "${temporary_manifest}"; then
+        rm -f -- "${temporary_manifest}"
+        die "Failed to discover cluster simulation TAP binaries from ${GROUPS_FILE}."
+    fi
+
+    mv -- "${temporary_manifest}" "${SIMULATOR_BINARIES_FILE}"
+}
+
+load_manifest_binaries() {
+    [[ -s "${SIMULATOR_BINARIES_FILE}" ]] ||
+        die "Simulation binary manifest is missing: ${SIMULATOR_BINARIES_FILE}"
+    mapfile -t SIMULATOR_BINARIES < "${SIMULATOR_BINARIES_FILE}"
+    [[ "${#SIMULATOR_BINARIES[@]}" -gt 0 ]] ||
+        die "No TAP binaries were written to ${SIMULATOR_BINARIES_FILE}."
+}
+
+load_group_binaries() {
+    local group="${1}"
+    local binaries_json
+
+    [[ "${group}" == cluster_sim_* ]] ||
+        die "'${group}' is not a cluster simulation group."
+
+    binaries_json="$(jq -ce --arg group "${group}" '
+        [
+            to_entries[]
+            | select(.value | index($group))
+            | .key
+        ]
+        | unique
+        | if length > 0 then . else error("group is not registered") end
+    ' "${GROUPS_FILE}")" ||
+        die "Cluster simulation group '${group}' is not registered in ${GROUPS_FILE}."
+
+    mapfile -t SIMULATOR_BINARIES < <(jq -r '.[]' <<< "${binaries_json}")
+}
+
+verify_runtime_paths() {
+    local root="${1}"
+    shift
+    local binary
+
+    require_executable "${root}/src/proxysql"
+    require_executable "${root}/test/deps/cluster_simulator/cluster_simulator"
+    require_directory "${root}/test/tap/tap"
+
+    for binary in "$@"; do
+        require_executable "${root}/test/tap/tests/${binary}"
+    done
+}
+
+cleanup_stage_temp() {
+    if [[ -n "${STAGE_TEMP_DIR}" && -d "${STAGE_TEMP_DIR}" ]]; then
+        rm -rf -- "${STAGE_TEMP_DIR}"
+    fi
+}
+
+trap cleanup_stage_temp EXIT
+
+# discover
+# Purpose: Generate the matrix group JSON and the TAP-binary build manifest.
+# Local use: Run `cluster-simulator-ci.bash discover` to inspect registry output.
+# GitHub use: Supplies the build job's matrix output before cache restoration.
+handle_discover() {
+    expect_no_arguments "discover" "$#"
+    require_command jq
+
+    local groups_json
+    local group_count
+    local binary_count
+
+    groups_json="$(discover_groups_json)" ||
+        die "Failed to discover cluster simulation groups from ${GROUPS_FILE}."
+    refresh_binaries_manifest
+
+    group_count="$(jq 'length' <<< "${groups_json}")"
+    binary_count="$(wc -l < "${SIMULATOR_BINARIES_FILE}")"
+
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf 'groups=%s\n' "${groups_json}" >> "${GITHUB_OUTPUT}"
+    fi
+
+    printf 'Discovered %s simulation groups and %s TAP binaries.\n' \
+        "${group_count}" "${binary_count}"
+    jq -r '.[] | "  group: \(.)"' <<< "${groups_json}"
+    sed 's/^/  binary: /' "${SIMULATOR_BINARIES_FILE}"
+}
+
+# build
+# Purpose: Build ProxySQL runtime with all simulation flags and every registered TAP binary.
+# Local use: Run `cluster-simulator-ci.bash build` to reproduce the CI build.
+# GitHub use: Invoked on an exact-SHA cache miss in the build job.
+handle_build() {
+    expect_no_arguments "build" "$#"
+    require_command docker
+    require_command git
+    require_command jq
+    refresh_binaries_manifest
+
+    local git_version
+    git_version="$(git -C "${REPO_ROOT}" describe --long --abbrev=7 2>/dev/null ||
+        git -C "${REPO_ROOT}" describe --long --abbrev=7 --always)" ||
+        die "Failed to derive the ProxySQL build version from Git."
+
+    (
+        cd "${REPO_ROOT}"
+        docker compose run --rm --no-deps \
+            --env "GIT_VERSION_BASE=${git_version}" \
+            --entrypoint /opt/proxysql/test/infra/control/cluster-simulator-ci.bash \
+            --workdir /opt/proxysql \
+            ubuntu22_build _build
+    )
+}
+
+# _build
+# Purpose: Execute the compiler commands inside the Ubuntu 22 packaging image.
+# Local use: Internal only; use the public `build` command from the host.
+# GitHub use: Called by `build` as the packaging container entrypoint.
+handle_internal_build() {
+    expect_no_arguments "_build" "$#"
+    load_manifest_binaries
+    [[ -n "${GIT_VERSION_BASE:-}" ]] ||
+        die "GIT_VERSION_BASE was not provided by the host build command."
+
+    cd "${REPO_ROOT}"
+    make -j"$(nproc)" GIT_VERSION_BASE="${GIT_VERSION_BASE}" testall
+    make -j"$(nproc)" GIT_VERSION_BASE="${GIT_VERSION_BASE}" build_cluster_simulator
+    make -C test/tap -j"$(nproc)" GIT_VERSION="${GIT_VERSION_BASE}" tap
+    make -C test/tap/tests -j"$(nproc)" \
+        GIT_VERSION="${GIT_VERSION_BASE}" "${SIMULATOR_BINARIES[@]}"
+}
+
+# verify
+# Purpose: Check the complete runtime, or only the TAP binaries for one group.
+# Local use: Run `verify` after a build, optionally with a cluster_sim_* group.
+# GitHub use: Checks the build job runtime and each restored matrix-job runtime.
+handle_verify() {
+    [[ "$#" -le 1 ]] ||
+        usage_error "'verify' accepts at most one simulation group."
+    require_command jq
+
+    local group="${1:-}"
+
+    if [[ -n "${group}" ]]; then
+        load_group_binaries "${group}"
+    else
+        refresh_binaries_manifest
+        load_manifest_binaries
+    fi
+
+    verify_runtime_paths "${REPO_ROOT}" "${SIMULATOR_BINARIES[@]}"
+
+    if [[ -n "${group}" ]]; then
+        printf 'Verified simulation runtime for %s.\n' "${group}"
+    else
+        printf 'Verified simulation runtime for all registered groups.\n'
+    fi
+}
+
+# stage
+# Purpose: Assemble only the runtime files that matrix jobs need in the cache.
+# Local use: Optional; run after `build` to inspect the cache payload locally.
+# GitHub use: Creates the exact-SHA cache payload after a successful build.
+handle_stage() {
+    expect_no_arguments "stage" "$#"
+    require_command jq
+    handle_verify
+
+    local binary
+    local runtime_parent
+
+    runtime_parent="$(dirname -- "${RUNTIME_CACHE_PATH}")"
+    mkdir -p -- "${runtime_parent}"
+    STAGE_TEMP_DIR="$(mktemp -d "${RUNTIME_CACHE_PATH}.tmp.XXXXXX")"
+
+    install -D -m 0755 \
+        "${REPO_ROOT}/src/proxysql" \
+        "${STAGE_TEMP_DIR}/src/proxysql"
+    install -D -m 0755 \
+        "${REPO_ROOT}/test/deps/cluster_simulator/cluster_simulator" \
+        "${STAGE_TEMP_DIR}/test/deps/cluster_simulator/cluster_simulator"
+    install -d "${STAGE_TEMP_DIR}/test/tap"
+    cp -a "${REPO_ROOT}/test/tap/tap" "${STAGE_TEMP_DIR}/test/tap/"
+
+    for binary in "${SIMULATOR_BINARIES[@]}"; do
+        install -D -m 0755 \
+            "${REPO_ROOT}/test/tap/tests/${binary}" \
+            "${STAGE_TEMP_DIR}/test/tap/tests/${binary}"
+    done
+
+    if [[ -e "${RUNTIME_CACHE_PATH}" || -L "${RUNTIME_CACHE_PATH}" ]]; then
+        rm -rf -- "${RUNTIME_CACHE_PATH}"
+    fi
+    mv -- "${STAGE_TEMP_DIR}" "${RUNTIME_CACHE_PATH}"
+    STAGE_TEMP_DIR=""
+
+    printf 'Staged simulation runtime in %s.\n' "${RUNTIME_CACHE_PATH}"
+}
+
+# install
+# Purpose: Restore a staged simulation runtime into the current checkout.
+# Local use: Usually unnecessary; use it only to validate a staged cache payload.
+# GitHub use: Installs files immediately after actions/cache restores the payload.
+handle_install() {
+    expect_no_arguments "install" "$#"
+    require_command jq
+    require_directory "${RUNTIME_CACHE_PATH}"
+    refresh_binaries_manifest
+    load_manifest_binaries
+    verify_runtime_paths "${RUNTIME_CACHE_PATH}" "${SIMULATOR_BINARIES[@]}"
+
+    cp -a "${RUNTIME_CACHE_PATH}/." "${REPO_ROOT}/"
+    printf 'Installed simulation runtime from %s.\n' "${RUNTIME_CACHE_PATH}"
+}
+
+# help
+# Purpose: Document the command interface, generated files, and common examples.
+# Local use: Run `cluster-simulator-ci.bash help` when reproducing workflow steps.
+# GitHub use: Not called by the workflow; it is maintainer-facing documentation.
+handle_help() {
+    expect_no_arguments "help" "$#"
+
+    cat <<EOF
+Usage: $0 <command> [arguments]
+
+Commands:
+  discover              Print registered simulation groups and write:
+                          ${SIMULATOR_BINARIES_FILE}
+  build                 Build ProxySQL with simulation support in ubuntu22_build.
+  verify [group]        Verify all runtime files, or one matrix group.
+  stage                 Create the cache payload at:
+                          ${RUNTIME_CACHE_PATH}
+  install               Restore that cache payload into the checkout.
+  help                  Show this help.
+
+Examples:
+  $0 discover
+  $0 build
+  $0 verify
+  $0 verify cluster_sim_galera-g1
+EOF
+}
+
+command_name="${1:-help}"
+if [[ "$#" -gt 0 ]]; then
+    shift
+fi
+
+case "${command_name}" in
+    discover) handle_discover "$@" ;;
+    build) handle_build "$@" ;;
+    _build) handle_internal_build "$@" ;;
+    verify) handle_verify "$@" ;;
+    stage) handle_stage "$@" ;;
+    install) handle_install "$@" ;;
+    help|-h|--help) handle_help "$@" ;;
+    *) usage_error "Unknown command '${command_name}'." ;;
+esac


### PR DESCRIPTION
## Summary

- add a standalone, read-only GitHub Actions workflow for simulation-backed TAP groups
- use the standard Ubuntu 22 packaging container to build one ProxySQL binary with every simulation flag
- cache only the exact-SHA runtime outputs needed by the matrix jobs
- discover all registered `cluster_sim_*` groups and run each as an independent, non-fail-fast matrix job
- always clean isolated infrastructure and upload logs for failed matrix jobs

## Validation

- [GitHub Actions run 29992286626](https://github.com/sysown/proxysql/actions/runs/29992286626): build and all six simulation groups passed
- cache handoff restored and verified in every matrix job; archive size is 147 MB, reduced from 1,287 MB
- `actionlint v1.7.7 .github/workflows/CI-cluster-simulator.yml`
- `python3 test/tap/groups/lint_groups_json.py`
- verified workflow discovery resolves exactly the six registered `cluster_sim_*` groups
- `git diff --check upstream/feature/aws-rds-monitor...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests / CI**
  * Added an automated GitHub Actions workflow for simulation build-and-test checks on pull requests and manual runs.
  * Automatically discovers simulation test groups, builds required artifacts on cache miss, and reuses cached outputs for faster feedback.
  * Runs group-scoped simulation tests in isolated infrastructure, including a CI base image build and executable validation.
  * Ensures best-effort cleanup and uploads infrastructure logs on genuine failures (not cancellations), with concurrency auto-cancellation for superseded runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

