### PR TITLE
fix(ci): nuke all docker state on self-hosted runners

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -126,10 +126,6 @@ jobs:
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.dist }}${{ matrix.type }}
       MATRIX: '(${{ matrix.dist }},${{ matrix.type }})'
-      # The active CI-builds matrix uses these Makefile IMG_NAME values. Keep
-      # the set in one place because a VM can receive a cancelled leg from a
-      # different distribution immediately before its next matrix entry.
-      CI_BUILD_COMPOSE_PROJECTS: 'debian12 ubuntu22 ubuntu24'
 
     steps:
 
@@ -157,46 +153,29 @@ jobs:
           proxysql/binaries/
 
     # Self-hosted runners reuse the working directory between jobs. A cancelled
-    # dockerized build can leave its Compose project running against the
+    # dockerized build can leave its Compose stack running against the
     # bind-mounted checkout (./:/opt/proxysql), where it continues to create
     # root-owned files while the next job starts. A VM receives all CI-builds
     # matrix legs serially, so the stale writer can belong to a different
-    # distribution than the new leg. Stop only the known CI-build projects;
-    # the Makefile maps IMG_NAME directly from these distribution names. If a
-    # failed cleanup already removed docker-compose.yml, remove the labelled
-    # containers directly so they cannot keep writing through the bind mount.
-    - name: Stop stale Docker Compose project (self-hosted)
+    # distribution than the new leg. The previous project-name-filtered cleanup
+    # never matched, because the Makefile names each project
+    # <BLD_NAME>-<GITVERSION> (e.g. ubuntu22-tap-3.0.11-502-gd8bdd5a), not the
+    # bare distribution name. Nuke ALL docker state on the runner instead: every
+    # container, every volume, every network. Nothing dockerized may survive
+    # into the next job.
+    - name: Nuke all docker state (self-hosted)
       if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
       run: |
         set -euo pipefail
-        workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
-        compose_file="${workspace}/proxysql/docker-compose.yml"
-
-        cleanup_status=0
-        for compose_project in ${CI_BUILD_COMPOSE_PROJECTS}; do
-          if [ -f "${compose_file}" ]; then
-            echo ">>> stopping stale Compose project: ${compose_project}"
-            if ! docker compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
-              cleanup_status=1
-            fi
-          fi
-
-          stale_containers="$(docker ps -aq --filter "label=com.docker.compose.project=${compose_project}")" || {
-            echo "::error::unable to list containers for Compose project: ${compose_project}"
-            cleanup_status=1
-            stale_containers=""
-          }
-          if [ -n "${stale_containers}" ]; then
-            while IFS= read -r container_id; do
-              [ -n "${container_id}" ] || continue
-              echo ">>> removing stale container: ${container_id} (${compose_project})"
-              if ! docker rm -f "${container_id}"; then
-                cleanup_status=1
-              fi
-            done <<< "${stale_containers}"
-          fi
-        done
-        exit "${cleanup_status}"
+        echo ">>> removing all docker containers"
+        containers="$(docker ps -aq)"
+        if [ -n "${containers}" ]; then
+          docker rm -f ${containers}
+        fi
+        echo ">>> removing all docker volumes"
+        docker volume prune -af
+        echo ">>> removing all docker networks"
+        docker network prune -af
 
     # The dockerized build writes files as root, so on the next job the
     # actions/checkout pre-clean can otherwise trip over them:
@@ -683,44 +662,25 @@ jobs:
         # cache_bin.tar.zst is produced by the "Pack bin cache" step above.
         path: cache_bin.tar.zst
 
-    # Tear down the known CI-build projects before repairing ownership. This
-    # prevents a failed or cancelled build from continuing to write root-owned
-    # files into the bind mount while the runner is being cleaned for its next
-    # job. Run on every outcome and fail loudly if Docker cannot clean the
-    # known CI-build projects. As with preflight, use project labels as a
-    # fallback if a failed job removed docker-compose.yml before this step.
-    - name: Stop Docker Compose project (leave runner clean)
+    # Nuke ALL docker state before leaving the runner clean for its next job.
+    # This prevents a failed or cancelled build from continuing to write
+    # root-owned files into the bind mount while the runner is being cleaned.
+    # Run on every outcome and fail loudly if Docker cannot be fully cleaned.
+    # As with preflight, this is intentionally an unconditional wipe of every
+    # container, volume and network -- nothing dockerized may survive.
+    - name: Nuke all docker state (leave runner clean)
       if: ${{ inputs.trusted && runner.environment == 'self-hosted' && always() }}
       run: |
         set -euo pipefail
-        workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
-        compose_file="${workspace}/proxysql/docker-compose.yml"
-
-        cleanup_status=0
-        for compose_project in ${CI_BUILD_COMPOSE_PROJECTS}; do
-          if [ -f "${compose_file}" ]; then
-            echo ">>> stopping Compose project before workspace cleanup: ${compose_project}"
-            if ! docker compose -f "${compose_file}" -p "${compose_project}" down -v --remove-orphans; then
-              cleanup_status=1
-            fi
-          fi
-
-          stale_containers="$(docker ps -aq --filter "label=com.docker.compose.project=${compose_project}")" || {
-            echo "::error::unable to list containers for Compose project: ${compose_project}"
-            cleanup_status=1
-            stale_containers=""
-          }
-          if [ -n "${stale_containers}" ]; then
-            while IFS= read -r container_id; do
-              [ -n "${container_id}" ] || continue
-              echo ">>> removing stale container: ${container_id} (${compose_project})"
-              if ! docker rm -f "${container_id}"; then
-                cleanup_status=1
-              fi
-            done <<< "${stale_containers}"
-          fi
-        done
-        exit "${cleanup_status}"
+        echo ">>> removing all docker containers"
+        containers="$(docker ps -aq)"
+        if [ -n "${containers}" ]; then
+          docker rm -f ${containers}
+        fi
+        echo ">>> removing all docker volumes"
+        docker volume prune -af
+        echo ">>> removing all docker networks"
+        docker network prune -af
 
     # Undo the root ownership the dockerized build left behind so the next job
     # on this self-hosted runner can clean and check out without EACCES.


### PR DESCRIPTION
## Problem

Self-hosted runners reuse the working directory serially across CI-builds matrix legs. A cancelled dockerized build leaks its Compose stack, which keeps writing root-owned files into the bind-mounted checkout (`./:/opt/proxysql`) while the next job starts.

The existing cleanup ("Stop stale Docker Compose project") was a **no-op**:

- It iterated `CI_BUILD_COMPOSE_PROJECTS: 'debian12 ubuntu22 ubuntu24'`, filtering on label `com.docker.compose.project=<bare-dist-name>`.
- But the Makefile names each project `<BLD_NAME>-<GITVERSION>` (e.g. `ubuntu22-tap-3.0.11-502-gd8bdd5a`) — see `Makefile:519`. The bare distribution name is the IMG_NAME, not the Compose project name.

So the leaked writer container was never matched, `chown -R` succeeded but the live container re-created root-owned files ~1.6s later, and the contamination guard aborted the job. This produced the recurring "workspace still contains files not owned by the runner" failures.

## Change

Nuke **all** docker state on self-hosted runners at both cleanup points:

- **Preflight** ("Nuke all docker state (self-hosted)") — before checkout.
- **Post-job** ("Nuke all docker state (leave runner clean)") — `always()`.

Both steps now remove **all** containers (`docker rm -f` on everything running), all volumes (`docker volume prune -af`), and all networks (`docker network prune -af`). No name guessing, no filter — nothing dockerized survives into the next job.

Also removed the now-dead `CI_BUILD_COMPOSE_PROJECTS` env var.

## Notes

- Workspace ownership reclaim and the Makefile bind-mount are intentionally untouched.
- Follow-up (out of scope): stop bind-mounting the checkout into build containers entirely, so root-owned files never touch the host workspace and the contamination guard becomes unnecessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wipes all Docker state on self-hosted runners before checkout and after each job to stop root-owned file contamination from leaked Compose stacks. Old behavior: filtered cleanup by bare distribution name and missed projects named <BLD_NAME>-<GITVERSION>; containers survived into the next job. New behavior: unconditional removal of all containers, volumes, and networks on trusted self-hosted runners.

- Runs in two places: preflight (before checkout) and post-job (`always()`), gated by trusted and self-hosted runner checks.
- Removes all containers (`docker rm -f $(docker ps -aq)`), prunes all volumes and networks; images are not pruned.
- Deletes now-dead env var `CI_BUILD_COMPOSE_PROJECTS`.
- Leaves workspace ownership repair and the Makefile bind-mount unchanged.
- Required: Do not rely on persistent Docker containers, volumes, or networks on self-hosted runners; any such state will be removed between jobs.

<sup>Written for commit 4408aae64e5a5a3dc7b7b10caf3949de135a471c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build cleanup to remove leftover containers, volumes, and networks from trusted build environments.
  * Updated cleanup behavior to run reliably after build jobs and when cached dependencies are unavailable.
  * Removed an unused build configuration setting, helping simplify the continuous integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->