### PR TITLE
fix(coverage): sparse-checkout lib/include/src so Codecov keeps daemon paths

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -65,7 +65,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -60,10 +60,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -58,7 +58,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -53,10 +53,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -119,7 +119,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -114,10 +114,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -52,7 +52,6 @@ jobs:
         # omits daemon sources, codecov-cli drops those SF: entries, and
         # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
-          codecov.yml
           include
           lib
           src

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -47,10 +47,17 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # include/lib/src required so Codecov can resolve LCOV SF: paths
+        # (repo-root lib/*.cpp, include/*). Without them sparse checkout
+        # omits daemon sources, codecov-cli drops those SF: entries, and
+        # Codecov shows only test/+src/ -- the regression after #5967.
         sparse-checkout: |
           codecov.yml
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff


### PR DESCRIPTION
## You were right — #5967/#5966 regressed Codecov

| Branch | Codecov tree |
|--------|----------------|
| `v3.0` | `lib/`, `include/`, `proxysql/test/`, `proxysql/src/` (lib mostly unit-tests 0%) |
| `fix/codecov-path-merge-v3.0` | **only** `src/` + `test/tap/` — **no lib/, no include/** |

### What actually worked

LCOV artifact from green `CI-legacy-g1` on the fix branch is **correct**:

- `SF:lib/MySQL_Monitor.cpp` present
- **22,895 lib hits** (same as before)
- no `proxysql/` prefix

So path normalization (#5966) is fine. **Codecov dropped lib/include at upload match time.**

### Root cause

Reusable TAP workflows sparse-checkout was only:

```yaml
codecov.yml
test/infra
test/tap/groups
test/scripts
```

Build handoff unpacks `src/` + `test/` (+ `lib/obj/*.gcno`), but **not** `lib/*.cpp` or `include/*`.

With `root_dir: proxysql` (#5967), codecov-cli resolves LCOV `SF:` paths against the runner tree. Paths without sources on disk are dropped:

| SF path | On runner? | Result |
|---------|------------|--------|
| `lib/MySQL_Monitor.cpp` | no | **dropped** |
| `include/...` | no | **dropped** |
| `src/main.cpp` | yes (handoff) | kept |
| `test/tap/...` | yes (handoff) | kept |

Before, unit-tests at least published `lib/` (often at 0%). On the fix branch unit-tests hadn’t uploaded yet either → **empty lib/**.

## Fix

Expand sparse-checkout on all 43 TAP codecov workflows:

```yaml
codecov.yml
include
lib
src
test/infra
test/tap
test/scripts
```

## Merge order

1. **Merge this PR** (GH-Actions)
2. Re-run / wait for CI on https://github.com/sysown/proxysql/pull/5966
3. Accept only when Codecov for that commit shows `lib/` with Monitor hits ≫ 0

## Acceptance

```text
Codecov tree has: lib/, include/, src/, test/tap/
lib/MySQL_Monitor.cpp coverage > 0%
LCOV still has SF:lib/MySQL_Monitor.cpp (unchanged)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage reporting by updating CI sparse checkouts to include the full set of repository source paths needed for accurate Codecov LCOV “SF” source mapping.
  * Expanded CI test coverage input selection by switching from narrower TAP subsets to the broader TAP directory, ensuring library/header/daemon sources are available for coverage attribution across supported CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->