### PR TITLE
ci: bound every self-contained job at 120 minutes

### DIFF
--- a/.github/workflows/CI-build-macos-macos-13-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-13-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: macos-13
+    timeout-minutes: 120
     env:
       ARCH: x86_64
       MATRIX: '(macos-x86_64-genai)'

--- a/.github/workflows/CI-build-macos-macos-13-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-13-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: macos-13
+    timeout-minutes: 120
     env:
       ARCH: x86_64
       MATRIX: '(macos-x86_64-v31)'

--- a/.github/workflows/CI-build-macos-macos-13.yml
+++ b/.github/workflows/CI-build-macos-macos-13.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: macos-13
+    timeout-minutes: 120
     env:
       ARCH: x86_64
       MATRIX: '(macos-x86_64)'

--- a/.github/workflows/CI-build-macos-macos-14-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-14-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: macos-14
+    timeout-minutes: 120
     env:
       ARCH: arm64
       MATRIX: '(macos-arm64-genai)'

--- a/.github/workflows/CI-build-macos-macos-14-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-14-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: macos-14
+    timeout-minutes: 120
     env:
       ARCH: arm64
       MATRIX: '(macos-arm64-v31)'

--- a/.github/workflows/CI-build-macos-macos-14.yml
+++ b/.github/workflows/CI-build-macos-macos-14.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: macos-14
+    timeout-minutes: 120
     env:
       ARCH: arm64
       MATRIX: '(macos-arm64)'

--- a/.github/workflows/CI-cluster-simulator.yml
+++ b/.github/workflows/CI-cluster-simulator.yml
@@ -31,6 +31,7 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     outputs:
       groups: ${{ steps.simulator-groups.outputs.groups }}
 
@@ -78,6 +79,7 @@ jobs:
     name: test / ${{ matrix.group }}
     needs: build
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI-cluster-simulator.yml
+++ b/.github/workflows/CI-cluster-simulator.yml
@@ -58,6 +58,7 @@ jobs:
       run: test/infra/control/cluster-simulator-ci.bash install
 
     - name: Build simulation test runtime
+      timeout-minutes: 90
       if: steps.simulator-build.outputs.cache-hit != 'true'
       run: test/infra/control/cluster-simulator-ci.bash build
 
@@ -115,6 +116,7 @@ jobs:
       run: test/infra/control/ensure-infras.bash
 
     - name: Run simulation tests
+      timeout-minutes: 90
       run: test/infra/control/run-tests-isolated.bash
 
     - name: Cleanup

--- a/.github/workflows/CI-lint-groups-json.yml
+++ b/.github/workflows/CI-lint-groups-json.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - name: Fetch GH-Actions branch

--- a/.github/workflows/CI-package-amd64-almalinux10-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux10.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux10

--- a/.github/workflows/CI-package-amd64-almalinux8-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux8.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux8

--- a/.github/workflows/CI-package-amd64-almalinux9-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-almalinux9.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: almalinux9

--- a/.github/workflows/CI-package-amd64-centos10-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos10.yml
+++ b/.github/workflows/CI-package-amd64-centos10.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos10

--- a/.github/workflows/CI-package-amd64-centos9-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-centos9.yml
+++ b/.github/workflows/CI-package-amd64-centos9.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: centos9

--- a/.github/workflows/CI-package-amd64-debian12-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian12.yml
+++ b/.github/workflows/CI-package-amd64-debian12.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian12

--- a/.github/workflows/CI-package-amd64-debian13-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-debian13.yml
+++ b/.github/workflows/CI-package-amd64-debian13.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: debian13

--- a/.github/workflows/CI-package-amd64-fedora42-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora42.yml
+++ b/.github/workflows/CI-package-amd64-fedora42.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora42

--- a/.github/workflows/CI-package-amd64-fedora43-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora43.yml
+++ b/.github/workflows/CI-package-amd64-fedora43.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: fedora43

--- a/.github/workflows/CI-package-amd64-fedora44-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-clang.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-dbg.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-fedora44.yml
+++ b/.github/workflows/CI-package-amd64-fedora44.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-opensuse15-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse15.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse15

--- a/.github/workflows/CI-package-amd64-opensuse16-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-opensuse16.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: opensuse16

--- a/.github/workflows/CI-package-amd64-tarball.yml
+++ b/.github/workflows/CI-package-amd64-tarball.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
     outputs:
@@ -72,6 +73,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu22.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-amd64-ubuntu24.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       ARCH: amd64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux10

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux10

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux10

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux8

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux8

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux8

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux9

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux9

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: almalinux9

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: centos10

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: centos10

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: centos10

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: centos9

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: centos9

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: centos9

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: debian12

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: debian12

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: debian12

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: debian13

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: debian13

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: debian13

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: fedora42

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: fedora42

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: fedora42

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: fedora43

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: fedora43

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: fedora43

--- a/.github/workflows/CI-package-arm64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-genai.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-arm64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-v31.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-arm64-fedora44.yml
+++ b/.github/workflows/CI-package-arm64-fedora44.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write
@@ -77,6 +78,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: opensuse15

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: opensuse15

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: opensuse15

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: opensuse16

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: opensuse16

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: opensuse16

--- a/.github/workflows/CI-package-arm64-tarball.yml
+++ b/.github/workflows/CI-package-arm64-tarball.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
     outputs:
@@ -72,6 +73,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: ubuntu22

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: ubuntu24

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   init_release:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # No concurrency group: GitHub's "1 running + 1 pending" rule causes
     # mass cancellations when many workflows share a group. Instead we
     # run all init jobs in parallel and converge via a race-tolerant
@@ -78,6 +79,7 @@ jobs:
   build:
     needs: init_release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
     env:
       ARCH: arm64
       DIST: ubuntu24

--- a/.github/workflows/CI-push-ci-base-image.yml
+++ b/.github/workflows/CI-push-ci-base-image.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Companion to #6005 (which bounds the reusable `ci-*.yml` jobs on `GH-Actions`). This covers workflows that define their jobs **directly on `v3.0`** — the package matrix, macOS builds, `CI-cluster-simulator`, `CI-lint-groups-json`, `CI-push-ci-base-image` — which the callee-side change cannot reach.

No job had a timeout, so a hang ran to GitHub's 6-hour ceiling. GitHub marks such a run `cancelled` rather than `failure`, which also skips every archive step guarded by `failure() && !cancelled()` — so the run that most needs its logs uploads none.

**358 jobs across 181 files.** Files already setting `timeout-minutes` are left alone, as are pure caller workflows (`timeout-minutes` is not a valid key on a `uses:`-only job).

All 181 files re-parse as valid YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added 120-minute execution limits across build, packaging, release, testing, linting, review, and container-image automation.
  * Applied consistent timeouts across supported macOS, Linux distributions, architectures, and package variants.
  * Added 90-minute limits to selected simulation build and test steps.
  * Existing workflow behavior remains unchanged apart from the updated execution limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->