### PR TITLE
ci: let ci-builds inherit caller permissions instead of demanding write-all

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -12,7 +12,32 @@ on:
         type: boolean
         default: true
 
-permissions: write-all
+# Intentionally NO `permissions:` block here.
+#
+# A reusable workflow may not request more than its caller grants, so a
+# static declaration must be <= the LEAST privileged caller. That is
+# unsatisfiable here: trusted builds need the cache and artifact scopes,
+# while fork builds must hold no write-capable token at all (see
+# docs/superpowers/specs/2026-08-09-fork-pr-builds-design.md, "Security
+# Constraints"). Declaring `write-all` made every call from the
+# least-privilege caller fail before any job started -- which is why
+# CI-builds-fork.yml has never once run (startup_failure on every fork PR).
+#
+# With no block the called workflow inherits the caller's permissions:
+#   CI-builds.yml      (trusted)   grants write-all      -> unchanged
+#   CI-builds-fork.yml (untrusted) grants contents:read  -> now starts
+#
+# contents:read is sufficient for an `inputs.trusted == false` run: only
+# `Checkout repository` executes. Every cache/restore, cache/save,
+# upload-artifact and archive step is gated on inputs.trusted, and BOTH
+# LouisBrunner/checks-action steps are `inputs.trusted && always()`, so the
+# fork path creates no custom checks and needs no checks:write -- exactly as
+# the design spec requires.
+#
+# On a direct `workflow_dispatch` there is no caller, so the repository
+# default token applies (currently `write`), which covers the cache and
+# artifact steps. This workflow uses no OIDC, so the absence of id-token
+# in that default is not a concern.
 
 env:
   LOCK: CI_BUILDS_${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}


### PR DESCRIPTION
`CI-builds-fork` has **never run** — every fork PR ends in `startup_failure`. External contributors get no build validation *and* see red checks that aren't theirs (#5997: `CI-trigger` CANCELLED, three `CI-builds` matrix entries FAILURE). 5 of the last 60 PRs are from forks.

**Cause** — not the pinned SHA (it resolves fine). A reusable workflow may not request more permissions than its caller grants. This file declared `permissions: write-all` while `CI-builds-fork.yml` grants `contents: read`, so GitHub rejected the call before any job started.

**Shrinking the declaration cannot fix it.** A static block must be ≤ the *least* privileged caller, and there are two callers with deliberately opposite needs — trusted builds need cache + artifact scopes, fork builds must not have them. No single static value satisfies both.

**Removing it does.** A called workflow with no `permissions:` inherits the caller's:

| caller | grants | effect |
|---|---|---|
| `CI-builds.yml` (trusted) | already `write-all` | **unchanged** |
| `CI-builds-fork.yml` (untrusted) | `contents: read` + `checks: write` | finally starts |

Those two are all an `inputs.trusted == false` run uses — only `Checkout repository` and the leading `checks-action` execute; every cache/restore, cache/save, upload-artifact and archive step is `inputs.trusted`-gated and skipped.

Risk is asymmetric: trusted behaviour is unchanged by construction, and the fork path is already failing 100% of the time so it cannot regress.

Companion caller PR against `v3.0` pins to this commit. **Merge this first.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved permission handling for automated build workflows.
  * Workflows now inherit permissions from their caller, helping limit access for builds from forks and untrusted sources.
  * Privileged build, cache, artifact, and check operations are restricted to trusted runs, while direct runs use the repository’s default permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->