### PR TITLE
ci: stop hashFiles() from failing jobs whose tests passed

### DIFF
--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -254,7 +254,7 @@ jobs:
         test/infra/control/destroy-infras.bash
 
     - name: Fix artifact permissions
-      if: ${{ failure() && !cancelled() }}
+      if: ${{ !cancelled() }}
       run: |
         # actions/upload-artifact dies with EACCES when it scandirs into
         # directories under ci_*_logs/ that were created inside docker
@@ -292,13 +292,30 @@ jobs:
           proxysql/ci_infra_logs/ci-basictests/coverage-report/
         if-no-files-found: ignore
 
+    - name: Detect coverage file
+      # Replaces hashFiles(): on the self-hosted runners this job can land on,
+      # the workspace persists between runs and ci_infra_logs is left root-owned
+      # by the test containers. hashFiles() walks the tree, hits EACCES and
+      # THROWS ('Fail to hash files under directory ...'), which invalidates the
+      # template and fails the job even when every test passed. A plain readable
+      # check on the exact file cannot throw, and matches the path used by the
+      # upload step below (the old glob was '**', far wider than needed).
+      id: cov
+      if: ${{ !cancelled() }}
+      run: |
+        if [ -r "proxysql/ci_infra_logs/ci-basictests/coverage-report/ci-basictests.info" ]; then
+          echo "found=1" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=0" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Report missing coverage file
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      if: ${{ !cancelled() && steps.cov.outputs.found == '0' }}
       run: |
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -252,7 +252,7 @@ jobs:
         test/infra/control/destroy-infras.bash
 
     - name: Fix artifact permissions
-      if: ${{ failure() && !cancelled() }}
+      if: ${{ !cancelled() }}
       run: |
         # actions/upload-artifact dies with EACCES when it scandirs into
         # directories under ci_*_logs/ that were created inside docker
@@ -280,13 +280,30 @@ jobs:
           proxysql/ci_infra_logs/ci-legacy-g2/coverage-report/
         if-no-files-found: ignore
 
+    - name: Detect coverage file
+      # Replaces hashFiles(): on the self-hosted runners this job can land on,
+      # the workspace persists between runs and ci_infra_logs is left root-owned
+      # by the test containers. hashFiles() walks the tree, hits EACCES and
+      # THROWS ('Fail to hash files under directory ...'), which invalidates the
+      # template and fails the job even when every test passed. A plain readable
+      # check on the exact file cannot throw, and matches the path used by the
+      # upload step below (the old glob was '**', far wider than needed).
+      id: cov
+      if: ${{ !cancelled() }}
+      run: |
+        if [ -r "proxysql/ci_infra_logs/ci-legacy-g2/coverage-report/ci-legacy-g2.info" ]; then
+          echo "found=1" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=0" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Report missing coverage file
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      if: ${{ !cancelled() && steps.cov.outputs.found == '0' }}
       run: |
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -216,7 +216,7 @@ jobs:
         test/infra/control/destroy-infras.bash || true
 
     - name: Fix artifact permissions
-      if: ${{ failure() && !cancelled() }}
+      if: ${{ !cancelled() }}
       run: |
         sudo chmod -R a+rX proxysql/ci_*_logs/ 2>/dev/null || true
 
@@ -237,13 +237,30 @@ jobs:
           proxysql/ci_infra_logs/ci-taptests-pgsql-cluster/coverage-report/
         if-no-files-found: ignore
 
+    - name: Detect coverage file
+      # Replaces hashFiles(): on the self-hosted runners this job can land on,
+      # the workspace persists between runs and ci_infra_logs is left root-owned
+      # by the test containers. hashFiles() walks the tree, hits EACCES and
+      # THROWS ('Fail to hash files under directory ...'), which invalidates the
+      # template and fails the job even when every test passed. A plain readable
+      # check on the exact file cannot throw, and matches the path used by the
+      # upload step below (the old glob was '**', far wider than needed).
+      id: cov
+      if: ${{ !cancelled() }}
+      run: |
+        if [ -r "proxysql/ci_infra_logs/ci-taptests-pgsql-cluster/coverage-report/ci-taptests-pgsql-cluster.info" ]; then
+          echo "found=1" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=0" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Report missing coverage file
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') == '' }}
+      if: ${{ !cancelled() && steps.cov.outputs.found == '0' }}
       run: |
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml


### PR DESCRIPTION
## Problem

`CI-basictests` failed on a run where **every test passed**:

```
SUMMARY: ret_rc = [0, 0, 0]
##[error]The template is not valid. System.InvalidOperationException:
hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') failed.
Fail to hash files under directory '/home/ci/_work/proxysql/proxysql'
```

#5995 added that guard to `ci-basictests`, `ci-legacy-g2` and `ci-taptests-pgsql-cluster`.

## Why it breaks here but not on the g9 workflows

The same expression already exists in `ci-mysql84-g9.yml` and works, so the expression alone isn't the problem — the runner is:

| workflow | `runs-on` | workspace in logs |
|---|---|---|
| `ci-mysql84-g9` | `ubuntu-22.04` (GitHub-hosted, ephemeral) | `/home/runner/work/...` |
| these three | resolved dynamically → **self-hosted** | `/home/ci/_work/...` |

On a self-hosted runner the workspace **persists between runs**, and the test containers leave `ci_infra_logs` root-owned. `hashFiles()` walks the tree to evaluate the glob, hits EACCES and **throws** instead of returning `''` — note the message is *"Fail to hash files under directory"*, a traversal failure, not a no-match. A throw inside an `if:` invalidates the template, so the job is marked failed after a completely green run. That's a false red, and false reds hide real ones.

Compounding it: `Fix artifact permissions` was gated `failure() && !cancelled()`, so on a **passing** run nothing ever chowned `ci_infra_logs` — exactly the case that broke.

## Fix

Per workflow:

- Replace the `hashFiles()` guard with a shell probe (`[ -r <file> ]`) exposed as a step output. A readability test cannot throw. It also checks the **exact** file the upload consumes — the old guard globbed `**` across the whole log tree, which is both wider than needed and what made it walk unreadable directories.
- Relax `Fix artifact permissions` to `!cancelled()`, so the tree is always readable before anything walks it — and, on a persistent runner, isn't inherited root-owned by the next job.

## Verification and limits

All three files validate as YAML, and the probe path equals the upload path in each.

**Not verified end to end:** I can't inspect the self-hosted runner's filesystem, so the EACCES step is inference from the error wording plus the hosted/self-hosted split. What *is* established: #5995 introduced the expression, the tests passed, and the job died evaluating it. The shell probe removes the failure mode regardless of the precise trigger, because it cannot throw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated test workflow reliability across supported test configurations.
  - Coverage reports are now detected more consistently before reporting or uploading.
  - Build artifacts receive the required permissions whenever workflows complete without cancellation, improving access to generated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->