### PR TITLE
fix(pgsql-ffto): stop ReadyForQuery finalizing pipelined extended queries (test_ffto_pgsql_pipeline-t)

### DIFF
--- a/include/PgSQLFFTO.hpp
+++ b/include/PgSQLFFTO.hpp
@@ -77,6 +77,14 @@ private:
     uint64_t m_affected_rows {0};          ///< Accumulated affected rows for the current query.
     uint64_t m_rows_sent {0};              ///< Accumulated rows sent for the current query.
     bool m_current_finalize_on_sync {false}; ///< Whether current query finalizes on ReadyForQuery ('Z').
+    /// Whether the current query has received its own response terminator
+    /// (CommandComplete, EmptyQueryResponse or PortalSuspended). This, not
+    /// m_current_finalize_on_sync, is what qualifies a ReadyForQuery to
+    /// finalize: a ReadyForQuery left over from an earlier exchange can arrive
+    /// while a freshly activated query is still awaiting its first response,
+    /// and finalizing there would report zeroed counters and drop the real
+    /// response that follows.
+    bool m_response_seen {false};
 
     struct PendingQuery {
         std::string query;

--- a/lib/PgSQLFFTO.cpp
+++ b/lib/PgSQLFFTO.cpp
@@ -160,6 +160,7 @@ void PgSQLFFTO::track_query(std::string query, bool finalize_on_sync) {
         m_current_finalize_on_sync = pending.finalize_on_sync;
         m_affected_rows = 0;
         m_rows_sent = 0;
+        m_response_seen = false;
         m_state = AWAITING_RESPONSE;
         return;
     }
@@ -173,6 +174,7 @@ void PgSQLFFTO::clear_current_query() {
     m_affected_rows = 0;
     m_rows_sent = 0;
     m_current_finalize_on_sync = false;
+    m_response_seen = false;
 }
 
 void PgSQLFFTO::activate_next_query() {
@@ -189,6 +191,7 @@ void PgSQLFFTO::activate_next_query() {
     m_current_finalize_on_sync = next_query.finalize_on_sync;
     m_affected_rows = 0;
     m_rows_sent = 0;
+    m_response_seen = false;
     m_state = AWAITING_RESPONSE;
 }
 
@@ -258,32 +261,54 @@ void PgSQLFFTO::process_server_message(char type, const unsigned char* payload, 
         uint64_t rows = extract_pg_rows_affected(payload, len, is_select);
         if (is_select) m_rows_sent += rows;
         else m_affected_rows += rows;
+        m_response_seen = true;
+        if (!m_current_finalize_on_sync) {
+            finalize_current_query();
+        }
+    } else if (type == 'I' || type == 's') {
+        // EmptyQueryResponse ('I') replaces CommandComplete when the query text
+        // is empty once comments/whitespace are stripped, and PortalSuspended
+        // ('s') replaces it when a row-limited Execute stops early. Both
+        // terminate the current query's response just as CommandComplete does,
+        // with no row counts to add. Without this, an extended Execute answered
+        // by either one would never be finalized -- neither branch below fires
+        // for it -- and the stalled query would block the pending queue and
+        // swallow the NEXT query's CommandComplete.
+        //
+        // ProxySQL does not emit PortalSuspended today (Execute's max-rows
+        // field is parsed but never acted on, issue #5900), so 's' is inert
+        // until that is fixed; handling it now costs two lines and avoids
+        // reintroducing the stall when it is.
+        m_response_seen = true;
         if (!m_current_finalize_on_sync) {
             finalize_current_query();
         }
     } else if (type == 'Z') {
-        // ReadyForQuery terminates a SIMPLE-query exchange, so it is the
-        // finalizer for 'Q' queries -- their CommandComplete deliberately does
-        // not finalize (see the m_current_finalize_on_sync check above).
+        // ReadyForQuery terminates an exchange, and is the finalizer for SIMPLE
+        // queries -- their CommandComplete deliberately does not finalize (see
+        // the m_current_finalize_on_sync check above).
         //
-        // It must NOT finalize an extended-protocol Execute. Those are
-        // finalized by their own CommandComplete, and in a pipelined batch
-        // several are queued at once. Finalizing one here reports it with
-        // zeroed counters and pops the queue, so every subsequent
-        // CommandComplete in the batch lands on the WRONG query and the last
-        // one is dropped entirely once the queue drains to IDLE -- silent,
+        // The qualifying condition is m_response_seen, NOT
+        // m_current_finalize_on_sync. A ReadyForQuery belongs to the exchange
+        // that produced it, but the query that happens to be current when it
+        // arrives may already belong to the NEXT one: a client that pipelines
+        // without reading its replies leaves an earlier exchange's
+        // ReadyForQuery in flight, and an extended CommandComplete can activate
+        // the following queued query before it lands. Finalizing then reports
+        // that query with zeroed counters and pops the queue, so its real
+        // response is attributed to whatever comes after and the last response
+        // in the batch is dropped once the queue drains to IDLE -- silent,
         // plausible-looking corruption of stats_pgsql_query_digest rather than
         // an obvious failure.
         //
-        // A stray ReadyForQuery reaching this point is not hypothetical: it
-        // only takes a client that pipelines a new batch without having read
-        // the responses to its previous exchange, at which point the earlier
-        // exchange's ReadyForQuery is still in flight and arrives while the
-        // new batch's first Execute is current. Ignoring it here makes the
-        // batch attribute correctly; the pending queue is still drained by the
-        // CommandCompletes that follow, and an ErrorResponse ('E' below) is
-        // what clears the queue when a batch really is abandoned.
-        if (m_current_finalize_on_sync) {
+        // Gating on "has this query actually seen its own response terminator"
+        // is correct for every ordering: a simple query that got its
+        // CommandComplete finalizes here as before; an extended Execute has
+        // already finalized itself above and cannot still be current; and a
+        // query still awaiting its first response is left alone for the
+        // CommandComplete that is genuinely its own. An abandoned batch is
+        // still cleared by ErrorResponse ('E' below).
+        if (m_response_seen) {
             finalize_current_query();
         }
     } else if (type == 'E') {

--- a/lib/PgSQLFFTO.cpp
+++ b/lib/PgSQLFFTO.cpp
@@ -262,7 +262,30 @@ void PgSQLFFTO::process_server_message(char type, const unsigned char* payload, 
             finalize_current_query();
         }
     } else if (type == 'Z') {
-        finalize_current_query();
+        // ReadyForQuery terminates a SIMPLE-query exchange, so it is the
+        // finalizer for 'Q' queries -- their CommandComplete deliberately does
+        // not finalize (see the m_current_finalize_on_sync check above).
+        //
+        // It must NOT finalize an extended-protocol Execute. Those are
+        // finalized by their own CommandComplete, and in a pipelined batch
+        // several are queued at once. Finalizing one here reports it with
+        // zeroed counters and pops the queue, so every subsequent
+        // CommandComplete in the batch lands on the WRONG query and the last
+        // one is dropped entirely once the queue drains to IDLE -- silent,
+        // plausible-looking corruption of stats_pgsql_query_digest rather than
+        // an obvious failure.
+        //
+        // A stray ReadyForQuery reaching this point is not hypothetical: it
+        // only takes a client that pipelines a new batch without having read
+        // the responses to its previous exchange, at which point the earlier
+        // exchange's ReadyForQuery is still in flight and arrives while the
+        // new batch's first Execute is current. Ignoring it here makes the
+        // batch attribute correctly; the pending queue is still drained by the
+        // CommandCompletes that follow, and an ErrorResponse ('E' below) is
+        // what clears the queue when a batch really is abandoned.
+        if (m_current_finalize_on_sync) {
+            finalize_current_query();
+        }
     } else if (type == 'E') {
         if (!m_current_query.empty() && m_query_start_time != 0) {
             unsigned long long duration = monotonic_time() - m_query_start_time;

--- a/test/tap/tests/test_ffto_pgsql_pipeline-t.cpp
+++ b/test/tap/tests/test_ffto_pgsql_pipeline-t.cpp
@@ -14,6 +14,8 @@
  * @par Test scenarios
  *  1. 3 different queries pipelined before Sync → 3 separate digests
  *  2. Same prepared statement executed 10 times in pipeline → count_star=10
+ *  3. Extended Execute + Sync + simple Query pipelined together → each digest
+ *     keeps its own row counts across the exchange boundary
  *
  * @pre  ProxySQL running with a PostgreSQL backend.
  *
@@ -38,12 +40,13 @@
  * @brief Total number of planned TAP assertions.
  *
  * Breakdown:
- *  - Setup:                 1 (connect)
+ *  - Setup:                  1 (connect)
  *  - Scenario 1 (3 queries): 3 x 3 = 9 (3 verify_pg_digest calls)
  *  - Scenario 2 (10x exec):  1 x 3 = 3 (1 verify_pg_digest call)
- *  Total = 13
+ *  - Scenario 3 (boundary):  2 x 3 = 6 (2 verify_pg_digest calls)
+ *  Total = 19
  */
-static constexpr int kPlannedTests = 13;
+static constexpr int kPlannedTests = 19;
 
 #define FAIL_AND_SKIP_REMAINING(cleanup_label, fmt, ...) \
     do { \
@@ -240,6 +243,57 @@ int main(int argc, char** argv) {
     }
 
     verify_pg_digest(admin, "SELECT val FROM ffto_pg_pipe WHERE id = $1", 10, 0, 10);
+
+    /* ================================================================
+     * Scenario 3:  extended Execute + Sync + SIMPLE query, pipelined
+     *
+     * Regression guard for stats attribution across an exchange boundary.
+     * The client sends Bind/Execute, Sync, and then a simple Query without
+     * reading anything in between, so two exchanges are in flight at once
+     * and the server answers:
+     *
+     *   CommandComplete(Execute), ReadyForQuery(Sync),
+     *   CommandComplete(Query),   ReadyForQuery(Query)
+     *
+     * The Execute's CommandComplete finalizes the Execute and activates the
+     * simple query, which is queued behind it. The ReadyForQuery that then
+     * arrives belongs to the *Sync*, i.e. to the exchange that just ended --
+     * not to the simple query now sitting in front of it. Finalizing on it
+     * reports the simple query with zero rows and pops the queue, so the
+     * CommandComplete that really is its own is discarded and its digest
+     * silently records rows_sent=0.
+     *
+     * Unlike scenarios 1 and 2 this ordering is deterministic, not a race:
+     * the response sequence above follows purely from what the client sends.
+     * ================================================================ */
+    diag("--- Scenario 3: extended Execute + Sync + simple query ---");
+    clear_pg_stats(admin);
+
+    try {
+        /* Exchange 1: extended Bind/Execute terminated by Sync. */
+        pgc->bindStatement("pipe_sel", "",
+            {{std::string("2"), 0}}, {}, false);
+        pgc->executePortal("", 0, false);
+        pgc->sendSync();
+
+        /* Exchange 2: a simple query, sent WITHOUT reading exchange 1's
+         * replies -- that overlap is the whole point of the scenario. */
+        pgc->execute("SELECT count(*) FROM ffto_pg_pipe");
+
+        /* Now drain both exchanges: one ReadyForQuery each. */
+        pgc->consumeInputUntilReady();
+        pgc->consumeInputUntilReady();
+    } catch (const PgException& e) {
+        diag("Pipeline scenario 3 failed: %s", e.what());
+        FAIL_AND_SKIP_REMAINING(cleanup, "Pipelined exchange-boundary test failed");
+    }
+
+    /* The extended Execute is unaffected -- it is finalized by its own
+     * CommandComplete before the boundary is crossed. */
+    verify_pg_digest(admin, "SELECT val FROM ffto_pg_pipe WHERE id = $1", 1, 0, 1);
+    /* The simple query is the one that gets zeroed when ReadyForQuery is
+     * allowed to finalize a query that has not yet seen its own response. */
+    verify_pg_digest(admin, "SELECT count(*) FROM ffto_pg_pipe", 1, 0, 1);
 
 cleanup:
     if (pgc) { delete pgc; }

--- a/test/tap/tests/test_ffto_pgsql_pipeline-t.cpp
+++ b/test/tap/tests/test_ffto_pgsql_pipeline-t.cpp
@@ -149,10 +149,26 @@ int main(int argc, char** argv) {
     }
     ok(pgc != NULL && pgc->isConnected(), "Connected via pg_lite_client");
 
-    /* Create test table via simple query */
+    /* Create test table via simple query.
+     *
+     * Each response MUST be consumed. execute() only writes the Query message;
+     * it does not read the reply, so firing three of them back-to-back leaves
+     * three unread ReadyForQuery messages in the socket. The next
+     * consumeInputUntilReady() -- the one after the Parse batch below -- stops
+     * at the FIRST ReadyForQuery it sees, which would be DROP TABLE's, not the
+     * one it is waiting for. From that point the client is a full exchange
+     * behind the server and keeps pipelining anyway, so an old ReadyForQuery is
+     * still in flight when the Bind/Execute batch starts. Whether that stray
+     * message reaches the proxy before or after the batch's first Execute is
+     * pure timing, which is exactly how this test failed intermittently in CI
+     * (SELECT/INSERT/UPDATE stats each shifted by one position) while passing
+     * locally. */
     pgc->execute("DROP TABLE IF EXISTS ffto_pg_pipe");
+    pgc->consumeInputUntilReady();
     pgc->execute("CREATE TABLE ffto_pg_pipe (id INT PRIMARY KEY, val TEXT)");
+    pgc->consumeInputUntilReady();
     pgc->execute("INSERT INTO ffto_pg_pipe VALUES (1,'a'), (2,'b'), (3,'c')");
+    pgc->consumeInputUntilReady();
 
     /* ================================================================
      * Scenario 1:  3 different queries pipelined before Sync


### PR DESCRIPTION
`CI-legacy-g9` failed on `test_ffto_pgsql_pipeline-t` while running #6020. The PR under test changes no runtime code at all, so this is a pre-existing bug in `v3.0` that the run merely surfaced — hence a separate PR against `v3.0` rather than a fix folded into #6020.

## The signature

Scenario 1 pipelines three *different* statements before a single Sync. The observed digest stats:

| digest | rows_affected | rows_sent | |
|---|---|---|---|
| `SELECT val FROM ffto_pg_pipe WHERE id = $1` | 0 (exp 0) | **0** (exp 1) | got nothing |
| `INSERT INTO ffto_pg_pipe VALUES ($1,$2)` | **0** (exp 1) | **1** (exp 0) | got SELECT's result |
| `UPDATE ffto_pg_pipe SET val = $2 WHERE id = $1` | 1 ✓ | 0 ✓ | got INSERT's — passes *by coincidence* |

Every result landed one position late. The UPDATE assertion passed only because INSERT and UPDATE happen to share the same expectation (`affected=1, sent=0`). The totals confirm the shift rather than a lag: expected `sent=1 / affected=2`, observed `sent=1 / affected=1` — the final CommandComplete was dropped entirely once the queue drained to `IDLE`.

Scenario 2 passed throughout because its ten executions share a single digest, which makes any shift invisible.

## Root cause

`PgSQLFFTO::process_server_message()` finalized the current query unconditionally on `'Z'` (ReadyForQuery):

```cpp
} else if (type == 'Z') {
    finalize_current_query();
}
```

ReadyForQuery *is* the right finalizer for **simple** queries — their CommandComplete deliberately skips finalizing, which is what the `m_current_finalize_on_sync` check immediately above exists for. But an **extended-protocol** Execute is finalized by its own CommandComplete, and a pipelined batch has several queued at once. Finalizing one on ReadyForQuery reports it with zeroed counters *and* pops the pending deque, so every subsequent response in the batch is attributed to the wrong query and the last is lost.

The `'Z'` branch is now restricted to finalize-on-sync queries.

## Where the stray ReadyForQuery came from

Not hypothetical — the test manufactures one:

- `PgConnection::execute()` only writes the Query message; it never reads the reply. Three back-to-back setup queries therefore leave **three unread ReadyForQuery messages** in the socket.
- `consumeInputUntilReady()` stops at the **first** ReadyForQuery it sees. So the wait after the Parse batch actually consumed `DROP TABLE`'s reply, not the one it was waiting for.
- From that point the client ran a full exchange behind the server while continuing to pipeline, leaving an old ReadyForQuery in flight exactly when the Bind/Execute batch started.

Each setup query now consumes its own response, so the client is protocol-correct. Both halves are worth keeping: the test no longer desynchronizes, and FFTO no longer corrupts `stats_pgsql_query_digest` for *any* client that pipelines this way. The corruption mode matters — silent, plausible-looking wrong numbers, not a visible error.

## Verification — please read before assuming this is proven

**The failure does not reproduce locally.** It is timing-dependent: whether the stray ReadyForQuery reaches the proxy before or after the batch's first Execute. On this machine the test passed **5/5 unfixed** and **6/6 fixed**; it failed on a 2-core GitHub runner. So the local passes are *not* evidence the fix works, and I have not produced a red-to-green reproduction. The fix rests on code analysis that matches the CI signature exactly — including the dropped final CommandComplete, which a simple "counters lagged" explanation cannot account for.

**What is verified is the absence of regression.** The full `test_ffto_*` set was run with and without the `lib/PgSQLFFTO.cpp` change, rebuilding and restarting the ProxySQL container each time:

```
without fix:  PASS 7/402 : FAIL 4/402
with fix:     PASS 7/402 : FAIL 4/402     (identical)
```

The 4 failures — `test_ffto_mysql_mixed_protocol-t`, `test_ffto_mysql_transactions-t`, `test_ffto_pgsql-t`, `test_ffto_pgsql_concurrent-t` — fail identically on unmodified `v3.0` in this local environment and passed in CI on the same commit range, so they are environment-specific and unrelated. Two of them are **MySQL** FFTO tests, which a `PgSQLFFTO` change cannot reach at all.

Making the race deterministic would need fault injection between the proxy's client-side and server-side reads, which is beyond what this fix warrants. CI on this branch is the next real signal.

## Related

Surfaced by #6020 (PG protocol/compat test stack SP-1..SP-3), which is test/infra/docs only and does not touch `lib/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extended-protocol query handling to prevent incorrect query completion, queue advancement, and statistics attribution.
  * Ensured setup operations remain synchronized before pipelined scenarios run, improving protocol reliability.
  * Improved handling of overlapping extended and simple queries to ensure both complete correctly and report accurate row counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->