### PR TITLE
ci: run fork PR builds in restricted workflow

### DIFF
--- a/.github/workflows/CI-builds-fork.yml
+++ b/.github/workflows/CI-builds-fork.yml
@@ -1,0 +1,17 @@
+name: CI-builds-fork
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    uses: sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions
+    with:
+      trusted: false

--- a/.github/workflows/CI-builds-fork.yml
+++ b/.github/workflows/CI-builds-fork.yml
@@ -12,6 +12,6 @@ permissions:
 jobs:
   run:
     if: ${{ github.event.pull_request.head.repo.fork }}
-    uses: sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions
+    uses: sysown/proxysql/.github/workflows/ci-builds.yml@f3f23d1e8ad10da475261e515776d2fee68d732b
     with:
       trusted: false

--- a/.github/workflows/CI-builds.yml
+++ b/.github/workflows/CI-builds.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   run:
+    if: ${{ !github.event.workflow_run || github.event.workflow_run.head_repository.full_name == github.repository }}
     # `write-all` is required because reusable-workflow permissions are the
     # intersection of caller + callee. Without it the workflow_run event's
     # GITHUB_TOKEN has no cache-writable scope, so the callee's

--- a/.github/workflows/CI-trigger.yml
+++ b/.github/workflows/CI-trigger.yml
@@ -21,5 +21,6 @@ concurrency:
 
 jobs:
   run:
+    if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
     uses: sysown/proxysql/.github/workflows/ci-trigger.yml@GH-Actions
     secrets: inherit

--- a/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
+++ b/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
@@ -1,0 +1,234 @@
+# Safe Fork Pull Request Builds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the four existing build variants for approved fork PRs without executing fork code in the privileged `workflow_run` cascade.
+
+**Architecture:** The existing `CI-trigger` → `CI-builds` cascade remains for same-repository heads and is skipped for fork heads. A fork-only direct `pull_request` caller invokes the shared build reusable workflow in an untrusted mode. That mode preserves build commands and matrix entries while removing privileged state transfers.
+
+**Tech Stack:** GitHub Actions YAML, reusable workflows on `GH-Actions`, Bash validation.
+
+## Global Constraints
+
+- Fork builds run `debian12,-dbg`, `ubuntu22,-tap`, `ubuntu24,-tap-genai-gcov`, and `ubuntu22,-tap-mysqlx`.
+- Fork code uses `pull_request`, `contents: read`, no inherited secrets, and GitHub-hosted runners only.
+- Fork builds must not use shared cache operations, handoff or diagnostic artifact uploads, or `LouisBrunner/checks-action`.
+- Never set `allow-unsafe-pr-checkout: true`.
+- Same-repository CI behavior remains unchanged.
+
+---
+
+### Task 1: Add a cross-branch CI workflow validator
+
+**Files:**
+
+- Create: `test/infra/control/validate-fork-pr-builds.bash`
+
+**Interfaces:**
+
+- Consumes: base ref `$1`, GH-Actions ref `$2`.
+- Produces: exit status 0 only when the trusted caller, fork caller, and reusable workflow satisfy the isolation contract.
+
+- [ ] **Step 1: Write the failing test script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref=${1:?usage: $0 <base-ref> <gh-actions-ref>}
+actions_ref=${2:?usage: $0 <base-ref> <gh-actions-ref>}
+base_builds=$(git show "$base_ref:.github/workflows/CI-builds.yml")
+fork_builds=$(git show "$base_ref:.github/workflows/CI-builds-fork.yml")
+reusable_builds=$(git show "$actions_ref:.github/workflows/ci-builds.yml")
+
+grep -Fq 'github.event.workflow_run.head_repository.full_name == github.repository' <<<"$base_builds"
+grep -Fq 'pull_request:' <<<"$fork_builds"
+grep -Fq 'contents: read' <<<"$fork_builds"
+grep -Fq 'trusted: false' <<<"$fork_builds"
+grep -Fq 'trusted:' <<<"$reusable_builds"
+grep -Fq 'inputs.trusted' <<<"$reusable_builds"
+! grep -Fq 'allow-unsafe-pr-checkout: true' <<<"$base_builds$fork_builds$reusable_builds"
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `bash test/infra/control/validate-fork-pr-builds.bash HEAD origin/GH-Actions`
+
+Expected: FAIL because the fork workflow and the reusable-workflow input do not exist.
+
+- [ ] **Step 3: Commit the test**
+
+```bash
+git add test/infra/control/validate-fork-pr-builds.bash
+git commit -m "test(ci): validate fork PR build isolation"
+```
+
+### Task 2: Add untrusted mode to the shared reusable workflow
+
+**Files:**
+
+- Modify on a branch from `origin/GH-Actions`: `.github/workflows/ci-builds.yml`
+
+**Interfaces:**
+
+- Consumes: `workflow_call.inputs.trusted`, a boolean with default `true`.
+- Produces: existing trusted behavior for true; the same four builds without privileged operations for false.
+
+- [ ] **Step 1: Create the GH-Actions worktree and extend the validator before changing the reusable workflow**
+
+From the primary checkout, create the sibling worktree and branch:
+
+```bash
+git worktree add .worktrees/ci-fork-pr-builds-actions -b ci/fork-pr-builds-actions origin/GH-Actions
+```
+
+Add checks that require `inputs.trusted` to guard the cache restore/save/packing steps, both `LouisBrunner/checks-action` steps, every handoff upload, and the diagnostic artifact upload.
+
+- [ ] **Step 2: Confirm the extended test fails**
+
+Run from `.worktrees/ci-fork-pr-builds-actions`:
+
+```bash
+bash ../ci-fork-pr-builds/test/infra/control/validate-fork-pr-builds.bash ci/fork-pr-builds HEAD
+```
+
+Expected: FAIL because `ci-builds.yml` has no `trusted` input or guards.
+
+- [ ] **Step 3: Implement the minimal reusable-workflow change**
+
+Add the input:
+
+```yaml
+workflow_call:
+  inputs:
+    trigger:
+      type: string
+    trusted:
+      description: Whether the caller may use privileged CI infrastructure.
+      required: false
+      type: boolean
+      default: true
+```
+
+When `trusted` is false, force `runs-on: ubuntu-24.04`. Gate both `LouisBrunner/checks-action` steps, cache restore/pack/save steps, handoff pack/upload steps, and failure artifact upload with `inputs.trusted`. Keep `Checkout repository`, `Build`, and `Check build` active; skipped cache restore leaves the existing cache-hit condition true.
+
+- [ ] **Step 4: Verify the reusable workflow**
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-builds.yml")'
+git diff --check
+bash ../ci-fork-pr-builds/test/infra/control/validate-fork-pr-builds.bash ci/fork-pr-builds HEAD
+```
+
+Expected: YAML and whitespace checks pass; the validator still fails only because the base fork caller is absent.
+
+- [ ] **Step 5: Commit the reusable change**
+
+```bash
+git add .github/workflows/ci-builds.yml
+git commit -m "ci: add untrusted fork build mode"
+```
+
+### Task 3: Add the fork caller and gate the trusted cascade
+
+**Files:**
+
+- Modify: `.github/workflows/CI-builds.yml`
+- Modify: `.github/workflows/CI-trigger.yml`
+- Create: `.github/workflows/CI-builds-fork.yml`
+
+**Interfaces:**
+
+- Consumes: `github.event.workflow_run.head_repository.full_name` and `github.event.pull_request.head.repo.fork`.
+- Produces: direct restricted builds for forks; unchanged trusted cascading builds for same-repository PRs.
+
+- [ ] **Step 1: Add the trusted-workflow guards**
+
+Set the existing `CI-builds` job condition to:
+
+```yaml
+if: ${{ !github.event.workflow_run || github.event.workflow_run.head_repository.full_name == github.repository }}
+```
+
+Set the `CI-trigger` reusable caller job condition to:
+
+```yaml
+if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
+```
+
+- [ ] **Step 2: Add the fork-only caller**
+
+Create `.github/workflows/CI-builds-fork.yml`:
+
+```yaml
+name: CI-builds-fork
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    uses: sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions
+    with:
+      trusted: false
+```
+
+Do not add `secrets: inherit`, `permissions: write-all`, or a custom checkout to this caller.
+
+- [ ] **Step 3: Run the validator and YAML checks**
+
+```bash
+for workflow in .github/workflows/CI-builds.yml .github/workflows/CI-builds-fork.yml .github/workflows/CI-trigger.yml; do
+  ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$workflow"
+done
+git diff --check
+bash test/infra/control/validate-fork-pr-builds.bash HEAD ci/fork-pr-builds-actions
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Commit the base-branch change**
+
+```bash
+git add .github/workflows/CI-builds.yml .github/workflows/CI-builds-fork.yml .github/workflows/CI-trigger.yml test/infra/control/validate-fork-pr-builds.bash
+git commit -m "ci: run fork PR builds in restricted workflow"
+```
+
+### Task 4: Security review and deployment sequencing
+
+**Files:**
+
+- Verify: the base-branch commit from Task 3 and GH-Actions commit from Task 2.
+
+**Interfaces:**
+
+- Consumes: both branch heads.
+- Produces: a merge order that never leaves a caller referring to a missing reusable input.
+
+- [ ] **Step 1: Inspect for privilege regressions**
+
+```bash
+git diff origin/v3.0...ci/fork-pr-builds -- .github/workflows test/infra/control/validate-fork-pr-builds.bash
+git -C ../ci-fork-pr-builds-actions diff origin/GH-Actions...ci/fork-pr-builds-actions -- .github/workflows/ci-builds.yml
+```
+
+Confirm the fork caller and untrusted path contain no `allow-unsafe-pr-checkout: true`, `secrets: inherit`, or `permissions: write-all`.
+
+- [ ] **Step 2: Re-run all validation**
+
+```bash
+bash test/infra/control/validate-fork-pr-builds.bash ci/fork-pr-builds ci/fork-pr-builds-actions
+git diff --check origin/v3.0...ci/fork-pr-builds
+git -C ../ci-fork-pr-builds-actions diff --check origin/GH-Actions...ci/fork-pr-builds-actions
+```
+
+- [ ] **Step 3: Merge in dependency order**
+
+Merge the GH-Actions reusable-workflow change first, then the v3.0 caller change. Confirm a controlled fork PR runs four `CI-builds-fork` jobs on GitHub-hosted runners while `CI-builds` skips its privileged job.

--- a/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
+++ b/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
@@ -37,24 +37,87 @@ set -euo pipefail
 
 base_ref=${1:?usage: $0 <base-ref> <gh-actions-ref>}
 actions_ref=${2:?usage: $0 <base-ref> <gh-actions-ref>}
-base_builds=$(git show "$base_ref:.github/workflows/CI-builds.yml")
-fork_builds=$(git show "$base_ref:.github/workflows/CI-builds-fork.yml")
-reusable_builds=$(git show "$actions_ref:.github/workflows/ci-builds.yml")
+export BASE_BUILDS="$base_ref:.github/workflows/CI-builds.yml"
+export FORK_BUILDS="$base_ref:.github/workflows/CI-builds-fork.yml"
+export REUSABLE_BUILDS="$actions_ref:.github/workflows/ci-builds.yml"
 
-grep -Fq 'github.event.workflow_run.head_repository.full_name == github.repository' <<<"$base_builds"
-grep -Fq 'pull_request:' <<<"$fork_builds"
-grep -Fq 'contents: read' <<<"$fork_builds"
-grep -Fq 'trusted: false' <<<"$fork_builds"
-grep -Fq 'trusted:' <<<"$reusable_builds"
-grep -Fq 'inputs.trusted' <<<"$reusable_builds"
-! grep -Fq 'allow-unsafe-pr-checkout: true' <<<"$base_builds$fork_builds$reusable_builds"
+ruby <<'RUBY'
+require 'open3'
+require 'yaml'
+
+def workflow(ref)
+  output, status = Open3.capture2('git', 'show', ref)
+  raise "cannot read #{ref}" unless status.success?
+  YAML.load(output)
+end
+
+def assert(condition, message)
+  raise message unless condition
+end
+
+base = workflow(ENV.fetch('BASE_BUILDS'))
+fork = workflow(ENV.fetch('FORK_BUILDS'))
+reusable = workflow(ENV.fetch('REUSABLE_BUILDS'))
+
+base_run = base.fetch('jobs').fetch('run')
+assert(base_run.fetch('if').include?('head_repository.full_name == github.repository'), 'trusted CI-builds lacks same-repository guard')
+assert(base_run.fetch('permissions') == 'write-all', 'trusted CI-builds permission changed')
+assert(base_run.fetch('secrets') == 'inherit', 'trusted CI-builds secret handoff changed')
+
+fork_event = fork['on'] || fork[true]
+fork_run = fork.fetch('jobs').fetch('run')
+assert(fork_event.key?('pull_request'), 'fork workflow is not pull_request-triggered')
+assert(fork.fetch('permissions') == { 'contents' => 'read' }, 'fork workflow permissions are not exactly contents: read')
+assert(fork_run.fetch('if').include?('head.repo.fork'), 'fork workflow is not restricted to fork heads')
+assert(fork_run.fetch('uses') == 'sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions', 'fork workflow uses the wrong reusable workflow')
+assert(fork_run.fetch('with').fetch('trusted') == false, 'fork workflow does not select untrusted mode')
+fork.fetch('jobs').each_value do |job|
+  assert(!job.key?('secrets'), 'fork workflow inherits or passes secrets')
+  assert(!job.key?('permissions'), 'fork job overrides read-only workflow permissions')
+end
+
+reusable_event = reusable['on'] || reusable.fetch(true)
+inputs = reusable_event.fetch('workflow_call').fetch('inputs')
+assert(inputs.fetch('trusted').fetch('default') == true, 'reusable workflow lacks trusted=true default')
+builds = reusable.fetch('jobs').fetch('builds')
+runs_on = builds.fetch('runs-on')
+assert(runs_on.match?(/\A\$\{\{\s*inputs\.trusted\s*&&\s*\(/) && runs_on.match?(/\)\s*\|\|\s*'ubuntu-24\.04'\s*\}\}\z/), 'untrusted mode does not force ubuntu-24.04')
+actual_matrix = builds.fetch('strategy').fetch('matrix').fetch('include').map { |entry| [entry.fetch('dist'), entry.fetch('type')] }.sort
+expected_matrix = [['debian12', '-dbg'], ['ubuntu22', '-tap'], ['ubuntu22', '-tap-mysqlx'], ['ubuntu24', '-tap-genai-gcov']].sort
+assert(actual_matrix == expected_matrix, "unexpected build matrix: #{actual_matrix.inspect}")
+
+privileged_steps = reusable.fetch('jobs').values.flat_map { |job| job.fetch('steps', []) }.select do |step|
+  step.fetch('uses', '').include?('LouisBrunner/checks-action') ||
+    step.fetch('uses', '').include?('actions/cache/') ||
+    step.fetch('uses', '').include?('actions/upload-artifact') ||
+    step.fetch('name', '').match?(/Pack (bin|test|src \+ matrix) cache|Upload handoff|Archive artifacts/)
+end
+assert(!privileged_steps.empty?, 'no privileged steps discovered')
+privileged_steps.each do |step|
+  condition = step.fetch('if', '')
+  assert(condition.match?(/\A\$\{\{\s*inputs\.trusted\s*&&/) && !condition.include?('||'), "privileged step is not trusted-gated: #{step['name'] || step['uses']}")
+end
+
+def contains_unsafe_checkout?(value)
+  case value
+  when Hash
+    value.any? { |key, child| (key.to_s == 'allow-unsafe-pr-checkout' && child == true) || contains_unsafe_checkout?(child) }
+  when Array
+    value.any? { |child| contains_unsafe_checkout?(child) }
+  else
+    false
+  end
+end
+
+assert(![base, fork, reusable].any? { |workflow| contains_unsafe_checkout?(workflow) }, 'unsafe fork checkout enabled')
+RUBY
 ```
 
 - [ ] **Step 2: Run the test and confirm it fails**
 
 Run: `bash test/infra/control/validate-fork-pr-builds.bash HEAD origin/GH-Actions`
 
-Expected: FAIL because the fork workflow and the reusable-workflow input do not exist.
+Expected: FAIL because the fork workflow and the reusable-workflow input do not exist. Once the implementation exists, this test semantically rejects absent or changed matrix pairs, fork callers with broader permissions or secrets, changes to the trusted caller's permission/secret contract, and privileged reusable-workflow steps that are not guarded by `inputs.trusted`.
 
 - [ ] **Step 3: Commit the test**
 
@@ -110,7 +173,7 @@ workflow_call:
       default: true
 ```
 
-When `trusted` is false, force `runs-on: ubuntu-24.04`. Gate both `LouisBrunner/checks-action` steps, cache restore/pack/save steps, handoff pack/upload steps, and failure artifact upload with `inputs.trusted`. Keep `Checkout repository`, `Build`, and `Check build` active; skipped cache restore leaves the existing cache-hit condition true.
+When `trusted` is false, force `runs-on: ubuntu-24.04`. Express the runner selection as a positive `inputs.trusted && (trusted-runner-selection) || 'ubuntu-24.04'` condition. Gate both `LouisBrunner/checks-action` steps, cache restore/pack/save steps, handoff pack/upload steps, and failure artifact upload with a positive `${{ inputs.trusted && ... }}` condition that contains no `||`. Keep `Checkout repository`, `Build`, and `Check build` active; skipped cache restore leaves the existing cache-hit condition true.
 
 - [ ] **Step 4: Verify the reusable workflow**
 

--- a/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
+++ b/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
@@ -69,7 +69,7 @@ fork_run = fork.fetch('jobs').fetch('run')
 assert(fork_event.key?('pull_request'), 'fork workflow is not pull_request-triggered')
 assert(fork.fetch('permissions') == { 'contents' => 'read' }, 'fork workflow permissions are not exactly contents: read')
 assert(fork_run.fetch('if').include?('head.repo.fork'), 'fork workflow is not restricted to fork heads')
-assert(fork_run.fetch('uses') == 'sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions', 'fork workflow uses the wrong reusable workflow')
+assert(fork_run.fetch('uses').match?(%r{\Asysown/proxysql/\.github/workflows/ci-builds\.yml@[0-9a-f]{40}\z}), 'fork workflow does not pin the reusable workflow to a full commit SHA')
 assert(fork_run.fetch('with').fetch('trusted') == false, 'fork workflow does not select untrusted mode')
 fork.fetch('jobs').each_value do |job|
   assert(!job.key?('secrets'), 'fork workflow inherits or passes secrets')

--- a/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
+++ b/docs/superpowers/plans/2026-08-09-fork-pr-builds.md
@@ -90,7 +90,7 @@ privileged_steps = reusable.fetch('jobs').values.flat_map { |job| job.fetch('ste
   step.fetch('uses', '').include?('LouisBrunner/checks-action') ||
     step.fetch('uses', '').include?('actions/cache/') ||
     step.fetch('uses', '').include?('actions/upload-artifact') ||
-    step.fetch('name', '').match?(/Pack (bin|test|src \+ matrix) cache|Upload handoff|Archive artifacts/)
+    step.fetch('name', '').match?(/Pack (bin|test) cache|Pack src \+ matrix for handoff|Upload handoff|Archive artifacts/)
 end
 assert(!privileged_steps.empty?, 'no privileged steps discovered')
 privileged_steps.each do |step|

--- a/docs/superpowers/specs/2026-08-09-fork-pr-builds-design.md
+++ b/docs/superpowers/specs/2026-08-09-fork-pr-builds-design.md
@@ -1,0 +1,53 @@
+# Fork Pull Request Builds Design
+
+## Goal
+
+Run the existing four build variants for approved pull requests from forks without allowing fork-controlled code to execute in the privileged `workflow_run` CI cascade.
+
+## Scope
+
+Fork pull requests must run these build variants on GitHub-hosted runners:
+
+| Variant |
+| --- |
+| `debian12,-dbg` |
+| `ubuntu22,-tap` |
+| `ubuntu24,-tap-genai-gcov` |
+| `ubuntu22,-tap-mysqlx` |
+
+The existing privileged build cascade remains the path for same-repository branches. Its cache and artifact handoff behavior is not extended to fork code.
+
+## Architecture
+
+`CI-builds` remains a `workflow_run` workflow. It must skip its privileged reusable build job when the upstream workflow run originates from a fork. This prevents `actions/checkout` from trying to fetch a fork commit while the job has the base repository's write-capable token.
+
+A new direct `pull_request` workflow runs the four build variants for fork heads. It uses a separate reusable build implementation designed for untrusted code. The caller grants only `contents: read`; the reusable workflow does not inherit secrets, use self-hosted runners, publish custom check runs, restore or save shared caches, upload handoff artifacts, or trigger downstream test workflows.
+
+GitHub's repository policy remains responsible for requiring a maintainer to approve fork workflow runs. Approval permits restricted GitHub-hosted execution; it does not elevate fork code into the privileged workflow-run context.
+
+## Data Flow
+
+1. A contributor opens or updates a fork pull request.
+2. GitHub applies the repository's fork-workflow approval policy.
+3. After approval, the new `pull_request` workflow checks out the PR merge commit and builds all four variants with a read-only token on GitHub-hosted runners.
+4. The existing `workflow_run` `CI-builds` workflow observes the trigger but skips its trusted build job for the fork source.
+5. Same-repository PRs continue to use the existing privileged `CI-trigger` -> `CI-builds` cascade unchanged.
+
+## Security Constraints
+
+- Never set `allow-unsafe-pr-checkout: true` for fork code in a `workflow_run` or `pull_request_target` workflow.
+- Never run fork code on self-hosted runners.
+- Fork builds receive no secrets and no write-capable token.
+- Fork builds do not consume or produce shared CI caches or artifacts that privileged workflows use.
+- The fork build workflow must not create custom checks via `LouisBrunner/checks-action`; native job results provide its status.
+
+## Error Handling and Visibility
+
+The fork build workflow's native matrix job names identify the variant that failed. Build logs remain in the GitHub-hosted run. The trusted cascade's fork guard must avoid producing a false failure: it should skip, rather than attempt a protected checkout.
+
+## Verification
+
+- Add static workflow tests that verify the trusted workflow is gated for same-repository heads and the fork workflow uses `pull_request` with read-only permissions.
+- Verify the fork workflow has exactly the four existing build variants.
+- Validate the workflow YAML locally.
+- Exercise the safe path with a fork PR after merge or through a controlled fork, confirming it runs only on a GitHub-hosted runner and does not enter the privileged checkout path.

--- a/test/infra/control/validate-fork-pr-builds.bash
+++ b/test/infra/control/validate-fork-pr-builds.bash
@@ -8,10 +8,13 @@ export FORK_BUILDS="$base_ref:.github/workflows/CI-builds-fork.yml"
 export REUSABLE_BUILDS="$actions_ref:.github/workflows/ci-builds.yml"
 
 ruby <<'RUBY'
+require 'open3'
 require 'yaml'
 
 def workflow(ref)
-  YAML.load(`git show #{ref}`)
+  output, status = Open3.capture2('git', 'show', ref)
+  raise "cannot read #{ref}" unless status.success?
+  YAML.load(output)
 end
 
 def assert(condition, message)
@@ -35,12 +38,14 @@ assert(fork_run.fetch('if').include?('head.repo.fork'), 'fork workflow is not re
 assert(fork_run.fetch('uses') == 'sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions', 'fork workflow uses the wrong reusable workflow')
 assert(fork_run.fetch('with').fetch('trusted') == false, 'fork workflow does not select untrusted mode')
 assert(!fork_run.key?('secrets'), 'fork workflow inherits or passes secrets')
+assert(!fork_run.key?('permissions'), 'fork job overrides read-only workflow permissions')
 
 reusable_event = reusable['on'] || reusable.fetch(true)
 inputs = reusable_event.fetch('workflow_call').fetch('inputs')
 assert(inputs.fetch('trusted').fetch('default') == true, 'reusable workflow lacks trusted=true default')
 builds = reusable.fetch('jobs').fetch('builds')
-assert(builds.fetch('runs-on').include?('inputs.trusted'), 'untrusted mode does not force hosted runner selection')
+runs_on = builds.fetch('runs-on')
+assert(runs_on.match?(/inputs\.trusted\s*&&/) && runs_on.match?(/\|\|\s*'ubuntu-24\.04'/), 'untrusted mode does not force ubuntu-24.04')
 actual_matrix = builds.fetch('strategy').fetch('matrix').fetch('include').map { |entry| [entry.fetch('dist'), entry.fetch('type')] }.sort
 expected_matrix = [['debian12', '-dbg'], ['ubuntu22', '-tap'], ['ubuntu22', '-tap-mysqlx'], ['ubuntu24', '-tap-genai-gcov']].sort
 assert(actual_matrix == expected_matrix, "unexpected build matrix: #{actual_matrix.inspect}")
@@ -53,9 +58,20 @@ privileged_steps = builds.fetch('steps').select do |step|
 end
 assert(!privileged_steps.empty?, 'no privileged steps discovered')
 privileged_steps.each do |step|
-  assert(step.fetch('if', '').include?('inputs.trusted'), "privileged step is not trusted-gated: #{step['name'] || step['uses']}")
+  condition = step.fetch('if', '')
+  assert(condition.match?(/inputs\.trusted\s*&&/) && !condition.include?('||'), "privileged step is not trusted-gated: #{step['name'] || step['uses']}")
 end
 
-raw = [base, fork, reusable].map(&:to_s).join
-assert(!raw.include?('allow-unsafe-pr-checkout: true'), 'unsafe fork checkout enabled')
+def contains_unsafe_checkout?(value)
+  case value
+  when Hash
+    value.any? { |key, child| (key.to_s == 'allow-unsafe-pr-checkout' && child == true) || contains_unsafe_checkout?(child) }
+  when Array
+    value.any? { |child| contains_unsafe_checkout?(child) }
+  else
+    false
+  end
+end
+
+assert(![base, fork, reusable].any? { |workflow| contains_unsafe_checkout?(workflow) }, 'unsafe fork checkout enabled')
 RUBY

--- a/test/infra/control/validate-fork-pr-builds.bash
+++ b/test/infra/control/validate-fork-pr-builds.bash
@@ -56,7 +56,7 @@ privileged_steps = reusable.fetch('jobs').values.flat_map { |job| job.fetch('ste
   step.fetch('uses', '').include?('LouisBrunner/checks-action') ||
     step.fetch('uses', '').include?('actions/cache/') ||
     step.fetch('uses', '').include?('actions/upload-artifact') ||
-    step.fetch('name', '').match?(/Pack (bin|test|src \+ matrix) cache|Upload handoff|Archive artifacts/)
+    step.fetch('name', '').match?(/Pack (bin|test) cache|Pack src \+ matrix for handoff|Upload handoff|Archive artifacts/)
 end
 assert(!privileged_steps.empty?, 'no privileged steps discovered')
 privileged_steps.each do |step|

--- a/test/infra/control/validate-fork-pr-builds.bash
+++ b/test/infra/control/validate-fork-pr-builds.bash
@@ -35,7 +35,7 @@ fork_run = fork.fetch('jobs').fetch('run')
 assert(fork_event.key?('pull_request'), 'fork workflow is not pull_request-triggered')
 assert(fork.fetch('permissions') == { 'contents' => 'read' }, 'fork workflow permissions are not exactly contents: read')
 assert(fork_run.fetch('if').include?('head.repo.fork'), 'fork workflow is not restricted to fork heads')
-assert(fork_run.fetch('uses') == 'sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions', 'fork workflow uses the wrong reusable workflow')
+assert(fork_run.fetch('uses').match?(%r{\Asysown/proxysql/\.github/workflows/ci-builds\.yml@[0-9a-f]{40}\z}), 'fork workflow does not pin the reusable workflow to a full commit SHA')
 assert(fork_run.fetch('with').fetch('trusted') == false, 'fork workflow does not select untrusted mode')
 fork.fetch('jobs').each_value do |job|
   assert(!job.key?('secrets'), 'fork workflow inherits or passes secrets')

--- a/test/infra/control/validate-fork-pr-builds.bash
+++ b/test/infra/control/validate-fork-pr-builds.bash
@@ -3,23 +3,59 @@ set -euo pipefail
 
 base_ref=${1:?usage: $0 <base-ref> <gh-actions-ref>}
 actions_ref=${2:?usage: $0 <base-ref> <gh-actions-ref>}
-base_builds=$(git show "$base_ref:.github/workflows/CI-builds.yml")
-fork_builds=$(git show "$base_ref:.github/workflows/CI-builds-fork.yml")
-reusable_builds=$(git show "$actions_ref:.github/workflows/ci-builds.yml")
+export BASE_BUILDS="$base_ref:.github/workflows/CI-builds.yml"
+export FORK_BUILDS="$base_ref:.github/workflows/CI-builds-fork.yml"
+export REUSABLE_BUILDS="$actions_ref:.github/workflows/ci-builds.yml"
 
-grep -Fq 'github.event.workflow_run.head_repository.full_name == github.repository' <<<"$base_builds"
-grep -Fq 'pull_request:' <<<"$fork_builds"
-grep -Fq 'contents: read' <<<"$fork_builds"
-grep -Fq 'trusted: false' <<<"$fork_builds"
-grep -Fq 'trusted:' <<<"$reusable_builds"
-grep -Fq 'inputs.trusted' <<<"$reusable_builds"
-for variant in 'debian12' 'ubuntu22' 'ubuntu24' '-dbg' '-tap' '-tap-genai-gcov' '-tap-mysqlx'; do
-  grep -Fq "$variant" <<<"$reusable_builds"
-done
-! grep -Fq 'secrets: inherit' <<<"$fork_builds"
-! grep -Fq 'permissions: write-all' <<<"$fork_builds"
-! grep -Fq 'self-hosted' <<<"$fork_builds"
-for privileged_step in 'LouisBrunner/checks-action' 'actions/cache/' 'Upload handoff' 'Archive artifacts'; do
-  grep -F "$privileged_step" <<<"$reusable_builds" | grep -Fq 'inputs.trusted'
-done
-! grep -Fq 'allow-unsafe-pr-checkout: true' <<<"$base_builds$fork_builds$reusable_builds"
+ruby <<'RUBY'
+require 'yaml'
+
+def workflow(ref)
+  YAML.load(`git show #{ref}`)
+end
+
+def assert(condition, message)
+  raise message unless condition
+end
+
+base = workflow(ENV.fetch('BASE_BUILDS'))
+fork = workflow(ENV.fetch('FORK_BUILDS'))
+reusable = workflow(ENV.fetch('REUSABLE_BUILDS'))
+
+base_run = base.fetch('jobs').fetch('run')
+assert(base_run.fetch('if').include?('head_repository.full_name == github.repository'), 'trusted CI-builds lacks same-repository guard')
+assert(base_run.fetch('permissions') == 'write-all', 'trusted CI-builds permission changed')
+assert(base_run.fetch('secrets') == 'inherit', 'trusted CI-builds secret handoff changed')
+
+fork_event = fork['on'] || fork[true]
+fork_run = fork.fetch('jobs').fetch('run')
+assert(fork_event.key?('pull_request'), 'fork workflow is not pull_request-triggered')
+assert(fork.fetch('permissions') == { 'contents' => 'read' }, 'fork workflow permissions are not exactly contents: read')
+assert(fork_run.fetch('if').include?('head.repo.fork'), 'fork workflow is not restricted to fork heads')
+assert(fork_run.fetch('uses') == 'sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions', 'fork workflow uses the wrong reusable workflow')
+assert(fork_run.fetch('with').fetch('trusted') == false, 'fork workflow does not select untrusted mode')
+assert(!fork_run.key?('secrets'), 'fork workflow inherits or passes secrets')
+
+reusable_event = reusable['on'] || reusable.fetch(true)
+inputs = reusable_event.fetch('workflow_call').fetch('inputs')
+assert(inputs.fetch('trusted').fetch('default') == true, 'reusable workflow lacks trusted=true default')
+builds = reusable.fetch('jobs').fetch('builds')
+assert(builds.fetch('runs-on').include?('inputs.trusted'), 'untrusted mode does not force hosted runner selection')
+actual_matrix = builds.fetch('strategy').fetch('matrix').fetch('include').map { |entry| [entry.fetch('dist'), entry.fetch('type')] }.sort
+expected_matrix = [['debian12', '-dbg'], ['ubuntu22', '-tap'], ['ubuntu22', '-tap-mysqlx'], ['ubuntu24', '-tap-genai-gcov']].sort
+assert(actual_matrix == expected_matrix, "unexpected build matrix: #{actual_matrix.inspect}")
+
+privileged_steps = builds.fetch('steps').select do |step|
+  step.fetch('uses', '').include?('LouisBrunner/checks-action') ||
+    step.fetch('uses', '').include?('actions/cache/') ||
+    step.fetch('uses', '').include?('actions/upload-artifact') ||
+    step.fetch('name', '').match?(/Pack (bin|test|src \+ matrix) cache|Upload handoff|Archive artifacts/)
+end
+assert(!privileged_steps.empty?, 'no privileged steps discovered')
+privileged_steps.each do |step|
+  assert(step.fetch('if', '').include?('inputs.trusted'), "privileged step is not trusted-gated: #{step['name'] || step['uses']}")
+end
+
+raw = [base, fork, reusable].map(&:to_s).join
+assert(!raw.include?('allow-unsafe-pr-checkout: true'), 'unsafe fork checkout enabled')
+RUBY

--- a/test/infra/control/validate-fork-pr-builds.bash
+++ b/test/infra/control/validate-fork-pr-builds.bash
@@ -13,4 +13,13 @@ grep -Fq 'contents: read' <<<"$fork_builds"
 grep -Fq 'trusted: false' <<<"$fork_builds"
 grep -Fq 'trusted:' <<<"$reusable_builds"
 grep -Fq 'inputs.trusted' <<<"$reusable_builds"
+for variant in 'debian12' 'ubuntu22' 'ubuntu24' '-dbg' '-tap' '-tap-genai-gcov' '-tap-mysqlx'; do
+  grep -Fq "$variant" <<<"$reusable_builds"
+done
+! grep -Fq 'secrets: inherit' <<<"$fork_builds"
+! grep -Fq 'permissions: write-all' <<<"$fork_builds"
+! grep -Fq 'self-hosted' <<<"$fork_builds"
+for privileged_step in 'LouisBrunner/checks-action' 'actions/cache/' 'Upload handoff' 'Archive artifacts'; do
+  grep -F "$privileged_step" <<<"$reusable_builds" | grep -Fq 'inputs.trusted'
+done
 ! grep -Fq 'allow-unsafe-pr-checkout: true' <<<"$base_builds$fork_builds$reusable_builds"

--- a/test/infra/control/validate-fork-pr-builds.bash
+++ b/test/infra/control/validate-fork-pr-builds.bash
@@ -37,20 +37,22 @@ assert(fork.fetch('permissions') == { 'contents' => 'read' }, 'fork workflow per
 assert(fork_run.fetch('if').include?('head.repo.fork'), 'fork workflow is not restricted to fork heads')
 assert(fork_run.fetch('uses') == 'sysown/proxysql/.github/workflows/ci-builds.yml@GH-Actions', 'fork workflow uses the wrong reusable workflow')
 assert(fork_run.fetch('with').fetch('trusted') == false, 'fork workflow does not select untrusted mode')
-assert(!fork_run.key?('secrets'), 'fork workflow inherits or passes secrets')
-assert(!fork_run.key?('permissions'), 'fork job overrides read-only workflow permissions')
+fork.fetch('jobs').each_value do |job|
+  assert(!job.key?('secrets'), 'fork workflow inherits or passes secrets')
+  assert(!job.key?('permissions'), 'fork job overrides read-only workflow permissions')
+end
 
 reusable_event = reusable['on'] || reusable.fetch(true)
 inputs = reusable_event.fetch('workflow_call').fetch('inputs')
 assert(inputs.fetch('trusted').fetch('default') == true, 'reusable workflow lacks trusted=true default')
 builds = reusable.fetch('jobs').fetch('builds')
 runs_on = builds.fetch('runs-on')
-assert(runs_on.match?(/inputs\.trusted\s*&&/) && runs_on.match?(/\|\|\s*'ubuntu-24\.04'/), 'untrusted mode does not force ubuntu-24.04')
+assert(runs_on.match?(/\A\$\{\{\s*inputs\.trusted\s*&&\s*\(/) && runs_on.match?(/\)\s*\|\|\s*'ubuntu-24\.04'\s*\}\}\z/), 'untrusted mode does not force ubuntu-24.04')
 actual_matrix = builds.fetch('strategy').fetch('matrix').fetch('include').map { |entry| [entry.fetch('dist'), entry.fetch('type')] }.sort
 expected_matrix = [['debian12', '-dbg'], ['ubuntu22', '-tap'], ['ubuntu22', '-tap-mysqlx'], ['ubuntu24', '-tap-genai-gcov']].sort
 assert(actual_matrix == expected_matrix, "unexpected build matrix: #{actual_matrix.inspect}")
 
-privileged_steps = builds.fetch('steps').select do |step|
+privileged_steps = reusable.fetch('jobs').values.flat_map { |job| job.fetch('steps', []) }.select do |step|
   step.fetch('uses', '').include?('LouisBrunner/checks-action') ||
     step.fetch('uses', '').include?('actions/cache/') ||
     step.fetch('uses', '').include?('actions/upload-artifact') ||
@@ -59,7 +61,7 @@ end
 assert(!privileged_steps.empty?, 'no privileged steps discovered')
 privileged_steps.each do |step|
   condition = step.fetch('if', '')
-  assert(condition.match?(/inputs\.trusted\s*&&/) && !condition.include?('||'), "privileged step is not trusted-gated: #{step['name'] || step['uses']}")
+  assert(condition.match?(/\A\$\{\{\s*inputs\.trusted\s*&&/) && !condition.include?('||'), "privileged step is not trusted-gated: #{step['name'] || step['uses']}")
 end
 
 def contains_unsafe_checkout?(value)

--- a/test/infra/control/validate-fork-pr-builds.bash
+++ b/test/infra/control/validate-fork-pr-builds.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref=${1:?usage: $0 <base-ref> <gh-actions-ref>}
+actions_ref=${2:?usage: $0 <base-ref> <gh-actions-ref>}
+base_builds=$(git show "$base_ref:.github/workflows/CI-builds.yml")
+fork_builds=$(git show "$base_ref:.github/workflows/CI-builds-fork.yml")
+reusable_builds=$(git show "$actions_ref:.github/workflows/ci-builds.yml")
+
+grep -Fq 'github.event.workflow_run.head_repository.full_name == github.repository' <<<"$base_builds"
+grep -Fq 'pull_request:' <<<"$fork_builds"
+grep -Fq 'contents: read' <<<"$fork_builds"
+grep -Fq 'trusted: false' <<<"$fork_builds"
+grep -Fq 'trusted:' <<<"$reusable_builds"
+grep -Fq 'inputs.trusted' <<<"$reusable_builds"
+! grep -Fq 'allow-unsafe-pr-checkout: true' <<<"$base_builds$fork_builds$reusable_builds"


### PR DESCRIPTION
## What changed

Adds a fork-only `pull_request` caller that runs the existing four build variants through the shared reusable workflow with `trusted: false`.

The existing `CI-trigger` → `CI-builds` cascade now skips fork heads; its write-capable path remains available for same-repository heads only.

## Why

Approved external PR workflows should build the contributor's code without running it in the privileged `workflow_run` context.

## Validation

- YAML parsing and whitespace checks
- Cross-branch isolation validator
- Independent security review

Depends on #6001. Merge #6001 first, then this PR. After both merge, verify a controlled fork PR creates four GitHub-hosted jobs and no privileged `CI-builds` job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure build support for pull requests originating from forks.
  * Fork builds use read-only access and isolated GitHub-hosted runners.
  * Prevented untrusted fork changes from entering privileged build workflows.
  * Preserved standard build behavior for changes made within the repository.

* **Documentation**
  * Added design and implementation documentation for fork pull-request builds.

* **Tests**
  * Added automated validation for workflow permissions, trust controls, runner isolation, secrets, and build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->