### PR TITLE
fix(packaging): remove runtime protobuf installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -519,9 +519,12 @@ binaries/proxysql%:
 	${MAKE} cleanbuild
 	${MAKE} cleantest
 	find . -not -path "./binaries/*" -not -path "./.git/*" | xargs touch -h --date=@${SOURCE_DATE_EPOCH}
-	@docker compose -p "$(COMPOSE_PROJECT)" down -v --remove-orphans
-	@docker compose -p "$(COMPOSE_PROJECT)" up $(IMG_NAME)$(IMG_TYPE)$(IMG_COMP)_build
-	@docker compose -p "$(COMPOSE_PROJECT)" down -v --remove-orphans
+	@set -e; \
+		docker compose -p "$(COMPOSE_PROJECT)" down -v --remove-orphans; \
+		trap 'docker compose -p "$(COMPOSE_PROJECT)" down -v --remove-orphans' EXIT; \
+		docker compose -p "$(COMPOSE_PROJECT)" up --abort-on-container-exit \
+			--exit-code-from "$(IMG_NAME)$(IMG_TYPE)$(IMG_COMP)_build" \
+			"$(IMG_NAME)$(IMG_TYPE)$(IMG_COMP)_build"
 
 
 ### clean targets

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -41,22 +41,6 @@ else
 	build_target="$PROXYSQL_BUILD_TYPE"
 fi
 
-# The v4.0 chassis tier (PROXYSQL40=1) builds plugins/mysqlx/ which
-# dynamically links against the system libprotobuf (3.x). Some of the
-# v4.0.0 packaging images were built before plugins/mysqlx existed and
-# do not yet ship libprotobuf-dev. Install it on demand here so the
-# plugin's pkg-config check succeeds.  The install is idempotent —
-# apt-get returns 0 if the package is already present.  PROXYSQL40=1
-# builds and packages all v4.0 plugins — there is no separate
-# PROXYSQLGENAI flag.
-if [[ "${PROXYSQL40:-}" == "1" ]]; then
-    if ! pkg-config --exists protobuf 2>/dev/null; then
-        echo "==> Installing libprotobuf-dev (required for the mysqlx plugin build under PROXYSQL40)"
-        apt-get update -qq
-        apt-get install -y --no-install-recommends libprotobuf-dev
-    fi
-fi
-
 # clean is expensive, do it before, outside of container
 #${MAKE} cleanbuild
 #

--- a/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
@@ -41,26 +41,6 @@ else
 	build_target="$PROXYSQL_BUILD_TYPE"
 fi
 
-# The v4.0 chassis tier (PROXYSQL40=1) builds plugins/mysqlx/ which
-# dynamically links against the system libprotobuf (3.x). Some of the
-# v4.0.0 packaging images were built before plugins/mysqlx existed and
-# do not yet ship protobuf-devel. Install it on demand for RHEL-family
-# images.  PROXYSQL40=1 builds and packages all v4.0 plugins — there
-# is no separate PROXYSQLGENAI flag.
-if [[ "${PROXYSQL40:-}" == "1" ]]; then
-    if ! pkg-config --exists protobuf 2>/dev/null; then
-        echo "==> Installing protobuf-devel (required for PROXYSQL40=1 mysqlx plugin build)"
-        if command -v dnf >/dev/null 2>&1; then
-            dnf install -y protobuf-devel
-        elif command -v yum >/dev/null 2>&1; then
-            yum install -y protobuf-devel
-        else
-            echo "ERROR: cannot install protobuf-devel (neither dnf nor yum present)" >&2
-            exit 1
-        fi
-    fi
-fi
-
 # clean is expensive, do it before, outside of container
 #${MAKE} cleanbuild
 # PROXYSQL40=1 enables the plugin chassis tier; all v4.0 plugins

--- a/docker/images/proxysql/suse-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/suse-compliant/entrypoint/entrypoint.bash
@@ -41,24 +41,6 @@ else
 	build_target="$PROXYSQL_BUILD_TYPE"
 fi
 
-# The v4.0 chassis tier (PROXYSQL40=1) builds plugins/mysqlx/ which
-# dynamically links against the system libprotobuf (3.x). Some of the
-# v4.0.0 packaging images were built before plugins/mysqlx existed and
-# do not yet ship protobuf-devel. Install it on demand for SUSE-family
-# images.  PROXYSQL40=1 builds and packages all v4.0 plugins — there
-# is no separate PROXYSQLGENAI flag.
-if [[ "${PROXYSQL40:-}" == "1" ]]; then
-    if ! pkg-config --exists protobuf 2>/dev/null && ! pkg-config --exists libprotobuf-c 2>/dev/null; then
-        echo "==> Installing protobuf-devel (required for PROXYSQL40=1 mysqlx plugin build)"
-        if command -v zypper >/dev/null 2>&1; then
-            zypper install -y libprotobuf-c-devel || zypper install -y protobuf-devel
-        else
-            echo "ERROR: cannot install protobuf-devel (zypper not present)" >&2
-            exit 1
-        fi
-    fi
-fi
-
 # clean is expensive, do it before, outside of container
 #${MAKE} cleanbuild
 # PROXYSQL40=1 enables the plugin chassis tier; all v4.0 plugins

--- a/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
@@ -29,31 +29,6 @@ EXTRA=""
 [[ "${PROXYSQL40:-}" == "1" ]] && EXTRA="${EXTRA} PROXYSQL40=1"
 [[ "${PROXYSQL31:-}" == "1" ]] && EXTRA="${EXTRA} PROXYSQL31=1"
 
-# The v4.0 chassis tier builds plugins/mysqlx/ which dynamically links the
-# system libprotobuf (3.x). Some v4.0.0 packaging images predate the plugin
-# and do not ship protobuf-devel; install it on demand for RHEL-family.
-# protobuf-devel lives in the CRB repo on AlmaLinux/RHEL 9 (PowerTools on
-# EL8), which is disabled by default, so try enabling those before a plain
-# install.
-if [[ "${PROXYSQL40:-}" == "1" ]] && ! pkg-config --exists protobuf 2>/dev/null; then
-    echo "==> Installing protobuf-devel (required for PROXYSQL40=1 mysqlx plugin build)"
-    if command -v dnf >/dev/null 2>&1; then
-        dnf install -y --enablerepo=crb protobuf-devel \
-            || dnf install -y --enablerepo=powertools protobuf-devel \
-            || dnf install -y protobuf-devel
-    elif command -v yum >/dev/null 2>&1; then
-        yum install -y --enablerepo=powertools protobuf-devel \
-            || yum install -y protobuf-devel
-    else
-        echo "ERROR: cannot install protobuf-devel (neither dnf nor yum present)" >&2
-        exit 1
-    fi
-    if ! pkg-config --exists protobuf 2>/dev/null; then
-        echo "ERROR: protobuf-devel install did not provide a usable protobuf pkg-config" >&2
-        exit 1
-    fi
-fi
-
 deps_target="build_deps_clickhouse"
 build_target="clickhouse"
 


### PR DESCRIPTION
## Summary
- remove on-demand system Protobuf installation from DEB, RHEL, SUSE, and tarball package entrypoints
- rely on the vendored Protobuf build used by the MySQLX plugin
- propagate package-container failures through Docker Compose while preserving cleanup

## Root cause
RHEL-family GenAI package builds tried to install unavailable `protobuf-devel` during packaging. The container failure was masked, then reported as an empty artifact upload.

## Validation
- confirmed package entrypoints contain no dynamic Protobuf package installation
- verified all edited entrypoints with `bash -n`
- verified Makefile includes `--abort-on-container-exit` and `--exit-code-from`
- local full package build is blocked before Docker by macOS BSD `touch` lacking GNU `--date`; GitHub Actions is required for end-to-end Linux validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build cleanup and failure handling so container-based builds reliably stop, remove temporary resources, and report the build container’s status.
  - Prevented misleading successful build results when a build container exits with an error.

- **Chores**
  - Removed automatic protobuf development-package installation from supported packaging environments. Builds now rely on required protobuf dependencies being available before packaging begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->