### PR TITLE
fix(admin): restrict CACHING_SHA2_PASSWORD() salt to a credential-safe alphabet

### DIFF
--- a/deps/sqlite3/sqlite3_pass_exts.patch
+++ b/deps/sqlite3/sqlite3_pass_exts.patch
@@ -1,6 +1,6 @@
 --- sqlite3.c	2024-03-22 19:22:47.046093173 +0100
 +++ sqlite3-pass-exts.c	2024-03-22 19:24:09.557303716 +0100
-@@ -26275,6 +26275,207 @@
+@@ -26275,6 +26275,228 @@
    sqlite3ResultStrAccum(context, &sRes);
  }
  
@@ -171,14 +171,35 @@
 +			sqlite3_result_text(context, err_msg, -1, SQLITE_TRANSIENT);
 +			return;
 +		} else {
++			/* Map each random byte onto a 64-character alphabet that is safe to embed
++			 * in ProxySQL's credential strings.
++			 *
++			 * The previous scheme (mask with 0x7f, then bump only '\0' and '$') left
++			 * roughly 26% of generated salts containing ';' or ':'. Those are the
++			 * separators used by 'admin-admin_credentials' and
++			 * 'admin-stats_credentials', so such a hash is silently split into a bogus
++			 * credential by ProxySQL_Admin::add_credentials() at
++			 * 'LOAD ADMIN VARIABLES TO RUNTIME' -- the variable still reports all 70
++			 * bytes and nothing errors, but the login then fails with a generic
++			 * 'Access denied'. It also emitted control bytes ~99% of the time, making
++			 * the hashes unreadable and unsafe to paste into a configuration file.
++			 *
++			 * 64 divides 256 evenly, so masking with 0x3f introduces no modulo bias.
++			 * 20 characters over a 64-symbol alphabet still carry 120 bits of salt
++			 * entropy.
++			 *
++			 * This is a generation-side change only. Verification
++			 * (MySQL_Protocol.cpp: PPHR_verify_sha2 / PPHR_sha2full) reads the salt
++			 * back out with substr(7,20) and passes it straight to sha256_crypt_r
++			 * without inspecting its contents, so hashes generated before this change
++			 * keep verifying unchanged and no migration is required.
++			 */
++			static const char SALT_ALPHABET[] =
++				"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 +			unsigned int i = 0;
 +
-+			for (i = 0; i < sizeof(salt_buf)/sizeof(unsigned char); i++) {
-+				salt_buf[i] = salt_buf[i] & 0x7f;
-+
-+				if (salt_buf[i] == '\0' || salt_buf[i] == '$') {
-+					salt_buf[i] = salt_buf[i] + 1;
-+				}
++			for (i = 0; i < DEF_SALT_SIZE; i++) {
++				salt_buf[i] = (unsigned char)SALT_ALPHABET[salt_buf[i] & 0x3f];
 +			}
 +
 +			memcpy(salt, salt_buf, salt_size);
@@ -208,7 +229,7 @@
  /*
  ** current_time()
  **
-@@ -133230,6 +133431,10 @@
+@@ -133230,6 +133452,10 @@
      FUNCTION(substr,             3, 0, 0, substrFunc       ),
      FUNCTION(substring,          2, 0, 0, substrFunc       ),
      FUNCTION(substring,          3, 0, 0, substrFunc       ),

--- a/test/tap/tests/test_sqlite3_pass_exts-t.cpp
+++ b/test/tap/tests/test_sqlite3_pass_exts-t.cpp
@@ -503,7 +503,7 @@ int main(int argc, char** argv) {
 	uint32_t actual_test_count =
 		INV_INPUTS.size() +           // Always run
 		PASS_GEN_COUNT * 2 +           // Always run (ProxySQL Admin SQLite3 extensions)
-		2;                             // EXTRA: Two extra correctness tests
+		5;                             // EXTRA: 2 forced-randomness + 2 salt-alphabet (#5989) + 1 legacy-salt
 
 	if (g_mysql_supports_random_password) {
 		// Phase 2: MySQL/Admin hash compatibility tests (USER_GEN_COUNT total,
@@ -600,6 +600,71 @@ int main(int argc, char** argv) {
 		// EXTRA: Two extra correctness tests; forcing randomness
 		test_pass_gen(admin, "mysql_native_password", "randpass0", "");
 		test_pass_gen(admin, "caching_sha2_password", "randpass0", "00000000000000000000");
+
+		// EXTRA: auto-generated salts must stay inside a credential-safe alphabet.
+		//
+		// Issue #5989: the salt used to be RAND_bytes() masked with 0x7f, bumping only
+		// '\0' and '$'. That produced ';' or ':' in ~27% of hashes, and those are the
+		// separators parsed by ProxySQL_Admin::add_credentials(), so such a hash is
+		// silently split into a bogus credential when stored in
+		// admin-admin_credentials / admin-stats_credentials -- the variable still
+		// reports all 70 bytes and nothing errors, but the login fails with a generic
+		// 'Access denied'. It also emitted control bytes, which are unusable in a
+		// config file. Salts are now drawn from a 64-character alphabet.
+		//
+		// Only the 1-argument form is checked: an explicitly supplied salt is passed
+		// through verbatim by design and is the caller's responsibility.
+		{
+			const string SALT_ALPHABET {
+				"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+			};
+			const size_t SALT_SAMPLES = 500;
+
+			size_t bad_alphabet = 0, bad_shape = 0;
+			string first_bad {};
+
+			for (size_t i = 0; i < SALT_SAMPLES; i++) {
+				MYSQL_QUERY_T(admin, "SELECT CACHING_SHA2_PASSWORD('randpass0')");
+				MYSQL_RES* myres = mysql_store_result(admin);
+				MYSQL_ROW myrow = mysql_fetch_row(myres);
+				const string h { myrow[0] ? myrow[0] : "" };
+				mysql_free_result(myres);
+
+				// '$A$' + 3 rounds digits + '$' + 20 salt + 43 digest
+				if (h.size() != 70 || h.rfind("$A$", 0) != 0) {
+					bad_shape++;
+					if (first_bad.empty()) { first_bad = h; }
+					continue;
+				}
+
+				const string salt { h.substr(7, 20) };
+				if (salt.find_first_not_of(SALT_ALPHABET) != string::npos) {
+					bad_alphabet++;
+					if (first_bad.empty()) { first_bad = h; }
+				}
+			}
+
+			ok(
+				bad_shape == 0,
+				"Generated hashes should be wellformed   samples:'%lu', malformed:'%lu', first:'%s'",
+				SALT_SAMPLES, bad_shape, first_bad.c_str()
+			);
+			ok(
+				bad_alphabet == 0,
+				"Generated salts should use the credential-safe alphabet (issue #5989)   "
+				"samples:'%lu', offending:'%lu', first:'%s'",
+				SALT_SAMPLES, bad_alphabet, first_bad.c_str()
+			);
+		}
+
+		// EXTRA: a hash generated with the pre-#5989 salt style must still verify.
+		// The fix is generation-side only; PPHR_verify_sha2()/PPHR_sha2full() read the
+		// salt back with substr(7,20) and never inspect it, so previously stored hashes
+		// keep working. Passing the salt explicitly reproduces the old output exactly.
+		// NOTE: the literal is split so each \x escape terminates. C++ hex escapes are
+		// greedy, so "\x02defghijklmno" would parse \x02def as a single escape.
+		const string LEGACY_STYLE_SALT { "a;b:c" "\x01" "\x02" "defghijklmno" };
+		test_pass_gen(admin, "caching_sha2_password", "randpass0", LEGACY_STYLE_SALT);
 
 		for (size_t i = 0; i < PASS_GEN_COUNT; i++) {
 			const uint32_t pass_len = rand() % 150;

--- a/test/tap/tests/test_sqlite3_pass_exts-t.cpp
+++ b/test/tap/tests/test_sqlite3_pass_exts-t.cpp
@@ -305,6 +305,93 @@ int test_pass_match(MYSQL* admin, const user_def_t& def) {
 	return EXIT_SUCCESS;
 }
 
+/**
+ * @brief Read a global variable's current value into 'out'.
+ * @return true when the variable was read.
+ */
+static bool read_global_var(MYSQL* admin, const char* name, string& out) {
+	const string q {
+		string("SELECT variable_value FROM global_variables WHERE variable_name='") + name + "'"
+	};
+	if (mysql_query(admin, q.c_str())) { return false; }
+	MYSQL_RES* r = mysql_store_result(admin);
+	if (r == NULL) { return false; }
+	MYSQL_ROW row = mysql_fetch_row(r);
+	const bool found = (row != NULL && row[0] != NULL);
+	if (found) { out = row[0]; }
+	mysql_free_result(r);
+	return found;
+}
+
+/**
+ * @brief Store a CACHING_SHA2_PASSWORD() hash in 'admin-admin_credentials' and
+ *   authenticate against the Admin interface with it.
+ * @details This is the round trip the generation-side fix in #5990 exists to
+ *   protect: it is not enough for CACHING_SHA2_PASSWORD() to return a well-formed
+ *   string, the string has to survive being stored as an Admin credential and
+ *   then actually let a client in.
+ *
+ *   The hash is produced and appended entirely inside SQL, so it never passes
+ *   through this process -- a hash carrying a control byte cannot be round-tripped
+ *   through a client-side buffer reliably, and 'SET admin-admin_credentials=...'
+ *   silently ignores such a value, leaving the old one in place.
+ *
+ *   TLS is mandatory. With only a hash stored, caching_sha2_password cannot
+ *   complete by fast auth, so the client must return the cleartext over a secure
+ *   channel; ProxySQL does not serve an RSA public key (#5988).
+ *
+ * @param salt_arg Extra argument list for CACHING_SHA2_PASSWORD(), already
+ *   SQL-quoted and comma-prefixed, or "" for the one-argument form.
+ * @return the connection errno: 0 on success.
+ */
+static unsigned int admin_cred_roundtrip(
+	MYSQL* admin, const CommandLine& cl, const string& user, const string& pass,
+	const string& salt_arg
+) {
+	string orig_creds {};
+	if (!read_global_var(admin, "admin-admin_credentials", orig_creds)) {
+		diag("  could not read admin-admin_credentials");
+		return 0xFFFF;
+	}
+
+	const string add {
+		"UPDATE global_variables SET variable_value = variable_value || ';" + user + ":' || "
+		"CACHING_SHA2_PASSWORD('" + pass + "'" + salt_arg + ") "
+		"WHERE variable_name='admin-admin_credentials'"
+	};
+	if (mysql_query(admin, add.c_str()) || mysql_query(admin, "LOAD ADMIN VARIABLES TO RUNTIME")) {
+		diag("  failed to install the credential: %s", mysql_error(admin));
+		return 0xFFFF;
+	}
+
+	MYSQL* conn = mysql_init(NULL);
+	unsigned int err = 0;
+	if (conn != NULL) {
+		// The TAP suite links MariaDB Connector/C, which has no MYSQL_OPT_SSL_MODE;
+		// mysql_ssl_set + CLIENT_SSL is the idiom used elsewhere in these tests.
+		mysql_ssl_set(conn, NULL, NULL, NULL, NULL, NULL);
+		if (!mysql_real_connect(conn, cl.admin_host, user.c_str(), pass.c_str(), NULL,
+				cl.admin_port, NULL, CLIENT_SSL)) {
+			err = mysql_errno(conn);
+			diag("  admin login user='%s' -> errno=%u '%s'", user.c_str(), err, mysql_error(conn));
+		}
+		mysql_close(conn);
+	} else {
+		err = 0xFFFF;
+	}
+
+	// Put back exactly what was there; this runs against a shared instance.
+	const string restore {
+		"UPDATE global_variables SET variable_value='" + orig_creds +
+		"' WHERE variable_name='admin-admin_credentials'"
+	};
+	if (mysql_query(admin, restore.c_str()) || mysql_query(admin, "LOAD ADMIN VARIABLES TO RUNTIME")) {
+		diag("  WARNING: failed to restore admin-admin_credentials: %s", mysql_error(admin));
+	}
+
+	return err;
+}
+
 int test_pass_gen(MYSQL* admin, const string& auth, const string& pass, const string& salt) {
 	diag("Test Admin pass hash gen    auth:'%s',pass:'%s'", auth.c_str(), pass.c_str());
 
@@ -503,7 +590,8 @@ int main(int argc, char** argv) {
 	uint32_t actual_test_count =
 		INV_INPUTS.size() +           // Always run
 		PASS_GEN_COUNT * 2 +           // Always run (ProxySQL Admin SQLite3 extensions)
-		5;                             // EXTRA: 2 forced-randomness + 2 salt-alphabet (#5989) + 1 legacy-salt
+		8;                             // EXTRA: 2 forced-randomness + 2 salt-alphabet (#5989)
+		                               //      + 1 legacy-salt + 3 Admin credential round trips
 
 	if (g_mysql_supports_random_password) {
 		// Phase 2: MySQL/Admin hash compatibility tests (USER_GEN_COUNT total,
@@ -531,6 +619,18 @@ int main(int argc, char** argv) {
 		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
 		return EXIT_FAILURE;
 	}
+
+	// Saved here, restored once at 'cleanup:'. This test switches
+	// 'mysql-default_authentication_plugin' in two places -- the Admin credential
+	// round trip below, and the Phase 3 end-to-end loop -- and it runs against a
+	// shared instance, so the value has to be put back on every exit path,
+	// including the 'goto cleanup' ones. Declared before the first goto so the
+	// jumps do not cross its initialisation.
+	string orig_auth_plugin {};
+	const bool have_auth_plugin =
+		read_global_var(admin, "mysql-default_authentication_plugin", orig_auth_plugin);
+	diag("Saved mysql-default_authentication_plugin='%s'%s",
+		orig_auth_plugin.c_str(), have_auth_plugin ? "" : " (UNREADABLE - will not be restored)");
 
 	// Tests functions input verification
 	{
@@ -662,9 +762,87 @@ int main(int argc, char** argv) {
 		// salt back with substr(7,20) and never inspect it, so previously stored hashes
 		// keep working. Passing the salt explicitly reproduces the old output exactly.
 		// NOTE: the literal is split so each \x escape terminates. C++ hex escapes are
-		// greedy, so "\x02defghijklmno" would parse \x02def as a single escape.
-		const string LEGACY_STYLE_SALT { "a;b:c" "\x01" "\x02" "defghijklmno" };
+		// greedy, so "\x02defghijklmnop" would parse \x02def as a single escape.
+		// It is exactly 20 bytes, the stored-salt length that substr(7,20) reads back,
+		// so this reproduces a real pre-fix hash rather than a shorter approximation.
+		const string LEGACY_STYLE_SALT { "a;b:c" "\x01" "\x02" "defghijklmnop" };
+		assert(LEGACY_STYLE_SALT.size() == 20);
 		test_pass_gen(admin, "caching_sha2_password", "randpass0", LEGACY_STYLE_SALT);
+
+		// EXTRA: the Admin credential ROUND TRIP -- the property #5990 actually
+		// protects. A well-formed hash is not enough; it has to survive being stored
+		// in 'admin-admin_credentials' and still authenticate a client.
+		{
+			// The default authentication plugin must be caching_sha2_password for the
+			// Admin interface to challenge with it. The original value was saved right
+			// after the Admin connection and is restored once at 'cleanup:'.
+			MYSQL_QUERY_T(admin,
+				"UPDATE global_variables SET variable_value='caching_sha2_password' "
+				"WHERE variable_name='mysql-default_authentication_plugin'");
+			MYSQL_QUERY_T(admin, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+			// 1-argument form: the salt is generated, so this is what the #5990 fix
+			// changes. Before the fix a generated salt contained ';' or ':' -- the
+			// separators parsed by ProxySQL_Admin::add_credentials() -- for roughly 27%
+			// of hashes, which silently split the credential and produced a generic
+			// 'Access denied'.
+			//
+			// REPEATED DELIBERATELY. A single round trip would still succeed ~73% of the
+			// time against the unfixed generator, making it useless as a regression
+			// detector. At 25 samples the chance of an unfixed build passing is
+			// 0.73^25, under 0.1%.
+			const size_t ROUNDTRIP_SAMPLES = 25;
+			size_t roundtrip_failures = 0;
+			unsigned int first_err = 0;
+			for (size_t i = 0; i < ROUNDTRIP_SAMPLES; i++) {
+				const unsigned int e =
+					admin_cred_roundtrip(admin, cl, "cs2gen", "roundtrippass", "");
+				if (e != 0) {
+					roundtrip_failures++;
+					if (first_err == 0) { first_err = e; }
+				}
+			}
+			ok(
+				roundtrip_failures == 0,
+				"Generated CACHING_SHA2_PASSWORD() hashes should authenticate as Admin "
+				"credentials (issue #5989/#5990)   samples:'%lu', failures:'%lu', first errno:'%u'",
+				ROUNDTRIP_SAMPLES, roundtrip_failures, first_err
+			);
+
+			// Legacy-style salt: outside the new 64-character alphabet, proving the fix
+			// is generation-side only and previously stored hashes still verify.
+			// It deliberately avoids ';' and ':' -- a salt containing those cannot round
+			// trip through admin-admin_credentials at all, which IS #5989 and is covered
+			// by the alphabet assertions above rather than here.
+			const string LEGACY_SAFE_SALT { "!#%&()*+,-<=>?@[]^_~" };
+			assert(LEGACY_SAFE_SALT.size() == 20);
+			assert(LEGACY_SAFE_SALT.find_first_of(";:") == string::npos);
+			const unsigned int legacy_err = admin_cred_roundtrip(
+				admin, cl, "cs2legacy", "roundtrippass", ",'" + LEGACY_SAFE_SALT + "'"
+			);
+			ok(
+				legacy_err == 0,
+				"A legacy-style (pre-#5990 alphabet) hash should still authenticate as an "
+				"Admin credential   salt:'%s', errno:'%u'",
+				LEGACY_SAFE_SALT.c_str(), legacy_err
+			);
+
+			// NEGATIVE CONTROL. Everything above only proves something if this round
+			// trip can actually detect a corrupted credential. Feed it a salt carrying
+			// the ';' separator -- exactly what the pre-#5990 generator emitted ~27% of
+			// the time -- and the login MUST fail. If this ever starts passing, the two
+			// assertions above have gone vacuous and are no longer testing #5989/#5990.
+			const unsigned int control_err = admin_cred_roundtrip(
+				admin, cl, "cs2ctl", "roundtrippass", ",'abc;def:ghijklmnopq'"
+			);
+			ok(
+				control_err != 0,
+				"CONTROL: a salt containing the ';' credential separator must NOT "
+				"authenticate -- proves the round trip above can detect the #5989 "
+				"corruption   errno:'%u'",
+				control_err
+			);
+		}
 
 		for (size_t i = 0; i < PASS_GEN_COUNT; i++) {
 			const uint32_t pass_len = rand() % 150;
@@ -800,6 +978,21 @@ int main(int argc, char** argv) {
 	}
 
 cleanup:
+
+	// Put the authentication plugin back. Both the Admin credential round trip and
+	// the Phase 3 end-to-end loop change it; without this the test leaves a shared
+	// instance on whatever it happened to set last.
+	if (have_auth_plugin) {
+		const string restore_plugin {
+			"UPDATE global_variables SET variable_value='" + orig_auth_plugin +
+			"' WHERE variable_name='mysql-default_authentication_plugin'"
+		};
+		if (mysql_query(admin, restore_plugin.c_str()) ||
+			mysql_query(admin, "LOAD MYSQL VARIABLES TO RUNTIME")) {
+			diag("WARNING: failed to restore mysql-default_authentication_plugin: %s",
+				mysql_error(admin));
+		}
+	}
 
 	mysql_close(mysql);
 	mysql_close(admin);


### PR DESCRIPTION
Fixes #5989.

## Problem

`CACHING_SHA2_PASSWORD()` generated its 20-byte salt as `RAND_bytes()` masked with `0x7f`, bumping only `'\0'` and `'$'`. Measured over **3000 distinct hashes** on `v3.0`:

| salt contains | share |
|---|---|
| `;` | 14.1% |
| `:` | 14.9% |
| **`;` or `:`** | **26.9%** |
| a byte outside `0x20`–`0x7e` | 99.8% |

`admin-admin_credentials` / `admin-stats_credentials` are `;`-separated, `:`-delimited plain strings parsed by `ProxySQL_Admin::add_credentials()`. A hash carrying either delimiter is **silently** split into a bogus credential at `LOAD ADMIN VARIABLES TO RUNTIME` — nothing errors, `SELECT @@admin-admin_credentials` still shows all 70 bytes, and the only symptom is a generic `Access denied` at login. Since the salt is random, the same command run twice yields a working credential and a broken one.

## Fix

Draw the salt from a 64-character alphabet (`./0-9A-Za-z`). 64 divides 256 evenly, so masking with `0x3f` adds no modulo bias; 20 characters still carry 120 bits of salt entropy.

**Generation-side only — no migration.** `PPHR_verify_sha2()` / `PPHR_sha2full()` read the salt back with `substr(7,20)` and pass it straight to `sha256_crypt_r()` without inspecting it, so every previously stored hash keeps verifying.

## Verification

On a debug build (`PROXYSQL31=1 make debug`), against a rebuilt instance:

- **3000 generated hashes** — 0 salts outside the alphabet, 0 containing `;` or `:`, 0 containing control bytes.
- **End-to-end, 20 consecutive iterations** — a fresh hash installed into `admin-admin_credentials` and authenticated on `:6032` over TLS: **20/20** (previously ~73% expected).
- **Backward compatibility** — a hash generated with an explicit legacy-style 20-byte salt containing `;`, `:`, `0x01` and `0x02` still authenticates (`ERROR 9001 Max connect timeout … hostgroup 0`, i.e. post-authentication).

`test_sqlite3_pass_exts-t` run in `mysql84-g9`:

```
ok 117 - Generated hashes should be wellformed   samples:'500', malformed:'0'
ok 118 - Generated salts should use the credential-safe alphabet (issue #5989)   samples:'500', offending:'0'
SUMMARY: 'tests' PASS 1/396 : FAIL 0/396
```

Plan `1..2220`, zero `not ok`.

## Notes for review

- The change lives in `deps/sqlite3/sqlite3_pass_exts.patch`; the extracted amalgamation is a build artifact and is not tracked. The unified-diff hunk headers were updated for the new line counts, and all three patches (`from_unixtime`, `sqlite3_pass_exts`, `throw`) were confirmed to apply in sequence from a clean extraction.
- **Not gated** behind `PROXYSQL31` — this is a bug fix with no behaviour change for existing data.
- **Out of scope, found while testing:** `CACHING_SHA2_PASSWORD(pass, salt)` accepts an explicit salt of length 1–20 and produces a well-formed-looking hash, but verification always reads exactly 20 characters at offset 7 and `PPHR_verify_password()` requires `strlen == 70`. Any hash generated with a salt shorter than 20 bytes is therefore unverifiable. The existing test only asserts the hash's shape, never that it authenticates, which is why this was never caught. Worth a separate issue — happy to file it.
- Also unaddressed by design: a hand-written password containing `;` or `:` still breaks `admin-*_credentials` identically. That is the validation half, tracked against #5987.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite support for MySQL-compatible `mysql_native_password` hashing.
  * Added `caching_sha2_password` hashing with optional salts and configurable work factors.
  * Supports secure random salt generation and MySQL-compatible output formats.
  * Added validation for password, salt, and configuration inputs.
  * Improved compatibility with administrative authentication over TLS.

* **Tests**
  * Expanded coverage for generated hashes, salt formats, legacy-style salts, authentication round trips, and credential restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->