### PR TITLE
build: fix build_deps_debug on Darwin

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -261,10 +261,12 @@ ifeq ($(UNAME_S),Darwin)
 else
 	cd mariadb-client-library/mariadb_client && cmake . -Wno-dev -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=$(SSL_IDIR) -DOPENSSL_LIBRARIES=$(SSL_LDIR) -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
 endif
+ifneq ($(UNAME_S),Darwin)
 ifeq ($(PROXYDEBUG),1)
 	cd mariadb-client-library/mariadb_client && patch -p0 < ../ma_context.h.patch
 else ifeq ($(USEVALGRIND),1)
 	cd mariadb-client-library/mariadb_client && patch -p0 < ../ma_context.h.patch
+endif
 endif
 	cd mariadb-client-library/mariadb_client && patch -p0 < ../mariadb_stmt.c.patch
 	cd mariadb-client-library/mariadb_client && patch -p0 < ../mariadb_lib.c.patch
@@ -420,7 +422,7 @@ endif
 libusual: libusual/libusual/.libs/libusual.a
 
 
-libscram/lib/libscram.a:postgresql/postgresql/src/interfaces/libpq/libpq.a 
+libscram/lib/libscram.a:postgresql/postgresql/src/interfaces/libpq/libpq.a
 	cd libscram && rm -rf lib/* || true
 	cd libscram && CC=${CC} CXX=${CXX} ${MAKE} LIBOPENSSL_DIR="$(SSL_IDIR)" POSTGRESQL_DIR="$(shell pwd)/postgresql/postgresql/"
 

--- a/doc/BUILD-MACOS.md
+++ b/doc/BUILD-MACOS.md
@@ -11,7 +11,7 @@ Ensure you have [Homebrew](https://brew.sh/) installed.
 Run the following command to install the required build tools and libraries:
 
 ```bash
-brew install automake bzip2 cmake make git gpatch gnutls openssl@3 icu4c pkg-config libiconv zlib
+brew install automake bzip2 cmake make git gpatch gnutls openssl@3 icu4c pkg-config libiconv libtool zlib
 ```
 
 ## Compilation Steps

--- a/src/Makefile
+++ b/src/Makefile
@@ -97,7 +97,9 @@ endif
 
 MYCXXFLAGS := $(STDCPP)
 ifeq ($(CXX),clang++)
+ifneq ($(UNAME_S),Darwin)
 	MYCXXFLAGS += -fuse-ld=lld
+endif
 endif
 MYCXXFLAGS += $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH) $(PSQL40) $(PSQL31) $(PSQLFFTO) $(PSQLTSDB) -DGITVERSION=\"$(GIT_VERSION)\" $(NOJEM) $(WGCOV) $(WASAN)
 


### PR DESCRIPTION
Couple of things I stumbled on when trying to build from source on mac.

- valgrind doesn't exist on darwin.
- libtool is needed for curl.
- don't force lld on mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build compatibility on macOS by adjusting platform-specific dependency and linker settings.
  - Added the required Homebrew `libtool` package to macOS setup instructions.
  - Prevented non-portable linker options from being applied to Darwin builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->