### PR TITLE
ci: matrix MySQLX soak Connector/Python versions

### DIFF
--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -508,6 +508,10 @@ jobs:
   soak-tests:
     runs-on: ubuntu-22.04
     needs: unit-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        connector_version: ['9.7.0', '26.7.0']
     permissions: write-all
     steps:
       - uses: LouisBrunner/checks-action@v2.0.0
@@ -515,7 +519,7 @@ jobs:
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: '${{ github.workflow }} / ${{ github.job }}'
+          name: '${{ github.workflow }} / ${{ github.job }} (Connector/Python ${{ matrix.connector_version }})'
           repo: ${{ github.repository }}
           sha: ${{ env.SHA }}
           status: 'in_progress'
@@ -531,6 +535,9 @@ jobs:
             test/infra
             test/tap/groups
             test/scripts
+
+      - name: Verify Connector/Python Dockerfile pins
+        run: proxysql/test/infra/docker-base/test-connector-version-pins.bash
 
       - name: Download build handoff
         # Build payload arrives as workflow artifacts, not an Actions cache:
@@ -628,9 +635,26 @@ jobs:
         # from test/infra/docker-base. Includes mysqlx-connector-python
         # so the soak harness scripts (behavioral_validation.py,
         # stress.py) can run inside the test-runner container.
+        env:
+          MYSQLX_SOAK_IMAGE: proxysql-ci-base:mysqlx-connector-${{ matrix.connector_version }}
         run: |
           cd proxysql/test/infra/docker-base
-          docker build -t proxysql-ci-base:latest .
+          docker build \
+            --build-arg MYSQL_CONNECTOR_PYTHON_VERSION=${{ matrix.connector_version }} \
+            -t "$MYSQLX_SOAK_IMAGE" \
+            -t proxysql-ci-base:latest \
+            .
+          docker run --rm -i "$MYSQLX_SOAK_IMAGE" python3 - "${{ matrix.connector_version }}" <<'PY'
+          from importlib.metadata import version
+          import sys
+
+          expected = sys.argv[1]
+          packages = ("mysql-connector-python", "mysqlx-connector-python")
+          actual = {package: version(package) for package in packages}
+          print(actual)
+          if any(found != expected for found in actual.values()):
+              raise SystemExit(f"expected {expected}, got {actual}")
+          PY
 
       - name: Start infrastructure
         run: |
@@ -673,7 +697,7 @@ jobs:
         if: ${{ failure() && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.workflow }}-${{ env.SHA }}-${{ github.job }}-run#${{ github.run_number }}
+          name: ${{ github.workflow }}-${{ env.SHA }}-${{ github.job }}-connector-${{ matrix.connector_version }}-run#${{ github.run_number }}
           path: |
             proxysql/ci_*_logs/
 


### PR DESCRIPTION
## Dependency

**#5980 must be merged before this PR.** The matrix checks out the triggering `v3.0` source SHA, which needs #5980's Docker build argument and static pin-contract test.

## What changed

Runs `soak-tests` as two ordinary, separately reported matrix checks using Connector/Python `9.7.0` and `26.7.0`. Each leg builds and validates both pinned distributions before starting the existing isolation harness.

## CI behavior

- Both legs remain normal red/green checks; no failure masking is added.
- Custom check names and failure artifacts include the Connector/Python version.
- Each matrix runner tags its selected image and the existing `proxysql-ci-base:latest` compatibility alias.

## Validation

- Seven-point workflow requirement probe passes.
- `git diff --check` passes.
- Matrix workflow code passed independent specification and code-quality reviews.
- `actionlint` reports only pre-existing shellcheck warnings elsewhere in the workflow; no new matrix-region findings.

This draft PR is ready for review but must remain unmerged until #5980 is on `v3.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded soak-test coverage across multiple Connector/Python versions.
  * Added validation to confirm container images use the expected connector versions.
  * Improved check and failure-artifact labeling to make test results easier to identify.

* **Chores**
  * Updated continuous integration image builds to support version-specific testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->