### PR TITLE
fix(ci): load Codecov config for TAP uploads

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -244,6 +244,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
         flags: tap-legacy-clickhouse-g1
         name: tap-legacy-clickhouse-g1-coverage

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
         flags: tap-legacy-g1
         name: tap-legacy-g1-coverage

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -259,6 +259,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/ci-legacy-g2-genai.info
         flags: tap-legacy-g2
         name: tap-legacy-g2-genai-coverage

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
         flags: tap-legacy-g3
         name: tap-legacy-g3-coverage

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -311,6 +311,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
         flags: tap-legacy-g4
         name: tap-legacy-g4-coverage

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -308,6 +308,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
         flags: tap-legacy-g5
         name: tap-legacy-g5-coverage

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
         flags: tap-legacy-g6
         name: tap-legacy-g6-coverage

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
         flags: tap-legacy-g7
         name: tap-legacy-g7-coverage

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
         flags: tap-legacy-g8
         name: tap-legacy-g8-coverage

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
         flags: tap-legacy-g9
         name: tap-legacy-g9-coverage

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
         flags: tap-mariadb10-galera-g1
         name: tap-mariadb10-galera-g1-coverage

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
         flags: tap-mariadb10-galera-g2
         name: tap-mariadb10-galera-g2-coverage

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
         flags: tap-mariadb10-galera-g3
         name: tap-mariadb10-galera-g3-coverage

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
         flags: tap-mariadb10-galera-g4
         name: tap-mariadb10-galera-g4-coverage

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -234,6 +234,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
         flags: tap-mariadb10-galera-g5
         name: tap-mariadb10-galera-g5-coverage

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
         flags: tap-mariadb10-galera-g6
         name: tap-mariadb10-galera-g6-coverage

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
         flags: tap-mariadb10-galera-g7
         name: tap-mariadb10-galera-g7-coverage

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
         flags: tap-mariadb10-galera-g8
         name: tap-mariadb10-galera-g8-coverage

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
         flags: tap-mariadb10-galera-g9
         name: tap-mariadb10-galera-g9-coverage

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -249,6 +249,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
         flags: tap-mysql56-single-g1
         name: tap-mysql56-single-g1-coverage

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
         flags: tap-mysql84-g1
         name: tap-mysql84-g1-coverage

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
         flags: tap-mysql84-g2
         name: tap-mysql84-g2-coverage

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
         flags: tap-mysql84-g3
         name: tap-mysql84-g3-coverage

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -310,6 +310,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
         flags: tap-mysql84-g4
         name: tap-mysql84-g4-coverage

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -241,6 +241,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
         flags: tap-mysql84-g5
         name: tap-mysql84-g5-coverage

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
         flags: tap-mysql84-g6
         name: tap-mysql84-g6-coverage

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
         flags: tap-mysql84-g7
         name: tap-mysql84-g7-coverage

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
         flags: tap-mysql84-g8
         name: tap-mysql84-g8-coverage

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
         flags: tap-mysql84-g9
         name: tap-mysql84-g9-coverage

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
         flags: tap-mysql84-gr-g1
         name: tap-mysql84-gr-g1-coverage

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
         flags: tap-mysql84-gr-g2
         name: tap-mysql84-gr-g2-coverage

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
         flags: tap-mysql84-gr-g3
         name: tap-mysql84-gr-g3-coverage

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
         flags: tap-mysql84-gr-g4
         name: tap-mysql84-gr-g4-coverage

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -234,6 +234,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
         flags: tap-mysql84-gr-g5
         name: tap-mysql84-gr-g5-coverage

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
         flags: tap-mysql84-gr-g6
         name: tap-mysql84-gr-g6-coverage

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
         flags: tap-mysql84-gr-g7
         name: tap-mysql84-gr-g7-coverage

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
         flags: tap-mysql84-gr-g8
         name: tap-mysql84-gr-g8-coverage

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
         flags: tap-mysql84-gr-g9
         name: tap-mysql84-gr-g9-coverage

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/ci-mysql90-gr-g1.info
         flags: tap-mysql90-gr-g1
         name: tap-mysql90-gr-g1-coverage

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/ci-mysql93-gr-g1.info
         flags: tap-mysql93-gr-g1
         name: tap-mysql93-gr-g1-coverage

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -236,6 +236,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/ci-mysql95-gr-g1.info
         flags: tap-mysql95-gr-g1
         name: tap-mysql95-gr-g1-coverage

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
         flags: tap-pgsql-socket-g1
         name: tap-pgsql-socket-g1-coverage

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -243,6 +243,7 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
+        codecov_yml_path: proxysql/codecov.yml
         files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
         flags: tap-set_parser_algorithm_3-g1
         name: tap-set_parser_algorithm_3-g1-coverage


### PR DESCRIPTION
## What changed

- Add `codecov_yml_path: proxysql/codecov.yml` to all 43 TAP Codecov upload steps.

## Why

The TAP workflows check out the repository under a `proxysql/` subdirectory. Their Codecov uploads were not loading the repository's `codecov.yml`, so the configured `proxysql/::` path fix was not applied and TAP coverage did not merge correctly with unit coverage.

## Impact

TAP and unit-test coverage uploads use the same Codecov path normalization and can be merged. Codecov service failures remain non-blocking.

## Validation

- Workflow contract validator passes for all 43 TAP workflows.
- YAML parsing and `git diff --check` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized coverage reporting across CI workflows by explicitly using the repository’s Codecov configuration.
  * Preserved existing coverage upload conditions, reports, flags, and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->