### PR TITLE
ci: pin all external GitHub Actions to commit SHAs (Sonar S7637)

### DIFF
--- a/.github/workflows/CI-build-macos-macos-13-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-13-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -106,7 +106,7 @@ jobs:
         brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-build-macos-macos-13-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-13-genai.yml
@@ -90,7 +90,7 @@ jobs:
       OPENSSL_ROOT_DIR: "/usr/local/opt/openssl@3"
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -162,7 +162,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-build-macos-macos-13-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-13-v31.yml
@@ -89,7 +89,7 @@ jobs:
       OPENSSL_ROOT_DIR: "/usr/local/opt/openssl@3"
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -161,7 +161,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-build-macos-macos-13-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-13-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -105,7 +105,7 @@ jobs:
         brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-build-macos-macos-13.yml
+++ b/.github/workflows/CI-build-macos-macos-13.yml
@@ -89,7 +89,7 @@ jobs:
       OPENSSL_ROOT_DIR: "/usr/local/opt/openssl@3"
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -161,7 +161,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-build-macos-macos-13.yml
+++ b/.github/workflows/CI-build-macos-macos-13.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -105,7 +105,7 @@ jobs:
         brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-build-macos-macos-14-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-14-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -106,7 +106,7 @@ jobs:
         brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-build-macos-macos-14-genai.yml
+++ b/.github/workflows/CI-build-macos-macos-14-genai.yml
@@ -90,7 +90,7 @@ jobs:
       OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -162,7 +162,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-build-macos-macos-14-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-14-v31.yml
@@ -89,7 +89,7 @@ jobs:
       OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -161,7 +161,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-build-macos-macos-14-v31.yml
+++ b/.github/workflows/CI-build-macos-macos-14-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -105,7 +105,7 @@ jobs:
         brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-build-macos-macos-14.yml
+++ b/.github/workflows/CI-build-macos-macos-14.yml
@@ -89,7 +89,7 @@ jobs:
       OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -161,7 +161,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-build-macos-macos-14.yml
+++ b/.github/workflows/CI-build-macos-macos-14.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -105,7 +105,7 @@ jobs:
         brew install automake bzip2 cmake gpatch gnutls libtool openssl@3 icu4c pkg-config libiconv zlib
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-cluster-simulator.yml
+++ b/.github/workflows/CI-cluster-simulator.yml
@@ -127,7 +127,7 @@ jobs:
 
     - name: Archive failure logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ matrix.group }}-${{ github.sha }}-logs-run${{ github.run_number }}
         path: ci_infra_logs/

--- a/.github/workflows/CI-cluster-simulator.yml
+++ b/.github/workflows/CI-cluster-simulator.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Save simulation build
       if: steps.simulator-build.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BUILD_CACHE_KEY }}
         path: ${{ env.RUNTIME_CACHE_DIR }}

--- a/.github/workflows/CI-cluster-simulator.yml
+++ b/.github/workflows/CI-cluster-simulator.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -91,7 +91,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/CI-cluster-simulator.yml
+++ b/.github/workflows/CI-cluster-simulator.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Restore simulation build
       id: simulator-build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BUILD_CACHE_KEY }}
         path: ${{ env.RUNTIME_CACHE_DIR }}
@@ -97,7 +97,7 @@ jobs:
         persist-credentials: false
 
     - name: Restore simulation build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BUILD_CACHE_KEY }}
         fail-on-cache-miss: true

--- a/.github/workflows/CI-lint-groups-json.yml
+++ b/.github/workflows/CI-lint-groups-json.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Fetch GH-Actions branch
         # The reusable half of every workflow pair lives on GH-Actions, so the
         # coverage lint needs that ref to tell an unwired group from one wired

--- a/.github/workflows/CI-package-amd64-almalinux10-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux10.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux10.yml
+++ b/.github/workflows/CI-package-amd64-almalinux10.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux8.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux8.yml
+++ b/.github/workflows/CI-package-amd64-almalinux8.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-almalinux9.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-almalinux9.yml
+++ b/.github/workflows/CI-package-amd64-almalinux9.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos10-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos10-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos10.yml
+++ b/.github/workflows/CI-package-amd64-centos10.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos10.yml
+++ b/.github/workflows/CI-package-amd64-centos10.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-genai.yml
+++ b/.github/workflows/CI-package-amd64-centos9-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9-v31.yml
+++ b/.github/workflows/CI-package-amd64-centos9-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-centos9.yml
+++ b/.github/workflows/CI-package-amd64-centos9.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-centos9.yml
+++ b/.github/workflows/CI-package-amd64-centos9.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian12-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian12-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian12.yml
+++ b/.github/workflows/CI-package-amd64-debian12.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian12.yml
+++ b/.github/workflows/CI-package-amd64-debian12.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-genai.yml
+++ b/.github/workflows/CI-package-amd64-debian13-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13-v31.yml
+++ b/.github/workflows/CI-package-amd64-debian13-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-debian13.yml
+++ b/.github/workflows/CI-package-amd64-debian13.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-debian13.yml
+++ b/.github/workflows/CI-package-amd64-debian13.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora42-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora42.yml
+++ b/.github/workflows/CI-package-amd64-fedora42.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora42.yml
+++ b/.github/workflows/CI-package-amd64-fedora42.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora43-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora43.yml
+++ b/.github/workflows/CI-package-amd64-fedora43.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora43.yml
+++ b/.github/workflows/CI-package-amd64-fedora43.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-fedora44-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-clang.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-dbg.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-clang.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai-dbg.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-genai.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-clang.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31-dbg.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-amd64-fedora44-v31.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-fedora44.yml
+++ b/.github/workflows/CI-package-amd64-fedora44.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse15.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse15.yml
+++ b/.github/workflows/CI-package-amd64-opensuse15.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-opensuse16.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-opensuse16.yml
+++ b/.github/workflows/CI-package-amd64-opensuse16.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-tarball.yml
+++ b/.github/workflows/CI-package-amd64-tarball.yml
@@ -96,7 +96,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       continue-on-error: true
@@ -149,7 +149,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       continue-on-error: true
       with:

--- a/.github/workflows/CI-package-amd64-tarball.yml
+++ b/.github/workflows/CI-package-amd64-tarball.yml
@@ -19,7 +19,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -109,7 +109,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu22.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu22.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu22.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-clang.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31-dbg.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-amd64-ubuntu24.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-amd64-ubuntu24.yml
+++ b/.github/workflows/CI-package-amd64-ubuntu24.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux10-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux8-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-almalinux9-v31.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-centos10-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos10-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-centos9-v31.yml
+++ b/.github/workflows/CI-package-arm64-centos9-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-debian12-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian12-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-debian13-v31.yml
+++ b/.github/workflows/CI-package-arm64-debian13-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora42-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora43-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-genai.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora44-v31.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-v31.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-fedora44.yml
+++ b/.github/workflows/CI-package-arm64-fedora44.yml
@@ -25,7 +25,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-opensuse15-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-opensuse16-v31.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-tarball.yml
+++ b/.github/workflows/CI-package-arm64-tarball.yml
@@ -96,7 +96,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       continue-on-error: true
@@ -149,7 +149,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       continue-on-error: true
       with:

--- a/.github/workflows/CI-package-arm64-tarball.yml
+++ b/.github/workflows/CI-package-arm64-tarball.yml
@@ -19,7 +19,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -109,7 +109,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-v31.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -140,7 +140,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -89,7 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.init_release.outputs.release_id }}
 
     steps:
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -150,7 +150,7 @@ jobs:
         fi
         echo "Uploaded $uploaded asset(s) to release id=${RELEASE_ID}"
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -26,7 +26,7 @@ jobs:
       release_name: ${{ steps.release.outputs.release_name }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.sha }}

--- a/.github/workflows/CI-push-ci-base-image.yml
+++ b/.github/workflows/CI-push-ci-base-image.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: test/infra/docker-base
           push: true

--- a/.github/workflows/CI-push-ci-base-image.yml
+++ b/.github/workflows/CI-push-ci-base-image.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -162,7 +162,7 @@ jobs:
 
     - name: Upload coverage LCOV file
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: unit-tests-coverage-lcov-${{ env.SHA }}
         path: coverage/lcov.info
@@ -214,7 +214,7 @@ jobs:
 
     - name: Upload coverage HTML report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: unit-tests-coverage-html-${{ env.SHA }}
         path: coverage/html/
@@ -222,7 +222,7 @@ jobs:
 
     - name: Upload unit-test logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: unit-tests-logs-${{ env.SHA }}
         path: unit-test-logs/

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -187,7 +187,7 @@ jobs:
       # is still useful). Skip only when require-lcov failed. Codecov SaaS
       # outages stay non-blocking via fail_ci_if_error: false.
       if: always() && steps.require-lcov.outcome == 'success'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         codecov_yml_path: codecov.yml
         override_commit: ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -228,7 +228,7 @@ jobs:
         path: unit-test-logs/
         if-no-files-found: warn
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -196,7 +196,7 @@ jobs:
         path: |
           ci_*_logs/
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -82,7 +82,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -190,7 +190,7 @@ jobs:
 
     - name: Archive logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs
         path: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -109,7 +109,7 @@ jobs:
         path: |
           proxysql/ci_*_logs/
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Cache restore src
       id: cache-src
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
@@ -56,7 +56,7 @@ jobs:
 
     - name: Cache restore test
       id: cache-test
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
         fail-on-cache-miss: true

--- a/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
@@ -35,7 +35,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-clickhouse-g1.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -109,7 +109,7 @@ jobs:
         path: |
           proxysql/ci_*_logs/
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Cache restore src
       id: cache-src
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
@@ -56,7 +56,7 @@ jobs:
 
     - name: Cache restore test
       id: cache-test
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
         fail-on-cache-miss: true

--- a/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
@@ -35,7 +35,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
+++ b/.github/workflows/gh-actions-reusable/ci-legacy-g4.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -109,7 +109,7 @@ jobs:
         path: |
           proxysql/ci_*_logs/
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Cache restore src
       id: cache-src
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true
@@ -56,7 +56,7 @@ jobs:
 
     - name: Cache restore test
       id: cache-test
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_test
         fail-on-cache-miss: true

--- a/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
@@ -35,7 +35,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/gh-actions-reusable/ci-set_parser_algorithm_3-g1.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/gh-actions-reusable/verify-package-install.yml
+++ b/.github/workflows/gh-actions-reusable/verify-package-install.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Resolves SonarCloud security hotspot rule S7637 ("External GitHub Actions and workflows should be pinned to a commit hash") for all external actions referenced under `.github/workflows/`.

Every external `uses:` reference is now pinned to the full commit SHA with a trailing `# <tag>` comment, matching the convention already used for `LouisBrunner/checks-action` in several package workflows. One commit per action (or per file group for the docker trio):

| Action | Tag | Pinned SHA |
|---|---|---|
| actions/checkout | v4 | `11d5960a326750d5838078e36cf38b85af677262` |
| LouisBrunner/checks-action | v2.0.0 | `6b626ffbad7cc56fd58627f774b9067e6118af23` |
| actions/upload-artifact | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| actions/cache/restore, actions/cache/save | v4 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| anthropics/claude-code-action | v1 | `6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975` |
| docker/login-action | v3 | `c94ce9fb468520275223c153574b00df6fe4bcc9` |
| docker/metadata-action | v5 | `c299e40c65443455700f0fdfc63efafe5b349051` |
| docker/build-push-action | v6 | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` |
| codecov/codecov-action | v4 | `b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238` |

Each SHA was verified against the upstream repository (tag resolution + commit lookup via the GitHub API) before replacing.

Scope notes:
- Internal reusable-workflow references (`sysown/proxysql/.github/workflows/ci-*.yml@GH-Actions`) are intentionally left on the branch ref: that is the established two-branch caller/reusable design, and the only SHA-pinned exception (`CI-builds-fork.yml`) was a deliberate fork-security measure.
- Illustrative `uses:` snippets in documentation (`doc/`, `docs/`, READMEs) are not workflows and are left untouched.
- All changed files re-parse cleanly as YAML (verified per commit).

Companion work (not in this PR): the reusable workflows on the `GH-Actions` branch carry the same unpinned references and will need the same treatment there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Pinned CI and automation actions to immutable commit references across build, test, packaging, deployment, and review workflows.
  * Improved workflow reproducibility and protection against unexpected action changes while preserving existing behavior and documented versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->