### PR TITLE
fix(ci-builds): harden mysqlx runtime-lib staging against lost .so symlinks

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -263,8 +263,33 @@ jobs:
           # build image, which overrides RUNPATH lookup.
           if [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
             mkdir -p test/tap/tap/_runtime_libs
-            cp -L deps/postgresql/postgresql/src/interfaces/libpq/libpq.so.5 test/tap/tap/_runtime_libs/
-            cp -L deps/re2/re2/obj/so/libre2.so.10 test/tap/tap/_runtime_libs/
+            # Stage a versioned runtime .so by its SONAME, tolerating a lost
+            # symlink. libpq.so.5 is a symlink to the real ELF (libpq.so.5.16);
+            # symlinks do not reliably survive the build/cache tar round-trip,
+            # so a bare `cp -L libpq.so.5` intermittently aborts the whole
+            # build with "cannot stat" when only the real file remains. Resolve
+            # the SONAME if present, else fall back to the newest matching real
+            # file, and stage THAT under the SONAME the e2e -t binaries
+            # DT_NEEDED. Only a genuine deps-build break (no file at all) fails
+            # -- loudly, with a directory listing, so it is distinguishable
+            # from the transient symlink-loss flake.
+            stage_lib() {
+              local dir="$1" soname="$2" dest="$3" src=""
+              if [ -e "$dir/$soname" ]; then
+                src="$dir/$soname"
+              else
+                src=$(ls -1 "$dir/$soname."* 2>/dev/null | sort -V | tail -n1 || true)
+              fi
+              if [ -z "$src" ] || [ ! -e "$src" ]; then
+                echo "ERROR: cannot stage $soname -- no file matching $dir/$soname* (deps build incomplete or shared lib not produced)"
+                ls -la "$dir" || true
+                return 1
+              fi
+              cp -L "$src" "$dest/$soname"
+              echo "staged $soname <- $(readlink -f "$src")"
+            }
+            stage_lib deps/postgresql/postgresql/src/interfaces/libpq libpq.so.5 test/tap/tap/_runtime_libs
+            stage_lib deps/re2/re2/obj/so libre2.so.10 test/tap/tap/_runtime_libs
             # Stage the chassis plugin .so files into the same dir for
             # the same reason: the _src cache path list is shared
             # infrastructure that we MUST NOT extend (changing it


### PR DESCRIPTION
## Problem

The `-tap-mysqlx` build intermittently fails with:
```
cp: cannot stat 'deps/postgresql/postgresql/src/interfaces/libpq/libpq.so.5': No such file or directory
##[error]Process completed with exit code 1.
```
and cascades into `CI-mysqlx / unit-tests` (which restores this build's `_test` cache).

## Root cause

The build stages `libpq.so.5` / `libre2.so.10` into `test/tap/tap/_runtime_libs/` because the mysqlx **e2e test binaries `DT_NEEDED` those SONAMEs** (they link the full dual-protocol `libproxysql`, whose PostgreSQL support is built on libpq — see "Why does mysqlx need libpq?" below). It did so with a bare `cp -L .../libpq.so.5`.

But `libpq.so.5` is a **symlink** → the real ELF `libpq.so.5.16`, and **symlinks don't reliably survive the build/cache tar round-trip** (a fragility the surrounding comment already notes for these deps paths). When only the real file remains, `cp -L` on the missing symlink aborts the whole job. The deps target's declared output is `libpq.a`, so `make` also treats libpq as up-to-date and never recreates the symlink.

This is why the **same commit passed and failed across builds minutes apart**:

| CI-builds run | time | `-tap-mysqlx` |
|---|---|---|
| 29938317604 | 16:30 | success |
| 29938760889 | 16:36 | fail |

Not a regression — a transient symlink-loss flake that predates the pass-through work (the tier gate is compiled out of the mysqlx build; #5947 only touched the `-genai` branch).

## Fix

Replace the two brittle `cp -L` lines with a `stage_lib` helper that:
1. uses the SONAME symlink if present;
2. else falls back to the newest matching **real** file (`libpq.so.5.16`) and stages **that** under the SONAME the binaries need;
3. fails **loudly with a directory listing** only when no matching file exists at all — so a genuine deps-build break stays distinguishable from the flake.

Verified locally under `bash -euo pipefail` for all three cases: symlink present, symlink lost / real file remains (the flake → recovers), and genuinely missing (→ `exit 1` with listing).

## Note (answers a question raised in review)

**Why does a mysqlx build depend on libpq at all?** It isn't the X-Protocol code — the mysqlx e2e `-t` binaries link `libproxysql`, the single dual-protocol core, which contains ProxySQL's PostgreSQL support (built on libpq). So libpq is a transitive `DT_NEEDED` of any core-linked binary, mysqlx included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime library staging for MySQL-compatible TAP builds.
  * Added fallback resolution for versioned library files when expected library names are unavailable.
  * Builds now provide clearer failure details when required runtime libraries cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->