### PR TITLE
ci: enable coverage for missing TAP workflows

### DIFF
--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -80,10 +80,11 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu22-tap' ]
+        testdist: [ 'ubuntu24-tap-genai-gcov' ]
         infradb: [ 'mysql57' ]
     env:
       TESTDIST: ${{ matrix.testdist }}
@@ -110,9 +111,13 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # Source trees are required so Codecov can resolve repo-root LCOV SF: paths.
         sparse-checkout: |
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff
@@ -128,7 +133,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ${{ matrix.testdist }}
-        HANDOFF_TYPES: src
+        HANDOFF_TYPES: src test
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
@@ -233,6 +238,7 @@ jobs:
         cd proxysql
         export INFRA_ID="ci-basictests"
         export TAP_GROUP="basictests"
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -276,6 +282,37 @@ jobs:
           proxysql/binaries/
           proxysql/src/
           proxysql/libs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-basictests/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-basictests/coverage-report/ci-basictests.info
+        flags: integration-tests
+        name: tap-basictests-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -80,12 +80,13 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    permissions: write-all
     strategy:
       fail-fast: false
       matrix:
         infradb: [ 'mysql57' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:
@@ -107,9 +108,13 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # Source trees are required so Codecov can resolve repo-root LCOV SF: paths.
         sparse-checkout: |
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff
@@ -124,7 +129,7 @@ jobs:
         REPO: ${{ github.repository }}
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-        HANDOFF_VARIANT: ubuntu22-tap
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
         HANDOFF_TYPES: src test
       run: |
         set -uo pipefail
@@ -232,6 +237,7 @@ jobs:
         export TAP_GROUP="legacy-g2"
         export SKIP_CLUSTER_START=1
         export TAP_USE_NOISE=1
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -264,6 +270,37 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-legacy-g2/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g2/coverage-report/ci-legacy-g2.info
+        flags: integration-tests
+        name: tap-legacy-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu22-tap' ]
+        testdist: [ 'ubuntu24-tap-genai-gcov' ]
     env:
       TESTDIST: ${{ matrix.testdist }}
       MATRIX: '(pgsql-cluster)'
@@ -88,9 +88,13 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         path: 'proxysql'
+        # Source trees are required so Codecov can resolve repo-root LCOV SF: paths.
         sparse-checkout: |
+          include
+          lib
+          src
           test/infra
-          test/tap/groups
+          test/tap
           test/scripts
 
     - name: Download build handoff
@@ -193,6 +197,7 @@ jobs:
         export TAP_GROUP="legacy-g3"
         export TEST_PY_TAP_INCL="test_cluster_sync_pgsql-t"
         export PROXYSQL_CLUSTER_NODES=2
+        export COVERAGE=1
         test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup
@@ -222,6 +227,37 @@ jobs:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
           proxysql/ci_*_logs/
+
+    - name: Archive coverage report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
+        path: |
+          proxysql/ci_infra_logs/ci-taptests-pgsql-cluster/coverage-report/
+        if-no-files-found: ignore
+
+    - name: Report missing coverage file
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      run: |
+        echo "No coverage report was produced; skipping Codecov upload."
+
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-taptests-pgsql-cluster/coverage-report/ci-taptests-pgsql-cluster.info
+        flags: integration-tests
+        name: tap-pgsql-cluster-sync-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
 
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true


### PR DESCRIPTION
Enables integration coverage for TAP workflows that currently execute ProxySQL tests without contributing LCOV:

- `ci-legacy-g2.yml`
- `ci-basictests.yml`
- `ci-taptests-pgsql-cluster.yml`

Each workflow now uses the existing `ubuntu24-tap-genai-gcov` handoff, checks out the source roots Codecov needs to resolve LCOV paths, sets `COVERAGE=1`, archives the generated coverage report, and uploads it under the existing `integration-tests` Codecov flag using OIDC.

The changes were generated and validated with `git diff --check` plus an audit that flags any unclassified workflow invoking `run-tests-isolated.bash` without coverage.

The separate centralized sparse-checkout `codecov.yml` materialization fix is being applied to PR #5984, because that harness is executed from the tested commit rather than from this `GH-Actions` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test runs to use the latest Ubuntu 24 testing environments.
  * Enabled code coverage collection across basic, legacy, and PostgreSQL cluster test suites.
  * Added coverage report archiving and conditional upload to Codecov.
  * Improved handling and visibility when coverage reports are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->