### PR TITLE
ci: pin all external GitHub Actions to commit SHAs (Sonar S7637)

### DIFF
--- a/.github/workflows/ci-3p-aiomysql.yml
+++ b/.github/workflows/ci-3p-aiomysql.yml
@@ -53,7 +53,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-aiomysql.yml
+++ b/.github/workflows/ci-3p-aiomysql.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -173,7 +173,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-aiomysql.yml
+++ b/.github/workflows/ci-3p-aiomysql.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-aiomysql.yml
+++ b/.github/workflows/ci-3p-aiomysql.yml
@@ -167,7 +167,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-django-framework.yml
+++ b/.github/workflows/ci-3p-django-framework.yml
@@ -53,7 +53,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-django-framework.yml
+++ b/.github/workflows/ci-3p-django-framework.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -191,7 +191,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-django-framework.yml
+++ b/.github/workflows/ci-3p-django-framework.yml
@@ -185,7 +185,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-django-framework.yml
+++ b/.github/workflows/ci-3p-django-framework.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-laravel-framework.yml
+++ b/.github/workflows/ci-3p-laravel-framework.yml
@@ -53,7 +53,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-laravel-framework.yml
+++ b/.github/workflows/ci-3p-laravel-framework.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -184,7 +184,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-laravel-framework.yml
+++ b/.github/workflows/ci-3p-laravel-framework.yml
@@ -178,7 +178,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-laravel-framework.yml
+++ b/.github/workflows/ci-3p-laravel-framework.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-mariadb-connector-c.yml
+++ b/.github/workflows/ci-3p-mariadb-connector-c.yml
@@ -53,7 +53,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-mariadb-connector-c.yml
+++ b/.github/workflows/ci-3p-mariadb-connector-c.yml
@@ -40,7 +40,7 @@ jobs:
       
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -179,7 +179,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-mariadb-connector-c.yml
+++ b/.github/workflows/ci-3p-mariadb-connector-c.yml
@@ -173,7 +173,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-mariadb-connector-c.yml
+++ b/.github/workflows/ci-3p-mariadb-connector-c.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-mysql-connector-j.yml
+++ b/.github/workflows/ci-3p-mysql-connector-j.yml
@@ -53,7 +53,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-mysql-connector-j.yml
+++ b/.github/workflows/ci-3p-mysql-connector-j.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -172,7 +172,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-mysql-connector-j.yml
+++ b/.github/workflows/ci-3p-mysql-connector-j.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-mysql-connector-j.yml
+++ b/.github/workflows/ci-3p-mysql-connector-j.yml
@@ -166,7 +166,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-pgjdbc.yml
+++ b/.github/workflows/ci-3p-pgjdbc.yml
@@ -50,7 +50,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-pgjdbc.yml
+++ b/.github/workflows/ci-3p-pgjdbc.yml
@@ -79,7 +79,7 @@ jobs:
 #        echo "Cache available '${BLDCACHE}'"
 
     - name: Cache restore bin
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-pgjdbc.yml
+++ b/.github/workflows/ci-3p-pgjdbc.yml
@@ -177,7 +177,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-pgjdbc.yml
+++ b/.github/workflows/ci-3p-pgjdbc.yml
@@ -37,7 +37,7 @@ jobs:
       
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -184,7 +184,7 @@ jobs:
           proxysql_3p_testing/proxysql
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-php-pdo-mysql.yml
+++ b/.github/workflows/ci-3p-php-pdo-mysql.yml
@@ -53,7 +53,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-php-pdo-mysql.yml
+++ b/.github/workflows/ci-3p-php-pdo-mysql.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -172,7 +172,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-php-pdo-mysql.yml
+++ b/.github/workflows/ci-3p-php-pdo-mysql.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-php-pdo-mysql.yml
+++ b/.github/workflows/ci-3p-php-pdo-mysql.yml
@@ -166,7 +166,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/ci-3p-php-pdo-pgsql.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/ci-3p-php-pdo-pgsql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -169,7 +169,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/ci-3p-php-pdo-pgsql.yml
@@ -50,7 +50,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-php-pdo-pgsql.yml
+++ b/.github/workflows/ci-3p-php-pdo-pgsql.yml
@@ -163,7 +163,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-postgresql.yml
+++ b/.github/workflows/ci-3p-postgresql.yml
@@ -50,7 +50,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-3p-postgresql.yml
+++ b/.github/workflows/ci-3p-postgresql.yml
@@ -79,7 +79,7 @@ jobs:
 #        echo "Cache available '${BLDCACHE}'"
 
     - name: Cache restore bin
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-postgresql.yml
+++ b/.github/workflows/ci-3p-postgresql.yml
@@ -173,7 +173,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-postgresql.yml
+++ b/.github/workflows/ci-3p-postgresql.yml
@@ -37,7 +37,7 @@ jobs:
       
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -180,7 +180,7 @@ jobs:
           proxysql_3p_testing/proxysql
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-sqlalchemy.yml
+++ b/.github/workflows/ci-3p-sqlalchemy.yml
@@ -180,7 +180,7 @@ jobs:
 
     - name: Summary output
       if: ${{ !cancelled() }}
-      uses: hoverkraft-tech/ci-github-common/actions/set-matrix-output@0.14.0
+      uses: hoverkraft-tech/ci-github-common/actions/set-matrix-output@d6367a8f0299d93cca9b42e287a56d2157f72060 # 0.14.0
       with:
         value: ${{ env.SUMMARY }}
         artifact-name: ${{ github.run_number }}-${{ matrix.infradb }}-summary
@@ -214,7 +214,7 @@ jobs:
     steps:
       - name: Collect summary
         id: collect
-        uses: hoverkraft-tech/ci-github-common/actions/get-matrix-outputs@0.14.0
+        uses: hoverkraft-tech/ci-github-common/actions/get-matrix-outputs@d6367a8f0299d93cca9b42e287a56d2157f72060 # 0.14.0
         with:
           artifact-name: ${{ github.run_number }}-${{ matrix.infradb }}-summary
           remove-artifact: true

--- a/.github/workflows/ci-3p-sqlalchemy.yml
+++ b/.github/workflows/ci-3p-sqlalchemy.yml
@@ -43,7 +43,7 @@ jobs:
         
     steps:
         
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -193,7 +193,7 @@ jobs:
         path: |
           proxysql_3p_testing/test_${{ env.TESTNAME }}/logs
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-3p-sqlalchemy.yml
+++ b/.github/workflows/ci-3p-sqlalchemy.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Cache restore bin
       if: ${{ env.BRANCH != 'none' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}
         fail-on-cache-miss: true

--- a/.github/workflows/ci-3p-sqlalchemy.yml
+++ b/.github/workflows/ci-3p-sqlalchemy.yml
@@ -187,7 +187,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-${{ matrix.infradb }}-${{ matrix.connector }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-3p-sqlalchemy.yml
+++ b/.github/workflows/ci-3p-sqlalchemy.yml
@@ -56,7 +56,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout proxysql_3p_testing
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: 'proxysql/proxysql_3p_testing'
         ref: ${{ env.TESTTREE }}

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -108,7 +108,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -270,7 +270,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -278,7 +278,7 @@ jobs:
 
     - name: Archive artifacts bin
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-bin-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -96,7 +96,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -385,7 +385,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -459,7 +459,7 @@ jobs:
     - name: Cache save bin
       id: cache-save-bin
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_bin
         enableCrossOsArchive: true
@@ -468,7 +468,7 @@ jobs:
     - name: Cache save src
       id: cache-save-src
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_src
         enableCrossOsArchive: true
@@ -524,7 +524,7 @@ jobs:
     - name: Cache save test
       id: cache-save-test
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_test
         enableCrossOsArchive: true
@@ -533,7 +533,7 @@ jobs:
     - name: Cache save matrix
       id: cache-save-matrix
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_matrix
         enableCrossOsArchive: true

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -577,7 +577,7 @@ jobs:
 
     - name: Upload handoff (src)
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-src
         retention-days: 1
@@ -587,7 +587,7 @@ jobs:
 
     - name: Upload handoff (test)
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-test
         retention-days: 1
@@ -598,7 +598,7 @@ jobs:
 
     - name: Upload handoff (matrix)
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-matrix
         retention-days: 1
@@ -611,7 +611,7 @@ jobs:
       # Only the debian12-dbg build feeds the 3p suites, and they consume bin
       # only. bin is large (.git/ + binaries/), so don't ship it for -tap.
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-dbg') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-bin
         retention-days: 1
@@ -630,7 +630,7 @@ jobs:
 
     - name: Archive artifacts
       if: ${{ inputs.trusted && failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-${{ env.SHA }}-run#${{ github.run_number }}-${{ matrix.dist }}${{ matrix.type }}
         path: |

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -164,7 +164,7 @@ jobs:
 
     - name: Checkout repository
       if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -127,7 +127,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: ${{ inputs.trusted && always() }}
       with:
@@ -636,7 +636,7 @@ jobs:
         path: |
           proxysql/
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: ${{ inputs.trusted && always() }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -142,7 +142,7 @@ jobs:
     - name: Cache check
       id: cache-check
       if: ${{ inputs.trusted && success() }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_bin
         enableCrossOsArchive: true

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -56,7 +56,7 @@ jobs:
       run: sudo apt-get -y install libssl-dev gnutls-dev libgnutls28-dev libmysqlclient-dev libboost-all-dev libunwind8 libunwind-dev uuid-dev ca-certificates
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -89,7 +89,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
       with:
         languages: ${{ matrix.language }}
 #        checkout_path: proxysql/
@@ -116,7 +116,7 @@ jobs:
         make -j$(nproc) clickhouse
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
       with:
         checkout_path: proxysql/
       

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -80,7 +80,7 @@ jobs:
 
 #    - name: Cache restore src
 #      id: cache-src
-#      uses: actions/cache/restore@v4
+#      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
 #      with:
 #        key: ${{ env.BLDCACHE }}
 #        fail-on-cache-miss: true

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -120,7 +120,7 @@ jobs:
       with:
         checkout_path: proxysql/
       
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -221,7 +221,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -332,7 +332,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -226,7 +226,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -234,7 +234,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -56,7 +56,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -347,7 +347,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -373,7 +373,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -268,7 +268,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -276,7 +276,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -105,7 +105,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -400,7 +400,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -281,7 +281,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -289,7 +289,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -397,7 +397,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -278,7 +278,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -286,7 +286,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-maketest.yml
+++ b/.github/workflows/ci-maketest.yml
@@ -41,7 +41,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-maketest.yml
+++ b/.github/workflows/ci-maketest.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
          
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -78,7 +78,7 @@ jobs:
         path: |
           ./build-*.log
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-maketest.yml
+++ b/.github/workflows/ci-maketest.yml
@@ -72,7 +72,7 @@ jobs:
         
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}-${{ matrix.target }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -322,7 +322,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -203,7 +203,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -211,7 +211,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -218,7 +218,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -226,7 +226,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -49,7 +49,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -337,7 +337,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -399,7 +399,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -288,7 +288,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -329,7 +329,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -210,7 +210,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -218,7 +218,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -322,7 +322,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -203,7 +203,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -211,7 +211,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -324,7 +324,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Archive logs on failure
         if: ${{ failure() && !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ github.workflow }}-${{ env.SHA }}-${{ github.job }}-run#${{ github.run_number }}
           path: |
@@ -699,7 +699,7 @@ jobs:
 
       - name: Archive logs
         if: ${{ failure() && !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ github.workflow }}-${{ env.SHA }}-${{ github.job }}-connector-${{ matrix.connector_version }}-run#${{ github.run_number }}
           path: |

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -50,7 +50,7 @@ jobs:
           details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ github.repository }}
           ref: ${{ env.SHA }}
@@ -251,7 +251,7 @@ jobs:
           details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ github.repository }}
           ref: ${{ env.SHA }}
@@ -529,7 +529,7 @@ jobs:
           details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ github.repository }}
           ref: ${{ env.SHA }}

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 120
     permissions: write-all
     steps:
-      - uses: LouisBrunner/checks-action@v2.0.0
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         id: checks
         if: always()
         with:
@@ -216,7 +216,7 @@ jobs:
             proxysql/test/tap/tests/unit/*.log
           if-no-files-found: ignore
 
-      - uses: LouisBrunner/checks-action@v2.0.0
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -239,7 +239,7 @@ jobs:
     needs: unit-tests
     permissions: write-all
     steps:
-      - uses: LouisBrunner/checks-action@v2.0.0
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         id: checks
         if: always()
         with:
@@ -490,7 +490,7 @@ jobs:
           VERSION=$(ls $HOME/opt/mysql/ | grep '^8\.4' | head -1 || echo "")
           [ -n "$VERSION" ] && dbdeployer delete single "$VERSION" 2>/dev/null || true
 
-      - uses: LouisBrunner/checks-action@v2.0.0
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -517,7 +517,7 @@ jobs:
         connector_version: ['9.7.0', '26.7.0']
     permissions: write-all
     steps:
-      - uses: LouisBrunner/checks-action@v2.0.0
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         id: checks
         if: always()
         with:
@@ -705,7 +705,7 @@ jobs:
           path: |
             proxysql/ci_*_logs/
 
-      - uses: LouisBrunner/checks-action@v2.0.0
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-no-infra-g1.yml
+++ b/.github/workflows/ci-no-infra-g1.yml
@@ -279,7 +279,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -287,7 +287,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-no-infra-g1.yml
+++ b/.github/workflows/ci-no-infra-g1.yml
@@ -111,7 +111,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-no-infra-g1.yml
+++ b/.github/workflows/ci-no-infra-g1.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -398,7 +398,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-package-build.yml
+++ b/.github/workflows/ci-package-build.yml
@@ -119,7 +119,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -153,7 +153,7 @@ jobs:
         [[ ${GIT_VERSION} == ${{ needs.clean.outputs.gitdescribe }} ]] || exit 1
         gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber ${{ env.BIN_PKG }}
  
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-package-build.yml
+++ b/.github/workflows/ci-package-build.yml
@@ -132,7 +132,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-pg-compat.yml
+++ b/.github/workflows/ci-pg-compat.yml
@@ -36,7 +36,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # Inline build (CI-3p-* model, not the CI-trigger/CI-builds cache-chain
       # model used by the TAP families): no ccache pattern exists elsewhere

--- a/.github/workflows/ci-pg-compat.yml
+++ b/.github/workflows/ci-pg-compat.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Publish report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pg-compat-report
           path: ${{ github.workspace }}/pg-compat-reports/pg-compat.xml

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -65,7 +65,7 @@ jobs:
       # off the private jenkins-build-scripts repo, so no GH_TOKEN_PROXYSQL PAT).
       # Sparse-checkout just that dir into proxysql/; the proxysql binary arrives
       # separately via the build handoff below (unpacked into the same proxysql/).
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -203,7 +203,7 @@ jobs:
           proxysql/libs/
 #          proxysql/deps/
     
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -186,7 +186,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -194,7 +194,7 @@ jobs:
           
     - name: Archive artifacts bin
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-bin-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -200,7 +200,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -208,7 +208,7 @@ jobs:
           
     - name: Archive artifacts bin
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-bin-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -217,7 +217,7 @@ jobs:
           proxysql/libs/
 #          proxysql/deps/
           
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -43,7 +43,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -331,7 +331,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -190,7 +190,7 @@ jobs:
           
     - name: Archive artifacts bin
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-bin-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -199,7 +199,7 @@ jobs:
           proxysql/libs/
 #          proxysql/deps/
             
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -65,7 +65,7 @@ jobs:
       # off the private jenkins-build-scripts repo, so no GH_TOKEN_PROXYSQL PAT).
       # Sparse-checkout just that dir into proxysql/; the proxysql binary arrives
       # separately via the build handoff below (unpacked into the same proxysql/).
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -85,7 +85,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -225,7 +225,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |
@@ -233,7 +233,7 @@ jobs:
 
     - name: Archive coverage report
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-coverage-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       continue-on-error: true
       if: always()
@@ -330,7 +330,7 @@ jobs:
     - name: Report Codecov upload failure
       if: ${{ !cancelled() && steps.codecov_3.outcome == 'failure' }}
       run: echo "::warning::Codecov upload failed after 3 attempts; tests were unaffected."
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       continue-on-error: true
       if: ${{ always() && steps.checks.outputs.check_id != '' }}
       with:

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -32,7 +32,7 @@ jobs:
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -136,7 +136,7 @@ jobs:
 
     - name: Archive artifacts logs
       if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.workflow }}-${{ env.SHA }}-logs-run#${{ github.run_number }}
         path: |

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       id: checks
       if: always()
       with:
@@ -142,7 +142,7 @@ jobs:
         path: |
           proxysql/ci_*_logs/
 
-    - uses: LouisBrunner/checks-action@v2.0.0
+    - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Companion to #6018 (v3.0 callers): resolves SonarCloud security hotspot rule S7637 ("External GitHub Actions and workflows should be pinned to a commit hash") for all external actions referenced by the reusable workflows on this branch.

Every external `uses:` reference is now pinned to the full commit SHA with a trailing `# <tag>` comment. One commit per action:

| Action | Tag | Pinned SHA |
|---|---|---|
| actions/checkout | v4 | `11d5960a326750d5838078e36cf38b85af677262` |
| LouisBrunner/checks-action | v2.0.0 | `6b626ffbad7cc56fd58627f774b9067e6118af23` |
| actions/upload-artifact | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| actions/cache/restore, actions/cache/save | v4 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| github/codeql-action (init, analyze) | v3 | `c4dd10e44af883a891fe31ced449bcb4a6728b9b` |
| hoverkraft-tech/ci-github-common (set/get-matrix-outputs) | 0.14.0 | `d6367a8f0299d93cca9b42e287a56d2157f72060` |

Each SHA was verified against the upstream repository (tag resolution + commit lookup via the GitHub API). The SHAs match the ones used in #6018 where the same action/tag is involved; `codecov/codecov-action` was already pinned on this branch (`cd6fee57b`) and is untouched.

Scope notes:
- The commented-out `github/codeql-action/autobuild@v2` line in `ci-codeql.yml` is left as-is.
- Internal reusable-workflow references (`sysown/proxysql/.github/workflows/*.yml@...`) are out of scope for S7637.
- All changed files re-parse cleanly as YAML (verified per commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned CI workflow actions to immutable commit references instead of mutable version tags.
  * Preserved existing workflow behavior, configuration, and version annotations.
  * Improved build and test pipeline reproducibility and supply-chain security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->