### PR TITLE
fix(ci): invoke Compose v2 during workspace cleanup

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -176,7 +176,7 @@ jobs:
         for compose_project in ${CI_BUILD_COMPOSE_PROJECTS}; do
           if [ -f "${compose_file}" ]; then
             echo ">>> stopping stale Compose project: ${compose_project}"
-            if ! docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
+            if ! docker compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
               cleanup_status=1
             fi
           fi
@@ -700,7 +700,7 @@ jobs:
         for compose_project in ${CI_BUILD_COMPOSE_PROJECTS}; do
           if [ -f "${compose_file}" ]; then
             echo ">>> stopping Compose project before workspace cleanup: ${compose_project}"
-            if ! docker-compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
+            if ! docker compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
               cleanup_status=1
             fi
           fi


### PR DESCRIPTION
## Summary

Use `docker compose` in the pre-build and post-build self-hosted workspace cleanup loops.

## Root cause

The CI VMs provide Compose v2 through the Docker CLI plugin but do not have the legacy standalone `docker-compose` binary. The cleanup added by #6040 therefore failed before checkout when a stale checkout existed, or after an otherwise successful build.

## Impact

Both cleanup loops now use the same Compose interface as the repository Makefile. Project-label fallback removal, ownership repair, and aggregate cleanup-error behavior are unchanged.

## Validation

- Parsed `.github/workflows/ci-builds.yml`
- Syntax-checked both cleanup shell scripts
- Executed both extracted cleanup scripts against a mocked Compose-v2 `docker` command for the Debian 12, Ubuntu 22, and Ubuntu 24 projects

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI workspace cleanup to Compose v2 by invoking `docker compose` instead of the legacy `docker-compose`, fixing failures on self-hosted runners. This aligns pre- and post-build cleanup with the Makefile; no changes to labels, ownership repair, or error handling.

<sup>Written for commit e976aaf5e593327817966a11c947e98ea7718fcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated self-hosted build cleanup commands to use the current Docker Compose CLI.
  * Cleanup behavior and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->