### PR TITLE
fix(ci): make TAP Codecov uploads use tested commit

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -245,7 +246,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
         flags: tap-legacy-clickhouse-g1
         name: tap-legacy-clickhouse-g1-coverage

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -245,6 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
         flags: tap-legacy-clickhouse-g1
         name: tap-legacy-clickhouse-g1-coverage

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
         flags: tap-legacy-g1
         name: tap-legacy-g1-coverage

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
         flags: tap-legacy-g1
         name: tap-legacy-g1-coverage

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -61,6 +61,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -260,7 +261,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/ci-legacy-g2-genai.info
         flags: tap-legacy-g2
         name: tap-legacy-g2-genai-coverage

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -260,6 +260,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/ci-legacy-g2-genai.info
         flags: tap-legacy-g2
         name: tap-legacy-g2-genai-coverage

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
         flags: tap-legacy-g3
         name: tap-legacy-g3-coverage

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
         flags: tap-legacy-g3
         name: tap-legacy-g3-coverage

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -312,6 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
         flags: tap-legacy-g4
         name: tap-legacy-g4-coverage

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -312,7 +313,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
         flags: tap-legacy-g4
         name: tap-legacy-g4-coverage

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -309,7 +310,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
         flags: tap-legacy-g5
         name: tap-legacy-g5-coverage

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -309,6 +309,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
         flags: tap-legacy-g5
         name: tap-legacy-g5-coverage

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
         flags: tap-legacy-g6
         name: tap-legacy-g6-coverage

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
         flags: tap-legacy-g6
         name: tap-legacy-g6-coverage

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
         flags: tap-legacy-g7
         name: tap-legacy-g7-coverage

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
         flags: tap-legacy-g7
         name: tap-legacy-g7-coverage

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
         flags: tap-legacy-g8
         name: tap-legacy-g8-coverage

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
         flags: tap-legacy-g8
         name: tap-legacy-g8-coverage

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
         flags: tap-legacy-g9
         name: tap-legacy-g9-coverage

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
         flags: tap-legacy-g9
         name: tap-legacy-g9-coverage

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
         flags: tap-mariadb10-galera-g1
         name: tap-mariadb10-galera-g1-coverage

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
         flags: tap-mariadb10-galera-g1
         name: tap-mariadb10-galera-g1-coverage

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
         flags: tap-mariadb10-galera-g2
         name: tap-mariadb10-galera-g2-coverage

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
         flags: tap-mariadb10-galera-g2
         name: tap-mariadb10-galera-g2-coverage

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
         flags: tap-mariadb10-galera-g3
         name: tap-mariadb10-galera-g3-coverage

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
         flags: tap-mariadb10-galera-g3
         name: tap-mariadb10-galera-g3-coverage

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
         flags: tap-mariadb10-galera-g4
         name: tap-mariadb10-galera-g4-coverage

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
         flags: tap-mariadb10-galera-g4
         name: tap-mariadb10-galera-g4-coverage

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -235,6 +235,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
         flags: tap-mariadb10-galera-g5
         name: tap-mariadb10-galera-g5-coverage

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -235,7 +236,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
         flags: tap-mariadb10-galera-g5
         name: tap-mariadb10-galera-g5-coverage

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
         flags: tap-mariadb10-galera-g6
         name: tap-mariadb10-galera-g6-coverage

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
         flags: tap-mariadb10-galera-g6
         name: tap-mariadb10-galera-g6-coverage

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
         flags: tap-mariadb10-galera-g7
         name: tap-mariadb10-galera-g7-coverage

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
         flags: tap-mariadb10-galera-g7
         name: tap-mariadb10-galera-g7-coverage

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
         flags: tap-mariadb10-galera-g8
         name: tap-mariadb10-galera-g8-coverage

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
         flags: tap-mariadb10-galera-g8
         name: tap-mariadb10-galera-g8-coverage

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
         flags: tap-mariadb10-galera-g9
         name: tap-mariadb10-galera-g9-coverage

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
         flags: tap-mariadb10-galera-g9
         name: tap-mariadb10-galera-g9-coverage

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -54,6 +54,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -250,7 +251,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
         flags: tap-mysql56-single-g1
         name: tap-mysql56-single-g1-coverage

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -250,6 +250,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
         flags: tap-mysql56-single-g1
         name: tap-mysql56-single-g1-coverage

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
         flags: tap-mysql84-g1
         name: tap-mysql84-g1-coverage

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
         flags: tap-mysql84-g1
         name: tap-mysql84-g1-coverage

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
         flags: tap-mysql84-g2
         name: tap-mysql84-g2-coverage

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
         flags: tap-mysql84-g2
         name: tap-mysql84-g2-coverage

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
         flags: tap-mysql84-g3
         name: tap-mysql84-g3-coverage

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
         flags: tap-mysql84-g3
         name: tap-mysql84-g3-coverage

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -311,6 +311,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
         flags: tap-mysql84-g4
         name: tap-mysql84-g4-coverage

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -115,6 +115,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -311,7 +312,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
         flags: tap-mysql84-g4
         name: tap-mysql84-g4-coverage

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -242,7 +243,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
         flags: tap-mysql84-g5
         name: tap-mysql84-g5-coverage

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -242,6 +242,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
         flags: tap-mysql84-g5
         name: tap-mysql84-g5-coverage

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
         flags: tap-mysql84-g6
         name: tap-mysql84-g6-coverage

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
         flags: tap-mysql84-g6
         name: tap-mysql84-g6-coverage

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
         flags: tap-mysql84-g7
         name: tap-mysql84-g7-coverage

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
         flags: tap-mysql84-g7
         name: tap-mysql84-g7-coverage

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
         flags: tap-mysql84-g8
         name: tap-mysql84-g8-coverage

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
         flags: tap-mysql84-g8
         name: tap-mysql84-g8-coverage

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
         flags: tap-mysql84-g9
         name: tap-mysql84-g9-coverage

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
         flags: tap-mysql84-g9
         name: tap-mysql84-g9-coverage

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
         flags: tap-mysql84-gr-g1
         name: tap-mysql84-gr-g1-coverage

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
         flags: tap-mysql84-gr-g1
         name: tap-mysql84-gr-g1-coverage

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
         flags: tap-mysql84-gr-g2
         name: tap-mysql84-gr-g2-coverage

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
         flags: tap-mysql84-gr-g2
         name: tap-mysql84-gr-g2-coverage

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
         flags: tap-mysql84-gr-g3
         name: tap-mysql84-gr-g3-coverage

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
         flags: tap-mysql84-gr-g3
         name: tap-mysql84-gr-g3-coverage

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
         flags: tap-mysql84-gr-g4
         name: tap-mysql84-gr-g4-coverage

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
         flags: tap-mysql84-gr-g4
         name: tap-mysql84-gr-g4-coverage

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -235,7 +236,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
         flags: tap-mysql84-gr-g5
         name: tap-mysql84-gr-g5-coverage

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -235,6 +235,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
         flags: tap-mysql84-gr-g5
         name: tap-mysql84-gr-g5-coverage

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
         flags: tap-mysql84-gr-g6
         name: tap-mysql84-gr-g6-coverage

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
         flags: tap-mysql84-gr-g6
         name: tap-mysql84-gr-g6-coverage

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
         flags: tap-mysql84-gr-g7
         name: tap-mysql84-gr-g7-coverage

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
         flags: tap-mysql84-gr-g7
         name: tap-mysql84-gr-g7-coverage

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
         flags: tap-mysql84-gr-g8
         name: tap-mysql84-gr-g8-coverage

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
         flags: tap-mysql84-gr-g8
         name: tap-mysql84-gr-g8-coverage

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
         flags: tap-mysql84-gr-g9
         name: tap-mysql84-gr-g9-coverage

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
         flags: tap-mysql84-gr-g9
         name: tap-mysql84-gr-g9-coverage

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/ci-mysql90-gr-g1.info
         flags: tap-mysql90-gr-g1
         name: tap-mysql90-gr-g1-coverage

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/ci-mysql90-gr-g1.info
         flags: tap-mysql90-gr-g1
         name: tap-mysql90-gr-g1-coverage

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/ci-mysql93-gr-g1.info
         flags: tap-mysql93-gr-g1
         name: tap-mysql93-gr-g1-coverage

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/ci-mysql93-gr-g1.info
         flags: tap-mysql93-gr-g1
         name: tap-mysql93-gr-g1-coverage

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -237,6 +237,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/ci-mysql95-gr-g1.info
         flags: tap-mysql95-gr-g1
         name: tap-mysql95-gr-g1-coverage

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -237,7 +238,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/ci-mysql95-gr-g1.info
         flags: tap-mysql95-gr-g1
         name: tap-mysql95-gr-g1-coverage

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
         flags: tap-pgsql-socket-g1
         name: tap-pgsql-socket-g1-coverage

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
         flags: tap-pgsql-socket-g1
         name: tap-pgsql-socket-g1-coverage

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -244,6 +244,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
+        override_commit: ${{ env.SHA }}
         files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
         flags: tap-set_parser_algorithm_3-g1
         name: tap-set_parser_algorithm_3-g1-coverage

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -48,6 +48,7 @@ jobs:
         ref: ${{ env.SHA }}
         path: 'proxysql'
         sparse-checkout: |
+          codecov.yml
           test/infra
           test/tap/groups
           test/scripts
@@ -244,7 +245,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: proxysql/codecov.yml
-        override_commit: ${{ env.SHA }}
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
         flags: tap-set_parser_algorithm_3-g1
         name: tap-set_parser_algorithm_3-g1-coverage


### PR DESCRIPTION
## What this changes

- Pass the actual `workflow_run.head_sha` directly to Codecov instead of relying on `env.SHA` inside action inputs.
- Include `codecov.yml` in the sparse checkout used by all 43 TAP coverage workflows.

## Why

The successful TAP run was uploading to the base `v3.0` SHA, and Codecov logged that `proxysql/codecov.yml` did not exist in the checkout. The generated LCOV report already contains nonzero coverage for `MySQL_Monitor.cpp`; these changes make that report process against the tested commit with the repository path fix loaded.

## Validation

- All 43 TAP Codecov workflows contain the direct tested-commit expression.
- All 43 sparse checkouts include `codecov.yml`.
- All 66 workflow YAML files parse successfully.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage reporting by ensuring Codecov uses the commit that triggered each workflow, including chained CI runs.
  * Made the Codecov configuration available across all affected test workflows, improving consistency and attribution of uploaded coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->