### PR TITLE
fix(ci): quiesce stale self-hosted Compose projects

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -152,10 +152,29 @@ jobs:
         path: |
           proxysql/binaries/
 
-    # Self-hosted runners reuse the working directory between jobs. The
-    # dockerized build below bind-mounts the checkout (./:/opt/proxysql) and
-    # writes files as root, so on the next job the actions/checkout pre-clean
-    # trips over them:
+    # Self-hosted runners reuse the working directory between jobs. A cancelled
+    # dockerized build can leave its Compose project running against the
+    # bind-mounted checkout (./:/opt/proxysql), where it continues to create
+    # root-owned files while the next job starts. A VM receives all CI-builds
+    # matrix legs serially, so the stale writer can belong to a different
+    # distribution than the new leg. Stop only the known CI-build projects;
+    # the Makefile maps IMG_NAME directly from these distribution names.
+    - name: Stop stale Docker Compose project (self-hosted)
+      if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
+      run: |
+        set -euo pipefail
+        workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
+        compose_file="${workspace}/proxysql/docker-compose.yml"
+
+        if [ -f "${compose_file}" ]; then
+          for compose_project in debian12 ubuntu22 ubuntu24; do
+            echo ">>> stopping stale Compose project: ${compose_project}"
+            docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans
+          done
+        fi
+
+    # The dockerized build writes files as root, so on the next job the
+    # actions/checkout pre-clean can otherwise trip over them:
     #   ##[error]File was unable to be removed Error: EACCES: permission denied,
     #   unlink '.../proxysql/deps/prometheus-cpp/.../.bazelignore'
     # and the job fails before it even builds. Reclaim ownership for the runner
@@ -638,11 +657,27 @@ jobs:
         # cache_bin.tar.zst is produced by the "Pack bin cache" step above.
         path: cache_bin.tar.zst
 
-    # Undo the root ownership the dockerized build left behind, so (a) the next
-    # job on this self-hosted runner can clean/checkout without EACCES and (b)
-    # the failure-path artifact upload below can read the whole tree. Run on
-    # every outcome and fail loudly if cleanup cannot be completed; silently
-    # ignoring this step only defers the failure to the next job's checkout.
+    # Tear down the known CI-build projects before repairing ownership. This
+    # prevents a failed or cancelled build from continuing to write root-owned
+    # files into the bind mount while the runner is being cleaned for its next
+    # job. Run on every outcome and fail loudly if Docker cannot clean the
+    # known CI-build project.
+    - name: Stop Docker Compose project (leave runner clean)
+      if: ${{ inputs.trusted && runner.environment == 'self-hosted' && always() }}
+      run: |
+        set -euo pipefail
+        workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
+        compose_file="${workspace}/proxysql/docker-compose.yml"
+
+        if [ -f "${compose_file}" ]; then
+          for compose_project in debian12 ubuntu22 ubuntu24; do
+            echo ">>> stopping Compose project before workspace cleanup: ${compose_project}"
+            docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans
+          done
+        fi
+
+    # Undo the root ownership the dockerized build left behind so the next job
+    # on this self-hosted runner can clean and check out without EACCES.
     - name: Reclaim workspace ownership (leave runner clean)
       if: ${{ inputs.trusted && runner.environment == 'self-hosted' && always() }}
       run: |
@@ -663,12 +698,16 @@ jobs:
         fi
 
     - name: Archive artifacts
-      if: ${{ inputs.trusted && failure() && !cancelled() }}
+      if: ${{ inputs.trusted && steps.build.outcome == 'failure' && !cancelled() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-${{ env.SHA }}-run#${{ github.run_number }}-${{ matrix.dist }}${{ matrix.type }}
-        path: |
-          proxysql/
+        # The checkout is a live bind mount on self-hosted runners. Uploading
+        # it after an unrelated preflight failure can race a stale container
+        # and turn a diagnostic upload into a second failure. Build logs are
+        # the relevant evidence when the Build step itself fails.
+        path: proxysql/ci_build_log/
+        if-no-files-found: warn
 
     - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: ${{ inputs.trusted && always() }}

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -126,6 +126,10 @@ jobs:
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.dist }}${{ matrix.type }}
       MATRIX: '(${{ matrix.dist }},${{ matrix.type }})'
+      # The active CI-builds matrix uses these Makefile IMG_NAME values. Keep
+      # the set in one place because a VM can receive a cancelled leg from a
+      # different distribution immediately before its next matrix entry.
+      CI_BUILD_COMPOSE_PROJECTS: 'debian12 ubuntu22 ubuntu24'
 
     steps:
 
@@ -158,7 +162,9 @@ jobs:
     # root-owned files while the next job starts. A VM receives all CI-builds
     # matrix legs serially, so the stale writer can belong to a different
     # distribution than the new leg. Stop only the known CI-build projects;
-    # the Makefile maps IMG_NAME directly from these distribution names.
+    # the Makefile maps IMG_NAME directly from these distribution names. If a
+    # failed cleanup already removed docker-compose.yml, remove the labelled
+    # containers directly so they cannot keep writing through the bind mount.
     - name: Stop stale Docker Compose project (self-hosted)
       if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
       run: |
@@ -166,12 +172,31 @@ jobs:
         workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
         compose_file="${workspace}/proxysql/docker-compose.yml"
 
-        if [ -f "${compose_file}" ]; then
-          for compose_project in debian12 ubuntu22 ubuntu24; do
+        cleanup_status=0
+        for compose_project in ${CI_BUILD_COMPOSE_PROJECTS}; do
+          if [ -f "${compose_file}" ]; then
             echo ">>> stopping stale Compose project: ${compose_project}"
-            docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans
-          done
-        fi
+            if ! docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
+              cleanup_status=1
+            fi
+          fi
+
+          stale_containers="$(docker ps -aq --filter "label=com.docker.compose.project=${compose_project}")" || {
+            echo "::error::unable to list containers for Compose project: ${compose_project}"
+            cleanup_status=1
+            stale_containers=""
+          }
+          if [ -n "${stale_containers}" ]; then
+            while IFS= read -r container_id; do
+              [ -n "${container_id}" ] || continue
+              echo ">>> removing stale container: ${container_id} (${compose_project})"
+              if ! docker rm -f "${container_id}"; then
+                cleanup_status=1
+              fi
+            done <<< "${stale_containers}"
+          fi
+        done
+        exit "${cleanup_status}"
 
     # The dockerized build writes files as root, so on the next job the
     # actions/checkout pre-clean can otherwise trip over them:
@@ -469,6 +494,7 @@ jobs:
         fi
 
     - name: Check build
+      id: check_build
       if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
       run: |
         for LOG in proxysql/ci_build_log/build*.log ; do
@@ -661,7 +687,8 @@ jobs:
     # prevents a failed or cancelled build from continuing to write root-owned
     # files into the bind mount while the runner is being cleaned for its next
     # job. Run on every outcome and fail loudly if Docker cannot clean the
-    # known CI-build project.
+    # known CI-build projects. As with preflight, use project labels as a
+    # fallback if a failed job removed docker-compose.yml before this step.
     - name: Stop Docker Compose project (leave runner clean)
       if: ${{ inputs.trusted && runner.environment == 'self-hosted' && always() }}
       run: |
@@ -669,12 +696,31 @@ jobs:
         workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
         compose_file="${workspace}/proxysql/docker-compose.yml"
 
-        if [ -f "${compose_file}" ]; then
-          for compose_project in debian12 ubuntu22 ubuntu24; do
+        cleanup_status=0
+        for compose_project in ${CI_BUILD_COMPOSE_PROJECTS}; do
+          if [ -f "${compose_file}" ]; then
             echo ">>> stopping Compose project before workspace cleanup: ${compose_project}"
-            docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans
-          done
-        fi
+            if ! docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
+              cleanup_status=1
+            fi
+          fi
+
+          stale_containers="$(docker ps -aq --filter "label=com.docker.compose.project=${compose_project}")" || {
+            echo "::error::unable to list containers for Compose project: ${compose_project}"
+            cleanup_status=1
+            stale_containers=""
+          }
+          if [ -n "${stale_containers}" ]; then
+            while IFS= read -r container_id; do
+              [ -n "${container_id}" ] || continue
+              echo ">>> removing stale container: ${container_id} (${compose_project})"
+              if ! docker rm -f "${container_id}"; then
+                cleanup_status=1
+              fi
+            done <<< "${stale_containers}"
+          fi
+        done
+        exit "${cleanup_status}"
 
     # Undo the root ownership the dockerized build left behind so the next job
     # on this self-hosted runner can clean and check out without EACCES.
@@ -698,14 +744,14 @@ jobs:
         fi
 
     - name: Archive artifacts
-      if: ${{ inputs.trusted && steps.build.outcome == 'failure' && !cancelled() }}
+      if: ${{ inputs.trusted && failure() && !cancelled() && (steps.build.outcome == 'failure' || steps.check_build.outcome == 'failure') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-${{ env.SHA }}-run#${{ github.run_number }}-${{ matrix.dist }}${{ matrix.type }}
         # The checkout is a live bind mount on self-hosted runners. Uploading
         # it after an unrelated preflight failure can race a stale container
         # and turn a diagnostic upload into a second failure. Build logs are
-        # the relevant evidence when the Build step itself fails.
+        # the relevant evidence when Build or its log validation fails.
         path: proxysql/ci_build_log/
         if-no-files-found: warn
 

--- a/docs/superpowers/plans/2026-08-11-ci-compose-workspace-cleanup.md
+++ b/docs/superpowers/plans/2026-08-11-ci-compose-workspace-cleanup.md
@@ -1,0 +1,91 @@
+# Self-hosted CI Compose Workspace Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent stale Docker Compose build containers from contaminating persistent self-hosted CI workspaces, while preserving useful and stable failure diagnostics.
+
+**Architecture:** `ci-builds.yml` already maps each Docker build project to its matrix distribution (`ubuntu24`, `ubuntu22`, or `debian12`). Add targeted Compose teardown before the pre-checkout ownership repair and before the final repair. Restrict failure artifacts to logs produced by a failed Build step, rather than the live checkout.
+
+**Tech Stack:** GitHub Actions reusable workflow YAML, Docker Compose, Python 3 YAML parsing, live self-hosted CI verification.
+
+## Global Constraints
+
+- Base the branch on `origin/GH-Actions`; do not modify `v3.0` or PR #6038.
+- Touch only `.github/workflows/ci-builds.yml` for the implementation.
+- Do not change workflow permissions or use broad Docker pruning.
+- Target Compose only with `${{ matrix.dist }}`, which matches the Makefile's `IMG_NAME`.
+- Preserve the existing ownership checks and run the postflight cleanup on every job outcome.
+- Use a descriptive commit message with a substantive body.
+
+---
+
+### Task 1: Make self-hosted Compose cleanup quiescent and failure artifacts stable
+
+**Files:**
+- Modify: `.github/workflows/ci-builds.yml:155-190,641-672`
+- Test: local YAML parser and a real CI-builds run on the self-hosted pool
+
+**Interfaces:**
+- Consumes: `${{ matrix.dist }}`, `GITHUB_WORKSPACE`, existing `docker-compose.yml`, and the `build` step id.
+- Produces: a workspace with no running Compose project for the active matrix distribution before ownership checks; a failure artifact limited to `ci_build_log` after a failed build.
+
+- [ ] **Step 1: Establish the configuration-test boundary**
+
+This workflow controls a self-hosted Docker daemon and persistent runner
+workspace, neither of which is available in the local worktree. Do not add a
+source-text assertion: it would only test YAML spelling, not container cleanup
+or workspace ownership. Use the existing failed CI run as the red observation,
+then validate YAML locally and run the corrected workflow on the real
+self-hosted pool after the GH-Actions PR is merged.
+
+- [ ] **Step 2: Add the preflight targeted cleanup**
+
+Insert a self-hosted-only step before the current ownership guard. It must:
+
+```yaml
+    - name: Stop stale Docker Compose project (self-hosted)
+      if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
+      run: |
+        set -euo pipefail
+        workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
+        compose_file="${workspace}/proxysql/docker-compose.yml"
+        if [ -f "${compose_file}" ]; then
+          docker-compose -f "${compose_file}" -p "${{ matrix.dist }}" down -v --remove-orphans
+        fi
+```
+
+- [ ] **Step 3: Add postflight cleanup and narrow the failure artifact**
+
+Insert the same targeted cleanup before the existing final ownership repair, with `always()` in its condition. Change the artifact condition and payload to:
+
+```yaml
+      if: ${{ inputs.trusted && steps.build.outcome == 'failure' && !cancelled() }}
+      with:
+        path: proxysql/ci_build_log/
+        if-no-files-found: warn
+```
+
+- [ ] **Step 4: Validate the workflow locally and schedule live verification**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import pathlib
+import yaml
+
+with pathlib.Path('.github/workflows/ci-builds.yml').open(encoding='utf-8') as workflow_file:
+    yaml.safe_load(workflow_file)
+print('YAML parsed: .github/workflows/ci-builds.yml')
+PY
+git diff --check
+```
+
+Expected: the workflow parses and the diff has no whitespace errors. After the
+GH-Actions change merges, retrigger a CI-builds run for the same PR and verify
+that the GenAI gcov matrix entry reaches checkout and Build without an
+ownership-guard or artifact-zipping failure.
+
+- [ ] **Step 5: Inspect the diff and commit**
+
+Verify that only the planned workflow and planning documents are staged. Commit with a title such as `fix(ci): quiesce stale Compose build projects` and a two-paragraph body explaining the observed root-owned writer race, the matrix-scoped cleanup, and the narrowed artifact behavior.

--- a/docs/superpowers/plans/2026-08-11-ci-compose-workspace-cleanup.md
+++ b/docs/superpowers/plans/2026-08-11-ci-compose-workspace-cleanup.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent stale Docker Compose build containers from contaminating persistent self-hosted CI workspaces, while preserving useful and stable failure diagnostics.
 
-**Architecture:** `ci-builds.yml` maps Docker build projects to distribution names. Because each self-hosted VM receives the CI-builds matrix legs serially, teardown must cover the explicit project set `debian12`, `ubuntu22`, and `ubuntu24` before ownership repair and again before the final repair. Restrict failure artifacts to logs produced by a failed Build step, rather than the live checkout.
+**Architecture:** `ci-builds.yml` maps Docker build projects to distribution names. Because each self-hosted VM receives the CI-builds matrix legs serially, teardown must cover the explicit project set `debian12`, `ubuntu22`, and `ubuntu24` before ownership repair and again before the final repair. The set is defined once as a job environment value. Each teardown attempts every project, including a label-based container fallback if the Compose file is absent. Restrict failure artifacts to logs produced by a failed Build or Check build step, rather than the live checkout.
 
 **Tech Stack:** GitHub Actions reusable workflow YAML, Docker Compose, Python 3 YAML parsing, live self-hosted CI verification.
 
@@ -26,7 +26,7 @@
 - Test: local YAML parser and a real CI-builds run on the self-hosted pool
 
 **Interfaces:**
-- Consumes: `${{ matrix.dist }}`, `GITHUB_WORKSPACE`, existing `docker-compose.yml`, and the `build` step id.
+- Consumes: `CI_BUILD_COMPOSE_PROJECTS`, `GITHUB_WORKSPACE`, `docker-compose.yml` when present, Compose project labels, and the `build` / `check_build` step ids.
 - Produces: a workspace with no running CI-build Compose project before ownership checks; a failure artifact limited to `ci_build_log` after a failed build.
 
 - [ ] **Step 1: Establish the configuration-test boundary**
@@ -41,7 +41,10 @@ self-hosted pool after the GH-Actions PR is merged.
 - [ ] **Step 2: Add the preflight targeted cleanup**
 
 Insert a self-hosted-only step before the current ownership guard. It must loop
-over the known CI-build projects, rather than only the active matrix project:
+over `CI_BUILD_COMPOSE_PROJECTS`, rather than only the active matrix project,
+and retain a failure status until every project has been attempted. When the
+Compose file is absent, it must force-remove only containers labelled with one
+of those explicit project names:
 
 ```yaml
     - name: Stop stale Docker Compose project (self-hosted)
@@ -50,19 +53,35 @@ over the known CI-build projects, rather than only the active matrix project:
         set -euo pipefail
         workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
         compose_file="${workspace}/proxysql/docker-compose.yml"
-        if [ -f "${compose_file}" ]; then
-          for compose_project in debian12 ubuntu22 ubuntu24; do
-            docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans
-          done
-        fi
+        cleanup_status=0
+        for compose_project in ${CI_BUILD_COMPOSE_PROJECTS}; do
+          if [ -f "${compose_file}" ]; then
+            if ! docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
+              cleanup_status=1
+            fi
+          fi
+          stale_containers="$(docker ps -aq --filter "label=com.docker.compose.project=${compose_project}")" || {
+            cleanup_status=1
+            stale_containers=""
+          }
+          if [ -n "${stale_containers}" ]; then
+            while IFS= read -r container_id; do
+              [ -n "${container_id}" ] || continue
+              if ! docker rm -f "${container_id}"; then
+                cleanup_status=1
+              fi
+            done <<< "${stale_containers}"
+          fi
+        done
+        exit "${cleanup_status}"
 ```
 
 - [ ] **Step 3: Add postflight cleanup and narrow the failure artifact**
 
-Insert the same targeted cleanup before the existing final ownership repair, with `always()` in its condition. Change the artifact condition and payload to:
+Insert the same targeted cleanup before the existing final ownership repair, with `always()` in its condition. Give Check build the `check_build` id. Change the artifact condition and payload to:
 
 ```yaml
-      if: ${{ inputs.trusted && steps.build.outcome == 'failure' && !cancelled() }}
+      if: ${{ inputs.trusted && failure() && !cancelled() && (steps.build.outcome == 'failure' || steps.check_build.outcome == 'failure') }}
       with:
         path: proxysql/ci_build_log/
         if-no-files-found: warn

--- a/docs/superpowers/plans/2026-08-11-ci-compose-workspace-cleanup.md
+++ b/docs/superpowers/plans/2026-08-11-ci-compose-workspace-cleanup.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent stale Docker Compose build containers from contaminating persistent self-hosted CI workspaces, while preserving useful and stable failure diagnostics.
 
-**Architecture:** `ci-builds.yml` already maps each Docker build project to its matrix distribution (`ubuntu24`, `ubuntu22`, or `debian12`). Add targeted Compose teardown before the pre-checkout ownership repair and before the final repair. Restrict failure artifacts to logs produced by a failed Build step, rather than the live checkout.
+**Architecture:** `ci-builds.yml` maps Docker build projects to distribution names. Because each self-hosted VM receives the CI-builds matrix legs serially, teardown must cover the explicit project set `debian12`, `ubuntu22`, and `ubuntu24` before ownership repair and again before the final repair. Restrict failure artifacts to logs produced by a failed Build step, rather than the live checkout.
 
 **Tech Stack:** GitHub Actions reusable workflow YAML, Docker Compose, Python 3 YAML parsing, live self-hosted CI verification.
 
@@ -13,7 +13,7 @@
 - Base the branch on `origin/GH-Actions`; do not modify `v3.0` or PR #6038.
 - Touch only `.github/workflows/ci-builds.yml` for the implementation.
 - Do not change workflow permissions or use broad Docker pruning.
-- Target Compose only with `${{ matrix.dist }}`, which matches the Makefile's `IMG_NAME`.
+- Target only the explicit CI-build project set `debian12`, `ubuntu22`, and `ubuntu24`, which matches the Makefile's `IMG_NAME` values.
 - Preserve the existing ownership checks and run the postflight cleanup on every job outcome.
 - Use a descriptive commit message with a substantive body.
 
@@ -27,7 +27,7 @@
 
 **Interfaces:**
 - Consumes: `${{ matrix.dist }}`, `GITHUB_WORKSPACE`, existing `docker-compose.yml`, and the `build` step id.
-- Produces: a workspace with no running Compose project for the active matrix distribution before ownership checks; a failure artifact limited to `ci_build_log` after a failed build.
+- Produces: a workspace with no running CI-build Compose project before ownership checks; a failure artifact limited to `ci_build_log` after a failed build.
 
 - [ ] **Step 1: Establish the configuration-test boundary**
 
@@ -40,7 +40,8 @@ self-hosted pool after the GH-Actions PR is merged.
 
 - [ ] **Step 2: Add the preflight targeted cleanup**
 
-Insert a self-hosted-only step before the current ownership guard. It must:
+Insert a self-hosted-only step before the current ownership guard. It must loop
+over the known CI-build projects, rather than only the active matrix project:
 
 ```yaml
     - name: Stop stale Docker Compose project (self-hosted)
@@ -50,7 +51,9 @@ Insert a self-hosted-only step before the current ownership guard. It must:
         workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
         compose_file="${workspace}/proxysql/docker-compose.yml"
         if [ -f "${compose_file}" ]; then
-          docker-compose -f "${compose_file}" -p "${{ matrix.dist }}" down -v --remove-orphans
+          for compose_project in debian12 ubuntu22 ubuntu24; do
+            docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans
+          done
         fi
 ```
 

--- a/docs/superpowers/specs/2026-08-11-ci-compose-workspace-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-11-ci-compose-workspace-cleanup-design.md
@@ -1,0 +1,49 @@
+# Self-hosted CI Compose Workspace Cleanup Design
+
+## Problem
+
+The `ubuntu24,-tap-genai-gcov` build on PR #6038 failed before checkout.
+Its self-hosted runner, `ci-vm-1`, contained root-owned files under the
+previous Docker build's bind mount. The workflow ran `chown -R`, but the
+subsequent ownership check immediately found different root-owned files. This
+demonstrates that a stale Docker Compose build container was still writing to
+the persistent workspace. The failure-path artifact upload then attempted to
+zip the whole changing checkout and failed with `ENOENT`.
+
+## Scope
+
+Modify only `.github/workflows/ci-builds.yml` on a branch based on
+`GH-Actions`. The change must not alter ProxySQL source code, test selection,
+Docker images, permissions, or unrelated runner workloads.
+
+## Design
+
+Each CI-builds matrix entry maps its Docker Compose project to `matrix.dist`:
+the Makefile invokes `docker-compose -p $(IMG_NAME)`, and `IMG_NAME` is the
+distribution name such as `ubuntu24`, `ubuntu22`, or `debian12`.
+
+Before the existing ownership guard, a self-hosted entry must tear down only
+that matrix-specific Compose project, including volumes and orphan containers.
+The workflow must then reclaim and verify workspace ownership before checkout.
+After every outcome, it must tear down the same project again before the final
+ownership repair. Both cleanup steps must fail loudly if Docker cannot perform
+the requested cleanup; they must not use broad Docker pruning or suppress an
+error.
+
+Failure artifacts are diagnostic data, not a snapshot of a live bind mount.
+Archive only `proxysql/ci_build_log/`, and only when the Build step itself ran
+and failed. This avoids scanning and zipping hundreds of thousands of files
+after a preflight failure while preserving the build logs that explain genuine
+build errors.
+
+## Acceptance Criteria
+
+- A self-hosted matrix entry removes only its `${{ matrix.dist }}` Compose
+  project before the first ownership check and after the job outcome.
+- The preflight cleanup runs before checkout; the postflight cleanup runs on
+  successful and failed builds.
+- Root ownership is still reclaimed and verified after each cleanup.
+- The failure artifact does not run for a preflight ownership failure and does
+  not include the full checkout.
+- `.github/workflows/ci-builds.yml` remains valid YAML and does not broaden
+  CI permissions.

--- a/docs/superpowers/specs/2026-08-11-ci-compose-workspace-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-11-ci-compose-workspace-cleanup-design.md
@@ -25,27 +25,34 @@ serially, so a cancelled `ubuntu22` build can contaminate the persistent
 workspace immediately before an `ubuntu24` build starts.
 
 Before the existing ownership guard, a self-hosted entry must tear down only
-only that explicit CI-build project set, including volumes and orphan
-containers. The workflow must then reclaim and verify workspace ownership
-before checkout. After every outcome, it must tear down the same set again
-before the final ownership repair. Both cleanup steps must fail loudly if
-Docker cannot perform the requested cleanup; they must not use broad Docker
-pruning or suppress an error.
+that explicit CI-build project set, including volumes and orphan containers.
+If a partial cleanup has already removed `docker-compose.yml`, it must also
+remove containers carrying the corresponding Compose project labels; otherwise
+the stale writer survives exactly when the configuration is absent. The
+workflow must then reclaim and verify workspace ownership before checkout.
+After every outcome, it must tear down the same set again before the final
+ownership repair. Both cleanup steps must attempt every project before they
+return a nonzero status; they must not use broad Docker pruning or suppress an
+error.
 
 Failure artifacts are diagnostic data, not a snapshot of a live bind mount.
-Archive only `proxysql/ci_build_log/`, and only when the Build step itself ran
-and failed. This avoids scanning and zipping hundreds of thousands of files
-after a preflight failure while preserving the build logs that explain genuine
-build errors.
+Archive only `proxysql/ci_build_log/`, and only when the Build step or its
+separate log-validation step failed. This avoids scanning and zipping hundreds
+of thousands of files after a preflight failure while preserving the build logs
+that explain genuine build errors.
 
 ## Acceptance Criteria
 
 - A self-hosted matrix entry removes only the known CI-build Compose projects
   (`debian12`, `ubuntu22`, and `ubuntu24`) before the first ownership check and
   after the job outcome.
+- Missing `docker-compose.yml` does not leave a labelled project container
+  running, and a teardown reports failure only after attempting every project.
 - The preflight cleanup runs before checkout; the postflight cleanup runs on
   successful and failed builds.
 - Root ownership is still reclaimed and verified after each cleanup.
+- The failure artifact is collected when Build or Check build failed, but not
+  for an ownership-only preflight failure.
 - The failure artifact does not run for a preflight ownership failure and does
   not include the full checkout.
 - `.github/workflows/ci-builds.yml` remains valid YAML and does not broaden

--- a/docs/superpowers/specs/2026-08-11-ci-compose-workspace-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-11-ci-compose-workspace-cleanup-design.md
@@ -18,17 +18,19 @@ Docker images, permissions, or unrelated runner workloads.
 
 ## Design
 
-Each CI-builds matrix entry maps its Docker Compose project to `matrix.dist`:
-the Makefile invokes `docker-compose -p $(IMG_NAME)`, and `IMG_NAME` is the
-distribution name such as `ubuntu24`, `ubuntu22`, or `debian12`.
+The Makefile invokes `docker-compose -p $(IMG_NAME)`, where `IMG_NAME` is the
+distribution name. The active CI-builds matrix therefore owns the explicit
+project set `debian12`, `ubuntu22`, and `ubuntu24`. A VM schedules those legs
+serially, so a cancelled `ubuntu22` build can contaminate the persistent
+workspace immediately before an `ubuntu24` build starts.
 
 Before the existing ownership guard, a self-hosted entry must tear down only
-that matrix-specific Compose project, including volumes and orphan containers.
-The workflow must then reclaim and verify workspace ownership before checkout.
-After every outcome, it must tear down the same project again before the final
-ownership repair. Both cleanup steps must fail loudly if Docker cannot perform
-the requested cleanup; they must not use broad Docker pruning or suppress an
-error.
+only that explicit CI-build project set, including volumes and orphan
+containers. The workflow must then reclaim and verify workspace ownership
+before checkout. After every outcome, it must tear down the same set again
+before the final ownership repair. Both cleanup steps must fail loudly if
+Docker cannot perform the requested cleanup; they must not use broad Docker
+pruning or suppress an error.
 
 Failure artifacts are diagnostic data, not a snapshot of a live bind mount.
 Archive only `proxysql/ci_build_log/`, and only when the Build step itself ran
@@ -38,8 +40,9 @@ build errors.
 
 ## Acceptance Criteria
 
-- A self-hosted matrix entry removes only its `${{ matrix.dist }}` Compose
-  project before the first ownership check and after the job outcome.
+- A self-hosted matrix entry removes only the known CI-build Compose projects
+  (`debian12`, `ubuntu22`, and `ubuntu24`) before the first ownership check and
+  after the job outcome.
 - The preflight cleanup runs before checkout; the postflight cleanup runs on
   successful and failed builds.
 - Root ownership is still reclaimed and verified after each cleanup.


### PR DESCRIPTION
## Summary

- stop the explicit CI-build Docker Compose projects (`debian12`, `ubuntu22`, and `ubuntu24`) before the pre-checkout ownership guard and again before final workspace cleanup
- retain ownership verification, but prevent it from racing a stale container that writes through the persistent checkout bind mount
- upload only `ci_build_log` when the Build step itself fails, avoiding a secondary artifact-zipping failure for preflight workspace errors

## Root cause

On PR #6038, `ci-vm-1` ran cancelled `ubuntu22` and `debian12` CI-builds legs immediately before the failed `ubuntu24,-tap-genai-gcov` leg. The ownership guard ran `chown -R`, then immediately found new root-owned Connector/C objects, proving a stale Compose container was still writing to the shared workspace. The fallback artifact upload subsequently raced the same mutable tree and failed with `ENOENT`.

The cleanup is constrained to the three Compose project names used by the active CI-builds matrix; it does not use a broad Docker prune and does not change workflow permissions.

## Validation

- Parsed `.github/workflows/ci-builds.yml` and `.github/workflows/ci-trigger.yml` with PyYAML.
- Ran `git diff --check origin/GH-Actions...HEAD`.
- Verified the workflow diff is limited to the cleanup/artifact behavior plus its design and implementation-plan documents.

A live self-hosted CI-builds run after merge is required to verify the Docker lifecycle behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale Docker Compose containers on self-hosted runners from writing into the persistent checkout and breaking later CI legs. We stop the CI projects (`debian12`, `ubuntu22`, `ubuntu24`) before ownership repair and again at teardown, and only upload build logs when Build or its log check fails.

- **Bug Fixes**
  - Define `CI_BUILD_COMPOSE_PROJECTS` once and attempt every project; stop via `docker-compose ... down -v --remove-orphans`, with a label-based container fallback when `docker-compose.yml` is missing.
  - Keep ownership reclaim/verification; run both preflight and postflight cleanup; no broad Docker prune and no permission changes.
  - Upload only `proxysql/ci_build_log/` when `build` or `check_build` failed; use `if-no-files-found: warn`.

<sup>Written for commit 1323a8f3bb9b8b393aec932b39c8e128cf42df1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-hosted build reliability by cleaning up known Docker Compose projects before checkout and after job completion.
  * Added fallback cleanup for stale containers when Compose configuration is unavailable.
  * Restricted failure artifacts to build logs collected only when the build or validation step fails.

* **Documentation**
  * Added implementation and design documentation covering workspace cleanup, ownership checks, validation, and verification procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->