### PR TITLE
fix(pgsql): guard monitor task removal against self-move

### DIFF
--- a/lib/PgSQL_Monitor.cpp
+++ b/lib/PgSQL_Monitor.cpp
@@ -1270,13 +1270,15 @@ void add_task(
 }
 
 void rm_task_fast(task_poll_t& task_poll, size_t idx) {
-	if (idx > task_poll.size || idx < 0) {
-		proxy_error("Receveid invalid task index   idx=%lu", idx);
+	if (idx >= task_poll.size) {
+		proxy_error("Received invalid task index   idx=%zu\n", idx);
 		assert(0);
 	}
 
-	task_poll.fds[idx] = task_poll.fds[task_poll.size - 1];
-	task_poll.tasks[idx] = std::move(task_poll.tasks[task_poll.size - 1]);
+	if (idx != task_poll.size - 1) {
+		task_poll.fds[idx] = task_poll.fds[task_poll.size - 1];
+		task_poll.tasks[idx] = std::move(task_poll.tasks[task_poll.size - 1]);
+	}
 	task_poll.size--;
 }
 


### PR DESCRIPTION
The build crashes at runtime when linked with `libc++` due to a self-`std::move` operation, which is unspecified behavior. It happens to work in our favour with `libstdc++`, but crashes with `libc++`.

Ref: https://cplusplus.github.io/LWG/issue2839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash in `libc++` builds by guarding against a self-move when removing PgSQL monitor tasks. Also fixes index validation and cleans up the error log.

- **Bug Fixes**
  - Skip copy/move when removing the last task (avoid self-`std::move` and fd overwrite).
  - Use `idx >= size` for bounds; fix typo, `%zu`, and add newline.

<sup>Written for commit 0990a2a1b0229aabbd02fae353555ce0b1eb8035. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task removal validation to prevent invalid index access.
  * Corrected the associated error message.
  * Avoided unnecessary task movement when removing the final task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->