### PR TITLE
fix(test): retry shunned connect error checks

### DIFF
--- a/test/tap/tests/test_mysql_connect_retries-t.cpp
+++ b/test/tap/tests/test_mysql_connect_retries-t.cpp
@@ -285,6 +285,33 @@ int check_connect_retries(
 	return tests_failed();
 }
 
+int query_until_connect_error(MYSQL* proxy) {
+	constexpr uint32_t max_attempts = 2;
+	// get_random_MySrvC() requires the elapsed whole seconds to be strictly
+	// greater than the one-second desperate-unshun interval.  Waiting 2.1
+	// seconds also accounts for the coarse time_t granularity used there.
+	constexpr useconds_t shunned_server_recovery_wait_us = 2100 * 1000;
+
+	for (uint32_t attempt = 0; attempt < max_attempts; attempt++) {
+		mysql_query_t(proxy, "DO 1");
+		int q_err = mysql_errno(proxy);
+		diag("Query failed with error '%d' with message '%s'", q_err, mysql_error(proxy));
+
+		if (q_err != 9001 || attempt + 1 == max_attempts) {
+			return q_err;
+		}
+
+		diag(
+			"Received max connect timeout while the only test backend is automatically shunned; "
+			"waiting %u us and retrying once",
+			static_cast<uint32_t>(shunned_server_recovery_wait_us)
+		);
+		usleep(shunned_server_recovery_wait_us);
+	}
+
+	return 9001;
+}
+
 int check_connect_error_consistency(
 	const CommandLine& cl, MYSQL* admin, uint32_t hg, bool ff, uint32_t queries
 ) {
@@ -321,17 +348,13 @@ int check_connect_error_consistency(
 	}
 
 	diag("START: checking behavior first 'ConnectionError' in the connection");
-	mysql_query_t(proxy, "DO 1");
-	int q_err = mysql_errno(proxy);
-	diag("Query failed with error '%d' with message '%s'", q_err, mysql_error(proxy));
+	int q_err = query_until_connect_error(proxy);
 
 	ok(q_err == 2002, "Connection should have failed with error 'Can't connect to MySQL server...'");
 
 	diag("START: Checking behavior of subsequent connection attempts (queries) in the connection");
 	for (uint32_t i = 0; i < queries; i++) {
-		mysql_query_t(proxy, "DO 1");
-		int q_err = mysql_errno(proxy);
-		diag("Query failed with error '%d' with message '%s'", q_err, mysql_error(proxy));
+		int q_err = query_until_connect_error(proxy);
 
 		ok(q_err == 2002, "Connection should have failed with error 'Can't connect to MySQL server...'");
 	}
@@ -340,9 +363,7 @@ int check_connect_error_consistency(
 	diag("Wait at least timeout '%d'us before issuing next query", timeout_sleep);
 	usleep(timeout_sleep);
 
-	mysql_query_t(proxy, "DO 1");
-	q_err = mysql_errno(proxy);
-	diag("Query failed with error '%d' with message '%s'", q_err, mysql_error(proxy));
+	q_err = query_until_connect_error(proxy);
 
 	ok(q_err == 2002, "Error should still be '2002' after waiting beyond 'connect_timeout_server'");
 	mysql_close(proxy);


### PR DESCRIPTION
## Summary

Add one bounded retry when the connection-retries TAP test receives error 9001 while its sole deliberately offline backend is automatically shunned.

## Root cause

The test expects error 2002, but a query starting on the shun timing boundary can hit its 3-second max connection timeout before ProxySQL retries the backend.

## Validation

- WITHGCOV=1 PROXYSQL40=1 make ubuntu24-tap
- Filtered isolated legacy-g8 run of test_mysql_connect_retries-t: PASS 1/402, FAIL 0/402, ret_rc = [0]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection retry handling when the sole backend is temporarily unavailable.
  * Connection checks now retry after a brief wait and continue validating expected connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->