### PR TITLE
fix(coverage): stop phantom proxysql/ namespace on TAP Codecov uploads

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -251,14 +251,23 @@ jobs:
         flags: tap-legacy-clickhouse-g1
         name: tap-legacy-clickhouse-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-legacy-g1
         name: tap-legacy-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -266,18 +266,23 @@ jobs:
         flags: tap-legacy-g2
         name: tap-legacy-g2-genai-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report to compute line-offset
-        # adjustments, and crashes with FileNotFoundError if any path
-        # is missing. fastcov runs inside the test container with
-        # cwd=/opt/proxysql and embeds paths like
-        # `proxysql/test/afl_digest_test/c_tokenizer.cpp` -- not all of
-        # those subdirs are restored on the runner (the _test cache
-        # prunes test deps to fit GitHub's 10 GB repo cache quota).
-        # disable_file_fixes:true skips the problematic step entirely.
-        # Trade-off: Codecov line-offset annotations on PR diffs may be
-        # less precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-legacy-g3
         name: tap-legacy-g3-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -318,14 +318,23 @@ jobs:
         flags: tap-legacy-g4
         name: tap-legacy-g4-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -315,14 +315,23 @@ jobs:
         flags: tap-legacy-g5
         name: tap-legacy-g5-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-legacy-g6
         name: tap-legacy-g6-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-legacy-g7
         name: tap-legacy-g7-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-legacy-g8
         name: tap-legacy-g8-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-legacy-g9
         name: tap-legacy-g9-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g1
         name: tap-mariadb10-galera-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g2
         name: tap-mariadb10-galera-g2-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g3
         name: tap-mariadb10-galera-g3-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g4
         name: tap-mariadb10-galera-g4-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -241,14 +241,23 @@ jobs:
         flags: tap-mariadb10-galera-g5
         name: tap-mariadb10-galera-g5-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g6
         name: tap-mariadb10-galera-g6-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g7
         name: tap-mariadb10-galera-g7-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g8
         name: tap-mariadb10-galera-g8-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mariadb10-galera-g9
         name: tap-mariadb10-galera-g9-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -256,14 +256,23 @@ jobs:
         flags: tap-mysql56-single-g1
         name: tap-mysql56-single-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-mysql84-g1
         name: tap-mysql84-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-mysql84-g2
         name: tap-mysql84-g2-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-mysql84-g3
         name: tap-mysql84-g3-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -317,14 +317,23 @@ jobs:
         flags: tap-mysql84-g4
         name: tap-mysql84-g4-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -248,14 +248,23 @@ jobs:
         flags: tap-mysql84-g5
         name: tap-mysql84-g5-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-mysql84-g6
         name: tap-mysql84-g6-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-mysql84-g7
         name: tap-mysql84-g7-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-mysql84-g8
         name: tap-mysql84-g8-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-mysql84-g9
         name: tap-mysql84-g9-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g1
         name: tap-mysql84-gr-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g2
         name: tap-mysql84-gr-g2-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g3
         name: tap-mysql84-gr-g3-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g4
         name: tap-mysql84-gr-g4-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -241,14 +241,23 @@ jobs:
         flags: tap-mysql84-gr-g5
         name: tap-mysql84-gr-g5-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g6
         name: tap-mysql84-gr-g6-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g7
         name: tap-mysql84-gr-g7-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g8
         name: tap-mysql84-gr-g8-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql84-gr-g9
         name: tap-mysql84-gr-g9-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql90-gr-g1
         name: tap-mysql90-gr-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql93-gr-g1
         name: tap-mysql93-gr-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -243,14 +243,23 @@ jobs:
         flags: tap-mysql95-gr-g1
         name: tap-mysql95-gr-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-pgsql-socket-g1
         name: tap-pgsql-socket-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -250,14 +250,23 @@ jobs:
         flags: tap-set_parser_algorithm_3-g1
         name: tap-set_parser_algorithm_3-g1-coverage
         use_oidc: true
-        network_prefix: proxysql/
-        # codecov-cli's _get_file_fixes step reads every source file
-        # referenced in the LCOV report and crashes with FileNotFoundError
-        # if any path is missing (the _test cache prunes test deps to fit
-        # GitHub's 10 GB repo cache quota, so not all subdirs are restored
-        # on the runner). disable_file_fixes:true skips that step. Trade-
-        # off: Codecov line-offset annotations on PR diffs may be less
-        # precise, but aggregate coverage numbers are unaffected.
+        # Upload ONLY the explicit LCOV .info file.
+        # - disable_search + plugins:noop: default plugins include gcov,
+        #   which auto-discovers leftover .gcno from the build handoff
+        #   (lib/obj/*.gcno) and polluted uploads ("Found 33 coverage
+        #   files" instead of 1).
+        # - no network_prefix: TAP LCOV SF: paths are repo-root-relative
+        #   (lib/, src/, test/tap/). network_prefix:proxysql/ created a
+        #   phantom proxysql/ namespace that never merged with unit-tests
+        #   lib/, leaving lib/MySQL_Monitor.cpp at 0% despite real hits.
+        # - root_dir:proxysql: checkout is at path:proxysql; point
+        #   codecov-cli network listing at the git root so lib/X matches.
+        # - disable_file_fixes:true: codecov-cli _get_file_fixes crashes
+        #   FileNotFoundError when sparse checkout lacks sources referenced
+        #   in the report. Aggregate coverage is unaffected.
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
         disable_file_fixes: true
         fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
## Problem

TAP coverage is collected correctly (legacy-g1 LCOV has **1874 hits** on `MySQL_Monitor.cpp`) but Codecov shows `lib/MySQL_Monitor.cpp` at **0%**. Live Codecov tree:

- `proxysql/test/`, `proxysql/src/` — TAP test/src only
- `lib/`, `include/` — unit-tests baseline (daemon-only files at 0%)
- **no `proxysql/lib/`** — TAP daemon hits discarded

## Root cause (uploader side)

1. `network_prefix: proxysql/` made the git network `proxysql/lib/...` while unit-tests own `lib/...` — disjoint namespaces
2. Default gcov plugin auto-discovered leftover `lib/obj/*.gcno` from the build handoff → "Found 33 coverage files" instead of 1
3. `fixes: proxysql/::` in codecov.yml never effectively collapsed the split

## Fix (this PR — GH-Actions)

All 43 TAP `codecov-action@v4` steps:

- **remove** `network_prefix: proxysql/`
- **add** `disable_search: true` + `plugins: noop`
- **add** `root_dir: proxysql` (checkout is at `path: proxysql`)
- keep `disable_file_fixes: true`

## Merge order

**Merge this PR first**, then the companion v3.0 PR (path sed + codecov.yml ignore).

| Order | If only this merges | Result |
|-------|---------------------|--------|
| GH-Actions only | LCOV still has `proxysql/lib/` prefix; `fixes:` strips it → `lib/` | Should work via fixes safety net |
| v3.0 only | LCOV is `lib/`; uploader still has `network_prefix` | **Breaks** — paths won't match network |

## Companion

v3.0 PR: normalizes LCOV `SF:` to repo-root paths + `ignore: test/deps/**` (keeps `test/tap/**`) + `codecov.branch: v3.0`.

## Acceptance

After both merge and a full v3.0 CI cycle:

1. Upload log: `Found 1 coverage files to report` (not 33)
2. Codecov: no top-level `proxysql/` folder
3. `lib/MySQL_Monitor.cpp` hits ≫ 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage report uploads across CI workflows by restricting uploads to the intended report and preventing unrelated artifacts from being included.
  * Corrected coverage source-path mapping so reports align with repository files.
  * Reduced coverage upload inconsistencies and path-related errors in reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->