### PR TITLE
fix(ci): align TAP Codecov network paths

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -251,6 +251,7 @@ jobs:
         flags: tap-legacy-clickhouse-g1
         name: tap-legacy-clickhouse-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-legacy-g1
         name: tap-legacy-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -266,6 +266,7 @@ jobs:
         flags: tap-legacy-g2
         name: tap-legacy-g2-genai-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report to compute line-offset
         # adjustments, and crashes with FileNotFoundError if any path

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-legacy-g3
         name: tap-legacy-g3-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -318,6 +318,7 @@ jobs:
         flags: tap-legacy-g4
         name: tap-legacy-g4-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -315,6 +315,7 @@ jobs:
         flags: tap-legacy-g5
         name: tap-legacy-g5-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-legacy-g6
         name: tap-legacy-g6-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-legacy-g7
         name: tap-legacy-g7-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-legacy-g8
         name: tap-legacy-g8-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-legacy-g9
         name: tap-legacy-g9-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g1
         name: tap-mariadb10-galera-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g2
         name: tap-mariadb10-galera-g2-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g3
         name: tap-mariadb10-galera-g3-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g4
         name: tap-mariadb10-galera-g4-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -241,6 +241,7 @@ jobs:
         flags: tap-mariadb10-galera-g5
         name: tap-mariadb10-galera-g5-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g6
         name: tap-mariadb10-galera-g6-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g7
         name: tap-mariadb10-galera-g7-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g8
         name: tap-mariadb10-galera-g8-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mariadb10-galera-g9
         name: tap-mariadb10-galera-g9-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -256,6 +256,7 @@ jobs:
         flags: tap-mysql56-single-g1
         name: tap-mysql56-single-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-mysql84-g1
         name: tap-mysql84-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-mysql84-g2
         name: tap-mysql84-g2-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-mysql84-g3
         name: tap-mysql84-g3-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -317,6 +317,7 @@ jobs:
         flags: tap-mysql84-g4
         name: tap-mysql84-g4-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -248,6 +248,7 @@ jobs:
         flags: tap-mysql84-g5
         name: tap-mysql84-g5-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-mysql84-g6
         name: tap-mysql84-g6-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-mysql84-g7
         name: tap-mysql84-g7-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-mysql84-g8
         name: tap-mysql84-g8-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-mysql84-g9
         name: tap-mysql84-g9-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g1
         name: tap-mysql84-gr-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g2
         name: tap-mysql84-gr-g2-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g3
         name: tap-mysql84-gr-g3-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g4
         name: tap-mysql84-gr-g4-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -241,6 +241,7 @@ jobs:
         flags: tap-mysql84-gr-g5
         name: tap-mysql84-gr-g5-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g6
         name: tap-mysql84-gr-g6-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g7
         name: tap-mysql84-gr-g7-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g8
         name: tap-mysql84-gr-g8-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql84-gr-g9
         name: tap-mysql84-gr-g9-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql90-gr-g1
         name: tap-mysql90-gr-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql93-gr-g1
         name: tap-mysql93-gr-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -243,6 +243,7 @@ jobs:
         flags: tap-mysql95-gr-g1
         name: tap-mysql95-gr-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-pgsql-socket-g1
         name: tap-pgsql-socket-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -250,6 +250,7 @@ jobs:
         flags: tap-set_parser_algorithm_3-g1
         name: tap-set_parser_algorithm_3-g1-coverage
         use_oidc: true
+        network_prefix: proxysql/
         # codecov-cli's _get_file_fixes step reads every source file
         # referenced in the LCOV report and crashes with FileNotFoundError
         # if any path is missing (the _test cache prunes test deps to fit


### PR DESCRIPTION
## Summary

- Add `network_prefix: proxysql/` to every TAP Codecov upload workflow.
- Keep `disable_file_fixes: true`; it avoids the existing sparse-checkout source-file crash and is unrelated to path mapping.

## Root cause

TAP LCOV reports contain `SF:proxysql/...` because the repository is checked out under the `proxysql/` workspace directory. Codecov CLI builds its network file list from the nested Git checkout and emits `lib/...`, `src/...`, etc. The namespaces did not match, so most TAP daemon coverage was discarded before merging; the successful legacy-g1 report had 220 LCOV files but only 50 processed files, leaving `lib/MySQL_Monitor.cpp` at the unit-test baseline of 0%.

`network_prefix: proxysql/` makes the Codecov network list match the LCOV namespace. The existing `codecov.yml` rule then maps `proxysql/...` to the repository paths.

## Validation

- YAML parsed successfully for all 43 Codecov workflows.
- All 43 workflows retain the tested commit override, `codecov.yml`, non-blocking upload, and sparse-checkout crash guard.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage report path mapping across CI workflows, helping Codecov correctly associate uploaded coverage data with repository source files.
* **Chores**
  * Applied consistent coverage upload configuration across legacy, database compatibility, parser, and socket test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->