### PR TITLE
Fix query-cache soft-TTL refresh race

### DIFF
--- a/docs/superpowers/specs/2026-08-09-query-cache-soft-ttl-single-flight-design.md
+++ b/docs/superpowers/specs/2026-08-09-query-cache-soft-ttl-single-flight-design.md
@@ -14,8 +14,10 @@ The shared `Query_Cache` template is the sole production-code change. It serves 
 
 At soft TTL, the request that wins the compare-and-swap returns a cache miss and refreshes the backend entry. Requests that lose the claim execute the normal cache-hit path and use the old entry. Values outside the soft-TTL window retain their current behaviour.
 
+Refresh ownership lasts for the lifetime of that cache generation. A successful cacheable backend result replaces the entry with a new generation whose `refreshing` flag is clear. If the refresh fails or produces a result that is not cacheable, the old entry remains the fallback until its hard TTL; the claim is deliberately not reopened for every subsequent request, avoiding repeated backend retries during an upstream failure.
+
 ## Testing
 
-The MySQL TAP test will expect the exact outcome for 24 concurrent client requests plus the initial cache fill: one slow client, 23 cache hits, and two hostgroup/backend hits. The existing test drives eight clients across the soft-TTL boundary; it fails on the current implementation when multiple clients claim refresh ownership.
+The MySQL TAP test will expect the exact outcome for 24 total requests from eight concurrent clients plus the initial cache fill: one slow client, 23 cache hits, and two hostgroup/backend hits. The existing test drives eight clients across the soft-TTL boundary; it fails on the current implementation when multiple clients claim refresh ownership.
 
 The focused MySQL test will be built and run through the documented isolated TAP harness. The matching PostgreSQL test will also be run when its infrastructure is available, because the production code is shared.

--- a/docs/superpowers/specs/2026-08-09-query-cache-soft-ttl-single-flight-design.md
+++ b/docs/superpowers/specs/2026-08-09-query-cache-soft-ttl-single-flight-design.md
@@ -1,0 +1,21 @@
+# Query-cache soft-TTL single-flight design
+
+## Goal
+
+Ensure that exactly one request refreshes a valid query-cache entry after its soft TTL is reached. Other concurrent requests must continue serving the existing entry.
+
+## Scope
+
+The shared `Query_Cache` template is the sole production-code change. It serves both MySQL and PostgreSQL query caches. The existing MySQL soft-TTL TAP test will be tightened to check the documented single-refresh contract.
+
+## Design
+
+`QC_entry_t::refreshing` remains a plain `bool` because cache entries are allocated with `malloc`. In `Query_Cache::get()`, the current non-atomic read followed by assignment will be replaced by `__sync_bool_compare_and_swap(&entry_shared->refreshing, false, true)`. This is an established codebase primitive for atomically claiming a boolean field without changing the entry allocation/destruction model.
+
+At soft TTL, the request that wins the compare-and-swap returns a cache miss and refreshes the backend entry. Requests that lose the claim execute the normal cache-hit path and use the old entry. Values outside the soft-TTL window retain their current behaviour.
+
+## Testing
+
+The MySQL TAP test will expect the exact outcome for 24 concurrent client requests plus the initial cache fill: one slow client, 23 cache hits, and two hostgroup/backend hits. The existing test drives eight clients across the soft-TTL boundary; it fails on the current implementation when multiple clients claim refresh ownership.
+
+The focused MySQL test will be built and run through the documented isolated TAP harness. The matching PostgreSQL test will also be run when its infrastructure is available, because the production code is shared.

--- a/lib/Query_Cache.cpp
+++ b/lib/Query_Cache.cpp
@@ -585,8 +585,9 @@ std::shared_ptr<QC_entry_t> Query_Cache<QC_DERIVED>::get(uint64_t user_hash, con
 		uint64_t t = curtime_ms;
 		if (entry_shared->expire_ms > t && entry_shared->create_ms + cache_ttl > t) {
 			if (
-				GET_THREAD_VARIABLE(query_cache_soft_ttl_pct) && !entry_shared->refreshing &&
-				entry_shared->create_ms + cache_ttl * GET_THREAD_VARIABLE(query_cache_soft_ttl_pct) / 100 <= t
+				GET_THREAD_VARIABLE(query_cache_soft_ttl_pct) &&
+				entry_shared->create_ms + cache_ttl * GET_THREAD_VARIABLE(query_cache_soft_ttl_pct) / 100 <= t &&
+				__sync_bool_compare_and_swap(&entry_shared->refreshing, false, true)
 			) {
 				// If the Query Cache entry reach the soft_ttl but do not reach
 				// the cache_ttl, the next query hit the backend and refresh
@@ -594,7 +595,6 @@ std::shared_ptr<QC_entry_t> Query_Cache<QC_DERIVED>::get(uint64_t user_hash, con
 				// refreshing is in process, other queries keep using the "old"
 				// Query Cache entry.
 				// soft_ttl_pct with value 0 and 100 disables the functionality.
-				entry_shared->refreshing = true;
 			} else {
 				THR_UPDATE_CNT(__thr_cntGetOK,Glo_cntGetOK,1,1);
 				THR_UPDATE_CNT(__thr_dataOUT,Glo_dataOUT, entry_shared->length,1);

--- a/test/tap/tests/test_query_cache_soft_ttl_pct-t.cpp
+++ b/test/tap/tests/test_query_cache_soft_ttl_pct-t.cpp
@@ -179,37 +179,28 @@ int main(int argc, char** argv) {
 	for (unsigned int i = 0; i < NUM_THREADS; i++) {
 		num_slow_clients += (int)timer_results[i];
 	}
-	// Allow tolerance of +1 for soft TTL race: when multiple threads hit the
-	// expiry boundary simultaneously, more than one may see "needs refresh"
-	// before the first one completes the backend query.
 	int expected_num_slow_clients = 1;
-	int tolerance = 1;
 	ok(
-		num_slow_clients >= expected_num_slow_clients &&
-		num_slow_clients <= expected_num_slow_clients + tolerance,
-		"Clients taking >1s should be %d (tolerance +%d). "
-		"Number of clients that take more than 1 second - Exp:'%d-%d', Act:'%d'",
-		expected_num_slow_clients, tolerance,
-		expected_num_slow_clients, expected_num_slow_clients + tolerance, num_slow_clients
+		num_slow_clients == expected_num_slow_clients,
+		"Clients taking >1s should be %d. "
+		"Number of clients that take more than 1 second - Exp:'%d', Act:'%d'",
+		expected_num_slow_clients, expected_num_slow_clients, num_slow_clients
 	);
 
 	std::map<string, int> stats_after = get_digest_stats_dummy_query(proxy_admin);
 
-	// Same tolerance applied: one extra backend hit means one fewer cache hit
 	std::map<string, int> expected_stats {{"cache", NUM_THREADS*NUM_QUERIES-1}, {"hostgroups", 2}};
 	int actual_cache = stats_after["cache"] - stats_before["cache"];
 	int actual_hg = stats_after["hostgroups"] - stats_before["hostgroups"];
 	ok(
-		actual_cache >= expected_stats["cache"] - tolerance &&
-		actual_cache <= expected_stats["cache"],
-		"Query cache hits within tolerance. Number of hits - Exp:'%d-%d', Act:'%d'",
-		expected_stats["cache"] - tolerance, expected_stats["cache"], actual_cache
+		actual_cache == expected_stats["cache"],
+		"Query cache hits should be exact. Number of hits - Exp:'%d', Act:'%d'",
+		expected_stats["cache"], actual_cache
 	);
 	ok(
-		actual_hg >= expected_stats["hostgroups"] &&
-		actual_hg <= expected_stats["hostgroups"] + tolerance,
-		"Hostgroup hits within tolerance. Number of hits - Exp:'%d-%d', Act:'%d'",
-		expected_stats["hostgroups"], expected_stats["hostgroups"] + tolerance, actual_hg
+		actual_hg == expected_stats["hostgroups"],
+		"Hostgroup hits should be exact. Number of hits - Exp:'%d', Act:'%d'",
+		expected_stats["hostgroups"], actual_hg
 	);
 
 	return exit_status();


### PR DESCRIPTION
## Summary

Fixes the rare query-cache soft-TTL race reported in #5961.

The cache now atomically claims refresh ownership only after the soft-TTL threshold is reached. Other concurrent lookups continue to receive the cached entry while the single owner refreshes it.

The TAP test now asserts the intended exact accounting: one refresh, 23 cache hits, and two backend hits.

## Root cause

The `refreshing` flag was read and written non-atomically after the cache-map lock was released. Concurrent soft-TTL lookups could all observe it as clear and independently refresh the same query.

## Validation

- `PROXYSQL31=1 make debug -j$(nproc)`
- `WORKSPACE=$(pwd) INFRA_ID=verify-qc-mysql-20260809 TAP_GROUP=mysql84-g4 TEST_PY_TAP_INCL='test_query_cache_soft_ttl_pct-t' test/infra/control/run-tests-isolated.bash`
  - Target test passed with the expected 1 slow client, 23 cache hits, and 2 backend hits.
- `git diff --check`

## Notes

The PostgreSQL counterpart could not be started locally because its isolated-infrastructure setup fails before test execution while forming a Docker container name; the shared query-cache template compiled successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query-cache soft-TTL handling so concurrent requests do not trigger duplicate refreshes.
  * Preserved cached results while a refresh is in progress.

* **Tests**
  * Strengthened coverage to verify a single refresh, expected cache-hit counts, and exactly two backend requests.

* **Documentation**
  * Added design documentation describing soft-TTL refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->