### PR TITLE
ci: wire no-infra-g1 into CI (caller half)

### DIFF
--- a/.github/workflows/CI-no-infra-g1.yml
+++ b/.github/workflows/CI-no-infra-g1.yml
@@ -1,0 +1,27 @@
+name: CI-no-infra-g1
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ completed ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # `write-all` is required for the callee's `use_oidc: true` Codecov
+    # upload step to mint a GitHub OIDC token. Reusable-workflow
+    # permissions are the intersection of caller + callee, so the
+    # caller has to grant id-token:write (and everything else included
+    # in write-all) for the callee's declaration to take effect. The
+    # callee at ci-<group>.yml@GH-Actions also declares write-all.
+    permissions: write-all
+    uses: sysown/proxysql/.github/workflows/ci-no-infra-g1.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}


### PR DESCRIPTION
Caller for `ci-no-infra-g1.yml`. See the companion PR against `GH-Actions` for the callee — **that one must merge first**, otherwise this caller resolves to a missing workflow.

`no-infra-g1` was the only group flagged NEW by `lint_group_coverage.py`; its five tests have never run in CI, including `reg_test_5363_admin_monitor_caching_sha2-t`.

With the pair in place:

```
group coverage lint: 94 groups | phantom-infra=0 | missing-workflow NEW=0 known=41
```

Closes the pending "wire no-infra-g1 into CI" item. Tracking for the 41 remaining (deliberately allowlisted) families: #6007.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow that can run manually or after successful CI completion.
  * Prevents redundant workflow runs by canceling older runs for the same branch and workflow.
  * Enables coverage reporting through secure workflow authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->