### PR TITLE
test: make TEST_TAP_TIMEOUT actually fire, and enable it by default

### DIFF
--- a/test/infra/control/env-isolated.bash
+++ b/test/infra/control/env-isolated.bash
@@ -104,7 +104,14 @@ export TEST_PY_TAP_REPEAT="${TEST_PY_TAP_REPEAT:-1}"
 export TEST_PY_TAP_SHUFFLE_LIMIT="${TEST_PY_TAP_SHUFFLE_LIMIT:-0}"
 export TEST_PY_TAP_DUMP_RUNTIME="${TEST_PY_TAP_DUMP_RUNTIME:-1}"
 export TEST_PY_TAP_DUMP_STATS="${TEST_PY_TAP_DUMP_STATS:-1}"
-export TEST_TAP_TIMEOUT="${TEST_TAP_TIMEOUT:-0}"
+# Per-test wall-clock budget, in seconds. 0 disables it entirely, which was
+# the previous default: a hung TAP test then ran until the CI job itself was
+# killed. 1800 is ~2.4x the slowest single test measured across 47 groups
+# (reg_test_3765_ssl_pollout-t, 12.5 min; then test_cluster_sync-t 10.5,
+# set_testing-240-t 7.8, test_auth_methods-t 7.7 -- only 4 tests exceed 5
+# minutes at all), so it cannot fire on a merely slow test while still
+# catching a hang long before the 90-minute step budget.
+export TEST_TAP_TIMEOUT="${TEST_TAP_TIMEOUT:-1800}"
 
 # Cluster sync test support — expose first cluster node admin port for replica validation
 if [ "${NUM_CLUSTER_NODES}" -gt 0 ]; then

--- a/test/scripts/bin/proxysql-tester.py
+++ b/test/scripts/bin/proxysql-tester.py
@@ -5,6 +5,7 @@ import json
 import os
 import pymysql
 import sys
+import select
 import subprocess
 import random
 import time
@@ -842,19 +843,42 @@ CREATE TABLE stats_history.mysql_server_read_only_log (
                         sys.exit(1)
                     continue
 
-                # Run test with timeout if specified
+                # Run test with timeout if specified.
+                #
+                # The read has to be non-blocking for tap_timeout to mean
+                # anything. readline() blocks until a full line arrives, so on
+                # a test that hangs while producing no output -- precisely the
+                # case this timeout exists to catch -- the deadline check below
+                # it was simply never reached, and the test ran until CI killed
+                # the job. select() bounds the wait so the check always runs,
+                # and reading raw chunks rather than lines means a test that
+                # stops mid-line cannot wedge us either.
                 try:
                     start_time = time.time()
+                    buf = b''
                     while True:
-                        line = fop.stdout.readline()
-                        if not line and fop.poll() is not None:
-                            break
-                        if line:
-                            log.debug(f"msg: {line.decode('utf-8').strip()}")
-                        
                         if tap_timeout > 0 and (time.time() - start_time) > tap_timeout:
                             raise subprocess.TimeoutExpired(fop.args, tap_timeout)
-                    
+
+                        wait = 1.0
+                        if tap_timeout > 0:
+                            wait = max(0.0, min(1.0, tap_timeout - (time.time() - start_time)))
+                        ready, _, _ = select.select([fop.stdout], [], [], wait)
+
+                        if ready:
+                            chunk = os.read(fop.stdout.fileno(), 65536)
+                            if not chunk:
+                                break                     # EOF: test finished
+                            buf += chunk
+                            while b'\n' in buf:
+                                line, buf = buf.split(b'\n', 1)
+                                log.debug(f"msg: {line.decode('utf-8', 'replace').strip()}")
+                        elif fop.poll() is not None:
+                            break
+
+                    if buf:                               # trailing partial line
+                        log.debug(f"msg: {buf.decode('utf-8', 'replace').strip()}")
+
                     fop.wait()
                 except subprocess.TimeoutExpired:
                     fop.kill()

--- a/test/scripts/bin/proxysql-tester.py
+++ b/test/scripts/bin/proxysql-tester.py
@@ -886,7 +886,15 @@ CREATE TABLE stats_history.mysql_server_read_only_log (
                     self.padmin_command(f"LOGENTRY '{TAP} test {fo_num+1}/{len(tap_tests)} \'{os.path.basename(fo_cmd)}\' timed out after {tap_timeout} seconds'")
                     # Drain any remaining output
                     for line in fop.stdout:
-                        log.debug(f"msg: {line.decode('utf-8').strip()}")
+                        log.debug(f"msg: {line.decode('utf-8', 'replace').strip()}")
+                    # Reap the child. kill() signals but does not wait, so
+                    # returncode stays None until we do -- and the shared exit
+                    # path below evaluates abs(int(fop.returncode)), which
+                    # raises TypeError on None. That path was unreachable while
+                    # the timeout could never fire; now that it can, a timed-out
+                    # test would abort the whole group instead of failing one
+                    # test. wait() yields -SIGKILL, so the test scores non-zero.
+                    fop.wait()
                 except Exception as e:
                     log.critical(f"TAP test {fo_num+1}/{len(tap_tests)} '{os.path.basename(fo_cmd)}' - test threw an exception !!!: {e}")
                     self.padmin_command(f"LOGENTRY '{TAP} test {fo_num+1}/{len(tap_tests)} \'{os.path.basename(fo_cmd)}\' - test threw an exception !!!'")


### PR DESCRIPTION
`TEST_TAP_TIMEOUT` could not catch the failure it exists for.

```python
line = fop.stdout.readline()          # blocks
...
if tap_timeout > 0 and (time.time() - start_time) > tap_timeout:
```

`readline()` blocks until a full line arrives, so a test that hangs **while producing no output** never reached the deadline check. Verified directly: with `tap_timeout=3` against `sleep 300`, the old loop was still blocked after 25 s; the new one raises at 3.0 s. That is the profile of the `CI-mysql84-g9` stall on #5991.

**Fix:** `select()` on a bounded wait + raw `os.read()` chunking. `select()` guarantees the deadline check runs while the child is silent; chunking rather than line-reading means a test that stops mid-line can't wedge the loop either. Output order/content unchanged; a trailing partial line is now flushed instead of dropped; decoding uses `errors='replace'` so a stray non-UTF-8 byte no longer throws.

Verified against 4 cases: normal chatty test (all lines in order), silent hang (fires), partial-line-then-hang (fires), clean exit.

**Also flips the default from 0 (disabled) to 1800s.** Measured across 47 groups / 401 tests:

| test | max observed |
|---|---|
| `reg_test_3765_ssl_pollout-t` | 12.5 min |
| `test_cluster_sync-t` | 10.5 min |
| `set_testing-240-t` | 7.8 min |
| `test_auth_methods-t` | 7.7 min |

Only 4 of 401 tests exceed 5 minutes, so 1800s (~2.4× the max) can't fire on a merely slow test.

Complements #6005/#6006: a step timeout bounds cost, but only this identifies **which** test hung and lets the run continue to its archive/coverage steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a default 30-minute timeout for test runs, while preserving custom timeout settings.
  - Improved test monitoring so timeouts are enforced even when no output is produced.
  - Improved handling of partial output and clean process completion during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->