### PR TITLE
ci(coverage): use integration-tests flag for all regular-daemon TAP uploads

### DIFF
--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -239,8 +239,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-clickhouse-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -251,10 +252,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
-        flags: tap-legacy-clickhouse-g1
+        flags: integration-tests
         name: tap-legacy-clickhouse-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
-        flags: tap-legacy-g1
+        flags: integration-tests
         name: tap-legacy-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -253,8 +253,9 @@ jobs:
       # production code paths exercised by integration tests, not just the
       # lib-only unit-test slice that CI-unit-tests-asan-coverage uploads.
       #
-      # `flags: tap-legacy-g2` lets Codecov merge per-group uploads and
-      # later show per-flag coverage trends. `use_oidc: true` is mandatory
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory
       # -- the repo has no CODECOV_TOKEN secret and Codecov rejects
       # tokenless legacy uploads with "branch is protected" HTTP 400 (see
       # the Phase 1 commit history on CI-unit-tests-asan-coverage.yml).
@@ -266,10 +267,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/ci-legacy-g2-genai.info
-        flags: tap-legacy-g2
+        flags: integration-tests
         name: tap-legacy-g2-genai-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g3` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
-        flags: tap-legacy-g3
+        flags: integration-tests
         name: tap-legacy-g3-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -306,8 +306,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g4` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -318,10 +319,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
-        flags: tap-legacy-g4
+        flags: integration-tests
         name: tap-legacy-g4-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -303,8 +303,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g5` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -315,10 +316,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
-        flags: tap-legacy-g5
+        flags: integration-tests
         name: tap-legacy-g5-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g6` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
-        flags: tap-legacy-g6
+        flags: integration-tests
         name: tap-legacy-g6-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g7` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
-        flags: tap-legacy-g7
+        flags: integration-tests
         name: tap-legacy-g7-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g8` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
-        flags: tap-legacy-g8
+        flags: integration-tests
         name: tap-legacy-g8-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-legacy-g9` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
-        flags: tap-legacy-g9
+        flags: integration-tests
         name: tap-legacy-g9-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
-        flags: tap-mariadb10-galera-g1
+        flags: integration-tests
         name: tap-mariadb10-galera-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g2` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
-        flags: tap-mariadb10-galera-g2
+        flags: integration-tests
         name: tap-mariadb10-galera-g2-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g3` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
-        flags: tap-mariadb10-galera-g3
+        flags: integration-tests
         name: tap-mariadb10-galera-g3-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g4` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
-        flags: tap-mariadb10-galera-g4
+        flags: integration-tests
         name: tap-mariadb10-galera-g4-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -229,8 +229,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g5` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -241,10 +242,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
-        flags: tap-mariadb10-galera-g5
+        flags: integration-tests
         name: tap-mariadb10-galera-g5-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g6` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
-        flags: tap-mariadb10-galera-g6
+        flags: integration-tests
         name: tap-mariadb10-galera-g6-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g7` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
-        flags: tap-mariadb10-galera-g7
+        flags: integration-tests
         name: tap-mariadb10-galera-g7-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g8` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
-        flags: tap-mariadb10-galera-g8
+        flags: integration-tests
         name: tap-mariadb10-galera-g8-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mariadb10-galera-g9` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
-        flags: tap-mariadb10-galera-g9
+        flags: integration-tests
         name: tap-mariadb10-galera-g9-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -244,8 +244,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql56-single-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -256,10 +257,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
-        flags: tap-mysql56-single-g1
+        flags: integration-tests
         name: tap-mysql56-single-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
-        flags: tap-mysql84-g1
+        flags: integration-tests
         name: tap-mysql84-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g2` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
-        flags: tap-mysql84-g2
+        flags: integration-tests
         name: tap-mysql84-g2-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g3` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
-        flags: tap-mysql84-g3
+        flags: integration-tests
         name: tap-mysql84-g3-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -305,8 +305,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g4` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -317,10 +318,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
-        flags: tap-mysql84-g4
+        flags: integration-tests
         name: tap-mysql84-g4-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -236,8 +236,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g5` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -248,10 +249,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
-        flags: tap-mysql84-g5
+        flags: integration-tests
         name: tap-mysql84-g5-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g6` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
-        flags: tap-mysql84-g6
+        flags: integration-tests
         name: tap-mysql84-g6-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g7` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
-        flags: tap-mysql84-g7
+        flags: integration-tests
         name: tap-mysql84-g7-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g8` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
-        flags: tap-mysql84-g8
+        flags: integration-tests
         name: tap-mysql84-g8-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-g9` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
-        flags: tap-mysql84-g9
+        flags: integration-tests
         name: tap-mysql84-g9-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
-        flags: tap-mysql84-gr-g1
+        flags: integration-tests
         name: tap-mysql84-gr-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g2` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
-        flags: tap-mysql84-gr-g2
+        flags: integration-tests
         name: tap-mysql84-gr-g2-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g3` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
-        flags: tap-mysql84-gr-g3
+        flags: integration-tests
         name: tap-mysql84-gr-g3-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g4` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
-        flags: tap-mysql84-gr-g4
+        flags: integration-tests
         name: tap-mysql84-gr-g4-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -229,8 +229,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g5` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -241,10 +242,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
-        flags: tap-mysql84-gr-g5
+        flags: integration-tests
         name: tap-mysql84-gr-g5-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g6` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
-        flags: tap-mysql84-gr-g6
+        flags: integration-tests
         name: tap-mysql84-gr-g6-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g7` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
-        flags: tap-mysql84-gr-g7
+        flags: integration-tests
         name: tap-mysql84-gr-g7-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g8` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
-        flags: tap-mysql84-gr-g8
+        flags: integration-tests
         name: tap-mysql84-gr-g8-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql84-gr-g9` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
-        flags: tap-mysql84-gr-g9
+        flags: integration-tests
         name: tap-mysql84-gr-g9-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql90-gr-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/ci-mysql90-gr-g1.info
-        flags: tap-mysql90-gr-g1
+        flags: integration-tests
         name: tap-mysql90-gr-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql93-gr-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/ci-mysql93-gr-g1.info
-        flags: tap-mysql93-gr-g1
+        flags: integration-tests
         name: tap-mysql93-gr-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -231,8 +231,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-mysql95-gr-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -243,10 +244,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/ci-mysql95-gr-g1.info
-        flags: tap-mysql95-gr-g1
+        flags: integration-tests
         name: tap-mysql95-gr-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-pgsql-socket-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
-        flags: tap-pgsql-socket-g1
+        flags: integration-tests
         name: tap-pgsql-socket-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -238,8 +238,9 @@ jobs:
       # suite, so the report reflects production code paths exercised by
       # integration tests, not just the lib-only unit-test slice.
       #
-      # `flags: tap-set_parser_algorithm_3-g1` lets Codecov merge per-group uploads and show
-      # per-flag coverage trends. `use_oidc: true` is mandatory -- the
+      # integration-tests merges regular-daemon TAP shards for this commit.
+      # The group-specific name remains available for diagnostics.
+      # `use_oidc: true` is mandatory -- the
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
@@ -250,10 +251,10 @@ jobs:
       if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
-        codecov_yml_path: proxysql/codecov.yml
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
-        flags: tap-set_parser_algorithm_3-g1
+        flags: integration-tests
         name: tap-set_parser_algorithm_3-g1-coverage
         use_oidc: true
         # Upload ONLY the explicit LCOV .info file.


### PR DESCRIPTION
## Summary

Replace 43 per-shard `tap-*` flags with a single shared `integration-tests` flag. All TAP groups exercise the same regular ProxySQL daemon, so their reports merge under one flag on Codecov.

| Flag | Binary class |
|------|-------------|
| `unit-tests` | ASAN/GCOV unit-test binary |
| `integration-tests` | regular ProxySQL daemon (all TAP groups) |
| `simulation-tests` | future cluster-simulator binary |

## Changes

- `flags: tap-<group>` → `flags: integration-tests` in all 43 TAP workflows
- `codecov_yml_path` → absolute `${{ github.workspace }}/proxysql/codecov.yml` (fixes the "config not found" warning from the successful #5968 rerun)
- Group-specific `name:` values retained for upload diagnostics

## Dependency

**Depends on https://github.com/sysown/proxysql/pull/5971** (v3.0) which defines the three flags in `codecov.yml`.

## Merge order

Merge #5971 first (defines flags), then this PR (uses them).

## Validation

- All 43 workflows pass YAML validation
- No stale `tap-*` flag references remain
- Exactly one `flags: integration-tests` per codecov upload block
- Absolute `codecov_yml_path` in every block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI coverage reporting by consistently grouping integration-test coverage uploads.
  * Updated coverage configuration path resolution to ensure Codecov reliably locates its configuration.
  * Preserved existing coverage artifacts and commit association behavior across test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->