### PR TITLE
Add ci-taptests-pgsql-cluster.yml reusable workflow

### DIFF
--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -1,0 +1,235 @@
+name: CI-taptests-pgsql-cluster
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+
+env:
+  SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+
+jobs:
+  pick-runner:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      runson: ${{ steps.pick.outputs.runson }}
+    steps:
+      - name: Pick runner pool
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          POOL_SIZE: ${{ vars.SELFHOSTED_POOL_SIZE || '6' }}
+          ELIGIBLE: ${{ (github.actor == 'renecannao' || (inputs.trigger && fromJson(inputs.trigger).event.workflow_run.actor.login == 'renecannao')) && vars.SELFHOSTED_WORKFLOWS && contains(fromJson(vars.SELFHOSTED_WORKFLOWS), github.workflow) }}
+        run: |
+          set -uo pipefail
+          choice='"ubuntu-22.04"'
+          if [ "${ELIGIBLE:-}" = "true" ]; then
+            POOL="${POOL_SIZE:-6}"
+            demand=0; err=0
+            ids=$( { gh api --paginate "repos/${REPO}/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id';
+                     gh api --paginate "repos/${REPO}/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id'; } 2>e1 ) || err=1
+            if [ "$err" = "0" ]; then
+              for rid in ${ids:-}; do
+                [ "$demand" -ge "$POOL" ] && break
+                n=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" --jq '[.jobs[]|select((.status=="in_progress" and ((.runner_name//"")|startswith("ci-vm"))) or (.status=="queued" and (([.labels[]]|index("proxysql-ci")) != null)))]|length' 2>/dev/null) || n=0
+                demand=$(( demand + ${n:-0} ))
+              done
+              free=$(( POOL - demand ))
+              echo ">>> self-hosted pool: demand=${demand}/${POOL} free=${free} (occupied+queued)"
+              if [ "${free}" -ge 1 ]; then
+                choice='["self-hosted","proxysql-ci"]'; echo ">>> capacity available -> self-hosted"
+              else
+                choice='"ubuntu-22.04"'; echo ">>> pool at/over capacity -> spill to GitHub-hosted"
+              fi
+            else
+              echo ">>> WARNING: could not read runs:"; sed 's/^/    /' e1
+              choice='["self-hosted","proxysql-ci"]'; echo ">>> failing SAFE to self-hosted (offload unchanged)"
+            fi
+          else
+            echo ">>> not eligible for self-hosted -> GitHub-hosted"
+          fi
+          echo "runson=${choice}" >> "$GITHUB_OUTPUT"
+          echo ">>> decision: runson=${choice}"
+
+  tests:
+    needs: pick-runner
+    runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        testdist: [ 'ubuntu22-tap' ]
+    env:
+      TESTDIST: ${{ matrix.testdist }}
+      MATRIX: '(pgsql-cluster)'
+
+    steps:
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      id: checks
+      continue-on-error: true
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: '${{ github.workflow }} / ${{ github.job }} ${{ env.MATRIX }}'
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        status: 'in_progress'
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ env.SHA }}
+        path: 'proxysql'
+        sparse-checkout: |
+          test/infra
+          test/tap/groups
+          test/scripts
+
+    - name: Download build handoff
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
+        HANDOFF_VARIANT: ${{ matrix.testdist }}
+        HANDOFF_TYPES: src test
+      run: |
+        set -uo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        : "${HANDOFF_MAX_ATTEMPTS:=20}"
+        ERRLOG="$(mktemp)"
+        resolve_aid() {
+          local name="$1" out=""
+          if [ -n "${BUILD_RUN_ID:-}" ]; then
+            out=$(gh api "repos/${REPO}/actions/runs/${BUILD_RUN_ID}/artifacts?per_page=100" \
+                    --jq "[.artifacts[]|select(.name==\"${name}\" and .expired==false)]|sort_by(.created_at)|last|.id // empty" 2>>"$ERRLOG") || true
+            [ -n "$out" ] && { printf '%s' "$out"; return 0; }
+          fi
+          out=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
+                  --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>>"$ERRLOG") || true
+          [ -n "$out" ] && { printf '%s' "$out"; return 0; }
+          return 1
+        }
+        for t in $HANDOFF_TYPES; do
+          name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
+          aid=""
+          for attempt in $(seq 1 "$HANDOFF_MAX_ATTEMPTS"); do
+            aid=$(resolve_aid "$name") && [ -n "$aid" ] && break
+            aid=""
+            echo ">>> ${name} not resolvable yet (${attempt}/${HANDOFF_MAX_ATTEMPTS}); sleeping 15s"; sleep 15
+          done
+          if [ -z "$aid" ]; then
+            echo "ERROR: handoff artifact ${name} not found after ${HANDOFF_MAX_ATTEMPTS} attempts (build_run=${BUILD_RUN_ID:-n/a}) -- did CI-builds succeed for ${SHA}?" >&2
+            echo "--- last gh errors ---" >&2; tail -n 20 "$ERRLOG" >&2
+            exit 1
+          fi
+          echo ">>> downloading ${name} (id=${aid})"
+          gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
+          unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
+        done
+        mkdir -p proxysql
+        cd proxysql/
+        for tb in ../cache_*.tar.zst; do
+          [ -e "$tb" ] || continue
+          echo ">>> unpacking $(basename "$tb")"
+          zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
+        done
+        rm -f ../cache_*.tar.zst ../handoff-*.zip
+
+    - name: Verify binary
+      run: |
+        chmod +x proxysql/src/proxysql
+        file proxysql/src/proxysql
+
+    - name: Log in to GHCR and pull CI base image
+      env:
+        GHCR_USER: ${{ github.actor }}
+        GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set +e
+        attempt=0
+        max_attempts=5
+        while [ $attempt -lt $max_attempts ]; do
+          attempt=$((attempt + 1))
+          echo ">>> GHCR login+pull attempt ${attempt}/${max_attempts}"
+          if echo "$GHCR_TOKEN" | docker login ghcr.io \
+              -u "$GHCR_USER" --password-stdin \
+              && docker pull ghcr.io/sysown/proxysql-ci-base:latest; then
+            echo ">>> GHCR login+pull OK on attempt ${attempt}"
+            docker tag ghcr.io/sysown/proxysql-ci-base:latest \
+                proxysql-ci-base:latest
+            exit 0
+          fi
+          if [ $attempt -lt $max_attempts ]; then
+            sleep_for=$((attempt * 10))
+            echo ">>> attempt ${attempt} failed; sleeping ${sleep_for}s"
+            sleep $sleep_for
+          fi
+        done
+        echo ">>> all ${max_attempts} GHCR attempts failed"
+        exit 1
+
+    - name: Start infrastructure
+      run: |
+        cd proxysql
+        export INFRA_ID="ci-taptests-pgsql-cluster"
+        export TAP_GROUP="legacy-g3"
+        export TEST_PY_TAP_INCL="test_cluster_sync_pgsql-t"
+        export PROXYSQL_CLUSTER_NODES=2
+        test/infra/control/ensure-infras.bash
+
+    - name: Run test_cluster_sync_pgsql-t
+      run: |
+        cd proxysql
+        export INFRA_ID="ci-taptests-pgsql-cluster"
+        export TAP_GROUP="legacy-g3"
+        export TEST_PY_TAP_INCL="test_cluster_sync_pgsql-t"
+        export PROXYSQL_CLUSTER_NODES=2
+        test/infra/control/run-tests-isolated.bash
+
+    - name: Cleanup
+      if: always()
+      run: |
+        set +e
+        if [ ! -d proxysql ]; then
+          echo "proxysql checkout not present; skipping cleanup."
+          exit 0
+        fi
+        cd proxysql
+        export INFRA_ID="ci-taptests-pgsql-cluster"
+        export TAP_GROUP="legacy-g3"
+        docker logs proxysql.ci-taptests-pgsql-cluster 2>&1 | tail -50 || true
+        test/infra/control/stop-proxysql-isolated.bash || true
+        test/infra/control/destroy-infras.bash || true
+
+    - name: Fix artifact permissions
+      if: ${{ failure() && !cancelled() }}
+      run: |
+        sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
+
+    - name: Archive artifacts logs
+      if: ${{ failure() && !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_*_logs/
+
+    - uses: LouisBrunner/checks-action@v2.0.0
+      continue-on-error: true
+      if: ${{ always() && steps.checks.outputs.check_id != '' }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        check_id: ${{ steps.checks.outputs.check_id }}
+        repo: ${{ github.repository }}
+        sha: ${{ env.SHA }}
+        conclusion: ${{ job.status }}
+        details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
## Problem

CI-taptests-pgsql-cluster has been failing on **every run** since at least July 24. It was the only test workflow still defined inline on v3.0, using `actions/cache/restore` with `fail-on-cache-miss: true`. GitHub made cache writes read-only for `workflow_run` triggers (changelog 2026-06-26), so CI-builds' `Cache save` steps silently no-op and the restore always fails at the first step.

## Fix

Adds the reusable callee (`ci-taptests-pgsql-cluster.yml`) following the same pattern as every other test workflow (ci-legacy-g3, ci-basictests, etc.):

- Artifact-based build handoff from CI-builds (`ci-builds-handoff-<sha>-ubuntu22-tap-{src,test}`) with bounded retry for artifact-index lag
- GHCR base-image pull with retry (replaces inline `docker build`)
- `pick-runner` self-hosted routing job
- `checks-action` reporting on the head SHA
- Preserves original test parameters: `TAP_GROUP=legacy-g3`, `TEST_PY_TAP_INCL=test_cluster_sync_pgsql-t`, `PROXYSQL_CLUSTER_NODES=2`

## Merge order

**This PR must merge before the companion v3.0 PR** that converts `CI-taptests-pgsql-cluster.yml` into a thin caller referencing `ci-taptests-pgsql-cluster.yml@GH-Actions`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated PostgreSQL cluster synchronization testing to CI.
  * Added support for both manually triggered and reusable test runs.
  * Improved test reliability with artifact validation, download retries, and infrastructure cleanup.
  * Added automatic collection and upload of diagnostic logs when tests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->