### PR TITLE
fix(ci): publish Codecov path fixes on default branch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,49 @@
+# Codecov server-side configuration for ProxySQL.
+#
+# ---------------------------------------------------------------------------
+# Coverage path alignment (the `fixes` block below)
+# ---------------------------------------------------------------------------
+# ProxySQL uploads coverage to Codecov from two independent pipelines that
+# historically disagreed on the *root* of every source path, which left the
+# daemon's lib/ coverage filed under a phantom folder Codecov could not align
+# to the git tree. Symptom: lib/MySQL_Monitor.cpp (and every other daemon-only
+# file) showing a flat 0% on https://app.codecov.io/gh/sysown/proxysql even
+# though the integration suite exercises it heavily.
+#
+# The two pipelines:
+#
+#   1. TAP integration groups (flags `tap-*`)
+#      test/infra/control/run-tests-isolated.bash rewrites every LCOV `SF:`
+#      path to a `proxysql/`-prefixed form (e.g. `proxysql/lib/MySQL_Monitor.cpp`).
+#      The prefix matches the CI checkout layout — the repo is checked out into
+#      a `proxysql/` subdirectory of the runner workspace, and codecov-cli's
+#      network-file listing is rooted one level above it — but it does NOT match
+#      the repository git tree, whose root holds lib/, src/, include/, test/.
+#
+#   2. Unit tests (flag `unit-tests`)
+#      test/infra/control/run-unit-tests-asan-coverage.bash captures with
+#      `lcov --capture --directory lib`, producing repo-root-relative paths
+#      (`lib/MySQL_Monitor.cpp`). A `--initial` baseline seeds every instrumented
+#      line at 0%, so files the unit tests never execute (the monitor thread,
+#      the admin handler, the session loop, ...) sit at 0% in this namespace.
+#
+# Because the TAP coverage landed under `proxysql/lib/...` and the unit-tests
+# baseline owned `lib/...`, the two never merged: browsing the canonical repo
+# path `lib/MySQL_Monitor.cpp` showed only the unit-tests 0% baseline, while the
+# real ~38% from the TAP daemon was orphaned (and ultimately dropped) under the
+# non-existent `proxysql/lib/` tree.
+#
+# `fixes` strips the `proxysql/` prefix from report paths during Codecov's
+# server-side processing, so the TAP namespace collapses onto the git-tree
+# paths (`proxysql/lib/MySQL_Monitor.cpp` -> `lib/MySQL_Monitor.cpp`) and merges
+# with the unit-tests sessions. Verified against a real `tap-legacy-g1` upload:
+# all 210 `SF:` paths resolve to an existing repo file after the strip, with
+# zero misses. The rule only matches paths beginning with `proxysql/`, so the
+# already-correct `unit-tests` paths (`lib/...`, `include/...`) are untouched.
+#
+# If the TAP pipeline is ever changed to emit repo-root-relative paths directly
+# (the cleaner long-term fix, which also needs the codecov-action `root_dir`
+# pointed at the checkout subdir in the reusable ci-*.yml workflows on the
+# GH-Actions branch), this rule becomes a harmless no-op and can be removed.
+fixes:
+  - "proxysql/::"


### PR DESCRIPTION
## Summary

- add the existing Codecov path-fix configuration to `master`, which Codecov currently uses as the project configuration branch
- normalize TAP uploads from `proxysql/lib/...` to repository-relative `lib/...` paths
- allow TAP daemon coverage to merge with the unit-test baseline

## Why

The CI upload jobs are succeeding, but Codecov still reports daemon files such as `lib/MySQL_Monitor.cpp` at 0%. The repository configuration currently exists only on `v3.0`, while the Codecov project API reports `master` as its configuration branch.

## Validation

- YAML parsing succeeds
- `git diff --check` succeeds
- follow-up coverage must confirm `lib/MySQL_Monitor.cpp` is no longer 0% after this PR is merged and a fresh upload runs

Related: #5958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved coverage report path handling so results from different test pipelines merge correctly.
  * Coverage reports now align with the repository structure instead of appearing under an invalid directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->