### PR TITLE
Admin: accept Connector/Python session autocommit setup

### DIFF
--- a/docs/superpowers/plans/2026-08-08-admin-session-autocommit.md
+++ b/docs/superpowers/plans/2026-08-08-admin-session-autocommit.md
@@ -1,0 +1,166 @@
+# Admin Session Autocommit Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Connector/Python's `SET @@session.autocommit = ON|OFF` complete successfully on ProxySQL's classic Admin interface.
+
+**Architecture:** The Admin handler already has a connect-setup compatibility block that replies with an OK packet and no result set for bare `SET AUTOCOMMIT`. Extend that same block with the Connector/Python spelling, preserving the Admin interface's existing no-op semantics. Extend its focused TAP regression test with exact Connector/Python payloads.
+
+**Tech Stack:** C++17, ProxySQL classic Admin protocol, TAP/libmysqlclient regression test, GNU Make.
+
+## Global Constraints
+
+- Keep the scope to connection-setup compatibility; do not add Admin transaction-state support.
+- Match `SET @@session.autocommit` case-insensitively after leading SQL comments are stripped.
+- Return the existing OK/no-result-set response and do not modify `global_variables`.
+- Build from a clean worktree with `make clean` followed by `make` using a bounded parallelism level derived from available CPUs and memory.
+- Preserve normal red/green CI semantics; do not mask the Connector/Python 26.7.0 soak failure.
+
+---
+
+### Task 1: Establish the Admin compatibility regression
+
+**Files:**
+- Modify: `test/tap/tests/mysql-reg_test_5786_admin_strip_leading_sql_comments-t.cpp:39-55`
+- Test: `test/tap/tests/mysql-reg_test_5786_admin_strip_leading_sql_comments-t.cpp`
+
+**Interfaces:**
+- Consumes: the existing `ACCEPT_CASES` array; each entry is sent via `mysql_query()` to the classic Admin interface.
+- Produces: three failing, exact Connector/Python compatibility assertions that become green only when the Admin handler sends an OK packet.
+
+- [ ] **Step 1: Add the precise failing connection-setup cases**
+
+  Add these three entries immediately after the existing bare `SET AUTOCOMMIT=1` cases:
+
+  ```cpp
+  "SET @@session.autocommit = OFF",                    // Connector/Python pure-Python post-connect setup
+  "SET @@session.autocommit = ON",                     // setter's opposite state uses the same syntax
+  "/*connector-python*/ SET @@session.autocommit = OFF", // comment-stripping compatibility path
+  ```
+
+- [ ] **Step 2: Build and run the regression test before the handler change**
+
+  Determine `build_jobs` as the smaller of the available CPU count and 8, then use it consistently:
+
+  ```bash
+  build_jobs=$(nproc)
+  [ "$build_jobs" -gt 8 ] && build_jobs=8
+  make clean
+  make -j"$build_jobs"
+  make -C test/tap/tests -j"$build_jobs" mysql-reg_test_5786_admin_strip_leading_sql_comments-t
+  ```
+
+  Run only the focused test through its normal isolated harness and clean up its
+  uniquely named infrastructure on exit:
+
+  ```bash
+  export INFRA_ID="admin-session-autocommit-red-$(date +%s)"
+  export TAP_GROUP=legacy-g1
+  export TEST_PY_TAP_INCL='mysql-reg_test_5786_admin_strip_leading_sql_comments-t'
+  export SKIP_CLUSTER_START=1
+  trap 'test/infra/control/stop-proxysql-isolated.bash || true; test/infra/control/destroy-infras.bash || true' EXIT
+  test/infra/control/ensure-infras.bash
+  test/infra/control/run-tests-isolated.bash
+  ```
+
+  The new cases must fail with `ERROR: Unknown global variable:
+  '@@session.autocommit'.`; retain the failing TAP output as the red-phase
+  evidence.
+
+- [ ] **Step 3: Commit the regression test**
+
+  ```bash
+  git add test/tap/tests/mysql-reg_test_5786_admin_strip_leading_sql_comments-t.cpp
+  git commit -m "test: cover admin session autocommit setup"
+  ```
+
+### Task 2: Accept the Connector/Python session spelling as an Admin setup no-op
+
+**Files:**
+- Modify: `lib/Admin_Handler.cpp:4065-4088`
+- Test: `test/tap/tests/mysql-reg_test_5786_admin_strip_leading_sql_comments-t.cpp`
+
+**Interfaces:**
+- Consumes: `mb`, the comment-stripped command pointer in `admin_session_handler()`.
+- Produces: an OK packet through `SPA->send_ok_msg_to_client()` for `SET @@session.autocommit`, with no SQLite query or ProxySQL global-variable update.
+
+- [ ] **Step 1: Extend only the existing compatibility predicate**
+
+  Add one branch next to the existing `SET AUTOCOMMIT` condition:
+
+  ```cpp
+  ||
+  (!strncasecmp("SET @@session.autocommit", mb, strlen("SET @@session.autocommit")))
+  ```
+
+  Do not change `admin_handler_command_set()`: the command must be consumed before it reaches the global-variable translator.
+
+- [ ] **Step 2: Rebuild cleanly and verify the focused TAP test is green**
+
+  ```bash
+  build_jobs=$(nproc)
+  [ "$build_jobs" -gt 8 ] && build_jobs=8
+  make clean
+  make -j"$build_jobs"
+  make -C test/tap/tests -j"$build_jobs" mysql-reg_test_5786_admin_strip_leading_sql_comments-t
+  ```
+
+  Run the focused group using the same exact isolated-harness command as the
+  red phase, with a new `INFRA_ID` ending in `-green`. Confirm all old and new
+  accept cases receive an OK packet with no result set, then run:
+
+  ```bash
+  git diff --check
+  ```
+
+- [ ] **Step 3: Commit the minimal handler fix**
+
+  ```bash
+  git add lib/Admin_Handler.cpp test/tap/tests/mysql-reg_test_5786_admin_strip_leading_sql_comments-t.cpp
+  git commit -m "fix(admin): accept session autocommit setup"
+  ```
+
+### Task 3: Verify the real Connector/Python 26.7.0 path and publish
+
+**Files:**
+- Modify: no additional source files
+- Test: `test/scripts/mysqlx/behavioral_validation.py` through the existing `mysqlx-soak-g1` harness
+
+**Interfaces:**
+- Consumes: the image built with `MYSQL_CONNECTOR_PYTHON_VERSION=26.7.0` and the existing behavioral-validation Admin connection.
+- Produces: evidence that the connector reaches its Admin delete/reload actions rather than failing during post-connect setup.
+
+- [ ] **Step 1: Build the test image with the compatibility connector version**
+
+  ```bash
+  docker build --network host \
+    --build-arg MYSQL_CONNECTOR_PYTHON_VERSION=26.7.0 \
+    -t proxysql-ci-base:mysqlx-connector-26.7.0 \
+    -f test/infra/docker-base/Dockerfile test/infra/docker-base
+  ```
+
+- [ ] **Step 2: Run the existing MySQLX soak harness against that image**
+
+  The isolation scripts consume `proxysql-ci-base:latest`, so temporarily
+  point that local compatibility alias at the versioned image, run only the
+  behavioral test, and restore the 9.7.0 alias afterwards:
+
+  ```bash
+  docker tag proxysql-ci-base:mysqlx-connector-26.7.0 proxysql-ci-base:latest
+  export INFRA_ID="admin-session-autocommit-mysqlx-$(date +%s)"
+  export TAP_GROUP=mysqlx-soak-g1
+  export TEST_PY_TAP_INCL='test_mysqlx_soak_behavioral-t'
+  export SKIP_CLUSTER_START=1
+  trap 'test/infra/control/stop-proxysql-isolated.bash || true; test/infra/control/destroy-infras.bash || true; docker tag proxysql-ci-base:mysqlx-connector-9.7.0 proxysql-ci-base:latest' EXIT
+  test/infra/control/ensure-infras.bash
+  test/infra/control/run-tests-isolated.bash
+  ```
+
+  Verify that `mysql.connector.connect()` reaches the Admin delete/reload
+  actions instead of emitting `Unknown global variable:
+  '@@session.autocommit'`; assess any subsequent route-reload result
+  separately.
+
+- [ ] **Step 3: Publish the focused branch as a pull request**
+
+  Rebase or merge the current `origin/v3.0` only if it has advanced, run `git diff --check`, push `fix/admin-session-autocommit`, and open a PR targeting `v3.0`. The PR description must state the pure-Python Connector/Python fallback mechanism, the Admin no-op behavior, focused TAP evidence, and that #5984 must land before CI can exercise the 26.7.0 soak matrix.

--- a/docs/superpowers/specs/2026-08-08-admin-session-autocommit-design.md
+++ b/docs/superpowers/specs/2026-08-08-admin-session-autocommit-design.md
@@ -1,0 +1,48 @@
+# Admin session-autocommit Connector/Python compatibility
+
+## Goal
+
+Allow MySQL Connector/Python 26.7.0 to connect to ProxySQL's classic Admin
+interface without treating its session-scoped autocommit setup statement as a
+ProxySQL global-variable update.
+
+## Root cause
+
+The 26.7.0 C extension cannot load in the CI base image because it requires
+`OPENSSL_3.2.0`. Connector/Python therefore uses its pure-Python connection,
+whose post-connect setup issues:
+
+```sql
+SET @@session.autocommit = OFF
+```
+
+`admin_session_handler()` already consumes `SET AUTOCOMMIT` as an accepted
+connect-setup no-op. Its matcher does not recognize the canonical
+`@@session.autocommit` spelling, so the command instead reaches
+`admin_handler_command_set()`, where it is rejected as an unknown ProxySQL
+global variable.
+
+## Design
+
+Extend the existing Admin connect-setup acceptance block to recognize the
+case-insensitive `SET @@session.autocommit` form. It will return the same OK
+packet and make no configuration or transaction-state change, exactly matching
+the current Admin treatment of bare `SET AUTOCOMMIT`.
+
+No attempt will be made to implement stateful MySQL transaction semantics on
+the SQLite-backed Admin interface. `SELECT @@session.autocommit` is also out of
+scope: the observed connector connection path requires only the `SET` command.
+
+## Regression coverage
+
+Extend the existing Admin connect-setup TAP regression test with the exact
+Connector/Python syntax for both `OFF` and `ON`, including a leading SQL-comment
+variant. The test will verify an OK packet and no result set, and will continue
+to cover the existing bare spelling and unrelated setup statements.
+
+## Verification
+
+Run the focused TAP test after a clean build, then run the MySQLX soak scenario
+with Connector/Python 26.7.0 once PR #5984's portable pin-check fix is merged.
+The resulting matrix leg must reach the actual soak test without failure
+masking.

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -4081,6 +4081,8 @@ void admin_session_handler(S* sess, void *_pa, PtrSize_t *pkt) {
 			||
 			(!strncasecmp("SET AUTOCOMMIT", mb, strlen("SET AUTOCOMMIT")))
 			||
+			(!strncasecmp("SET @@session.autocommit", mb, strlen("SET @@session.autocommit")))
+			||
 			(!strncasecmp("SET LOCK_WAIT_TIMEOUT", mb, strlen("SET LOCK_WAIT_TIMEOUT")))
 		) {
 			SPA->send_ok_msg_to_client(sess, NULL, 0, query_no_space);

--- a/test/tap/tests/mysql-reg_test_5786_admin_strip_leading_sql_comments-t.cpp
+++ b/test/tap/tests/mysql-reg_test_5786_admin_strip_leading_sql_comments-t.cpp
@@ -41,6 +41,9 @@ static const char* ACCEPT_CASES[] = {
 	"/*svc=dd*/ SET AUTOCOMMIT=1",
 	"/*service='datadog-agent'*/ SET AUTOCOMMIT=1",                  // exact DD Agent payload
 	"/* a *//* b */ SET AUTOCOMMIT=1",                               // stacked comments
+	"SET @@session.autocommit = OFF",                                // Connector/Python pure-Python post-connect setup
+	"SET @@session.autocommit = ON",                                 // same connector setter, opposite state
+	"/*connector-python*/ SET @@session.autocommit = OFF",           // comment-stripping compatibility path
 	"/*svc=dd*/ SET NAMES utf8",
 	"/*svc=dd*/ SET character_set_results=utf8",
 	"/*svc=dd*/ SET SQL_AUTO_IS_NULL=0",


### PR DESCRIPTION
## Summary

Accept `SET @@session.autocommit = ON|OFF` in the Admin connection-setup compatibility path. This mirrors the existing bare `SET AUTOCOMMIT` handling and remains a no-op for the Admin interface.

## Root cause

MySQL Connector/Python 26.7.0 falls back to its pure-Python implementation in the CI image because its C extension requires a newer OpenSSL ABI. That implementation issues `SET @@session.autocommit` after connecting, which ProxySQL Admin previously sent to the generic global-variable handler and rejected.

## Validation

- `make clean && PROXYSQL40=1 make -j8 build_deps_debug && PROXYSQL40=1 make -j8 debug && PROXYSQL40=1 make -j8 build_tap_test_debug`
- Standard isolated `legacy-g1` run filtered to `mysql-reg_test_5786_admin_strip_leading_sql_comments-t`
- Standard isolated `mysqlx-soak-g1` run filtered to `test_mysqlx_soak_behavioral-t`, with a base image built using `MYSQL_CONNECTOR_PYTHON_VERSION=26.7.0`

The regression covers ON, OFF, and a leading-comment form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Admin connection compatibility with MySQL Connector/Python setup commands that set session autocommit to `ON` or `OFF`.
  - Commands preceded by SQL comments are now accepted during connection setup.
  - These compatibility commands complete successfully without changing proxy configuration or transaction state.

- **Tests**
  - Added regression coverage for both autocommit values and comment-prefixed connection setup statements.

- **Documentation**
  - Added design and implementation documentation for the compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->