### PR TITLE
test: tolerate one-second query digest timestamp jitter

### DIFF
--- a/test/tap/tests/test_purge_query_digest-t.cpp
+++ b/test/tap/tests/test_purge_query_digest-t.cpp
@@ -26,6 +26,7 @@
 
 #include <unistd.h>
 #include <string.h>
+#include <cstdlib>
 #include <atomic>
 #include <string>
 #include <thread>
@@ -282,11 +283,14 @@ int main(int argc, char** argv) {
 	);
 
 	digest_row b0_after = get_digest_row(admin, "SELECT ? AS batch_b_0");
+	// first_seen and last_seen are converted from monotonic timestamps to epoch
+	// seconds on every read, so consecutive reads may differ by one second due
+	// to whole-second clock conversion.
 	ok(
 		b0_before.valid && b0_after.valid &&
 		b0_before.count_star == b0_after.count_star &&
-		b0_before.first_seen == b0_after.first_seen &&
-		b0_before.last_seen == b0_after.last_seen &&
+		std::abs(b0_before.first_seen - b0_after.first_seen) <= 1 &&
+		std::abs(b0_before.last_seen - b0_after.last_seen) <= 1 &&
 		b0_before.sum_time == b0_after.sum_time,
 		"Surviving digest stats must not be altered by purges.\n"
 		"    count_star -> before:%lld after:%lld\n"


### PR DESCRIPTION
## Summary

- allow a one-second difference in `first_seen` and `last_seen` when validating a no-op query-digest purge
- keep `count_star` and `sum_time` exact

## Root cause

Query-digest timestamps are stored using the monotonic clock and converted to whole-second epoch timestamps on each stats read. Consecutive reads can therefore differ by one second without the purge modifying the surviving digest.

## Validation

- `git diff --check`
- C++ syntax check for `test_purge_query_digest-t.cpp`
- focused test compilation using the existing repository build artifacts
- full TAP execution was not run because the fresh worktree lacks the CI-only vendored dependencies required to build the test harness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated purge-preservation test tolerances to accommodate up to one second of variation in timestamp values.
  * Retained exact validation for counts and total time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->