### PR TITLE
feat(admin): give Admin/stats credentials their own credential scope (PROXYSQL31)

### DIFF
--- a/include/MySQL_Authentication.hpp
+++ b/include/MySQL_Authentication.hpp
@@ -65,6 +65,28 @@ typedef struct _creds_group_t {
 } creds_group_t;
 #endif // CREDS_GROUPS_T
 
+/**
+ * @brief The credential scope that 'admin-admin_credentials' and
+ *   'admin-stats_credentials' are stored in and looked up from.
+ *
+ * @details Historically these shared 'USERNAME_FRONTEND' with 'mysql_users',
+ *   one flat map keyed by username, so a row and an Admin credential of the same
+ *   name overwrote each other -- which is why the documentation states that
+ *   users in 'admin-admin_credentials' / 'admin-stats_credentials' cannot also
+ *   be used in 'mysql_users'.
+ *
+ *   From the Innovative tier onward they get their own scope, which removes the
+ *   collision entirely rather than policing it. This is an INCOMPATIBLE change
+ *   -- a colliding name currently resolves to a single entry and afterwards the
+ *   two are independent -- so it is gated to PROXYSQL31 and the stable tier
+ *   keeps the documented behaviour.
+ */
+#ifdef PROXYSQL31
+#define ADMIN_CRED_SCOPE USERNAME_ADMIN
+#else
+#define ADMIN_CRED_SCOPE USERNAME_FRONTEND
+#endif /* PROXYSQL31 */
+
 class MySQL_Authentication {
 	private:
 	/**
@@ -74,6 +96,17 @@ class MySQL_Authentication {
 	std::unique_ptr<SQLite3_result> mysql_users_resultset { nullptr };
 	creds_group_t creds_backends;
 	creds_group_t creds_frontends;
+	/**
+	 * @brief Scope holding 'admin-admin_credentials' and 'admin-stats_credentials'.
+	 * @details Separate from 'creds_frontends' so an Admin credential and a
+	 *   'mysql_users' row of the same name cannot overwrite each other. Only
+	 *   populated when PROXYSQL31 is defined (see ADMIN_CRED_SCOPE); on the stable
+	 *   tier it stays empty and admin credentials remain in 'creds_frontends'.
+	 *   Never included in 'dump_all_users()', so 'runtime_mysql_users' and the
+	 *   cluster checksum are unaffected.
+	 */
+	creds_group_t creds_admins;
+	creds_group_t& creds_for(enum cred_username_type usertype);
 	bool _reset(enum cred_username_type usertype);
 	uint64_t _get_runtime_checksum(enum cred_username_type usertype);
 	public:

--- a/include/MySQL_Authentication.hpp
+++ b/include/MySQL_Authentication.hpp
@@ -65,28 +65,6 @@ typedef struct _creds_group_t {
 } creds_group_t;
 #endif // CREDS_GROUPS_T
 
-/**
- * @brief The credential scope that 'admin-admin_credentials' and
- *   'admin-stats_credentials' are stored in and looked up from.
- *
- * @details Historically these shared 'USERNAME_FRONTEND' with 'mysql_users',
- *   one flat map keyed by username, so a row and an Admin credential of the same
- *   name overwrote each other -- which is why the documentation states that
- *   users in 'admin-admin_credentials' / 'admin-stats_credentials' cannot also
- *   be used in 'mysql_users'.
- *
- *   From the Innovative tier onward they get their own scope, which removes the
- *   collision entirely rather than policing it. This is an INCOMPATIBLE change
- *   -- a colliding name currently resolves to a single entry and afterwards the
- *   two are independent -- so it is gated to PROXYSQL31 and the stable tier
- *   keeps the documented behaviour.
- */
-#ifdef PROXYSQL31
-#define ADMIN_CRED_SCOPE USERNAME_ADMIN
-#else
-#define ADMIN_CRED_SCOPE USERNAME_FRONTEND
-#endif /* PROXYSQL31 */
-
 class MySQL_Authentication {
 	private:
 	/**

--- a/include/PgSQL_Authentication.h
+++ b/include/PgSQL_Authentication.h
@@ -69,6 +69,16 @@ class PgSQL_Authentication {
 	std::unique_ptr<SQLite3_result> pgsql_users_resultset { nullptr };
 	creds_group_t creds_backends;
 	creds_group_t creds_frontends;
+	/**
+	 * @brief Scope holding 'admin-admin_credentials' / 'admin-stats_credentials'.
+	 * @details Mirrors MySQL_Authentication::creds_admins. Only populated when
+	 *   PROXYSQL31 is defined (see ADMIN_CRED_SCOPE in MySQL_Authentication.hpp);
+	 *   on the stable tier admin credentials stay in 'creds_frontends' alongside
+	 *   'pgsql_users' and behaviour is unchanged. Never walked by
+	 *   dump_all_users(), so 'runtime_pgsql_users' and the checksum are unaffected.
+	 */
+	creds_group_t creds_admins;
+	creds_group_t& creds_for(enum cred_username_type usertype);
 	bool _reset(enum cred_username_type usertype);
 	uint64_t _get_runtime_checksum(enum cred_username_type usertype);
 	public:

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -775,6 +775,42 @@ enum proxysql_session_type {
 	PROXYSQL_SESSION_NONE
 };
 
+/**
+ * @brief The credential scope holding 'admin-admin_credentials' and
+ *   'admin-stats_credentials'.
+ *
+ * @details Historically these shared USERNAME_FRONTEND with mysql_users /
+ *   pgsql_users -- one flat map keyed by username -- so an Admin credential and
+ *   a row of the same name overwrote each other. That is the only reason the
+ *   documentation states those users cannot also appear in mysql_users.
+ *
+ *   From the Innovative tier onward they get their own scope, removing the
+ *   collision rather than policing it. This is an INCOMPATIBLE change (a
+ *   colliding name currently resolves to one entry; afterwards the two are
+ *   independent), so it is gated to PROXYSQL31. On the stable tier this is
+ *   USERNAME_FRONTEND, every call site passes what it always passed, and
+ *   behaviour is unchanged. See issue #5987.
+ */
+#ifdef PROXYSQL31
+#define ADMIN_CRED_SCOPE USERNAME_ADMIN
+#else
+#define ADMIN_CRED_SCOPE USERNAME_FRONTEND
+#endif /* PROXYSQL31 */
+
+/**
+ * @brief Credential scope to resolve a username in, for a given session type.
+ * @details ADMIN and STATS sessions use ADMIN_CRED_SCOPE; every other session
+ *   type (MySQL/PgSQL frontend, SQLite server, ClickHouse) uses
+ *   USERNAME_FRONTEND. Shared by both protocol implementations so the policy
+ *   exists once.
+ */
+static inline enum cred_username_type cred_scope_for_session(enum proxysql_session_type session_type) {
+	if (session_type == PROXYSQL_SESSION_ADMIN || session_type == PROXYSQL_SESSION_STATS) {
+		return ADMIN_CRED_SCOPE;
+	}
+	return USERNAME_FRONTEND;
+}
+
 #endif /* PROXYSQL_ENUMS */
 
 

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -47,7 +47,11 @@ enum log_event_type {
 	PROXYSQL_METADATA
 };
 
-enum cred_username_type { USERNAME_BACKEND, USERNAME_FRONTEND, USERNAME_NONE };
+// USERNAME_ADMIN is a scope for 'admin-admin_credentials' / 'admin-stats_credentials'.
+// It is compiled unconditionally, but only *used* when PROXYSQL31 is defined --
+// see ADMIN_CRED_SCOPE in MySQL_Authentication.hpp. On the stable tier those
+// credentials continue to live in USERNAME_FRONTEND alongside mysql_users.
+enum cred_username_type { USERNAME_BACKEND, USERNAME_FRONTEND, USERNAME_NONE, USERNAME_ADMIN };
 
 #define PROXYSQL_USE_RESULT
 

--- a/lib/MySQL_Authentication.cpp
+++ b/lib/MySQL_Authentication.cpp
@@ -754,6 +754,11 @@ bool MySQL_Authentication::_reset(enum cred_username_type usertype) {
 bool MySQL_Authentication::reset() {
 	_reset(USERNAME_BACKEND);
 	_reset(USERNAME_FRONTEND);
+	// creds_admins is a distinct scope from PROXYSQL31 onward; without this its
+	// accounts are handed to setAllInactive() without ever being released and the
+	// account_details strings leak. On the stable tier ADMIN_CRED_SCOPE is
+	// USERNAME_FRONTEND so the scope is empty and this is a no-op.
+	_reset(USERNAME_ADMIN);
 	return true;
 }
 

--- a/lib/MySQL_Authentication.cpp
+++ b/lib/MySQL_Authentication.cpp
@@ -57,18 +57,22 @@ MySQL_Authentication::MySQL_Authentication() {
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_init(&creds_backends.lock, NULL);
 	pthread_rwlock_init(&creds_frontends.lock, NULL);
+	pthread_rwlock_init(&creds_admins.lock, NULL);
 #else
 	spinlock_rwlock_init(&creds_backends.lock);
 	spinlock_rwlock_init(&creds_frontends.lock);
+	spinlock_rwlock_init(&creds_admins.lock);
 #endif
 	creds_backends.cred_array = new PtrArray();
 	creds_frontends.cred_array = new PtrArray();
+	creds_admins.cred_array = new PtrArray();
 };
 
 MySQL_Authentication::~MySQL_Authentication() {
 	reset();
 	delete creds_backends.cred_array;
 	delete creds_frontends.cred_array;
+	delete creds_admins.cred_array;
 };
 
 void MySQL_Authentication::print_version() {
@@ -76,7 +80,7 @@ void MySQL_Authentication::print_version() {
 	};
 
 void MySQL_Authentication::set_all_inactive(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
 #else
@@ -95,7 +99,7 @@ void MySQL_Authentication::set_all_inactive(enum cred_username_type usertype) {
 }
 
 void MySQL_Authentication::remove_inactives(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
 #else
@@ -117,6 +121,23 @@ __loop_remove_inactives:
 #endif
 }
 
+/**
+ * @brief Select the credential scope for a username type.
+ * @details USERNAME_ADMIN is only ever passed when PROXYSQL31 is defined; on the
+ *   stable tier ADMIN_CRED_SCOPE is USERNAME_FRONTEND so this never returns
+ *   'creds_admins' and behaviour is unchanged.
+ */
+creds_group_t& MySQL_Authentication::creds_for(enum cred_username_type usertype) {
+	switch (usertype) {
+		case USERNAME_BACKEND:
+			return creds_backends;
+		case USERNAME_ADMIN:
+			return creds_admins;
+		default:
+			return creds_frontends;
+	}
+}
+
 bool MySQL_Authentication::add(char * username, char * password, enum cred_username_type usertype, bool use_ssl, int default_hostgroup, char *default_schema, bool schema_locked, bool transaction_persistent, bool fast_forward, int max_connections, char* attributes, char *comment) {
 	uint64_t hash1, hash2;
 	SpookyHash myhash;
@@ -124,7 +145,7 @@ bool MySQL_Authentication::add(char * username, char * password, enum cred_usern
 	myhash.Update(username,strlen(username));
 	myhash.Final(&hash1,&hash2);
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 	
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
@@ -483,7 +504,7 @@ bool MySQL_Authentication::del(char * username, enum cred_username_type usertype
 	myhash->Final(&hash1,&hash2);
 	delete myhash;
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 	if (set_lock)
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
@@ -526,7 +547,7 @@ bool MySQL_Authentication::set_SHA1(char * username, enum cred_username_type use
 	myhash->Final(&hash1,&hash2);
 	delete myhash;
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
@@ -563,7 +584,7 @@ bool MySQL_Authentication::set_clear_text_password(
 	myhash->Final(&hash1,&hash2);
 	delete myhash;
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
@@ -631,7 +652,7 @@ account_details_t MySQL_Authentication::lookup(
 	myhash.Update(username,strlen(username));
 	myhash.Final(&hash1,&hash2);
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_rdlock(&cg.lock);
@@ -688,7 +709,7 @@ account_details_t MySQL_Authentication::lookup(
 }
 
 bool MySQL_Authentication::_reset(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
@@ -780,7 +801,7 @@ static uint64_t compute_accounts_hash(const umap_auth& accs_map) {
 }
 
 uint64_t MySQL_Authentication::_get_runtime_checksum(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 	uint64_t accs_hash = compute_accounts_hash(cg.bt_map);
 
 	return accs_hash;

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -1259,7 +1259,7 @@ bool MySQL_Protocol::process_pkt_auth_swich_response(unsigned char *pkt, unsigne
 				if (ret) {
 					if (account_details.sha1_pass==NULL) {
 						// currently proxysql doesn't know any sha1_pass for that specific user, let's set it!
-						GloMyAuth->set_SHA1((char *)userinfo->username, USERNAME_FRONTEND,reply);
+						GloMyAuth->set_SHA1((char *)userinfo->username, cred_scope_for_session(session_type),reply);
 					}
 					if (userinfo->sha1_pass) free(userinfo->sha1_pass);
 					userinfo->sha1_pass=sha1_pass_hex(reply);
@@ -1328,7 +1328,7 @@ bool MySQL_Protocol::verify_user_pass(
 				ret=proxy_scramble_sha1((char *)pass,(*myds)->myconn->scramble_buff,password+1, reply);
 				if (ret) {
 					if (sha1_pass==NULL) {
-						GloMyAuth->set_SHA1((char *)user, USERNAME_FRONTEND,reply);
+						GloMyAuth->set_SHA1((char *)user, cred_scope_for_session(session_type),reply);
 					}
 					if (userinfo->sha1_pass) free(userinfo->sha1_pass);
 					userinfo->sha1_pass=sha1_pass_hex(reply);
@@ -1346,7 +1346,7 @@ bool MySQL_Protocol::verify_user_pass(
 				if (strcasecmp(double_hashed_password,password)==0) {
 					ret = true;
 					if (sha1_pass==NULL) {
-						GloMyAuth->set_SHA1((char *)user, USERNAME_FRONTEND,md1_buf);
+						GloMyAuth->set_SHA1((char *)user, cred_scope_for_session(session_type),md1_buf);
 					}
 					if (userinfo->sha1_pass)
 						free(userinfo->sha1_pass);
@@ -2256,6 +2256,9 @@ void MySQL_Protocol::PPHR_5passwordFalse_auth2(
 						if (attr1.sha1_pass==NULL) {
 							// currently proxysql doesn't know any sha1_pass for that specific user, let's set it!
 							// TODO: CHECK these usages of 'reply'
+							// USERNAME_FRONTEND, not the session scope: this is the LDAP
+							// path, which only ever backs frontend users -- an ADMIN/STATS
+							// session never reaches it.
 							GloMyAuth->set_SHA1((char *)userinfo->username, USERNAME_FRONTEND,reply);
 						}
 						if (userinfo->sha1_pass) free(userinfo->sha1_pass);
@@ -2356,7 +2359,7 @@ void MySQL_Protocol::PPHR_7auth1(
 		if (ret) {
 			if (attr1.sha1_pass==NULL) {
 				// currently proxysql doesn't know any sha1_pass for that specific user, let's set it!
-				GloMyAuth->set_SHA1((char *)vars1.user, USERNAME_FRONTEND,reply);
+				GloMyAuth->set_SHA1((char *)vars1.user, cred_scope_for_session(session_type),reply);
 			}
 			if (userinfo->sha1_pass)
 				free(userinfo->sha1_pass);
@@ -2397,7 +2400,7 @@ void MySQL_Protocol::PPHR_7auth2(
 			ret = true;
 			if (attr1.sha1_pass==NULL) {
 				// currently proxysql doesn't know any sha1_pass for that specific user, let's set it!
-				GloMyAuth->set_SHA1((char *)vars1.user, USERNAME_FRONTEND,md1_buf);
+				GloMyAuth->set_SHA1((char *)vars1.user, cred_scope_for_session(session_type),md1_buf);
 			}
 			if (userinfo->sha1_pass)
 				free(userinfo->sha1_pass);

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -60,6 +60,26 @@ static const char *plugins[3] = {
 
 #include "MySQL_encode.h"
 
+/**
+ * @brief Credential scope to look a username up in for a given session type.
+ * @details ADMIN and STATS sessions resolve against ADMIN_CRED_SCOPE; everything
+ *   else (MySQL frontend, SQLite server, ClickHouse) uses USERNAME_FRONTEND.
+ *
+ *   On the stable tier ADMIN_CRED_SCOPE *is* USERNAME_FRONTEND, so this returns
+ *   the same value for every session type and nothing changes. From PROXYSQL31
+ *   the scopes are distinct, which means an Admin session no longer resolves
+ *   'mysql_users' rows and a frontend session no longer resolves Admin
+ *   credentials -- neither could usefully authenticate with the other's entry
+ *   anyway (the post-auth hostgroup gate in MySQL_Session rejects both), but
+ *   sharing one map let them overwrite each other. See #5987.
+ */
+static inline enum cred_username_type cred_scope_for_session(enum proxysql_session_type session_type) {
+	if (session_type == PROXYSQL_SESSION_ADMIN || session_type == PROXYSQL_SESSION_STATS) {
+		return ADMIN_CRED_SCOPE;
+	}
+	return USERNAME_FRONTEND;
+}
+
 char* get_password(account_details_t& ad, PASSWORD_TYPE::E passtype) {
 	char* ret = nullptr;
 
@@ -1238,7 +1258,7 @@ bool MySQL_Protocol::process_pkt_auth_swich_response(unsigned char *pkt, unsigne
 		password = ch_account.password;
 #endif /* PROXYSQLCLICKHOUSE */
 	} else {
-		account_details = GloMyAuth->lookup((char*)userinfo->username, USERNAME_FRONTEND, dup_details);
+		account_details = GloMyAuth->lookup((char*)userinfo->username, cred_scope_for_session(session_type), dup_details);
 		password = account_details.password;
 	}
 	// FIXME: add support for default schema and fast forward , issues #255 and #256
@@ -1460,7 +1480,7 @@ bool MySQL_Protocol::process_pkt_COM_CHANGE_USER(unsigned char *pkt, unsigned in
 		ch_account_to_my(account_details, ch_account_details);
 #endif /* PROXYSQLCLICKHOUSE */
 	} else {
-		account_details = GloMyAuth->lookup((char *)user, USERNAME_FRONTEND, dup_details);
+		account_details = GloMyAuth->lookup((char *)user, cred_scope_for_session(session_type), dup_details);
 	}
 
 	/**
@@ -3214,7 +3234,7 @@ __do_auth:
 		ch_account_to_my(account_details, ch_account);
 #endif /* PROXYSQLCLICKHOUSE */
 	} else {
-		account_details = GloMyAuth->lookup((char*)vars1.user, USERNAME_FRONTEND, dup_details);
+		account_details = GloMyAuth->lookup((char*)vars1.user, cred_scope_for_session(session_type), dup_details);
 	}
 
 	vars1.password = get_password(account_details, PASSWORD_TYPE::PRIMARY);

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -1695,6 +1695,29 @@ int MySQL_Protocol::PPHR_1(unsigned char *pkt, unsigned int len, bool& ret, MyPr
 	if (len==5) {
 		ret = false;
 		vars1.user = (unsigned char *)(*myds)->myconn->userinfo->username;
+		// A 1-byte payload of 0x02 at this stage is not a disconnect: it is the
+		// caching_sha2_password 'request_public_key' packet. ProxySQL has no RSA
+		// key to serve (tracked in #5988), so the exchange cannot continue -- but
+		// reporting it as "client is disconnecting" sent operators looking in
+		// entirely the wrong place. Name the real cause.
+		//
+		// This only fixes the log line. The client still receives the generic
+		// error produced by the normal failure path in
+		// MySQL_Session::handler___status_CONNECTING_CLIENT___STATE_SERVER_HANDSHAKE;
+		// giving the client a specific message needs that path to carry one, and
+		// #5988 replaces this branch with a real RSA implementation anyway.
+		if ((*myds)->switching_auth_stage == 5 && *pkt == 2) {
+			proxy_debug(PROXY_DEBUG_MYSQL_AUTH, 5,
+				"Session=%p , DS=%p , user='%s' . Client requested the caching_sha2_password RSA public key\n",
+				(*myds), (*myds)->sess, vars1.user);
+			proxy_error(
+				"User '%s'@'%s' requested the caching_sha2_password RSA public key, which ProxySQL does not"
+				" serve. Connect using TLS instead.\n",
+				vars1.user, (*myds)->addr.addr
+			);
+			(*myds)->auth_in_progress = 0;
+			return 1;
+		}
 		proxy_debug(PROXY_DEBUG_MYSQL_AUTH, 5, "Session=%p , DS=%p , user='%s' . Client is disconnecting\n", (*myds), (*myds)->sess, vars1.user);
 		proxy_error("User '%s'@'%s' is disconnecting during switch auth\n", vars1.user, (*myds)->addr.addr);
 		(*myds)->auth_in_progress = 0;
@@ -2049,26 +2072,112 @@ void MySQL_Protocol::PPHR_5passwordTrue(
 }
 
 
+// Defined below, next to PPHR_6auth2, the other caller.
+static bool caching_sha2_fast_auth_verify(
+	const char* cleartext_password,
+	const char* scramble,
+	const unsigned char* client_response
+);
+
+/**
+ * @brief Authenticate the 'mysql-monitor_*' credential.
+ * @details This is the only code path that authenticates
+ *   'mysql-monitor_username' / 'mysql-monitor_password'. That credential is not
+ *   stored in 'GloMyAuth', so @ref MySQL_Protocol::PPHR_verify_password reaches
+ *   here through its 'vars1.password == NULL' branch, for ADMIN / STATS / SQLITE
+ *   sessions only.
+ *
+ *   It used to be hardcoded to the 'mysql_native_password' scramble: a SHA1
+ *   'proxy_scramble' compared over SHA_DIGEST_LENGTH (20) bytes. Under
+ *   'caching_sha2_password' the client's fast-auth response is a 32-byte
+ *   SHA256-derived value, so that comparison could never succeed and the
+ *   credential was rejected outright -- breaking Kubernetes liveness/readiness
+ *   probes and metrics exporters connecting to the Admin interface (issue #5363).
+ *   Note it returned false without ever sending 'perform full authentication',
+ *   which is why TLS was not a workaround either.
+ *
+ *   The password is held in cleartext (as documented for 'mysql-monitor_password'),
+ *   so every supported plugin can be verified directly and no full-auth round trip
+ *   is ever required here.
+ */
 void MySQL_Protocol::PPHR_5passwordFalse_0(
-	// FIXME: does this work only for mysql_native_password ?
 	bool& ret,
 	MyProt_tmp_auth_vars& vars1,
 	char * reply,
 	account_details_t& attr1) {
-	if (strcmp((const char *)vars1.user,mysql_thread___monitor_username)==0) {
-		proxy_scramble(reply, (*myds)->myconn->scramble_buff, mysql_thread___monitor_password);
-		if (memcmp(reply, vars1.pass, SHA_DIGEST_LENGTH)==0) {
-			(*myds)->sess->default_hostgroup=STATS_HOSTGROUP;
-			(*myds)->sess->default_schema=strdup((char *)"main"); // just the pointer is passed
-			(*myds)->sess->schema_locked=false;
-			(*myds)->sess->transaction_persistent=false;
-			(*myds)->sess->session_fast_forward=SESSION_FORWARD_TYPE_NONE;
-			(*myds)->sess->user_max_connections=0;
-			vars1.password=l_strdup(mysql_thread___monitor_password);
-			ret=true;
-		}
-	} else {
+	if (strcmp((const char *)vars1.user,mysql_thread___monitor_username)!=0) {
 		ret=false;
+		return;
+	}
+
+	bool verified = false;
+
+	switch (auth_plugin_id) {
+		case AUTH_MYSQL_NATIVE_PASSWORD:
+			proxy_scramble(reply, (*myds)->myconn->scramble_buff, mysql_thread___monitor_password);
+			// NOTE: do NOT gate this on 'vars1.pass_len == SHA_DIGEST_LENGTH'.
+			// 'pass_len' is not the amount of valid data in 'vars1.pass': PPHR_2
+			// strips a trailing NUL byte from the client's response
+			// ("remove the extra 0 if present"), so a legitimate 20-byte native
+			// response whose last byte is 0x00 -- about 1 in 256 -- arrives with
+			// pass_len == 19 while all 20 bytes are present in the buffer.
+			verified = (memcmp(reply, vars1.pass, SHA_DIGEST_LENGTH) == 0);
+			break;
+
+		case AUTH_MYSQL_CACHING_SHA2_PASSWORD:
+			if ((*myds)->switching_auth_stage == 5) {
+				// A full-auth round trip was driven by another path (e.g. pass-through
+				// auth), so 'vars1.pass' already holds the cleartext.
+				verified =
+					(vars1.pass != NULL) &&
+					(strcmp(mysql_thread___monitor_password, (const char *)vars1.pass) == 0);
+			} else {
+				verified = caching_sha2_fast_auth_verify(
+					mysql_thread___monitor_password, (*myds)->myconn->scramble_buff,
+					vars1.pass
+				);
+			}
+			break;
+
+		case AUTH_MYSQL_CLEAR_PASSWORD:
+			verified =
+				(vars1.pass != NULL) &&
+				(strcmp(mysql_thread___monitor_password, (const char *)vars1.pass) == 0);
+			break;
+
+		default:
+			// A client can request an arbitrary plugin; this is not a programming
+			// error, so do not assert. Reject and say why.
+			proxy_debug(PROXY_DEBUG_MYSQL_AUTH, 5,
+				"Session=%p , DS=%p , user='%s' . Unsupported auth_plugin_id=%d for the monitor credential\n",
+				(*myds), (*myds)->sess, vars1.user, auth_plugin_id);
+			break;
+	}
+
+	if (verified == false) {
+		ret=false;
+		return;
+	}
+
+	(*myds)->sess->default_hostgroup=STATS_HOSTGROUP;
+	(*myds)->sess->default_schema=strdup((char *)"main"); // just the pointer is passed
+	(*myds)->sess->schema_locked=false;
+	(*myds)->sess->transaction_persistent=false;
+	(*myds)->sess->session_fast_forward=SESSION_FORWARD_TYPE_NONE;
+	(*myds)->sess->user_max_connections=0;
+	vars1.password=l_strdup(mysql_thread___monitor_password);
+	ret=true;
+
+	// caching_sha2_password requires an explicit 'fast_auth_success' marker before
+	// the OK packet; mirrors what the PPHR_6auth2 call site does in
+	// PPHR_verify_password. Without it the client rejects the subsequent OK.
+	if (
+		auth_plugin_id == AUTH_MYSQL_CACHING_SHA2_PASSWORD
+		&&
+		(*myds)->switching_auth_stage == 0
+	) {
+		const unsigned char fast_auth_success = '\3';
+		generate_one_byte_pkt(fast_auth_success);
 	}
 }
 
@@ -2168,26 +2277,68 @@ void MySQL_Protocol::PPHR_5passwordFalse_auth2(
 	}
 }
 
+/**
+ * @brief Verify a 'caching_sha2_password' fast-auth response.
+ * @details The client sends
+ *     XOR( SHA256(pw), SHA256( SHA256(SHA256(pw)) || scramble ) )
+ *   which the server recomputes from a password it can derive. This is the
+ *   cache-hit path of the plugin; it requires no extra round trip and is the
+ *   only completion possible when ProxySQL holds the cleartext.
+ *
+ *   Extracted so there is exactly one implementation of the algorithm: it is
+ *   used both by @ref MySQL_Protocol::PPHR_6auth2 for credentials found in
+ *   'GloMyAuth' and by @ref MySQL_Protocol::PPHR_5passwordFalse_0 for the
+ *   'mysql-monitor_*' credential, which is not stored there.
+ *
+ * @param cleartext_password The password ProxySQL holds, NUL-terminated.
+ * @param scramble The 20-byte connection scramble.
+ * @param client_response The response bytes sent by the client.
+ * @return true when the response matches.
+ */
+static bool caching_sha2_fast_auth_verify(
+	const char* cleartext_password,
+	const char* scramble,
+	const unsigned char* client_response
+) {
+	// Deliberately NOT length-checked against 'vars1.pass_len'. That field is not
+	// the amount of valid data in the response buffer: PPHR_2 strips a trailing
+	// NUL byte ("remove the extra 0 if present"), so a legitimate 32-byte
+	// caching_sha2 response ending in 0x00 -- about 1 in 256 -- reports
+	// pass_len == 31 while all 32 bytes are present. Gating on it rejects real
+	// logins intermittently; measured at 20 spurious denials across ~6520
+	// connections in test_auth_methods-t.
+	if (cleartext_password == NULL || client_response == NULL) {
+		return false;
+	}
+
+	unsigned char a[SHA256_DIGEST_LENGTH];
+	unsigned char b[SHA256_DIGEST_LENGTH];
+	unsigned char c[SHA256_DIGEST_LENGTH+20];
+	unsigned char d[SHA256_DIGEST_LENGTH];
+	unsigned char e[SHA256_DIGEST_LENGTH];
+	SHA256((const unsigned char *)cleartext_password, strlen(cleartext_password), a);
+	SHA256(a, SHA256_DIGEST_LENGTH, b);
+	memcpy(c,b,SHA256_DIGEST_LENGTH);
+	memcpy(c+SHA256_DIGEST_LENGTH, scramble, 20);
+	SHA256(c, SHA256_DIGEST_LENGTH+20, d);
+	for (int i=0; i<SHA256_DIGEST_LENGTH; i++) {
+		e[i] = a[i] ^ d[i];
+	}
+
+	return memcmp(e, client_response, SHA256_DIGEST_LENGTH) == 0;
+}
+
 void MySQL_Protocol::PPHR_6auth2(
 	bool& ret,
 	MyProt_tmp_auth_vars& vars1
 	) {
 	enum proxysql_session_type session_type = (*myds)->sess->session_type;
 	if (session_type == PROXYSQL_SESSION_MYSQL || session_type == PROXYSQL_SESSION_SQLITE || session_type == PROXYSQL_SESSION_ADMIN || session_type == PROXYSQL_SESSION_STATS) {
-		unsigned char a[SHA256_DIGEST_LENGTH];
-		unsigned char b[SHA256_DIGEST_LENGTH];
-		unsigned char c[SHA256_DIGEST_LENGTH+20];
-		unsigned char d[SHA256_DIGEST_LENGTH];
-		unsigned char e[SHA256_DIGEST_LENGTH];
-		SHA256((const unsigned char *)vars1.password, strlen(vars1.password), a);
-		SHA256(a, SHA256_DIGEST_LENGTH, b);
-		memcpy(c,b,SHA256_DIGEST_LENGTH);
-		memcpy(c+SHA256_DIGEST_LENGTH, (*myds)->myconn->scramble_buff, 20);
-		SHA256(c, SHA256_DIGEST_LENGTH+20, d);
-		for (int i=0; i<SHA256_DIGEST_LENGTH; i++) {
-			e[i] = a[i] ^ d[i];
-		}
-		if (memcmp(e,vars1.pass,SHA256_DIGEST_LENGTH)==0) {
+		if (
+			caching_sha2_fast_auth_verify(
+				vars1.password, (*myds)->myconn->scramble_buff, vars1.pass
+			)
+		) {
 			ret = true;
 		}
 	}

--- a/lib/MySQL_Protocol.cpp
+++ b/lib/MySQL_Protocol.cpp
@@ -60,26 +60,6 @@ static const char *plugins[3] = {
 
 #include "MySQL_encode.h"
 
-/**
- * @brief Credential scope to look a username up in for a given session type.
- * @details ADMIN and STATS sessions resolve against ADMIN_CRED_SCOPE; everything
- *   else (MySQL frontend, SQLite server, ClickHouse) uses USERNAME_FRONTEND.
- *
- *   On the stable tier ADMIN_CRED_SCOPE *is* USERNAME_FRONTEND, so this returns
- *   the same value for every session type and nothing changes. From PROXYSQL31
- *   the scopes are distinct, which means an Admin session no longer resolves
- *   'mysql_users' rows and a frontend session no longer resolves Admin
- *   credentials -- neither could usefully authenticate with the other's entry
- *   anyway (the post-auth hostgroup gate in MySQL_Session rejects both), but
- *   sharing one map let them overwrite each other. See #5987.
- */
-static inline enum cred_username_type cred_scope_for_session(enum proxysql_session_type session_type) {
-	if (session_type == PROXYSQL_SESSION_ADMIN || session_type == PROXYSQL_SESSION_STATS) {
-		return ADMIN_CRED_SCOPE;
-	}
-	return USERNAME_FRONTEND;
-}
-
 char* get_password(account_details_t& ad, PASSWORD_TYPE::E passtype) {
 	char* ret = nullptr;
 

--- a/lib/PgSQL_Authentication.cpp
+++ b/lib/PgSQL_Authentication.cpp
@@ -26,18 +26,22 @@ PgSQL_Authentication::PgSQL_Authentication() {
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_init(&creds_backends.lock, NULL);
 	pthread_rwlock_init(&creds_frontends.lock, NULL);
+	pthread_rwlock_init(&creds_admins.lock, NULL);
 #else
 	spinlock_rwlock_init(&creds_backends.lock);
 	spinlock_rwlock_init(&creds_frontends.lock);
+	spinlock_rwlock_init(&creds_admins.lock);
 #endif
 	creds_backends.cred_array = new PtrArray();
 	creds_frontends.cred_array = new PtrArray();
+	creds_admins.cred_array = new PtrArray();
 };
 
 PgSQL_Authentication::~PgSQL_Authentication() {
 	reset();
 	delete creds_backends.cred_array;
 	delete creds_frontends.cred_array;
+	delete creds_admins.cred_array;
 };
 
 void PgSQL_Authentication::print_version() {
@@ -45,7 +49,7 @@ void PgSQL_Authentication::print_version() {
 	};
 
 void PgSQL_Authentication::set_all_inactive(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
 #else
@@ -64,7 +68,7 @@ void PgSQL_Authentication::set_all_inactive(enum cred_username_type usertype) {
 }
 
 void PgSQL_Authentication::remove_inactives(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
 #else
@@ -86,6 +90,23 @@ __loop_remove_inactives:
 #endif
 }
 
+/**
+ * @brief Select the credential scope for a username type.
+ * @details Mirrors MySQL_Authentication::creds_for(). USERNAME_ADMIN is only
+ *   passed when PROXYSQL31 is defined; otherwise ADMIN_CRED_SCOPE is
+ *   USERNAME_FRONTEND and 'creds_admins' is never reached.
+ */
+creds_group_t& PgSQL_Authentication::creds_for(enum cred_username_type usertype) {
+	switch (usertype) {
+		case USERNAME_BACKEND:
+			return creds_backends;
+		case USERNAME_ADMIN:
+			return creds_admins;
+		default:
+			return creds_frontends;
+	}
+}
+
 bool PgSQL_Authentication::add(char * username, char * password, enum cred_username_type usertype, bool use_ssl, int default_hostgroup, bool transaction_persistent, bool fast_forward, int max_connections, char* attributes, char *comment) {
 	uint64_t hash1, hash2;
 	SpookyHash myhash;
@@ -93,7 +114,7 @@ bool PgSQL_Authentication::add(char * username, char * password, enum cred_usern
 	myhash.Update(username,strlen(username));
 	myhash.Final(&hash1,&hash2);
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 	
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
@@ -408,7 +429,7 @@ bool PgSQL_Authentication::del(char * username, enum cred_username_type usertype
 	myhash->Final(&hash1,&hash2);
 	delete myhash;
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 	if (set_lock)
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
@@ -448,7 +469,7 @@ bool PgSQL_Authentication::set_SHA1(char * username, enum cred_username_type use
 	myhash->Final(&hash1,&hash2);
 	delete myhash;
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
@@ -501,7 +522,7 @@ char * PgSQL_Authentication::lookup(char * username, enum cred_username_type use
 	myhash.Update(username,strlen(username));
 	myhash.Final(&hash1,&hash2);
 
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_rdlock(&cg.lock);
@@ -536,7 +557,7 @@ char * PgSQL_Authentication::lookup(char * username, enum cred_username_type use
 }
 
 bool PgSQL_Authentication::_reset(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 
 #ifdef PROXYSQL_AUTH_PTHREAD_MUTEX
 	pthread_rwlock_wrlock(&cg.lock);
@@ -617,7 +638,7 @@ static uint64_t compute_accounts_hash(const umap_pgauth& accs_map) {
 }
 
 uint64_t PgSQL_Authentication::_get_runtime_checksum(enum cred_username_type usertype) {
-	creds_group_t &cg=(usertype==USERNAME_BACKEND ? creds_backends : creds_frontends);
+	creds_group_t &cg = creds_for(usertype);
 	uint64_t accs_hash = compute_accounts_hash(cg.bt_map);
 
 	return accs_hash;

--- a/lib/PgSQL_Protocol.cpp
+++ b/lib/PgSQL_Protocol.cpp
@@ -904,7 +904,10 @@ EXECUTION_STATE PgSQL_Protocol::process_handshake_response_packet(unsigned char*
 		goto __exit_process_pkt_handshake_response;
 	}
 
-	password = GloPgAuth->lookup((char*)user, USERNAME_FRONTEND, &_ret_use_ssl, &default_hostgroup, &transaction_persistent, &fast_forward, &max_connections, &sha1_pass, &attributes);
+	// ADMIN/STATS sessions resolve against the Admin credential scope; see
+	// cred_scope_for_session(). On the stable tier this is USERNAME_FRONTEND and
+	// behaviour is unchanged. See #5987.
+	password = GloPgAuth->lookup((char*)user, cred_scope_for_session((*myds)->sess->session_type), &_ret_use_ssl, &default_hostgroup, &transaction_persistent, &fast_forward, &max_connections, &sha1_pass, &attributes);
 
 	if (password) {
 #ifdef DEBUG

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -3941,7 +3941,7 @@ void ProxySQL_Admin::add_credentials(char *credentials, int hostgroup_id) {
 			}
 		} else if constexpr (pt == SERVER_TYPE_PGSQL) {
 			if (GloPgAuth) { // this check if required if GloPgAuth doesn't exist yet
-				GloPgAuth->add(user, pass, USERNAME_FRONTEND, 0, hostgroup_id, 0, 0, 1000, (char*)"", (char*)"");
+				GloPgAuth->add(user, pass, ADMIN_CRED_SCOPE, 0, hostgroup_id, 0, 0, 1000, (char*)"", (char*)"");
 			}
 		}
 
@@ -3980,7 +3980,7 @@ void ProxySQL_Admin::delete_credentials(char *credentials) {
 		}
 		else if constexpr (pt == SERVER_TYPE_PGSQL) {
 			if (GloPgAuth) { // this check if required if GloPgAuth doesn't exist yet
-				GloPgAuth->del(user, USERNAME_FRONTEND);
+				GloPgAuth->del(user, ADMIN_CRED_SCOPE);
 			}
 		}
 		free(user);

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -3934,7 +3934,10 @@ void ProxySQL_Admin::add_credentials(char *credentials, int hostgroup_id) {
 		
 		if constexpr (pt == SERVER_TYPE_MYSQL) { 
 			if (GloMyAuth) { // this check if required if GloMyAuth doesn't exist yet
-				GloMyAuth->add(user, pass, USERNAME_FRONTEND, 0, hostgroup_id, (char*)"main", 0, 0, 0, 1000, (char*)"", (char*)"");
+				// ADMIN_CRED_SCOPE keeps these out of the mysql_users namespace from
+				// the Innovative tier onward; on the stable tier it is
+				// USERNAME_FRONTEND and behaviour is unchanged. See #5987.
+				GloMyAuth->add(user, pass, ADMIN_CRED_SCOPE, 0, hostgroup_id, (char*)"main", 0, 0, 0, 1000, (char*)"", (char*)"");
 			}
 		} else if constexpr (pt == SERVER_TYPE_PGSQL) {
 			if (GloPgAuth) { // this check if required if GloPgAuth doesn't exist yet
@@ -3966,7 +3969,13 @@ void ProxySQL_Admin::delete_credentials(char *credentials) {
 
 		if constexpr (pt == SERVER_TYPE_MYSQL) {
 			if (GloMyAuth) { // this check if required if GloMyAuth doesn't exist yet
-				GloMyAuth->del(user, USERNAME_FRONTEND);
+				// Deleting from ADMIN_CRED_SCOPE. On the stable tier this is
+				// USERNAME_FRONTEND, so changing admin-admin_credentials still
+				// removes a same-named mysql_users row from the runtime auth map
+				// until the next LOAD MYSQL USERS TO RUNTIME -- the documented
+				// "do not reuse the name" rule. From PROXYSQL31 the scopes are
+				// separate and the two cannot touch each other. See #5987.
+				GloMyAuth->del(user, ADMIN_CRED_SCOPE);
 			}
 		}
 		else if constexpr (pt == SERVER_TYPE_PGSQL) {

--- a/lib/ProxySQL_HTTP_Server.cpp
+++ b/lib/ProxySQL_HTTP_Server.cpp
@@ -386,7 +386,15 @@ int ProxySQL_HTTP_Server::handler(void *cls, struct MHD_Connection *connection, 
 		MHD_destroy_response(response);
 		return ret;
 	}
-	account_details_t ad { GloMyAuth->lookup(username, USERNAME_FRONTEND, { false, false, false }) };
+	// The web UI authenticates the 'stats' account, which is populated from
+	// 'admin-stats_credentials' (see add_credentials() in ProxySQL_Admin.cpp).
+	// It must therefore be looked up in the SAME scope those credentials are
+	// added to -- ADMIN_CRED_SCOPE -- not in USERNAME_FRONTEND. On the stable
+	// tier ADMIN_CRED_SCOPE *is* USERNAME_FRONTEND, so this is a no-op there;
+	// under PROXYSQL31 the admin/stats accounts live in USERNAME_ADMIN and a
+	// USERNAME_FRONTEND lookup returns no password, failing every request with
+	// HTTP 401. See #5987.
+	account_details_t ad { GloMyAuth->lookup(username, ADMIN_CRED_SCOPE, { false, false, false }) };
 	{
 		if (
 			(ad.default_hostgroup != STATS_HOSTGROUP)

--- a/test/repro/README.md
+++ b/test/repro/README.md
@@ -1,0 +1,69 @@
+# test/repro
+
+Standalone, self-verifying reproductions for specific issues.
+
+These are **developer-facing tools**, not part of CI. They exist so that a claim
+about ProxySQL's behaviour can be re-checked in one command instead of being
+re-derived from the source each time. The CI artifacts are the TAP tests; where a
+reproduction here has a TAP counterpart, both are listed below.
+
+## Scripts
+
+| Script | Issue | Exits |
+|---|---|---|
+| `reg_test_5363_admin_monitor_caching_sha2.bash` | [#5363](https://github.com/sysown/proxysql/issues/5363) | `0` fixed · `1` reproduced · `2` environment/baseline broken |
+| `reg_test_5985_admin_caching_sha2_full_auth.bash` | [#5985](https://github.com/sysown/proxysql/issues/5985) | `0` behaves as documented · `1` assertion failed · `2` cannot be tested |
+
+`reg_test_5363_*` distinguishes exit `1` (the reported bug reproduced, every
+failure tagged `[BUG #5363]`) from exit `2` (the baseline itself failed, so the
+run should not be trusted). The TAP counterpart is
+`test/tap/tests/reg_test_5363_admin_monitor_caching_sha2-t.cpp` in group
+`no-infra-g1`.
+
+`reg_test_5985_*` demonstrates that caching_sha2_password full authentication
+completes on the Admin interface against a hashed credential — the behaviour that
+issue #5985 ask 2 assumed was broken.
+
+## Running them
+
+```bash
+make clean && PROXYSQL31=1 make debug -j"$(nproc)"      # a DEBUG build is required
+WORKSPACE=$(pwd) INFRA_ID=dev-$USER test/repro/<script>.bash
+```
+
+Both scripts refuse to run against a release build, because the isolated harness
+needs debug-only admin commands.
+
+## COLD_START
+
+```
+COLD_START=0   (default) use the existing ProxySQL instance
+COLD_START=1   destroy and recreate it first
+```
+
+`COLD_START=1` is **destructive**: it stops the ProxySQL container for
+`$INFRA_ID` and deletes its persisted `proxysql.db`. Backend infrastructure and
+other `INFRA_ID`s are untouched.
+
+It matters for `reg_test_5985_*`. That script proves full authentication happened
+by showing a login succeeded while `Client_Connections_sha2cached` was still `0` —
+ProxySQL caches the cleartext recovered by a successful full auth and reuses it,
+so a warm cache would make a passing login prove nothing. If the cache is already
+warm the script exits `2` and tells you to re-run with `COLD_START=1`, rather
+than reporting a pass it cannot justify.
+
+`reg_test_5363_*` does not need it: the monitor credential is handled by
+`PPHR_5passwordFalse_0()`, which never populates that cache.
+
+## Adding a script
+
+Keep them honest about what they prove:
+
+- Assert the **desired** behaviour, so the script goes green when the bug is
+  fixed without being edited.
+- Separate "the bug reproduced" from "the environment is wrong" in the exit code.
+  A reproduction that cannot tell those apart is worse than none.
+- Include a control that fails if the mechanism under test is not the one being
+  exercised.
+- Restore any global state that was changed, including on failure paths — these
+  run against a shared instance.

--- a/test/repro/reg_test_5363_admin_monitor_caching_sha2.bash
+++ b/test/repro/reg_test_5363_admin_monitor_caching_sha2.bash
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# reg_test_5363_admin_monitor_caching_sha2.bash
+#
+# Reproduces: the mysql-monitor_username / mysql-monitor_password credential
+# cannot authenticate on the ProxySQL Admin interface (:6032) when
+# mysql-default_authentication_plugin = 'caching_sha2_password'.
+# It works under mysql_native_password. TLS does not help.
+#
+#   https://github.com/sysown/proxysql/issues/5363   (k8s liveness/readiness
+#                                                     probes failing)
+#   https://github.com/sysown/proxysql/issues/5985   Finding 2
+#
+# EXPECTED EXIT CODE
+#   Non-zero WHILE THE BUG EXISTS. The assertions below describe the desired
+#   behaviour, so the caching_sha2 cases fail today and are tagged [BUG #5363].
+#   When the bug is fixed this script must exit 0 with no tagged failures.
+#
+# ROOT CAUSE (for the reader; not asserted by this script)
+#   mysql-monitor_* is not stored in GloMyAuth, so PPHR_verify_password() takes
+#   its vars1.password == NULL branch and the credential is handled solely by
+#   MySQL_Protocol::PPHR_5passwordFalse_0() (lib/MySQL_Protocol.cpp:2052), which
+#   is hardcoded to the mysql_native_password scramble:
+#       proxy_scramble(reply, scramble_buff, mysql_thread___monitor_password);
+#       if (memcmp(reply, vars1.pass, SHA_DIGEST_LENGTH)==0)   // 20 bytes
+#   Under caching_sha2_password the client's fast-auth response is a 32-byte
+#   SHA256-derived value, so this comparison can never succeed. The pre-existing
+#   comment on line 2053 -- "FIXME: does this work only for mysql_native_password ?"
+#   -- is this bug.
+#
+# WHY THE CLIENT RUNS INSIDE THE CONTAINER
+#   The monitor credential is subject to a locality restriction: connecting from
+#   off-box yields "ERROR 1040 User 'monitor' can only connect locally", which is
+#   raised AFTER a successful authentication and would mask the result. Running
+#   the client on 127.0.0.1 inside the container both avoids that and matches the
+#   real-world case in #5363 (a probe running inside the pod).
+#
+# SCOPE
+#   No mysql_users rows are created and no admin credential named 'monitor'
+#   exists, so PPHR_5passwordFalse_0() is genuinely the code path under test.
+#   A control case proves caching_sha2 itself works on Admin, so a failure here
+#   is specific to the monitor credential.
+#
+# REQUIREMENTS
+#   DEBUG build at $WORKSPACE/src/proxysql:
+#       make clean && PROXYSQL31=1 make debug -j"$(nproc)"
+#
+# USAGE
+#   WORKSPACE=$(pwd) INFRA_ID=dev-$USER \
+#     test/repro/reg_test_5363_admin_monitor_caching_sha2.bash
+#
+# COLD START
+#   Not required by this script -- the monitor credential never touches the
+#   caching_sha2 cleartext cache -- but available for a guaranteed-clean run:
+#
+#     COLD_START=1   destroy and recreate the ProxySQL instance first. DESTRUCTIVE:
+#                    deletes the persisted proxysql.db for $INFRA_ID. Backend
+#                    infrastructure and other INFRA_IDs are untouched.
+#     COLD_START=0   (default) use the instance as-is.
+#
+#   Either way the script refuses to run if the container predates
+#   $WORKSPACE/src/proxysql, since that would test a binary you did not just build.
+#
+set -uo pipefail
+
+WORKSPACE="${WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+INFRA_ID="${INFRA_ID:-dev-$USER}"
+TAP_GROUP="${TAP_GROUP:-no-infra-g1}"
+COLD_START="${COLD_START:-0}"
+
+CTR="proxysql.${INFRA_ID}"
+DATADIR="${WORKSPACE}/ci_infra_logs/${INFRA_ID}/proxysql"
+MON_USER='monitor'
+MON_PASS='monitorpass'
+BASE_CREDS='admin:admin;radmin:radmin;cluster1:secret1pass'
+
+PASS=0; FAIL=0; BUGS=0
+ok()  { PASS=$((PASS+1)); printf '  ok %d - %s\n'     "$((PASS+FAIL))" "$1"; }
+nok() { FAIL=$((FAIL+1)); printf '  NOT OK %d - %s\n' "$((PASS+FAIL))" "$1"; }
+bug() { FAIL=$((FAIL+1)); BUGS=$((BUGS+1)); printf '  NOT OK %d - [BUG #5363] %s\n' "$((PASS+FAIL))" "$1"; }
+hdr() { printf '\n== %s ==\n' "$1"; }
+die() { printf '\nFATAL: %s\n' "$1" >&2; exit 2; }
+
+IP=''
+adm() { mysql -h"$IP" -P6032 -uradmin -pradmin --protocol=TCP -NBe "$1" 2>/dev/null; }
+setvar() {  # setvar <variable_name> <value> <LOAD statement>
+	adm "UPDATE global_variables SET variable_value='$2' WHERE variable_name='$1'; $3" >/dev/null
+}
+# login_local <user> <pass> <ssl-mode>  -- runs the client INSIDE the container
+login_local() {
+	docker exec "$CTR" mysql -h127.0.0.1 -P6032 -u"$1" -p"$2" \
+		--protocol=TCP --ssl-mode="$3" -NBe "SELECT 1;" >/dev/null 2>&1
+}
+
+# ------------------------------------------------------------- preflight ---
+command -v docker >/dev/null || die "docker not found"
+command -v mysql  >/dev/null || die "mysql client not found"
+[ -x "${WORKSPACE}/src/proxysql" ] || die "no binary at ${WORKSPACE}/src/proxysql -- build it first"
+"${WORKSPACE}/src/proxysql" --version 2>&1 | grep -q '_DEBUG' \
+	|| die "${WORKSPACE}/src/proxysql is not a DEBUG build"
+
+# ------------------------------------------------------------ instance ---
+# This script does NOT need a cold cache: the monitor credential is handled by
+# PPHR_5passwordFalse_0(), which never calls set_clear_text_password(), so the
+# caching_sha2 cleartext cache plays no part in the result. COLD_START is offered
+# only for symmetry with the #5985 companion and for a guaranteed-clean run.
+if [ "$COLD_START" = "1" ]; then
+	hdr "Cold start: destroying and recreating ProxySQL for INFRA_ID=${INFRA_ID}"
+	WORKSPACE="$WORKSPACE" INFRA_ID="$INFRA_ID" TAP_GROUP="$TAP_GROUP" \
+		"${WORKSPACE}/test/infra/control/stop-proxysql-isolated.bash" >/dev/null 2>&1
+	rm -f "${DATADIR}"/proxysql.db "${DATADIR}"/proxysql_debug.db \
+	      "${DATADIR}"/proxysql_stats.db "${DATADIR}"/sqlite3server.db 2>/dev/null
+	WORKSPACE="$WORKSPACE" INFRA_ID="$INFRA_ID" TAP_GROUP="$TAP_GROUP" \
+		"${WORKSPACE}/test/infra/control/start-proxysql-isolated.bash" >/dev/null 2>&1 \
+		|| die "start-proxysql-isolated.bash failed"
+else
+	hdr "Using the existing ProxySQL instance (set COLD_START=1 to recreate it)"
+	WORKSPACE="$WORKSPACE" INFRA_ID="$INFRA_ID" TAP_GROUP="$TAP_GROUP" \
+		"${WORKSPACE}/test/infra/control/ensure-infras.bash" >/dev/null 2>&1 \
+		|| die "ensure-infras.bash failed"
+fi
+
+IP="$(docker inspect "$CTR" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null)"
+[ -n "$IP" ] || die "could not determine IP of ${CTR}"
+docker exec "$CTR" which mysql >/dev/null 2>&1 || die "no mysql client inside ${CTR}"
+
+# Guard against testing a STALE binary. The container bind-mounts
+# $WORKSPACE/src/proxysql, but the RUNNING process is whatever was started: a
+# rebuild does not restart it, and ensure-infras.bash deliberately will not
+# recreate a container that is already up. Without this check a freshly built fix
+# can appear absent -- or a reverted one appear present -- purely because the
+# container predates the binary, which is a very easy way to draw the wrong
+# conclusion from this script.
+BIN_MTIME="$(stat -c %Y "${WORKSPACE}/src/proxysql" 2>/dev/null || echo 0)"
+CTR_STARTED="$(docker inspect -f '{{.State.StartedAt}}' "$CTR" 2>/dev/null)"
+CTR_EPOCH="$(date -d "$CTR_STARTED" +%s 2>/dev/null || echo 0)"
+if [ "$BIN_MTIME" -gt "$CTR_EPOCH" ] 2>/dev/null; then
+	die "the running ProxySQL container predates ${WORKSPACE}/src/proxysql, so it is
+       NOT running the binary you just built. Re-run with COLD_START=1, or refresh
+       the container with:
+         WORKSPACE=\$(pwd) INFRA_ID=${INFRA_ID} TAP_GROUP=${TAP_GROUP} \\
+           test/infra/control/start-proxysql-isolated.bash"
+fi
+echo "  ${CTR} at ${IP} -- $(adm 'SELECT @@admin-version;')"
+
+restore() {
+	setvar 'admin-admin_credentials' "$BASE_CREDS" 'LOAD ADMIN VARIABLES TO RUNTIME;'
+	setvar 'mysql-default_authentication_plugin' 'mysql_native_password' 'LOAD MYSQL VARIABLES TO RUNTIME;'
+	setvar 'mysql-monitor_password' 'monitor' 'LOAD MYSQL VARIABLES TO RUNTIME;'
+}
+trap restore EXIT
+
+# ----------------------------------------------------------- preconditions ---
+hdr "Preconditions"
+[ "$(adm 'SELECT count(*) FROM runtime_mysql_users;')" = "0" ] \
+	&& ok "no mysql_users rows (nothing can shadow the monitor credential)" \
+	|| nok "mysql_users is not empty -- result would be confounded"
+adm "SELECT @@admin-admin_credentials;" | grep -q "${MON_USER}:" \
+	&& nok "an admin credential named '${MON_USER}' exists -- wrong code path" \
+	|| ok "no admin credential named '${MON_USER}' (PPHR_5passwordFalse_0 is the path)"
+
+setvar 'mysql-monitor_username' "$MON_USER" 'LOAD MYSQL VARIABLES TO RUNTIME;'
+setvar 'mysql-monitor_password' "$MON_PASS" 'LOAD MYSQL VARIABLES TO RUNTIME;'
+[ "$(adm 'SELECT @@mysql-monitor_username;')" = "$MON_USER" ] &&
+[ "$(adm 'SELECT @@mysql-monitor_password;')" = "$MON_PASS" ] \
+	&& ok "mysql-monitor_username/password set to ${MON_USER}/${MON_PASS} (cleartext, as documented)" \
+	|| nok "failed to set mysql-monitor_* variables"
+
+# ------------------------------------------------- baseline: native works ---
+hdr "Baseline: mysql_native_password"
+setvar 'mysql-default_authentication_plugin' 'mysql_native_password' 'LOAD MYSQL VARIABLES TO RUNTIME;'
+login_local "$MON_USER" "$MON_PASS" DISABLED \
+	&& ok  "${MON_USER} authenticates on :6032 over plaintext" \
+	|| nok "${MON_USER} FAILED under native/plaintext -- baseline broken, investigate before trusting the rest"
+login_local "$MON_USER" "$MON_PASS" REQUIRED \
+	&& ok  "${MON_USER} authenticates on :6032 over TLS" \
+	|| nok "${MON_USER} FAILED under native/TLS -- baseline broken"
+
+# ------------------------------------------------------------- the bug ---
+hdr "caching_sha2_password"
+setvar 'mysql-default_authentication_plugin' 'caching_sha2_password' 'LOAD MYSQL VARIABLES TO RUNTIME;'
+[ "$(adm 'SELECT @@mysql-default_authentication_plugin;')" = "caching_sha2_password" ] \
+	&& ok "mysql-default_authentication_plugin = caching_sha2_password" \
+	|| nok "failed to switch the default authentication plugin"
+
+login_local "$MON_USER" "$MON_PASS" DISABLED \
+	&& ok  "${MON_USER} authenticates on :6032 over plaintext" \
+	|| bug "${MON_USER} cannot authenticate on :6032 over plaintext (Access denied)"
+login_local "$MON_USER" "$MON_PASS" REQUIRED \
+	&& ok  "${MON_USER} authenticates on :6032 over TLS" \
+	|| bug "${MON_USER} cannot authenticate on :6032 over TLS -- TLS is not a workaround"
+
+# -------------------------------------------------------------- control ---
+# Proves the failure above is specific to the monitor credential and not to
+# caching_sha2 on the Admin interface generally.
+hdr "Control: an ordinary admin credential under the same settings"
+login_local admin admin DISABLED \
+	&& ok  "admin/admin authenticates on :6032 under caching_sha2 (so caching_sha2 works on Admin)" \
+	|| nok "admin/admin also failed -- the monitor result is not specific; investigate"
+login_local "$MON_USER" "WRONGPASS" DISABLED \
+	&& nok "a wrong monitor password was ACCEPTED" \
+	|| ok  "wrong monitor password rejected"
+
+# --------------------------------------------------------------- summary ---
+hdr "Summary"
+printf '  passed: %d\n  failed: %d (of which %d are the reported bug)\n' "$PASS" "$FAIL" "$BUGS"
+if [ "$FAIL" -eq 0 ]; then
+	echo
+	echo "  All assertions pass: #5363 appears FIXED on this build."
+	exit 0
+fi
+if [ "$FAIL" -eq "$BUGS" ]; then
+	cat <<'EOS'
+
+  REPRODUCED. Every failure is a [BUG #5363] assertion:
+    mysql-monitor_* authenticates on the Admin interface under
+    mysql_native_password and is rejected under caching_sha2_password, on both
+    plaintext and TLS, with no mysql_users row and no same-named admin
+    credential involved. An ordinary admin credential works under the identical
+    settings, so this is specific to the monitor credential.
+
+  Non-zero exit is expected until the bug is fixed.
+EOS
+	exit 1
+fi
+echo
+echo "  Some failures are NOT the reported bug -- the environment or baseline is wrong."
+exit 2

--- a/test/repro/reg_test_5985_admin_caching_sha2_full_auth.bash
+++ b/test/repro/reg_test_5985_admin_caching_sha2_full_auth.bash
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+#
+# reg_test_5985_admin_caching_sha2_full_auth.bash
+#
+# Demonstrates that caching_sha2_password FULL AUTHENTICATION works on the
+# ProxySQL ADMIN interface (:6032) against a caching_sha2-hashed credential.
+#
+# Context: https://github.com/sysown/proxysql/issues/5985
+#   Ask 2 of that issue asserts that Admin fails to verify a cleartext password
+#   received over TLS, and asks for the Admin full-auth completion to be fixed.
+#   This script shows that completion already works.
+#
+# HOW THE RESULT IS PROVEN
+#   caching_sha2_password completes either by FAST auth (challenge-response,
+#   possible only when ProxySQL can derive the password) or by FULL auth
+#   (ProxySQL sends 'perform full authentication' 0x04 and the client returns
+#   the cleartext over TLS). With only a hash stored, fast auth is impossible.
+#
+#   ProxySQL caches the cleartext recovered by a successful full auth and reuses
+#   it later; every cache HIT increments
+#       stats_mysql_global.Client_Connections_sha2cached
+#   A login that succeeds while that counter is still 0 therefore cannot have
+#   come from the cache, and must have completed a full auth. That is the
+#   assertion this script is built around, which is why it insists on a cold
+#   start: a warm cache would invalidate the proof.
+#
+# SCOPE
+#   Only the question above. No mysql_users rows are created (issue #5985
+#   Finding 1 is a different problem and would confound the result), and
+#   mysql-monitor_* is not touched (#5363 is a different bug on a different
+#   code path).
+#
+# REQUIREMENTS
+#   - DEBUG build at $WORKSPACE/src/proxysql:
+#         make clean && PROXYSQL31=1 make debug -j"$(nproc)"
+#   - docker, and a MySQL client supporting --ssl-mode
+#
+# USAGE
+#   WORKSPACE=$(pwd) INFRA_ID=dev-$USER \
+#     test/repro/reg_test_5985_admin_caching_sha2_full_auth.bash
+#
+# COLD START
+#   This script REQUIRES a cold cleartext cache, because the whole proof is that a
+#   login succeeded while Client_Connections_sha2cached was still 0.
+#
+#     COLD_START=1   destroy and recreate the ProxySQL instance first. DESTRUCTIVE:
+#                    deletes the persisted proxysql.db for $INFRA_ID. Backend
+#                    infrastructure and other INFRA_IDs are untouched.
+#     COLD_START=0   (default) use the instance as-is. If the cache is already warm
+#                    the script exits 2 rather than reporting a meaningless pass.
+#
+set -uo pipefail
+
+WORKSPACE="${WORKSPACE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+INFRA_ID="${INFRA_ID:-dev-$USER}"
+TAP_GROUP="${TAP_GROUP:-no-infra-g1}"
+COLD_START="${COLD_START:-0}"
+
+CTR="proxysql.${INFRA_ID}"
+DATADIR="${WORKSPACE}/ci_infra_logs/${INFRA_ID}/proxysql"
+USR='cs2adm'
+PW='secret'
+BASE_CREDS='admin:admin;radmin:radmin;cluster1:secret1pass'
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ok %d - %s\n'     "$((PASS+FAIL))" "$1"; }
+nok() { FAIL=$((FAIL+1)); printf '  NOT OK %d - %s\n' "$((PASS+FAIL))" "$1"; }
+hdr() { printf '\n== %s ==\n' "$1"; }
+die() { printf '\nFATAL: %s\n' "$1" >&2; exit 2; }
+
+IP=''
+adm() { mysql -h"$IP" -P6032 -uradmin -pradmin --protocol=TCP -NBe "$1" 2>/dev/null; }
+sha2cached() { adm "SELECT Variable_Value FROM stats_mysql_global WHERE Variable_Name='Client_Connections_sha2cached';"; }
+login() {  # login <user> <pass> <ssl-mode> -> 0 on success
+	mysql -h"$IP" -P6032 -u"$1" -p"$2" --protocol=TCP --ssl-mode="$3" -NBe "SELECT 1;" >/dev/null 2>&1
+}
+
+# ------------------------------------------------------------- preflight ---
+command -v docker >/dev/null || die "docker not found"
+command -v mysql  >/dev/null || die "mysql client not found"
+[ -x "${WORKSPACE}/src/proxysql" ] || die "no binary at ${WORKSPACE}/src/proxysql -- build it first"
+"${WORKSPACE}/src/proxysql" --version 2>&1 | grep -q '_DEBUG' \
+	|| die "${WORKSPACE}/src/proxysql is not a DEBUG build"
+
+# ------------------------------------------------------------ instance ---
+# This script REQUIRES a cold cleartext cache: the whole proof is that a login
+# succeeded while Client_Connections_sha2cached was still 0. If the cache is warm
+# the run is aborted rather than reporting a meaningless pass -- see the guard
+# immediately after the instance is up.
+if [ "$COLD_START" = "1" ]; then
+	hdr "Cold start: destroying and recreating ProxySQL for INFRA_ID=${INFRA_ID}"
+	WORKSPACE="$WORKSPACE" INFRA_ID="$INFRA_ID" TAP_GROUP="$TAP_GROUP" \
+		"${WORKSPACE}/test/infra/control/stop-proxysql-isolated.bash" >/dev/null 2>&1
+	rm -f "${DATADIR}"/proxysql.db "${DATADIR}"/proxysql_debug.db \
+	      "${DATADIR}"/proxysql_stats.db "${DATADIR}"/sqlite3server.db 2>/dev/null
+	docker ps -a --filter "name=^${CTR}$" --format '{{.Names}}' | grep -q . \
+		&& die "container ${CTR} still present after stop"
+	WORKSPACE="$WORKSPACE" INFRA_ID="$INFRA_ID" TAP_GROUP="$TAP_GROUP" \
+		"${WORKSPACE}/test/infra/control/start-proxysql-isolated.bash" >/dev/null 2>&1 \
+		|| die "start-proxysql-isolated.bash failed"
+else
+	hdr "Using the existing ProxySQL instance (set COLD_START=1 to recreate it)"
+	WORKSPACE="$WORKSPACE" INFRA_ID="$INFRA_ID" TAP_GROUP="$TAP_GROUP" \
+		"${WORKSPACE}/test/infra/control/ensure-infras.bash" >/dev/null 2>&1 \
+		|| die "ensure-infras.bash failed"
+fi
+
+IP="$(docker inspect "$CTR" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null)"
+[ -n "$IP" ] || die "could not determine IP of ${CTR}"
+echo "  ${CTR} at ${IP} -- $(adm 'SELECT @@admin-version;')"
+
+# Guard against testing a STALE binary. The container bind-mounts
+# $WORKSPACE/src/proxysql, but the RUNNING process is whatever was started: a
+# rebuild does not restart it, and ensure-infras.bash deliberately will not
+# recreate a container that is already up. Without this check a freshly built fix
+# can appear absent -- or a reverted one appear present -- purely because the
+# container predates the binary, which is a very easy way to draw the wrong
+# conclusion from this script.
+BIN_MTIME="$(stat -c %Y "${WORKSPACE}/src/proxysql" 2>/dev/null || echo 0)"
+CTR_STARTED="$(docker inspect -f '{{.State.StartedAt}}' "$CTR" 2>/dev/null)"
+CTR_EPOCH="$(date -d "$CTR_STARTED" +%s 2>/dev/null || echo 0)"
+if [ "$BIN_MTIME" -gt "$CTR_EPOCH" ] 2>/dev/null; then
+	die "the running ProxySQL container predates ${WORKSPACE}/src/proxysql, so it is
+       NOT running the binary you just built. Re-run with COLD_START=1, or refresh
+       the container with:
+         WORKSPACE=\$(pwd) INFRA_ID=${INFRA_ID} TAP_GROUP=${TAP_GROUP} \\
+           test/infra/control/start-proxysql-isolated.bash"
+fi
+
+# Hard requirement, not an assertion: without a cold cache the central claim
+# cannot be tested at all, so refuse to run rather than emit a false pass.
+if [ "$(sha2cached)" != "0" ]; then
+	die "Client_Connections_sha2cached is '$(sha2cached)', not 0: the cleartext cache is
+       already warm, so a successful login here would prove nothing. Re-run with
+       COLD_START=1 to recreate the instance."
+fi
+
+restore() {
+	adm "UPDATE global_variables SET variable_value='${BASE_CREDS}' WHERE variable_name='admin-admin_credentials';
+	     LOAD ADMIN VARIABLES TO RUNTIME;
+	     UPDATE global_variables SET variable_value='mysql_native_password' WHERE variable_name='mysql-default_authentication_plugin';
+	     LOAD MYSQL VARIABLES TO RUNTIME;" >/dev/null
+}
+trap restore EXIT
+
+hdr "Preconditions"
+[ "$(adm 'SELECT count(*) FROM runtime_mysql_users;')" = "0" ] \
+	&& ok "no mysql_users rows (Finding 1 cannot interfere)" \
+	|| nok "mysql_users is not empty -- result would be confounded"
+[ "$(sha2cached)" = "0" ] \
+	&& ok "Client_Connections_sha2cached == 0 (cleartext cache is cold)" \
+	|| nok "cleartext cache already warm -- the full-auth proof would be invalid"
+
+# --------------------------------------------------- install credential ---
+# The hash is generated by ProxySQL's own CACHING_SHA2_PASSWORD() and appended
+# in SQL, so it never passes through the shell. Note this uses
+# UPDATE global_variables rather than SET: a SET whose value carries a control
+# byte -- which CACHING_SHA2_PASSWORD() salts contain most of the time -- is
+# silently ignored, leaving the old value in place.
+hdr "Installing a caching_sha2-hashed Admin credential"
+adm "UPDATE global_variables SET variable_value='caching_sha2_password' WHERE variable_name='mysql-default_authentication_plugin';
+     LOAD MYSQL VARIABLES TO RUNTIME;" >/dev/null
+[ "$(adm 'SELECT @@mysql-default_authentication_plugin;')" = "caching_sha2_password" ] \
+	&& ok "mysql-default_authentication_plugin = caching_sha2_password" \
+	|| nok "failed to set the default authentication plugin"
+
+# Work around issue #5989 so it cannot influence the result of THIS test.
+#
+# Before #5989 was fixed, CACHING_SHA2_PASSWORD() drew its 20-byte salt from an
+# unrestricted byte range, so ~27% of generated hashes contained ';' or ':'.
+# admin-admin_credentials is tokenized on ';' and split on ':' by
+# ProxySQL_Admin::add_credentials(), so such a hash is silently split into a bogus
+# credential at LOAD ADMIN VARIABLES TO RUNTIME -- the variable still holds all 70
+# bytes and nothing errors, so a length check alone does NOT catch it, and the
+# login simply fails with a generic 'Access denied'.
+#
+# Regenerating until the hash is delimiter-free keeps that separate bug from being
+# misread as a full-auth failure here. On a build carrying the #5989 fix the loop
+# succeeds on the first attempt; it is retained so this script still gives a
+# correct answer when run against an older binary.
+EXPECT_LEN=$(( ${#BASE_CREDS} + 1 + ${#USR} + 1 + 70 ))
+TAIL_EXPR="SUBSTR(variable_value, INSTR(variable_value,';${USR}:')+$(( ${#USR} + 2 )))"
+CLEAN=0
+for _ in $(seq 1 20); do
+	adm "UPDATE global_variables SET variable_value='${BASE_CREDS}' WHERE variable_name='admin-admin_credentials';
+	     UPDATE global_variables
+	        SET variable_value = variable_value || ';${USR}:' || CACHING_SHA2_PASSWORD('${PW}')
+	      WHERE variable_name='admin-admin_credentials';" >/dev/null
+	read -r LEN SEMI COLON <<<"$(adm "SELECT LENGTH(variable_value), INSTR(${TAIL_EXPR},';'), INSTR(${TAIL_EXPR},':') FROM global_variables WHERE variable_name='admin-admin_credentials';")"
+	if [ "$LEN" = "$EXPECT_LEN" ] && [ "$SEMI" = "0" ] && [ "$COLON" = "0" ]; then CLEAN=1; break; fi
+done
+[ "$CLEAN" = "1" ] \
+	&& ok "generated a 70-byte \$A\$ hash free of ';' and ':' (credentials len ${LEN})" \
+	|| nok "could not generate a delimiter-free hash in 20 attempts"
+adm "LOAD ADMIN VARIABLES TO RUNTIME;" >/dev/null
+[ "$(sha2cached)" = "0" ] \
+	&& ok "cache still cold immediately before the auth test" \
+	|| nok "cache warmed prematurely"
+
+# ============================== THE RESULT ==============================
+hdr "RESULT: caching_sha2 full auth on the Admin interface"
+login "$USR" "$PW" REQUIRED \
+	&& ok  "${USR} authenticated on :6032 over TLS against a \$A\$ hash" \
+	|| nok "${USR} FAILED on :6032 over TLS -- full auth did not complete"
+
+C="$(sha2cached)"
+[ "$C" = "0" ] \
+	&& ok "Client_Connections_sha2cached still 0 -> that was a FULL AUTH, not a cache hit" \
+	|| nok "counter is ${C} -- the login may have been served from the cleartext cache"
+
+hdr "Controls"
+login "$USR" "WRONG" REQUIRED \
+	&& nok "wrong password ACCEPTED -- the hash is not really being verified" \
+	|| ok  "wrong password rejected over TLS"
+
+login "$USR" "$PW" REQUIRED \
+	&& ok  "second TLS connection succeeded" \
+	|| nok "second TLS connection failed"
+C2="$(sha2cached)"
+[ "${C2:-0}" -gt 0 ] 2>/dev/null \
+	&& ok "counter rose to ${C2} -> repeat connection used the cache, confirming the counter tracks cache hits" \
+	|| nok "counter did not rise on a repeat connection; the proof above is not meaningful"
+
+# ---------------------------------------------------------------- done ---
+hdr "Summary"
+printf '  passed: %d\n  failed: %d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -eq 0 ]; then
+	cat <<'EOS'
+
+  CONCLUSION
+    The Admin interface performs and completes caching_sha2_password full
+    authentication against a caching_sha2-hashed credential, from a cold
+    cache, with no mysql_users row present.
+
+    Issue #5985 ask 2 -- "fix the Admin module's full-auth completion so a
+    cleartext password received over TLS is verified against the stored
+    credential" -- therefore describes behaviour that already works.
+EOS
+	exit 0
+fi
+echo; echo "  One or more assertions failed; see above."
+exit 1

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -273,6 +273,7 @@
   "reg_test_5212_tcp_keepalive_warnings-t" : [ "legacy-g6","mysql84-g6","mysql90-g1","mysql95-g1" ],
   "reg_test_5233_set_warning-t" : [ "legacy-g6","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g6","mysql90-g1","mysql95-g1","set_parser_algorithm_3-g1" ],
   "reg_test_5306-show_warnings_with_comment-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
+  "reg_test_5363_admin_monitor_caching_sha2-t" : [ "no-infra-g1" ],
   "reg_test_5389-flush_logs_no_drop-t" : [ "legacy-g4","mysql84-g4","mysql90-g4","mysql95-g4" ],
   "reg_test_5620_fast_routing_qr_leak-t" : [ "legacy-g6" ],
   "reg_test_5639_stmt_execute_max_allowed_packet-t" : [ "mysql84-g6","mysql95-g1" ],

--- a/test/tap/tests/reg_test_5363_admin_monitor_caching_sha2-t.cpp
+++ b/test/tap/tests/reg_test_5363_admin_monitor_caching_sha2-t.cpp
@@ -1,0 +1,243 @@
+/**
+ * @file reg_test_5363_admin_monitor_caching_sha2-t.cpp
+ * @brief Regression test for issue #5363 -- the 'mysql-monitor_*' credential could
+ *   not authenticate on the Admin interface under 'caching_sha2_password'.
+ *
+ * @details
+ * 'mysql-monitor_username' / 'mysql-monitor_password' is not stored in
+ * 'GloMyAuth'. MySQL_Protocol::PPHR_verify_password() therefore reaches it via
+ * its 'vars1.password == NULL' branch, and PPHR_5passwordFalse_0() is the only
+ * code that authenticates it. That function used to be hardcoded to the
+ * mysql_native_password scramble -- a SHA1 'proxy_scramble' compared over 20
+ * bytes -- so under 'caching_sha2_password', where the client's fast-auth
+ * response is a 32-byte SHA256-derived value, it could never match. Kubernetes
+ * liveness/readiness probes and metrics exporters connecting to :6032 as the
+ * monitor user failed with 'Access denied'. TLS was not a workaround, because
+ * the function returned false without ever sending 'perform full authentication'.
+ *
+ * HOW THE ASSERTION WORKS
+ *
+ *   The monitor credential is additionally subject to a locality restriction, so
+ *   a connection from off-box is refused even when the password is correct. That
+ *   turns out to be exactly what makes this testable from CI, because the two
+ *   rejections are distinguishable and happen at different stages:
+ *
+ *     1040 ER_HOST_NOT_PRIVILEGED  "User 'monitor' can only connect locally"
+ *          -> authentication SUCCEEDED; rejected afterwards by the locality check
+ *     1045 ER_ACCESS_DENIED_ERROR  "Access denied for user 'monitor'"
+ *          -> authentication FAILED
+ *
+ *   So the regression is precisely "correct password yields 1045 instead of
+ *   1040 under caching_sha2_password". Before the fix the caching_sha2 rows
+ *   below returned 1045; they must now return 1040.
+ *
+ *   This avoids needing to run the client inside the ProxySQL container, which a
+ *   TAP test cannot do. The developer-facing reproduction in
+ *   test/repro/reg_test_5363_admin_monitor_caching_sha2.bash does connect locally
+ *   and asserts a real successful login; the two are complementary.
+ *
+ * SCOPE
+ *   No mysql_users rows are involved, and no admin credential named after the
+ *   monitor user exists -- both are asserted as preconditions. Issue #5985
+ *   Finding 1 (a mysql_users row shadowing a same-named Admin credential) is a
+ *   different problem and would confound this result.
+ *
+ * The test restores 'mysql-default_authentication_plugin' and
+ * 'mysql-monitor_password' before exiting, including on failure paths: the
+ * group runs against a shared instance.
+ */
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "mysql.h"
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+using std::string;
+using std::vector;
+
+static const char* MON_USER = "monitor";
+static const char* MON_PASS = "monitorpass";
+
+/* Rejected after a successful authentication by the locality check. */
+static const unsigned int ERR_ONLY_LOCAL   = 1040;
+/* Rejected during authentication. */
+static const unsigned int ERR_ACCESS_DENIED = 1045;
+
+struct case_t {
+	const char* plugin;
+	bool use_tls;
+	const char* pass;
+	unsigned int exp_errno;
+	const char* desc;
+};
+
+/**
+ * @brief Attempt an Admin login and return the resulting mysql_errno().
+ * @return 0 when the connection unexpectedly succeeds.
+ */
+static unsigned int try_admin_login(
+	const CommandLine& cl, const char* user, const char* pass, bool use_tls
+) {
+	MYSQL* conn = mysql_init(NULL);
+	if (conn == NULL) { return 0; }
+
+	// The TAP suite links MariaDB Connector/C, which has no MYSQL_OPT_SSL_MODE;
+	// mysql_ssl_set + CLIENT_SSL is the idiom used elsewhere in these tests.
+	unsigned long client_flags = 0;
+	if (use_tls) {
+		mysql_ssl_set(conn, NULL, NULL, NULL, NULL, NULL);
+		client_flags |= CLIENT_SSL;
+	}
+
+	unsigned int err = 0;
+	if (!mysql_real_connect(conn, cl.admin_host, user, pass, NULL, cl.admin_port, NULL, client_flags)) {
+		err = mysql_errno(conn);
+		diag("  login user='%s' tls=%s -> errno=%u '%s'",
+			user, use_tls ? "yes" : "no", err, mysql_error(conn));
+	} else {
+		diag("  login user='%s' tls=%s -> CONNECTED (unexpected)", user, use_tls ? "yes" : "no");
+	}
+
+	mysql_close(conn);
+	return err;
+}
+
+static int set_var(MYSQL* admin, const char* name, const char* value, const char* load_stmt) {
+	const string q {
+		string("UPDATE global_variables SET variable_value='") + value +
+		"' WHERE variable_name='" + name + "'"
+	};
+	MYSQL_QUERY_T(admin, q.c_str());
+	MYSQL_QUERY_T(admin, load_stmt);
+	return EXIT_SUCCESS;
+}
+
+int main() {
+	CommandLine cl;
+
+	if (cl.getEnv()) {
+		diag("Failed to get the required environmental variables.");
+		return EXIT_FAILURE;
+	}
+
+	const vector<case_t> CASES {
+		// Baseline: this already worked before the fix.
+		{ "mysql_native_password",  false, MON_PASS, ERR_ONLY_LOCAL,
+		  "native/plaintext, correct password -> authenticated (1040 locality)" },
+		{ "mysql_native_password",  true,  MON_PASS, ERR_ONLY_LOCAL,
+		  "native/TLS, correct password -> authenticated (1040 locality)" },
+		{ "mysql_native_password",  false, "WRONGPASS", ERR_ACCESS_DENIED,
+		  "native/plaintext, wrong password -> rejected (1045)" },
+
+		// The regression: these returned 1045 before the fix.
+		{ "caching_sha2_password",  false, MON_PASS, ERR_ONLY_LOCAL,
+		  "caching_sha2/plaintext, correct password -> authenticated (1040 locality)" },
+		{ "caching_sha2_password",  true,  MON_PASS, ERR_ONLY_LOCAL,
+		  "caching_sha2/TLS, correct password -> authenticated (1040 locality)" },
+		{ "caching_sha2_password",  false, "WRONGPASS", ERR_ACCESS_DENIED,
+		  "caching_sha2/plaintext, wrong password -> rejected (1045)" },
+		{ "caching_sha2_password",  true,  "WRONGPASS", ERR_ACCESS_DENIED,
+		  "caching_sha2/TLS, wrong password -> rejected (1045)" },
+	};
+
+	// 1 admin connection + 2 preconditions + the cases + 2 restore checks
+	plan(1 + 2 + static_cast<int>(CASES.size()) + 2);
+
+	MYSQL* admin = mysql_init(NULL);
+	if (!mysql_real_connect(admin, cl.admin_host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+		return EXIT_FAILURE;
+	}
+	ok(true, "Connected to ProxySQL Admin at %s:%d", cl.admin_host, cl.admin_port);
+
+	// Remember what to put back.
+	string orig_plugin {};
+	string orig_mon_pass {};
+	{
+		MYSQL_QUERY_T(admin, "SELECT variable_value FROM global_variables WHERE variable_name='mysql-default_authentication_plugin'");
+		MYSQL_RES* r = mysql_store_result(admin);
+		MYSQL_ROW row = mysql_fetch_row(r);
+		if (row && row[0]) { orig_plugin = row[0]; }
+		mysql_free_result(r);
+
+		MYSQL_QUERY_T(admin, "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_password'");
+		r = mysql_store_result(admin);
+		row = mysql_fetch_row(r);
+		if (row && row[0]) { orig_mon_pass = row[0]; }
+		mysql_free_result(r);
+	}
+	diag("Saved mysql-default_authentication_plugin='%s', mysql-monitor_password='%s'",
+		orig_plugin.c_str(), orig_mon_pass.c_str());
+
+	// --- Preconditions ------------------------------------------------------
+	{
+		MYSQL_QUERY_T(admin,
+			("SELECT COUNT(*) FROM runtime_mysql_users WHERE username='" + string(MON_USER) + "'").c_str());
+		MYSQL_RES* r = mysql_store_result(admin);
+		MYSQL_ROW row = mysql_fetch_row(r);
+		const long n = (row && row[0]) ? strtol(row[0], NULL, 10) : -1;
+		mysql_free_result(r);
+		ok(n == 0, "No mysql_users row named '%s' (Finding 1 cannot interfere)   count:'%ld'", MON_USER, n);
+	}
+	{
+		MYSQL_QUERY_T(admin, "SELECT variable_value FROM global_variables WHERE variable_name='admin-admin_credentials'");
+		MYSQL_RES* r = mysql_store_result(admin);
+		MYSQL_ROW row = mysql_fetch_row(r);
+		const string creds { (row && row[0]) ? row[0] : "" };
+		mysql_free_result(r);
+		const bool clash = creds.find(string(MON_USER) + ":") != string::npos;
+		ok(!clash, "No admin credential named '%s' (PPHR_5passwordFalse_0 is the path)   creds:'%s'",
+			MON_USER, creds.c_str());
+	}
+
+	set_var(admin, "mysql-monitor_username", MON_USER, "LOAD MYSQL VARIABLES TO RUNTIME");
+	set_var(admin, "mysql-monitor_password", MON_PASS, "LOAD MYSQL VARIABLES TO RUNTIME");
+
+	// --- Cases --------------------------------------------------------------
+	string cur_plugin {};
+	for (const case_t& c : CASES) {
+		if (cur_plugin != c.plugin) {
+			set_var(admin, "mysql-default_authentication_plugin", c.plugin, "LOAD MYSQL VARIABLES TO RUNTIME");
+			cur_plugin = c.plugin;
+			diag("--- mysql-default_authentication_plugin = %s ---", c.plugin);
+		}
+
+		const unsigned int got = try_admin_login(cl, MON_USER, c.pass, c.use_tls);
+		ok(got == c.exp_errno, "%s   expected errno:'%u', got:'%u'", c.desc, c.exp_errno, got);
+	}
+
+	// --- Restore ------------------------------------------------------------
+	set_var(admin, "mysql-default_authentication_plugin",
+		orig_plugin.empty() ? "mysql_native_password" : orig_plugin.c_str(),
+		"LOAD MYSQL VARIABLES TO RUNTIME");
+	set_var(admin, "mysql-monitor_password",
+		orig_mon_pass.empty() ? "monitor" : orig_mon_pass.c_str(),
+		"LOAD MYSQL VARIABLES TO RUNTIME");
+
+	{
+		MYSQL_QUERY_T(admin, "SELECT variable_value FROM global_variables WHERE variable_name='mysql-default_authentication_plugin'");
+		MYSQL_RES* r = mysql_store_result(admin);
+		MYSQL_ROW row = mysql_fetch_row(r);
+		const string now { (row && row[0]) ? row[0] : "" };
+		mysql_free_result(r);
+		ok(now == orig_plugin, "mysql-default_authentication_plugin restored   exp:'%s', got:'%s'",
+			orig_plugin.c_str(), now.c_str());
+	}
+	{
+		MYSQL_QUERY_T(admin, "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_password'");
+		MYSQL_RES* r = mysql_store_result(admin);
+		MYSQL_ROW row = mysql_fetch_row(r);
+		const string now { (row && row[0]) ? row[0] : "" };
+		mysql_free_result(r);
+		ok(now == orig_mon_pass, "mysql-monitor_password restored   exp:'%s', got:'%s'",
+			orig_mon_pass.c_str(), now.c_str());
+	}
+
+	mysql_close(admin);
+	return exit_status();
+}


### PR DESCRIPTION
Implements #5987. **Draft — the MySQL side is complete and verified; the PgSQL arm and the TAP tests are not written yet.** See "Outstanding" below.

Stacked on #5991 (branched from `fix/5363-monitor-caching-sha2`, since both touch `PPHR_verify_password`). Rebase onto `v3.0` once that merges.

## What and why

`admin-admin_credentials` / `admin-stats_credentials` shared `USERNAME_FRONTEND` with `mysql_users` — one flat map keyed by username — so an Admin credential and a row of the same name overwrote each other. That is the sole reason the documentation says those users [cannot also appear in `mysql_users`](https://proxysql.com/documentation/global-variables/admin-variables#admin-admin_credentials). The two are used on different ports, for different session types, and are never interchangeable; the restriction is an artefact of the shared map, not a design constraint.

This adds a third scope, `USERNAME_ADMIN`, selected through one macro:

```c
#ifdef PROXYSQL31
#define ADMIN_CRED_SCOPE USERNAME_ADMIN
#else
#define ADMIN_CRED_SCOPE USERNAME_FRONTEND
#endif
```

Gated to the Innovative tier because it **is** an incompatible change: a colliding name currently resolves to a single entry, afterwards the two are independent. On the stable tier the macro is `USERNAME_FRONTEND`, every call site passes exactly what it passed before, and behaviour is unchanged by construction.

Both collision directions are fixed, including the one **not** in the original report: `SET admin-admin_credentials` calls `delete_credentials()`, which issued an unconditional `GloMyAuth->del()` by username and so removed a same-named `mysql_users` row from the runtime auth map until the next `LOAD MYSQL USERS TO RUNTIME`.

## Shape of the change

- `cred_username_type` gains `USERNAME_ADMIN` (compiled unconditionally, used only under `PROXYSQL31`).
- `MySQL_Authentication` gains `creds_admins` plus `creds_for()`, replacing nine copies of `usertype==USERNAME_BACKEND ? creds_backends : creds_frontends`.
- `ProxySQL_Admin::add_credentials()` / `delete_credentials()` target `ADMIN_CRED_SCOPE`.
- The three `GloMyAuth->lookup(...)` sites in `MySQL_Protocol.cpp` go through `cred_scope_for_session()`, which returns `ADMIN_CRED_SCOPE` for `ADMIN`/`STATS` sessions and `USERNAME_FRONTEND` otherwise.

`creds_admins` is never walked by `dump_all_users()`, so `runtime_mysql_users` and the cluster checksum are untouched — admin credentials were already excluded there by the `default_hostgroup >= 0` filter at `ProxySQL_Admin.cpp:6852`.

## Verified — both tiers, same scenario

Admin credential `dual:adminpass`, plus a `mysql_users` row `dual` with a *different* password `frontpass`:

| | `PROXYSQL31=1` | stable |
|---|---|---|
| `:6032` with `adminpass`, no row | OK | OK |
| `:6032` with `adminpass`, **row present** | **ADMIN_OK** | `Access denied` *(documented collision, unchanged)* |
| `:6032` with `frontpass` | denied | denied |
| row still in `runtime_mysql_users` | yes | yes |
| `SET admin-admin_credentials` deletes the row | **no** | n/a |

The stable-tier row is the compatibility guarantee, and it was **run**, not inferred from the macro — the identity argument is obvious enough that I'd normally trust it, and obvious-looking reasoning about this exact code has already cost one regression today (see #5991).

Both tiers compile: `PROXYSQL31=1 make debug` and plain `make debug`, each after `make clean`.

## Outstanding — why this is a draft

1. **PgSQL arm not implemented.** `add_credentials`/`delete_credentials` are templated over `SERVER_TYPE` and the `SERVER_TYPE_PGSQL` arm still writes to `GloPgAuth`'s frontend scope. #5987 explicitly says not to skip it; leaving the two asymmetric is a future bug.
2. **No TAP tests yet.** The issue calls for a 3.1-gated variant asserting independence and a stable-tier variant asserting today's collapse, registered with `@proxysql_min_version:3.1`. Without both, gating silently drops coverage on one side.
3. **Doc follow-up** — the three restriction notes become 3.1+-specific once this ships. Not to be edited in this PR.

The behaviour above is real and reproducible, but I'd rather have it reviewed as a draft than have the missing PgSQL arm and tests read as complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate credential handling for administrator and monitoring accounts across MySQL and PostgreSQL.
  - Added session-aware credential lookup for Admin, Stats, frontend, and HTTP connections.
  - Improved administrator authentication with native, clear-text, and `caching_sha2_password` methods.
  - Added clearer diagnostics for RSA key requests and malformed authentication attempts.

- **Bug Fixes**
  - Improved cached SHA-2 authentication, including monitor accounts and secure connections.
  - Added safeguards for unsupported `CHANGE_USER` authentication flows.

- **Documentation & Tests**
  - Added developer documentation and regression coverage for administrator authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->