### PR TITLE
ci(coverage): define Codecov flags by test binary class

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@
 #
 # Path contract (both upload pipelines MUST emit the same shape):
 #
-#   TAP integration (flags tap-*)
+#   TAP integration (flag integration-tests)
 #     test/infra/control/run-tests-isolated.bash normalizes every LCOV SF:
 #     path to repo-root-relative form (lib/MySQL_Monitor.cpp, src/main.cpp,
 #     test/tap/..., include/...).
@@ -34,3 +34,16 @@ fixes:
 # coverage. Keep test/tap/** included -- those are first-party TAP sources.
 ignore:
   - "test/deps/**"
+
+# Flags represent test/binary classes, not individual matrix shards. All TAP
+# groups exercise the same regular ProxySQL daemon and therefore merge under
+# integration-tests. The ASAN unit-test and cluster-simulator binaries use
+# different build flags and remain separate. Keep carryforward disabled:
+# manually dispatched single TAP groups must not appear as complete coverage.
+flags:
+  unit-tests:
+    carryforward: false
+  integration-tests:
+    carryforward: false
+  simulation-tests:
+    carryforward: false


### PR DESCRIPTION
## Goal

Use Codecov flags for test/binary classes instead of one flag per TAP matrix shard.

| Flag | Binary / report class |
| --- | --- |
| `unit-tests` | ASAN/GCOV unit-test binary |
| `integration-tests` | regular ProxySQL daemon, all TAP groups |
| `simulation-tests` | future cluster-simulator binary with distinct build flags |

## Configuration

Adds the three flags to `codecov.yml` with `carryforward: false`. A manually dispatched single TAP group must not be represented as complete integration coverage.

## Dependency

Depends on the GH-Actions companion PR that changes all current `tap-*` uploads to `integration-tests` and repairs the Codecov config-path warning.

The uploads keep unique group-specific `name:` values for diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage reporting configuration to separate unit, integration, and simulation test results.
  * Improved coverage handling for integration tests and prevented incomplete single-group runs from being treated as full coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->