### PR TITLE
fix(coverage): emit repo-root LCOV paths so TAP merges with unit-tests

### DIFF
--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -198,6 +198,10 @@ jobs:
         # action silently falls back to legacy tokenless mode and the
         # upload fails.
         use_oidc: true
+        # Only the explicit LCOV file. Default plugins include gcov which
+        # auto-discovers leftover .gcno and pollutes the upload.
+        disable_search: true
+        plugins: noop
         fail_ci_if_error: false
         verbose: true
 

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -168,18 +168,25 @@ jobs:
         path: coverage/lcov.info
         if-no-files-found: warn
 
+    - name: Require non-empty coverage/lcov.info
+      # With disable_search + plugins:noop, a missing/empty LCOV would
+      # make the Codecov step a silent no-op while fail_ci_if_error:false
+      # keeps the job green. Fail here so coverage-generation regressions
+      # are visible; Codecov SaaS outages remain non-blocking below.
+      id: require-lcov
+      if: always()
+      run: test -s coverage/lcov.info
+
     - name: Upload coverage to Codecov
       # Send the same lcov.info we already archive as a workflow artifact
       # to Codecov so PRs get the "this PR changes coverage of touched
       # files from N% to M%" comment and main accumulates a historical
       # graph at https://app.codecov.io/gh/sysown/proxysql.
       #
-      # `if: always()` so coverage uploads regardless of whether the unit
-      # tests themselves passed; partial coverage is still useful for
-      # diagnosing why a PR went red. `fail_ci_if_error: false` so a
-      # transient Codecov outage never gates a green CI run on a
-      # third-party SaaS.
-      if: always()
+      # Upload when LCOV exists even if unit tests failed (partial coverage
+      # is still useful). Skip only when require-lcov failed. Codecov SaaS
+      # outages stay non-blocking via fail_ci_if_error: false.
+      if: always() && steps.require-lcov.outcome == 'success'
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: codecov.yml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,49 +1,36 @@
-# Codecov server-side configuration for ProxySQL.
+# Codecov configuration for ProxySQL.
 #
-# ---------------------------------------------------------------------------
-# Coverage path alignment (the `fixes` block below)
-# ---------------------------------------------------------------------------
-# ProxySQL uploads coverage to Codecov from two independent pipelines that
-# historically disagreed on the *root* of every source path, which left the
-# daemon's lib/ coverage filed under a phantom folder Codecov could not align
-# to the git tree. Symptom: lib/MySQL_Monitor.cpp (and every other daemon-only
-# file) showing a flat 0% on https://app.codecov.io/gh/sysown/proxysql even
-# though the integration suite exercises it heavily.
+# Path contract (both upload pipelines MUST emit the same shape):
 #
-# The two pipelines:
+#   TAP integration (flags tap-*)
+#     test/infra/control/run-tests-isolated.bash normalizes every LCOV SF:
+#     path to repo-root-relative form (lib/MySQL_Monitor.cpp, src/main.cpp,
+#     test/tap/..., include/...).
 #
-#   1. TAP integration groups (flags `tap-*`)
-#      test/infra/control/run-tests-isolated.bash rewrites every LCOV `SF:`
-#      path to a `proxysql/`-prefixed form (e.g. `proxysql/lib/MySQL_Monitor.cpp`).
-#      The prefix matches the CI checkout layout — the repo is checked out into
-#      a `proxysql/` subdirectory of the runner workspace, and codecov-cli's
-#      network-file listing is rooted one level above it — but it does NOT match
-#      the repository git tree, whose root holds lib/, src/, include/, test/.
+#   Unit tests (flag unit-tests)
+#     test/infra/control/run-unit-tests-asan-coverage.bash already emits
+#     repo-root-relative paths (lcov --directory lib).
 #
-#   2. Unit tests (flag `unit-tests`)
-#      test/infra/control/run-unit-tests-asan-coverage.bash captures with
-#      `lcov --capture --directory lib`, producing repo-root-relative paths
-#      (`lib/MySQL_Monitor.cpp`). A `--initial` baseline seeds every instrumented
-#      line at 0%, so files the unit tests never execute (the monitor thread,
-#      the admin handler, the session loop, ...) sit at 0% in this namespace.
+# Historically TAP prefixed paths with proxysql/ (matching the CI checkout
+# subdirectory). That created a phantom proxysql/ namespace on Codecov that
+# never merged with unit-tests lib/, so daemon-only files like
+# lib/MySQL_Monitor.cpp showed 0% despite thousands of real TAP hits.
+# The TAP sed rewrite and the GH-Actions codecov-action settings
+# (no network_prefix, disable_search, plugins:noop, root_dir:proxysql)
+# keep both pipelines on the git-tree path scheme.
 #
-# Because the TAP coverage landed under `proxysql/lib/...` and the unit-tests
-# baseline owned `lib/...`, the two never merged: browsing the canonical repo
-# path `lib/MySQL_Monitor.cpp` showed only the unit-tests 0% baseline, while the
-# real ~38% from the TAP daemon was orphaned (and ultimately dropped) under the
-# non-existent `proxysql/lib/` tree.
-#
-# `fixes` strips the `proxysql/` prefix from report paths during Codecov's
-# server-side processing, so the TAP namespace collapses onto the git-tree
-# paths (`proxysql/lib/MySQL_Monitor.cpp` -> `lib/MySQL_Monitor.cpp`) and merges
-# with the unit-tests sessions. Verified against a real `tap-legacy-g1` upload:
-# all 210 `SF:` paths resolve to an existing repo file after the strip, with
-# zero misses. The rule only matches paths beginning with `proxysql/`, so the
-# already-correct `unit-tests` paths (`lib/...`, `include/...`) are untouched.
-#
-# If the TAP pipeline is ever changed to emit repo-root-relative paths directly
-# (the cleaner long-term fix, which also needs the codecov-action `root_dir`
-# pointed at the checkout subdir in the reusable ci-*.yml workflows on the
-# GH-Actions branch), this rule becomes a harmless no-op and can be removed.
+# fixes: kept as a safety net for any leftover proxysql/-prefixed SF: lines
+# from older artifacts or partial rollouts. Becomes a no-op once every
+# producer emits repo-root paths.
+
+codecov:
+  # GitHub default branch is v3.0 (master is stale and has no codecov.yml).
+  branch: v3.0
+
 fixes:
   - "proxysql/::"
+
+# Vendored test dependencies (Boost, googletest, etc.) drown out daemon
+# coverage. Keep test/tap/** included -- those are first-party TAP sources.
+ignore:
+  - "test/deps/**"

--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -389,34 +389,25 @@ docker run \
                             if [ -f \"\${coverage_file}\" ]; then
                                 echo \">>> Coverage report generated: \${coverage_file}\"
 
-                                # Normalize SF: source-file paths in the LCOV report
-                                # so Codecov can resolve them against the runner workspace.
+                                # Normalize SF: paths to repo-root-relative form so TAP
+                                # coverage merges with unit-tests on Codecov.
                                 # fastcov emits a mix of:
-                                #   SF:/opt/proxysql/include/X.h    (absolute container path
-                                #                                     embedded in .gcno files)
-                                #   SF:lib/Y.cpp                    (relative to fastcov cwd
-                                #                                     = /opt/proxysql)
-                                #   SF:proxysql/src/Z.cpp           (already correct)
-                                # codecov-cli's network_root_folder is the runner's
-                                # /home/runner/work/proxysql/proxysql and the repo content
-                                # lives at <network_root>/proxysql/, so only paths shaped
-                                # as 'SF:proxysql/...' get resolved -- the other two forms
+                                #   SF:/opt/proxysql/include/X.h   (absolute container path)
+                                #   SF:/gcov/proxysql/lib/Y.cpp    (GCOV_PREFIX layout)
+                                #   SF:lib/Y.cpp                   (relative to /opt/proxysql)
+                                #   SF:proxysql/src/Z.cpp          (legacy prefixed form)
+                                # Unit-tests upload SF:lib/... (repo-root). Emitting the
+                                # same shape here is required: the old proxysql/ prefix
+                                # created a phantom namespace that never merged, leaving
+                                # lib/MySQL_Monitor.cpp at 0% despite real TAP hits.
                                 # NB to future editors: this whole script body is the
                                 # argument to an outer bash -c that is wrapped in
-                                # DOUBLE QUOTES. Inside those outer double quotes,
-                                # backticks still trigger command substitution and bare
-                                # double-quote characters terminate the argument early.
-                                # That means comments here must avoid backticks (use
-                                # apostrophes for inline code) and avoid any literal
-                                # double-quote character (use apostrophes, or escape
-                                # as backslash-double-quote like the script body does
-                                # for genuine strings).
-                                # are silently dropped server-side. On the previous green
-                                # run that meant Codecov stored 27 files / 5694 lines out
-                                # of the 84621 lines fastcov actually measured.
+                                # DOUBLE QUOTES. Comments must avoid backticks and bare
+                                # double-quote characters.
                                 sed -i \
-                                    -e 's|^SF:/opt/proxysql/|SF:proxysql/|' \
-                                    -e '/^SF:proxysql\\//!s|^SF:|SF:proxysql/|' \
+                                    -e 's|^SF:/opt/proxysql/|SF:|' \
+                                    -e 's|^SF:/gcov/proxysql/|SF:|' \
+                                    -e 's|^SF:proxysql/|SF:|' \
                                     \"\${coverage_file}\"
 
                                 if command -v genhtml >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

`lib/MySQL_Monitor.cpp` shows **0%** on Codecov despite real TAP coverage. Evidence from green `CI-legacy-g1` artifact on commit `8ca2df54`:

| Source | Path | Hits |
|--------|------|-----:|
| LCOV artifact | `proxysql/lib/MySQL_Monitor.cpp` | **1874** |
| Codecov API | `lib/MySQL_Monitor.cpp` | **0** |
| Codecov | `proxysql/lib/MySQL_Monitor.cpp` | missing |

TAP alone had **22,891 lib/ hits** in that one group; Codecov's entire `lib/` tree has only 10,647 (unit-tests only).

## Root cause

TAP LCOV used `SF:proxysql/lib/...`; unit-tests used `SF:lib/...`. Codecov never merged them. The unit-tests `--initial` baseline owns `lib/MySQL_Monitor.cpp` at 0% forever when TAP hits land in a phantom namespace.

## Fix (this PR — v3.0)

1. **`run-tests-isolated.bash`** — normalize `SF:` to repo-root:
   - strip `/opt/proxysql/`, `/gcov/proxysql/`, legacy `proxysql/`
   - emit `lib/MySQL_Monitor.cpp` (same as unit-tests)
2. **`codecov.yml`**
   - `codecov.branch: v3.0`
   - `ignore: test/deps/**` only (keeps **test/tap/**)
   - keep `fixes: proxysql/::` as safety net during rollout
3. **`CI-unit-tests-asan-coverage.yml`** — `disable_search` + `plugins: noop`

## Merge order

**Depends on GH-Actions companion PR** (removes `network_prefix`, adds uploader flags).

Merge **GH-Actions first**, then this. Merging this alone while uploaders still have `network_prefix: proxysql/` will drop TAP paths (report `lib/X` vs network `proxysql/lib/X`).

## Not sufficient alone

https://github.com/sysown/proxysql/pull/5965 only sets `codecov.branch: v3.0` and keeps `fixes:`. That does not fix path merge (live Codecov still has a `proxysql/` tree). This PR + the GH-Actions companion replace that approach.

## Acceptance

After both PRs merge and a full v3.0 CI cycle:

1. LCOV artifact: `SF:lib/MySQL_Monitor.cpp` (no `proxysql/` prefix)
2. Upload log: `Found 1 coverage files`
3. Codecov: no top-level `proxysql/` folder
4. `lib/MySQL_Monitor.cpp` coverage ≫ 0%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI code coverage handling by failing when the LCOV report is missing or empty.
  * Prevented coverage uploads when coverage generation fails, while keeping Codecov outages non-blocking.
  * Improved source path normalization so LCOV/fastcov `SF:` entries merge consistently across isolated test environments.
* **Chores**
  * Updated coverage configuration for Codecov v3 branch targeting and aligned uploaded source paths with repository layout.
  * Excluded vendored test dependencies from coverage calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->