### PR TITLE
ci: bound every job at 120 minutes

### DIFF
--- a/.github/workflows/ci-3p-aiomysql.yml
+++ b/.github/workflows/ci-3p-aiomysql.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-aiomysql.yml
+++ b/.github/workflows/ci-3p-aiomysql.yml
@@ -121,6 +121,7 @@ jobs:
         sed -i 's/timeout -v -s1 800 //' run-tests.bash
         
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-django-framework.yml
+++ b/.github/workflows/ci-3p-django-framework.yml
@@ -138,6 +138,7 @@ jobs:
         fi
         
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-django-framework.yml
+++ b/.github/workflows/ci-3p-django-framework.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-laravel-framework.yml
+++ b/.github/workflows/ci-3p-laravel-framework.yml
@@ -132,6 +132,7 @@ jobs:
         #sed -i '/EXPDATA=/i ls -l' test_${{ env.TESTNAME }}/run-tests.bash
 
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-laravel-framework.yml
+++ b/.github/workflows/ci-3p-laravel-framework.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-mariadb-connector-c.yml
+++ b/.github/workflows/ci-3p-mariadb-connector-c.yml
@@ -126,6 +126,7 @@ jobs:
         sed -i '/^fn_start_prep$/a fn_test_proxysql_dev ${{ matrix.infradb }}' run-tests.bash
 
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-mariadb-connector-c.yml
+++ b/.github/workflows/ci-3p-mariadb-connector-c.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-mysql-connector-j.yml
+++ b/.github/workflows/ci-3p-mysql-connector-j.yml
@@ -120,6 +120,7 @@ jobs:
         sed -i 's/timeout -v -s1 800 //' run-tests.bash
         
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-mysql-connector-j.yml
+++ b/.github/workflows/ci-3p-mysql-connector-j.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-pgjdbc.yml
+++ b/.github/workflows/ci-3p-pgjdbc.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-pgjdbc.yml
+++ b/.github/workflows/ci-3p-pgjdbc.yml
@@ -128,6 +128,7 @@ jobs:
         rm pgjdbc/src/test/java/org/postgresql/test/jdbc2/CopyTest.java
 
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-php-pdo-mysql.yml
+++ b/.github/workflows/ci-3p-php-pdo-mysql.yml
@@ -120,6 +120,7 @@ jobs:
         sed -i 's/timeout -v -s1 800 //' run-tests.bash
         
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-php-pdo-mysql.yml
+++ b/.github/workflows/ci-3p-php-pdo-mysql.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/ci-3p-php-pdo-pgsql.yml
@@ -117,6 +117,7 @@ jobs:
         sed -i 's/timeout -v -s1 800 //' run-tests.bash
         
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/ci-3p-php-pdo-pgsql.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-postgresql.yml
+++ b/.github/workflows/ci-3p-postgresql.yml
@@ -124,6 +124,7 @@ jobs:
         #sed -i '/^fn_start_prep$/a fn_test_proxysql_dev ${{ matrix.infradb }}' run-tests.bash
 
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-postgresql.yml
+++ b/.github/workflows/ci-3p-postgresql.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-3p-sqlalchemy.yml
+++ b/.github/workflows/ci-3p-sqlalchemy.yml
@@ -119,6 +119,7 @@ jobs:
         git -C ./proxysql describe --long --abbrev=7 
 
     - name: Run tests
+      timeout-minutes: 90
       run: |
         set +e
         

--- a/.github/workflows/ci-3p-sqlalchemy.yml
+++ b/.github/workflows/ci-3p-sqlalchemy.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -205,6 +206,7 @@ jobs:
 
   summarize:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     needs: [ test ]
     continue-on-error: true
     if: ${{ !cancelled() }}

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -236,6 +236,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run basic tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-basictests"

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     permissions: write-all
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -51,6 +51,7 @@ jobs:
     # (trusted) AND this workflow is listed in the SELFHOSTED_WORKFLOWS repo variable.
     # Otherwise fall back to GitHub-hosted ubuntu-24.04. Empty/absent variable = no routing.
     runs-on: ${{ inputs.trusted && ((github.actor == 'renecannao' || (inputs.trigger && fromJson(inputs.trigger).event.workflow_run.actor.login == 'renecannao')) && vars.SELFHOSTED_WORKFLOWS && contains(fromJson(vars.SELFHOSTED_WORKFLOWS), github.workflow) && fromJson('["self-hosted","proxysql-ci"]')) || 'ubuntu-24.04' }}
+    timeout-minutes: 120
 #    needs: [ lock ]
 #    outputs:
 #      matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -160,6 +160,7 @@ jobs:
 #        ls -l proxysql/test/tap
 
     - name: Build
+      timeout-minutes: 90
       id: build
       if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
       run: |

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -14,6 +14,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 #    permissions:
 #      actions: read
 #      contents: read

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-clickhouse-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-clickhouse-g1"

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g1"

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -187,6 +187,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g2 tests (GenAI + Coverage)
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g2-genai"

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. We arrived at this after a tight

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -233,6 +233,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g2 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g2"

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     permissions: write-all
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g3 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g3"

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g4 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g4"

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -241,6 +241,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g5 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g5"

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g6 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g6"

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g7 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g7"

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g8 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g8"

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run legacy-g9 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-legacy-g9"

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-maketest.yml
+++ b/.github/workflows/ci-maketest.yml
@@ -53,6 +53,7 @@ jobs:
 #        sed -i 's/-I$(CURL_IDIR) -I$(IDIR)/-I$(CURL_IDIR) -I${SQLITE3_DIR} -I$(IDIR)/' proxysql/test/tap/tests/Makefile
         
     - name: Make-test
+      timeout-minutes: 90
       run: |
         cd proxysql/
         sed -i 's/docker-compose/docker compose/g' Makefile

--- a/.github/workflows/ci-maketest.yml
+++ b/.github/workflows/ci-maketest.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   builds:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g1"

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g2 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g2"

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g3 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g3"

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g4 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g4"

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -173,6 +173,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g5 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g5"

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g6 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g6"

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g7 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g7"

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g8 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g8"

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mariadb10-galera-g9 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mariadb10-galera-g9"

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -180,6 +180,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql56-single-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql56-single-g1"

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g1"

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g2 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g2"

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g3 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g3"

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -25,6 +25,7 @@ jobs:
   # ---------------------------------------------------------------------------
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read          # read in-progress runs/jobs (no repo admin needed)
     outputs:
@@ -80,6 +81,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -242,6 +242,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g4 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g4"

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -173,6 +173,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g5 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g5"

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g6 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g6"

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g7 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g7"

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g8 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g8"

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-g9 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-g9"

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g1"

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g2 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g2"

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g3 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g3"

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g4 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g4"

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -173,6 +173,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g5 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g5"

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g6 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g6"

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g7 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g7"

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g8 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g8"

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql84-gr-g9 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql84-gr-g9"

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql90-gr-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql90-gr-g1"

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql93-gr-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql93-gr-g1"

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run mysql95-gr-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-mysql95-gr-g1"

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -35,6 +35,7 @@ jobs:
   # image ships protobuf 5.x; ubuntu-22.04 packages only protobuf 3.x).
   unit-tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     permissions: write-all
     steps:
       - uses: LouisBrunner/checks-action@v2.0.0
@@ -234,6 +235,7 @@ jobs:
   # arrangement.
   e2e-tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     needs: unit-tests
     permissions: write-all
     steps:
@@ -507,6 +509,7 @@ jobs:
   # mysqlx-soak/env.sh.
   soak-tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     needs: unit-tests
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -668,6 +668,7 @@ jobs:
           test/infra/control/ensure-infras.bash
 
       - name: Run mysqlx-soak-g1 tests
+        timeout-minutes: 90
         run: |
           cd proxysql
           export INFRA_ID="ci-mysqlx-soak-${GITHUB_RUN_ID}"

--- a/.github/workflows/ci-package-build.yml
+++ b/.github/workflows/ci-package-build.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   clean:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     outputs:
       gitdescribe: ${{ steps.gitdescribe.outputs.gitdescribe }}
     steps:
@@ -53,6 +54,7 @@ jobs:
    
   select:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     outputs:
       dists: ${{ steps.select.outputs.dists }}
     steps:
@@ -108,6 +110,7 @@ jobs:
             type: '-dbg'
 
     runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
+    timeout-minutes: 120
     env:
       ARCH: ${{ matrix.arch }}
       DIST: ${{ matrix.dist }}
@@ -163,6 +166,7 @@ jobs:
 
   finalize:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     needs: [ clean, select, build ]
     steps:
     - name: Update release

--- a/.github/workflows/ci-pg-compat.yml
+++ b/.github/workflows/ci-pg-compat.yml
@@ -78,6 +78,7 @@ jobs:
       # Writing the report there is what makes it visible to the upload
       # step below.
       - name: Run pg-compat suite (non-gating, discovery phase)
+        timeout-minutes: 90
         env:
           INFRA_ID: ci-${{ github.run_id }}
           WORKSPACE: ${{ github.workspace }}

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run pgsql-socket-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-pgsql-socket-g1"

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -147,6 +147,7 @@ jobs:
         docker compose up -d
 
     - name: Replication-tests
+      timeout-minutes: 35
       run: |
         set +e
 

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -139,6 +139,7 @@ jobs:
         mysql -uadmin -padmin -h127.0.0.1 -P6032 -e "SELECT version();" 2>&1 | grep -v 'Using a password'
 
     - name: Self-tests
+      timeout-minutes: 90
       run: |
         #set -x
         set +e

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -174,6 +174,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run set_parser_algorithm_3-g1 tests
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-set-parser-algorithm-3-g1"

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     # `write-all` grants every default GITHUB_TOKEN scope plus the
     # id-token:write scope codecov-action@v4 needs to mint a GitHub OIDC
     # token for `use_oidc: true`. Caller workflow on v3.0 must also

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -147,6 +147,7 @@ jobs:
         docker compose up -d
 
     - name: Shun-tests
+      timeout-minutes: 35
       run: |
         set +e
         

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read
     outputs:
@@ -59,6 +60,7 @@ jobs:
   tests:
     needs: pick-runner
     runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
     permissions: write-all
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -193,6 +193,7 @@ jobs:
         test/infra/control/ensure-infras.bash
 
     - name: Run test_cluster_sync_pgsql-t
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-taptests-pgsql-cluster"

--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -7,7 +7,11 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    # Must exceed the timeout of the job it watches (ci-builds, 120) -- this
+    # job blocks on `gh run watch` until that build finishes, so an equal
+    # budget lets the watcher expire first and the workflow_run[completed]
+    # fan-out never fires.
+    timeout-minutes: 240
 
     steps:
     - name: Trigger workflow_run[in_progress]

--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
 
     steps:
     - name: Trigger workflow_run[in_progress]

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -115,6 +115,7 @@ jobs:
         file proxysql/src/proxysql
 
     - name: Run unit-tests-g1
+      timeout-minutes: 90
       run: |
         cd proxysql
         export INFRA_ID="ci-unittests"

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
       MATRIX: '(unit-tests-g1)'


### PR DESCRIPTION
No TAP job had a timeout, and `TEST_TAP_TIMEOUT` defaults to 0, so a single hung test ran to GitHub's 6-hour ceiling — as happened on #5991 (`CI-mysql84-g9` stalled on `test_ssl_fast_forward-3_libmariadb-t`).

Worse than slow: GitHub marks a 6h-ceiling kill as `cancelled`, not `failure`, so archive steps guarded by `failure() && !cancelled()` are skipped — the run that most needs its logs uploads none.

Adds `timeout-minutes: 120` to **83 jobs across 64 workflows**. 120 is well above the slowest observed successful group (`CI-legacy-g4`, ~58 min) and matches what `ci-pg-compat.yml` already uses.

Untouched: `ci-pg-compat.yml` (already 120), `ci-repltests.yml` / `ci-shuntest.yml` (already 45, deliberately tighter).

Jobs that only call a reusable workflow are untouched — `timeout-minutes` is not a valid key on a `uses:` job, which is why this belongs on the callee side rather than in the `CI-*.yml` callers on `v3.0`.

All 64 files re-parse as valid YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended CI job timeouts to 120 minutes across integration, legacy, database compatibility, build, security analysis, packaging, and unit test workflows.
  * Increased individual test-step limits to 90 minutes and extended the CI trigger limit to 240 minutes.
* **Impact**
  * Reduces premature cancellations during longer-running validation, build, end-to-end, soak-test, and analysis tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->