### PR TITLE
ci: pin MySQLX Connector/Python baseline

### DIFF
--- a/test/infra/docker-base/Dockerfile
+++ b/test/infra/docker-base/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+ARG MYSQL_CONNECTOR_PYTHON_VERSION=9.7.0
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && \
@@ -28,7 +30,9 @@ RUN apt-get update -qq && \
     php-cli \
     php-mysql \
     lcov \
-    && pip3 install --break-system-packages fastcov mysql-connector-python mysqlx-connector-python \
+    && pip3 install --break-system-packages fastcov \
+        "mysql-connector-python==${MYSQL_CONNECTOR_PYTHON_VERSION}" \
+        "mysqlx-connector-python==${MYSQL_CONNECTOR_PYTHON_VERSION}" \
     && wget https://github.com/openark/orchestrator/releases/download/v3.2.6/orchestrator-client_3.2.6_amd64.deb -O /tmp/orc.deb \
     && apt-get install -y /tmp/orc.deb \
     && rm -rf /var/lib/apt/lists/* /tmp/orc.deb

--- a/test/infra/docker-base/test-connector-version-pins.bash
+++ b/test/infra/docker-base/test-connector-version-pins.bash
@@ -11,7 +11,8 @@ fi
 
 for package in mysql-connector-python mysqlx-connector-python; do
     expected_pin="${package}==\${MYSQL_CONNECTOR_PYTHON_VERSION}"
-    if ! rg -Fq -- "$expected_pin" "$dockerfile_path"; then
+    expected_dependency="\"${expected_pin}\" \\"
+    if ! rg -Fq -- "$expected_dependency" "$dockerfile_path"; then
         echo "ERROR: missing package pin: $expected_pin" >&2
         exit 1
     fi

--- a/test/infra/docker-base/test-connector-version-pins.bash
+++ b/test/infra/docker-base/test-connector-version-pins.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dockerfile_path="${1:-$(dirname "$0")/Dockerfile}"
+
+expected_arg='ARG MYSQL_CONNECTOR_PYTHON_VERSION=9.7.0'
+if ! rg -Fqx -- "$expected_arg" "$dockerfile_path"; then
+    echo "ERROR: missing Dockerfile argument: $expected_arg" >&2
+    exit 1
+fi
+
+for package in mysql-connector-python mysqlx-connector-python; do
+    expected_pin="${package}==\${MYSQL_CONNECTOR_PYTHON_VERSION}"
+    if ! rg -Fq -- "$expected_pin" "$dockerfile_path"; then
+        echo "ERROR: missing package pin: $expected_pin" >&2
+        exit 1
+    fi
+done
+
+echo "PASS: MySQLX Connector/Python version pins are present"


### PR DESCRIPTION
## What changed

Pins `mysql-connector-python` and `mysqlx-connector-python` in the CI base image to the reproducible `9.7.0` baseline. Adds a focused static regression test that enforces the Docker build argument and both package pins.

## Why

The MySQLX soak image previously installed both packages without versions, allowing dependency resolution to change CI behavior without a source change. This is the first delivery step for #5960.

## Validation

- Static Dockerfile contract test passes.
- Clean no-cache Docker build passed using host networking because the local Docker bridge has a DNS issue.
- Runtime package-metadata assertion reports `9.7.0` for both distributions.
- Separate specification-compliance and code-quality reviews passed.

## Follow-up

After this lands on `v3.0`, the GH-Actions reusable workflow will run the MySQLX soak suite as separate ordinary checks with Connector/Python `9.7.0` and `26.7.0`. The compatibility leg will remain unmasked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned MySQL Connector/Python packages to version 9.7.0 for consistent and reproducible build environments.
  * Prevented unexpected package version changes during installation by applying the same explicit version to both connector packages.

* **Tests**
  * Added automated validation to confirm the configured connector version is 9.7.0.
  * Verified that both MySQL connector packages use the defined version pin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->