### PR TITLE
ci: retry the Codecov upload, and never let it fail a green run

### DIFF
--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -318,7 +318,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
       if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
+      continue-on-error: true
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -334,6 +336,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-basictests/coverage-report/ci-basictests.info
+        flags: integration-tests
+        name: tap-basictests-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-basictests/coverage-report/ci-basictests.info
+        flags: integration-tests
+        name: tap-basictests-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()
       with:

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -333,7 +333,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -356,7 +356,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -379,7 +379,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -321,7 +321,7 @@ jobs:
       id: codecov_1
       if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -344,7 +344,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -367,7 +367,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -250,7 +250,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -280,7 +280,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -303,7 +303,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -326,7 +326,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -234,6 +234,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -251,7 +254,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -281,6 +283,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
+        flags: integration-tests
+        name: tap-legacy-clickhouse-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-clickhouse-g1/coverage-report/ci-legacy-clickhouse-g1.info
+        flags: integration-tests
+        name: tap-legacy-clickhouse-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -254,7 +254,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -291,7 +291,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -314,7 +314,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
+        flags: integration-tests
+        name: tap-legacy-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g1/coverage-report/ci-legacy-g1.info
+        flags: integration-tests
+        name: tap-legacy-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -269,7 +269,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -329,7 +329,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -265,7 +265,7 @@ jobs:
       # tokenless legacy uploads with "branch is protected" HTTP 400 (see
       # the Phase 1 commit history on CI-unit-tests-asan-coverage.yml).
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -341,7 +341,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -247,6 +247,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/)
       # to Codecov. This is REAL ProxySQL coverage -- the proxysql binary
@@ -266,7 +269,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -296,6 +298,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/ci-legacy-g2-genai.info
+        flags: integration-tests
+        name: tap-legacy-g2-genai-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g2-genai/coverage-report/ci-legacy-g2-genai.info
+        flags: integration-tests
+        name: tap-legacy-g2-genai-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -309,7 +309,7 @@ jobs:
       id: codecov_1
       if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -332,7 +332,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -355,7 +355,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -321,7 +321,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -344,7 +344,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -367,7 +367,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -306,7 +306,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
       if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
+      continue-on-error: true
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -322,6 +324,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g2/coverage-report/ci-legacy-g2.info
+        flags: integration-tests
+        name: tap-legacy-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g2/coverage-report/ci-legacy-g2.info
+        flags: integration-tests
+        name: tap-legacy-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       if: always()
       with:

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
+        flags: integration-tests
+        name: tap-legacy-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g3/coverage-report/ci-legacy-g3.info
+        flags: integration-tests
+        name: tap-legacy-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -318,7 +318,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -348,7 +348,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -371,7 +371,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -394,7 +394,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -302,6 +302,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -319,7 +322,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -349,6 +351,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
+        flags: integration-tests
+        name: tap-legacy-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g4/coverage-report/ci-legacy-g4.info
+        flags: integration-tests
+        name: tap-legacy-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -322,7 +322,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -359,7 +359,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -382,7 +382,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -299,6 +299,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -316,7 +319,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -346,6 +348,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
+        flags: integration-tests
+        name: tap-legacy-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g5/coverage-report/ci-legacy-g5.info
+        flags: integration-tests
+        name: tap-legacy-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -315,7 +315,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -345,7 +345,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -368,7 +368,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -391,7 +391,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -319,7 +319,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -356,7 +356,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -379,7 +379,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
+        flags: integration-tests
+        name: tap-legacy-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g6/coverage-report/ci-legacy-g6.info
+        flags: integration-tests
+        name: tap-legacy-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
+        flags: integration-tests
+        name: tap-legacy-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g7/coverage-report/ci-legacy-g7.info
+        flags: integration-tests
+        name: tap-legacy-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
+        flags: integration-tests
+        name: tap-legacy-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g8/coverage-report/ci-legacy-g8.info
+        flags: integration-tests
+        name: tap-legacy-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
+        flags: integration-tests
+        name: tap-legacy-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-legacy-g9/coverage-report/ci-legacy-g9.info
+        flags: integration-tests
+        name: tap-legacy-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g1/coverage-report/ci-mariadb10-galera-g1.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g2/coverage-report/ci-mariadb10-galera-g2.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g3/coverage-report/ci-mariadb10-galera-g3.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g4/coverage-report/ci-mariadb10-galera-g4.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -244,7 +244,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -281,7 +281,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -304,7 +304,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -224,6 +224,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -241,7 +244,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -271,6 +273,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g5/coverage-report/ci-mariadb10-galera-g5.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -240,7 +240,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -270,7 +270,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -293,7 +293,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -316,7 +316,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g6/coverage-report/ci-mariadb10-galera-g6.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g7/coverage-report/ci-mariadb10-galera-g7.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g8/coverage-report/ci-mariadb10-galera-g8.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mariadb10-galera-g9/coverage-report/ci-mariadb10-galera-g9.info
+        flags: integration-tests
+        name: tap-mariadb10-galera-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -239,6 +239,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -256,7 +259,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -286,6 +288,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
+        flags: integration-tests
+        name: tap-mysql56-single-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql56-single-g1/coverage-report/ci-mysql56-single-g1.info
+        flags: integration-tests
+        name: tap-mysql56-single-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -255,7 +255,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -285,7 +285,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -308,7 +308,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -331,7 +331,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -259,7 +259,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -296,7 +296,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -319,7 +319,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
+        flags: integration-tests
+        name: tap-mysql84-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g1/coverage-report/ci-mysql84-g1.info
+        flags: integration-tests
+        name: tap-mysql84-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
+        flags: integration-tests
+        name: tap-mysql84-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g2/coverage-report/ci-mysql84-g2.info
+        flags: integration-tests
+        name: tap-mysql84-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
+        flags: integration-tests
+        name: tap-mysql84-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g3/coverage-report/ci-mysql84-g3.info
+        flags: integration-tests
+        name: tap-mysql84-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -317,7 +317,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -347,7 +347,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -370,7 +370,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -393,7 +393,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -301,6 +301,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -318,7 +321,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -348,6 +350,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
+        flags: integration-tests
+        name: tap-mysql84-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g4/coverage-report/ci-mysql84-g4.info
+        flags: integration-tests
+        name: tap-mysql84-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -321,7 +321,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -358,7 +358,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -381,7 +381,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -251,7 +251,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -288,7 +288,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -311,7 +311,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -247,7 +247,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -277,7 +277,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -300,7 +300,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -323,7 +323,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -231,6 +231,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -248,7 +251,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -278,6 +280,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
+        flags: integration-tests
+        name: tap-mysql84-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g5/coverage-report/ci-mysql84-g5.info
+        flags: integration-tests
+        name: tap-mysql84-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
+        flags: integration-tests
+        name: tap-mysql84-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g6/coverage-report/ci-mysql84-g6.info
+        flags: integration-tests
+        name: tap-mysql84-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
+        flags: integration-tests
+        name: tap-mysql84-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g7/coverage-report/ci-mysql84-g7.info
+        flags: integration-tests
+        name: tap-mysql84-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
+        flags: integration-tests
+        name: tap-mysql84-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g8/coverage-report/ci-mysql84-g8.info
+        flags: integration-tests
+        name: tap-mysql84-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
+        flags: integration-tests
+        name: tap-mysql84-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-g9/coverage-report/ci-mysql84-g9.info
+        flags: integration-tests
+        name: tap-mysql84-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g1/coverage-report/ci-mysql84-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g2/coverage-report/ci-mysql84-gr-g2.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g2-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g3/coverage-report/ci-mysql84-gr-g3.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g3-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g4/coverage-report/ci-mysql84-gr-g4.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g4-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -224,6 +224,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -241,7 +244,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -271,6 +273,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g5/coverage-report/ci-mysql84-gr-g5.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g5-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -244,7 +244,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -281,7 +281,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -304,7 +304,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -240,7 +240,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -270,7 +270,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -293,7 +293,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -316,7 +316,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g6/coverage-report/ci-mysql84-gr-g6.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g6-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g7/coverage-report/ci-mysql84-gr-g7.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g7-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g8/coverage-report/ci-mysql84-gr-g8.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g8-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql84-gr-g9/coverage-report/ci-mysql84-gr-g9.info
+        flags: integration-tests
+        name: tap-mysql84-gr-g9-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/ci-mysql90-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql90-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql90-gr-g1/coverage-report/ci-mysql90-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql90-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/ci-mysql93-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql93-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql93-gr-g1/coverage-report/ci-mysql93-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql93-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -226,6 +226,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -243,7 +246,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -273,6 +275,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/ci-mysql95-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql95-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-mysql95-gr-g1/coverage-report/ci-mysql95-gr-g1.info
+        flags: integration-tests
+        name: tap-mysql95-gr-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -242,7 +242,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -272,7 +272,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -295,7 +295,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -318,7 +318,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -246,7 +246,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -283,7 +283,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -306,7 +306,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-no-infra-g1.yml
+++ b/.github/workflows/ci-no-infra-g1.yml
@@ -300,6 +300,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-no-infra-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -317,7 +320,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -347,6 +349,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-no-infra-g1/coverage-report/ci-no-infra-g1.info
+        flags: integration-tests
+        name: tap-no-infra-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-no-infra-g1/coverage-report/ci-no-infra-g1.info
+        flags: integration-tests
+        name: tap-no-infra-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-no-infra-g1.yml
+++ b/.github/workflows/ci-no-infra-g1.yml
@@ -316,7 +316,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -346,7 +346,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -369,7 +369,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -392,7 +392,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-no-infra-g1.yml
+++ b/.github/workflows/ci-no-infra-g1.yml
@@ -320,7 +320,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -357,7 +357,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -380,7 +380,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
+        flags: integration-tests
+        name: tap-pgsql-socket-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-pgsql-socket-g1/coverage-report/ci-pgsql-socket-g1.info
+        flags: integration-tests
+        name: tap-pgsql-socket-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -249,7 +249,7 @@ jobs:
       # repo has no CODECOV_TOKEN secret and Codecov rejects tokenless
       # legacy uploads with "branch is protected" HTTP 400.
       #
-      # `fail_ci_if_error: false` so a Codecov outage never fails the
+      # `fail_ci_if_error: true` so a Codecov outage never fails the
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
@@ -279,7 +279,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -302,7 +302,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -325,7 +325,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -253,7 +253,7 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -290,7 +290,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -313,7 +313,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -233,6 +233,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
+      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
+      continue-on-error: true
       # Send the LCOV .info file fastcov produces in run-tests-isolated.bash
       # (under proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/) to
       # Codecov. The proxysql binary was built WITHGCOV=1 (-tap-genai-gcov
@@ -250,7 +253,6 @@ jobs:
       # whole TAP group; `!cancelled()` so coverage uploads even when
       # the test step itself reported a failure (partial coverage is
       # still useful diagnostically).
-      if: ${{ !cancelled() && hashFiles('proxysql/ci_infra_logs/**/coverage-report/*.info') != '' }}
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -280,6 +282,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
+        flags: integration-tests
+        name: tap-set_parser_algorithm_3-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-set_parser_algorithm_3-g1/coverage-report/ci-set_parser_algorithm_3-g1.info
+        flags: integration-tests
+        name: tap-set_parser_algorithm_3-g1-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -266,7 +266,7 @@ jobs:
       id: codecov_1
       if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -289,7 +289,7 @@ jobs:
       id: codecov_2
       if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
@@ -312,7 +312,7 @@ jobs:
       id: codecov_3
       if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
       continue-on-error: true
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
         override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -263,7 +263,9 @@ jobs:
         echo "No coverage report was produced; skipping Codecov upload."
 
     - name: Upload coverage to Codecov
+      id: codecov_1
       if: ${{ !cancelled() && steps.cov.outputs.found == '1' }}
+      continue-on-error: true
       uses: codecov/codecov-action@v4
       with:
         codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
@@ -279,6 +281,55 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
+    - name: Wait before Codecov retry 1
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      run: sleep 15
+
+    - name: Upload coverage to Codecov (retry 1)
+      id: codecov_2
+      if: ${{ !cancelled() && steps.codecov_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-taptests-pgsql-cluster/coverage-report/ci-taptests-pgsql-cluster.info
+        flags: integration-tests
+        name: tap-pgsql-cluster-sync-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Wait before Codecov retry 2
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      run: sleep 45
+
+    - name: Upload coverage to Codecov (retry 2)
+      id: codecov_3
+      if: ${{ !cancelled() && steps.codecov_2.outcome == 'failure' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v4
+      with:
+        codecov_yml_path: ${{ github.workspace }}/proxysql/codecov.yml
+        override_commit: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+        files: proxysql/ci_infra_logs/ci-taptests-pgsql-cluster/coverage-report/ci-taptests-pgsql-cluster.info
+        flags: integration-tests
+        name: tap-pgsql-cluster-sync-coverage
+        use_oidc: true
+        disable_search: true
+        plugins: noop
+        root_dir: proxysql
+        disable_file_fixes: true
+        fail_ci_if_error: false
+        verbose: true
+
+    - name: Report Codecov upload failure
+      if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
+      run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
     - uses: LouisBrunner/checks-action@v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -278,7 +278,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 1
@@ -301,7 +301,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Wait before Codecov retry 2
@@ -324,7 +324,7 @@ jobs:
         plugins: noop
         root_dir: proxysql
         disable_file_fixes: true
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         verbose: true
 
     - name: Report Codecov upload failure


### PR DESCRIPTION
`CI-mysql84-gr-g8` failed on #5998 with **every test passing**:

```
SUMMARY: 'tests' PASS 1/402 : FAIL 0/402 : SKIP 401/402
SUMMARY: ret_rc = [0]
##[error]Codecov: Failed to get OIDC token with url: https://codecov.io.
  Error Message: Request timeout: /37//idtoken/...
```

The only failing step was `Upload coverage to Codecov`. `fail_ci_if_error: false` does not cover this — the timeout happens while minting the GitHub OIDC token, *before* any upload — so the action fails the step and the step fails the job. A transient blip reds a run whose tests were entirely green.

### Changes (47 workflows)

1. **Three attempts**, chained on `steps.codecov_N.outcome == 'failure'`, with 15 s / 45 s backoff.
2. **`continue-on-error: true`** on each, so even three failures leave the job green; a `::warning::` is emitted instead. Coverage must never gate correctness.
3. **`fail_ci_if_error: true`** — review catch, and without it most of this PR was inert: with it `false`, the action swallows upload errors, `outcome` stays `success`, and retries 1–2 are dead code. Only the OIDC failure fails the step regardless, so the retries would have covered exactly one failure mode.
4. **`codecov-action` pinned to a full commit SHA** — SonarCloud flagged 94 new `githubactions:S7637`, all from duplicating an already-unpinned reference. Pinning all 141 refs clears the 94 new findings *and* the 47 pre-existing ones. Behaviourally a no-op today (`v4` → `v4.6.0` → `b9fd7d16…`), but a future repoint of the tag can no longer change what runs with our token.

`outcome` (not `conclusion`) is the field the retries branch on — `continue-on-error` rewrites `conclusion` to `success`, which would make them dead code.

All 47 files re-parse as valid YAML; the generated step chain was verified structurally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage-report uploads with up to three attempts, including delays between retries.
  * Coverage upload failures no longer fail test or validation workflows.
  * Added clear warnings when coverage uploads remain unsuccessful after all retries.
  * Uploads now run only when a valid coverage report is available and the workflow has not been cancelled.
  * Improved failure reporting and diagnostics to make upload issues easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->