### PR TITLE
fix(admin): require CACHING_SHA2_PASSWORD() salts to be exactly 20 bytes

### DIFF
--- a/deps/sqlite3/sqlite3_pass_exts.patch
+++ b/deps/sqlite3/sqlite3_pass_exts.patch
@@ -1,6 +1,6 @@
 --- sqlite3.c	2024-03-22 19:22:47.046093173 +0100
 +++ sqlite3-pass-exts.c	2024-03-22 19:24:09.557303716 +0100
-@@ -26275,6 +26275,228 @@
+@@ -26275,6 +26275,235 @@
    sqlite3ResultStrAccum(context, &sRes);
  }
  
@@ -48,7 +48,14 @@
 +
 +	if (argc >= 2) {
 +		int salt_size = sqlite3_value_bytes(argv[1]);
-+		if (salt_size <= 0 || salt_size > DEF_SALT_SIZE) {
++		/* The salt must be EXACTLY DEF_SALT_SIZE. The stored '$A$rrr$' hash has no
++		 * delimiter after the salt, so verification reads it back positionally with
++		 * substr(7,20) (see PPHR_verify_sha2/PPHR_sha2full in MySQL_Protocol.cpp).
++		 * A shorter salt makes that read take salt + the first bytes of the digest,
++		 * so the hash can never verify: it is accepted here, stored without error,
++		 * and then every login fails with a generic 'Access denied'. Reject it at
++		 * generation instead of emitting a credential that cannot work. */
++		if (salt_size != DEF_SALT_SIZE) {
 +			return 1;
 +		}
 +	}
@@ -115,7 +122,7 @@
 + * @param argc Number of arguments; 1, 2, or 3.
 + * @param argv Argument list:
 + *   1. Password to be hashed; len > 0, type 'SQLITE_TEXT'.
-+ *   2. Optional salt; len in (0,20], type 'SQLITE_TEXT' or 'SQLITE_BLOB'. Random if omitted.
++ *   2. Optional salt; len EXACTLY 20, type 'SQLITE_TEXT' or 'SQLITE_BLOB'. Random if omitted.
 + *   3. Optional rounds; integer in [5000,4095000] in steps of 1000 (matches MySQL's
 + *      caching_sha2_password_digest_rounds). Defaults to 5000 when omitted.
 + */
@@ -229,7 +236,7 @@
  /*
  ** current_time()
  **
-@@ -133230,6 +133452,10 @@
+@@ -133230,6 +133459,10 @@
      FUNCTION(substr,             3, 0, 0, substrFunc       ),
      FUNCTION(substring,          2, 0, 0, substrFunc       ),
      FUNCTION(substring,          3, 0, 0, substrFunc       ),

--- a/deps/sqlite3/sqlite3_pass_exts.patch
+++ b/deps/sqlite3/sqlite3_pass_exts.patch
@@ -1,6 +1,6 @@
 --- sqlite3.c	2024-03-22 19:22:47.046093173 +0100
 +++ sqlite3-pass-exts.c	2024-03-22 19:24:09.557303716 +0100
-@@ -26275,6 +26275,235 @@
+@@ -26275,6 +26275,250 @@
    sqlite3ResultStrAccum(context, &sRes);
  }
  
@@ -58,6 +58,13 @@
 +		if (salt_size != DEF_SALT_SIZE) {
 +			return 1;
 +		}
++		/* An embedded NUL is just as unusable: the salt is appended with strcat()
++		 * below, which stops at the NUL, while the digest offset is computed from
++		 * the DECLARED salt_size. The hash comes out malformed and cannot
++		 * authenticate -- silently, exactly like a short salt. */
++		if (memchr(sqlite3_value_blob(argv[1]), '\0', salt_size) != NULL) {
++			return 2;
++		}
 +	}
 +
 +	/* argc == 3: rounds is an integer; range is checked in caching_sha2_passwordFunc(). */
@@ -81,7 +88,11 @@
 +			sqlite3_result_text(context, "Invalid argument type", -1, SQLITE_TRANSIENT);
 +			return;
 +		}
-+		if (check_args_lengths(argc, argv)) {
++		int len_err = check_args_lengths(argc, argv);
++		if (len_err == 2) {
++			sqlite3_result_text(context, "Invalid salt: must not contain NUL bytes", -1, SQLITE_TRANSIENT);
++			return;
++		} else if (len_err) {
 +			sqlite3_result_text(context, "Invalid argument size", -1, SQLITE_TRANSIENT);
 +			return;
 +		}
@@ -135,7 +146,11 @@
 +			sqlite3_result_text(context, "Invalid argument type", -1, SQLITE_TRANSIENT);
 +			return;
 +		}
-+		if (check_args_lengths(argc, argv)) {
++		int len_err = check_args_lengths(argc, argv);
++		if (len_err == 2) {
++			sqlite3_result_text(context, "Invalid salt: must not contain NUL bytes", -1, SQLITE_TRANSIENT);
++			return;
++		} else if (len_err) {
 +			sqlite3_result_text(context, "Invalid argument size", -1, SQLITE_TRANSIENT);
 +			return;
 +		}
@@ -236,7 +251,7 @@
  /*
  ** current_time()
  **
-@@ -133230,6 +133459,10 @@
+@@ -133230,6 +133474,10 @@
      FUNCTION(substr,             3, 0, 0, substrFunc       ),
      FUNCTION(substring,          2, 0, 0, substrFunc       ),
      FUNCTION(substring,          3, 0, 0, substrFunc       ),

--- a/test/tap/tests/test_sqlite3_pass_exts-t.cpp
+++ b/test/tap/tests/test_sqlite3_pass_exts-t.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <cassert>
+#include <random>
 #include <ctime>
 #include <string>
 #include <vector>
@@ -544,6 +545,17 @@ const vector<inv_input_t> INV_INPUTS {
 	{ "SELECT CACHING_SHA2_PASSWORD('somepass', '0123456789')", 0, "Invalid argument size" },
 	{ "SELECT CACHING_SHA2_PASSWORD('somepass', '0123456789012345678')", 0, "Invalid argument size" },
 	{ "SELECT CACHING_SHA2_PASSWORD('somepass', '012345678901234567890')", 0, "Invalid argument size" },
+
+	// A 20-byte salt containing an embedded NUL is the right LENGTH but is equally
+	// unusable: the salt is appended with strcat(), which stops at the NUL, while
+	// the digest offset is computed from the declared salt_size. The resulting hash
+	// is malformed and cannot authenticate -- silently, just like a short salt.
+	// X'00...' is a 20-byte BLOB whose first byte is NUL.
+	{ "SELECT CACHING_SHA2_PASSWORD('somepass', X'000102030405060708090A0B0C0D0E0F10111213')", 0,
+		"Invalid salt: must not contain NUL bytes" },
+	// ...and one with the NUL in the middle, so it is not simply an empty-string case.
+	{ "SELECT CACHING_SHA2_PASSWORD('somepass', X'01020304050607080900000C0D0E0F1011121314')", 0,
+		"Invalid salt: must not contain NUL bytes" },
 };
 
 
@@ -883,9 +895,13 @@ int main(int argc, char** argv) {
 			const uint32_t pass_len = rand() % 150;
 			const string pass { random_string(pass_len) };
 
+			// <random> rather than rand(): SonarCloud flags rand() as cpp:S5020 /
+			// cpp:S2245 on new code. Seeded deterministically so a failing run is
+			// reproducible.
+			static std::mt19937 salt_rng { 20260809u };
 			uint32_t salt_len = 20;
 			if (i % 2 == 1) {
-				salt_len = rand() % 40;              // 0..39
+				salt_len = std::uniform_int_distribution<uint32_t>(0, 39)(salt_rng);
 				if (salt_len == 20) { salt_len = 21; }   // keep this half invalid
 			}
 			const string salt { random_string(salt_len) };

--- a/test/tap/tests/test_sqlite3_pass_exts-t.cpp
+++ b/test/tap/tests/test_sqlite3_pass_exts-t.cpp
@@ -430,7 +430,11 @@ int test_pass_gen(MYSQL* admin, const string& auth, const string& pass, const st
 		MYSQL_RES* myres = mysql_store_result(admin);
 		MYSQL_ROW myrow = mysql_fetch_row(myres);
 
-		if (pass.size() > 0 && salt.size() > 0 && salt.size() <= 20) {
+		// An explicitly supplied salt must be EXACTLY 20 bytes: the stored
+		// '$A$rrr$' format has no delimiter after the salt, so verification reads
+		// it back positionally with substr(7,20). Any other length is rejected at
+		// generation with "Invalid argument size" (handled by the else branch).
+		if (pass.size() > 0 && salt.size() == 20) {
 			const string admin_hash { myrow[0] };
 			const string hash_start { "$A$005$" + salt };
 
@@ -520,12 +524,26 @@ const vector<inv_input_t> INV_INPUTS {
 	{ "SELECT CACHING_SHA2_PASSWORD(2, '00')", 0, "Invalid argument type" },
 	{ "SELECT CACHING_SHA2_PASSWORD('00', 2)", 0, "Invalid argument type" },
 	{ "SELECT CACHING_SHA2_PASSWORD('00', '00', '00')", 0, "Invalid argument type" },
-	{ "SELECT CACHING_SHA2_PASSWORD('00', '00', 1000)", 0,
+	// NOTE: these three exercise the ROUNDS validation, so the salt must be a
+	// valid 20 bytes -- lengths are checked before rounds, and a short salt would
+	// short-circuit with "Invalid argument size" and stop testing rounds at all.
+	{ "SELECT CACHING_SHA2_PASSWORD('00', '00000000000000000000', 1000)", 0,
 		"Invalid rounds: expected multiple of 1000 in [5000,4095000]" },
-	{ "SELECT CACHING_SHA2_PASSWORD('00', '00', 5500)", 0,
+	{ "SELECT CACHING_SHA2_PASSWORD('00', '00000000000000000000', 5500)", 0,
 		"Invalid rounds: expected multiple of 1000 in [5000,4095000]" },
-	{ "SELECT CACHING_SHA2_PASSWORD('00', '00', 4096000)", 0,
+	{ "SELECT CACHING_SHA2_PASSWORD('00', '00000000000000000000', 4096000)", 0,
 		"Invalid rounds: expected multiple of 1000 in [5000,4095000]" },
+
+	// An explicitly supplied salt must be EXACTLY 20 bytes. Anything shorter used
+	// to be accepted and produced a hash that could never authenticate: the stored
+	// '$A$rrr$' format has no delimiter after the salt, so verification reads it
+	// back positionally with substr(7,20) and picks up digest bytes as salt. The
+	// credential stored without error and every login failed with a generic
+	// 'Access denied'.
+	{ "SELECT CACHING_SHA2_PASSWORD('somepass', '0')", 0, "Invalid argument size" },
+	{ "SELECT CACHING_SHA2_PASSWORD('somepass', '0123456789')", 0, "Invalid argument size" },
+	{ "SELECT CACHING_SHA2_PASSWORD('somepass', '0123456789012345678')", 0, "Invalid argument size" },
+	{ "SELECT CACHING_SHA2_PASSWORD('somepass', '012345678901234567890')", 0, "Invalid argument size" },
 };
 
 
@@ -851,11 +869,26 @@ int main(int argc, char** argv) {
 			test_pass_gen(admin, "mysql_native_password", pass, "");
 		}
 
+		// Salt lengths are now exercised deliberately rather than at random: an
+		// explicit salt must be exactly 20 bytes, so alternate between a valid
+		// 20-byte salt (hash must be wellformed) and a random invalid length (must
+		// be rejected with "Invalid argument size"). Both outcomes are asserted by
+		// test_pass_gen().
+		//
+		// This also replaces a long-standing copy/paste bug: 'salt_len' was computed
+		// as 'rand() % 20' and then never used -- the salt was built with
+		// 'random_string(pass_len)', so it tracked the PASSWORD length (0..149) and
+		// the intended salt-length sweep never happened.
 		for (size_t i = 0; i < PASS_GEN_COUNT; i++) {
 			const uint32_t pass_len = rand() % 150;
-			const uint32_t salt_len = rand() % 20;
 			const string pass { random_string(pass_len) };
-			const string salt { random_string(pass_len) };
+
+			uint32_t salt_len = 20;
+			if (i % 2 == 1) {
+				salt_len = rand() % 40;              // 0..39
+				if (salt_len == 20) { salt_len = 21; }   // keep this half invalid
+			}
+			const string salt { random_string(salt_len) };
 
 			test_pass_gen(admin, "caching_sha2_password", pass, salt);
 		}

--- a/test/tap/tests/test_sqlite3_pass_exts-t.cpp
+++ b/test/tap/tests/test_sqlite3_pass_exts-t.cpp
@@ -12,7 +12,6 @@
  */
 
 #include <cassert>
-#include <random>
 #include <ctime>
 #include <string>
 #include <vector>
@@ -895,14 +894,15 @@ int main(int argc, char** argv) {
 			const uint32_t pass_len = rand() % 150;
 			const string pass { random_string(pass_len) };
 
-			// <random> rather than rand(): SonarCloud flags rand() as cpp:S5020 /
-			// cpp:S2245 on new code. Seeded deterministically so a failing run is
-			// reproducible.
-			static std::mt19937 salt_rng { 20260809u };
+			// No PRNG here on purpose. A random length adds nothing -- the property
+			// under test is "exactly 20 is accepted, anything else is rejected" --
+			// and both rand() and <random> trip SonarCloud (cpp:S5020, cpp:S2245).
+			// A fixed sweep is fully deterministic and covers the boundaries
+			// explicitly: 0, 1, 19, 21, 40 and a few in between.
+			static const uint32_t INVALID_SALT_LENS[] = { 0, 1, 2, 19, 21, 22, 40, 64 };
 			uint32_t salt_len = 20;
 			if (i % 2 == 1) {
-				salt_len = std::uniform_int_distribution<uint32_t>(0, 39)(salt_rng);
-				if (salt_len == 20) { salt_len = 21; }   // keep this half invalid
+				salt_len = INVALID_SALT_LENS[(i / 2) % (sizeof(INVALID_SALT_LENS) / sizeof(INVALID_SALT_LENS[0]))];
 			}
 			const string salt { random_string(salt_len) };
 


### PR DESCRIPTION
## Problem

`CACHING_SHA2_PASSWORD(pass, salt)` accepted any salt in `(0,20]`:

```c
if (salt_size <= 0 || salt_size > DEF_SALT_SIZE) { return 1; }
```

But verification reads the salt back **positionally, at a fixed width**:

```cpp
string salt = sp.substr(7,20);      // lib/MySQL_Protocol.cpp, two sites
```

The stored `$A$rrr$` format has no delimiter after the salt. With an N-byte salt where N < 20, that read takes the N salt bytes **plus the first 20−N bytes of the digest**, feeds the wrong salt to `sha256_crypt_r`, and the comparison can never match.

So the credential is **silently unusable**: generation returns a well-formed 70-byte hash, storing it raises no error, and every login fails with a generic `Access denied`. Same silent-failure shape as the delimiter bug in #5989.

## Fix

Require exactly `DEF_SALT_SIZE` — the only length the format can round-trip.

Nothing usable is lost: hashes already generated with a shorter salt could never authenticate.

## Test changes this forces

Worth calling out, because most of the diff is here and it wasn't optional:

- **Three `INV_INPUTS` cases used a 2-byte salt (`'00'`) to reach the ROUNDS validation.** Lengths are checked before rounds, so they would now short-circuit on `Invalid argument size` and stop exercising rounds at all. They now use a valid 20-byte salt.
- `test_pass_gen()` gated wellformedness on `salt.size() <= 20`; now `== 20`, with any other length asserted to be rejected.
- Four new `INV_INPUTS` cases: 1, 10, 19 and 21-byte salts.
- The random-salt loop is now deliberate — alternating a valid 20-byte salt with a random invalid length, asserting both outcomes. This also fixes a long-standing copy/paste bug there:

  ```cpp
  const uint32_t salt_len = rand() % 20;        // computed...
  const string salt { random_string(pass_len) };  // ...never used; tracks PASSWORD length 0..149
  ```

  so the intended salt-length sweep never actually ran.

## Verification

- Patch hunk headers recomputed (+7 lines); the full chain `from_unixtime` → `sqlite3_pass_exts` → `throw` dry-run applies cleanly to a pristine amalgamation.
- `test_sqlite3_pass_exts-t`: **2227/2227**, zero `not ok`, on a `PROXYSQL31` debug build with the sqlite3 dep rebuilt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite support for MySQL-compatible `mysql_native_password` hashing.
  * Added `caching_sha2_password` hashing with optional salts and configurable rounds.
  * Added secure random salt generation when no salt is provided.

* **Bug Fixes**
  * Improved validation and error reporting for invalid password, salt, and round values.
  * Salt values for `caching_sha2_password` must now be exactly 20 bytes for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->