### PR TITLE
fix(coverage): align Codecov default branch with v3.0

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -45,5 +45,10 @@
 # (the cleaner long-term fix, which also needs the codecov-action `root_dir`
 # pointed at the checkout subdir in the reusable ci-*.yml workflows on the
 # GH-Actions branch), this rule becomes a harmless no-op and can be removed.
+codecov:
+  # GitHub's default branch is v3.0. Keep Codecov's repository YAML and
+  # dashboard branch aligned with the branch that owns this configuration.
+  branch: v3.0
+
 fixes:
   - "proxysql/::"


### PR DESCRIPTION
## Summary

- set Codecov's configured branch to `v3.0`
- preserve the existing `proxysql/::` path normalization rule

## Root cause evidence

- GitHub repository default branch is `v3.0`; `master` is stale and unrelated
- the TAP artifact contains hits for `proxysql/lib/MySQL_Monitor.cpp` (`LF 5768`, `LH 1874`)
- the Codecov uploader loads `v3.0`'s `codecov.yml`, but Codecov project metadata still reports `master` as its branch
- Codecov documents `codecov.branch` as the setting for changing its configured default branch

## Validation

- failing config contract reproduced before the change
- config contract passes after the change
- Codecov validator returns HTTP 200
- `git diff --check` passes

## Acceptance

After merge, a fresh full `v3.0` CI upload must show `lib/MySQL_Monitor.cpp` above 0%. CI success alone is not sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration to align with the v3.0 branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->