### PR TITLE
fix(ci): docker network prune does not support -a

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -175,7 +175,7 @@ jobs:
         echo ">>> removing all docker volumes"
         docker volume prune -af
         echo ">>> removing all docker networks"
-        docker network prune -af
+        docker network prune -f
 
     # The dockerized build writes files as root, so on the next job the
     # actions/checkout pre-clean can otherwise trip over them:
@@ -680,7 +680,7 @@ jobs:
         echo ">>> removing all docker volumes"
         docker volume prune -af
         echo ">>> removing all docker networks"
-        docker network prune -af
+        docker network prune -f
 
     # Undo the root ownership the dockerized build left behind so the next job
     # on this self-hosted runner can clean and check out without EACCES.


### PR DESCRIPTION
## Problem

The docker-state nuke from PR #6049 fails on the self-hosted runners:

```
Usage:  docker network prune [OPTIONS]
##[error]Process completed with exit code 125.
```

## Root cause

`docker network prune` only accepts `-f/--force` and `--filter` — the `-a/--all` flag is **not** supported (unlike `docker volume prune`, which has `-a`). Passing `-af` is an invalid flag combination, so the command aborts with a usage error.

## Fix

Use `docker network prune -f` in both the preflight and post-job nuke steps. Network prune already removes all unused networks, so no `-a` is needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI cleanup by replacing `docker network prune -af` with `docker network prune -f` in `.github/workflows/ci-builds.yml` preflight and post-job nuke steps. Previously, `-a` was invalid for network prune and caused exit 125 on self-hosted runners; now the command runs non-interactively and prunes all unused networks, preventing cleanup failures without changing volume pruning.

<sup>Written for commit 04eb487d9ccc752d14fce6a890f09b42415147e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

