### PR TITLE
fix(build): make tap unit_tests wait for the tap library directory (intermittent 'libcurl.so: file too short')

### DIFF
--- a/test/tap/Makefile
+++ b/test/tap/Makefile
@@ -29,8 +29,24 @@ tests_with_deps: tap test_deps
 	cd tests_with_deps && CC=${CC} CXX=${CXX} ${MAKE} $(MAKECMDGOALS)
 
 
+# `tap test_deps` is NOT optional here, even though nothing under tests/unit is
+# built by those targets. The unit tests link -lcurl with -L$(TAP_LDIR), i.e.
+# test/tap/tap, and the `tap` recipe populates that directory by copying the
+# vendored library into it:
+#
+#     libcurl$(SHLIB_EXT): $(DEPS_PATH)/curl/curl/lib/.libs/libcurl$(SHLIB_EXT)
+#             cp -a $(DEPS_PATH)/curl/curl/lib/.libs/libcurl$(SHLIB_EXT)* .
+#
+# Without this prerequisite `unit_tests` runs CONCURRENTLY with `tap` under the
+# `all`/`debug` targets above, so a unit test's linker can open libcurl.so while
+# that cp is still writing it and fail with `file too short`. Intermittent by
+# nature -- it needs the copy and a link to overlap -- and it presents as a
+# corrupt library rather than a build-order problem, which makes it easy to
+# misread as a real toolchain or dependency failure. Every sibling target here
+# (tests, tests_no_infra, tests_with_deps) already declares these prerequisites;
+# unit_tests was the only one that did not.
 .PHONY: unit_tests
-unit_tests:
+unit_tests: tap test_deps
 	cd tests/unit && CC=${CC} CXX=${CXX} ${MAKE} $(MAKECMDGOALS)
 
 


### PR DESCRIPTION
A one-line build-ordering fix for an intermittent CI failure that presents as a corrupt dependency.

## Symptom

`CI-unit-tests-asan-coverage` fails in its **build** step (the tests never run, and the follow-on `Require non-empty coverage/lcov.info` failure is just the same root cause):

```
/usr/bin/ld: error: /opt/proxysql/test/tap/tap/libcurl.so: file too short
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:794: genai_fts_string_unit-t] Error 1
```

Observed on #6021, whose diff touches only `PgSQLFFTO` and one PG TAP test — nothing that could reach libcurl or a genai unit test. The same workflow passed on the immediately preceding commit of that same branch.

## Cause

`test/tap/Makefile` fans `all` / `debug` out to `tests tests_with_deps unit_tests`. Of those four sibling targets, `unit_tests` was the **only** one lacking the `tap test_deps` prerequisites:

```make
tests:           tap test_deps      # ✅
tests_no_infra:  tap test_deps      # ✅
tests_with_deps: tap test_deps      # ✅
unit_tests:                         # ❌
```

So under parallel make it ran concurrently with `tap`.

The unit tests link `-lcurl` with `-L$(TAP_LDIR)` — that is, `test/tap/tap` (`tests/unit/Makefile:83,218`) — and the `tap` recipe populates that directory by copying the vendored library into it:

```make
libcurl$(SHLIB_EXT): $(DEPS_PATH)/curl/curl/lib/.libs/libcurl$(SHLIB_EXT)
        cp -a $(DEPS_PATH)/curl/curl/lib/.libs/libcurl$(SHLIB_EXT)* .
```

`libcurl.so` and `libcurl.so.4` are 16-byte symlinks onto `libcurl.so.4.8.0`, ~700 KB of actual payload. A linker following that chain while `cp` is still writing the payload reads a truncated ELF — which is precisely what `file too short` means. It is a partial read, not a bad library.

The CI log catches the overlap in the act; these lines are consecutive:

```
cp -a /opt/proxysql/deps/curl/curl/lib/.libs/libcurl.so* .
-- Detecting C compiler ABI info                              <- another job's cmake, i.e. concurrent
/usr/bin/ld: error: /opt/proxysql/test/tap/tap/libcurl.so: file too short
...
make[2]: *** Waiting for unfinished jobs....
```

## Fix

Give `unit_tests` the prerequisites its three siblings already have, which serialises it after `tap`.

## Why it looks random

It needs a copy and a link to overlap, so it hits some runs and not others. Nothing about it is specific to ASAN or to genai — that job simply builds the unit tests under a slower toolchain, which widens the window. Any PR can draw the short straw.

## Verification

- `make -C test/tap -n unit_tests` now descends into `../deps` and `tap` before `tests/unit`. Before the change it went straight to `tests/unit`:

  ```
  BEFORE:  cd tests/unit && ... make unit_tests
  AFTER:   cd ../deps && ... make
           cd tap && ... make
           cd tests/unit && ... make unit_tests
  ```

- Deleted `test/tap/tap/libcurl.so*` and ran `make -C test/tap unit_tests -j$(nproc)`: completes cleanly and restores the full symlink chain (`libcurl.so` → `libcurl.so.4` → `libcurl.so.4.8.0`).

## Related

Surfaced while investigating the ASAN failure on #6021. That PR needs no change for this — a re-run of the job would likely have gone green on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unit-test build reliability by ensuring required test components and dependencies are prepared before linking.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->