### PR TITLE
ci: point the fork build at a callee that can actually start

### DIFF
--- a/.github/workflows/CI-builds-fork.yml
+++ b/.github/workflows/CI-builds-fork.yml
@@ -12,6 +12,6 @@ permissions:
 jobs:
   run:
     if: ${{ github.event.pull_request.head.repo.fork }}
-    uses: sysown/proxysql/.github/workflows/ci-builds.yml@f3f23d1e8ad10da475261e515776d2fee68d732b
+    uses: sysown/proxysql/.github/workflows/ci-builds.yml@44ff88ee4c6949bdab5315e952b859e2f06f757b
     with:
       trusted: false


### PR DESCRIPTION
Caller half of the fork-build fix — see #6013 (**merge that first**; this pins to its commit).

`CI-builds-fork` has never run: every fork PR ends in `startup_failure`, because the pinned `ci-builds.yml` declares `permissions: write-all` while this caller grants only `contents: read`, and a callee may not request more than its caller grants. #6013 removes that declaration; this side only has to point at it.

**Permissions are deliberately unchanged at exactly `contents: read`.** An earlier revision of this PR also added `checks: write`, on my mistaken belief that the leading `LouisBrunner/checks-action` step ran for untrusted builds. It does not — **both** `checks-action` steps are gated `inputs.trusted && always()`. That extra scope was unnecessary and violated two things I should have read first:

- `docs/superpowers/specs/2026-08-09-fork-pr-builds-design.md` — *"Fork builds receive no secrets and no write-capable token"*, and *"The fork build workflow must not create custom checks via LouisBrunner/checks-action"*
- `test/infra/control/validate-fork-pr-builds.bash` — `assert(fork.fetch('permissions') == { 'contents' => 'read' })`

Reduced to the pin bump, the validator's assertions hold: read-only token, no checks created, no caches or artifacts consumed or produced. Verified by porting the validator's assertions and running them against both branch pairs — baseline PASS, the `checks: write` revision FAIL on exactly that assertion, this revision PASS.