### PR TITLE
fix(tap): make clean removes stale unit-test binaries; ci(infra): switch to proxysql/orchestrator fork

### DIFF
--- a/test/infra/docker-base/Dockerfile
+++ b/test/infra/docker-base/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update -qq && \
     && pip3 install --break-system-packages fastcov \
         "mysql-connector-python==${MYSQL_CONNECTOR_PYTHON_VERSION}" \
         "mysqlx-connector-python==${MYSQL_CONNECTOR_PYTHON_VERSION}" \
-    && wget https://github.com/openark/orchestrator/releases/download/v3.2.6/orchestrator-client_3.2.6_amd64.deb -O /tmp/orc.deb \
+    && wget https://github.com/proxysql/orchestrator/releases/download/v4.31.1/orchestrator-client_4.31.1_amd64.deb -O /tmp/orc.deb \
     && apt-get install -y /tmp/orc.deb \
     && rm -rf /var/lib/apt/lists/* /tmp/orc.deb
 

--- a/test/infra/infra-mysql57-binlog/docker-compose.yml
+++ b/test/infra/infra-mysql57-binlog/docker-compose.yml
@@ -132,7 +132,7 @@ services:
 
   orc1:
     hostname: orc1.${INFRA}
-    image: proxysql/ci-infra:openark-orchestrator
+    image: proxysql/ci-infra:percona-orchestrator
     container_name: ${COMPOSE_PROJECT}-orc1-1
     volumes:
       - ./conf/orchestrator/orc1/orchestrator.conf.json:/etc/orchestrator.conf.json
@@ -149,7 +149,7 @@ services:
 
   orc2:
     hostname: orc2.${INFRA}
-    image: proxysql/ci-infra:openark-orchestrator
+    image: proxysql/ci-infra:percona-orchestrator
     container_name: ${COMPOSE_PROJECT}-orc2-1
     volumes:
       - ./conf/orchestrator/orc2/orchestrator.conf.json:/etc/orchestrator.conf.json
@@ -166,7 +166,7 @@ services:
 
   orc3:
     hostname: orc3.${INFRA}
-    image: proxysql/ci-infra:openark-orchestrator
+    image: proxysql/ci-infra:percona-orchestrator
     container_name: ${COMPOSE_PROJECT}-orc3-1
     volumes:
       - ./conf/orchestrator/orc3/orchestrator.conf.json:/etc/orchestrator.conf.json

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -892,4 +892,5 @@ endif
 .PHONY: clean
 .SILENT: clean
 clean:
-	rm -rf $(ODIR) $(UNIT_TESTS) $(FAKE_PLUGIN_SO) $(FAKE_PLUGIN2_SO)
+	rm -rf $(ODIR)
+	rm -f *-t $(FAKE_PLUGIN_SO) $(FAKE_PLUGIN2_SO)


### PR DESCRIPTION
Two small infrastructure fixes that close #6051 and #6052. Both are surgical and don't change runtime behavior beyond what's described.

## Commit 1 — fix(tap): make clean removes stale unit-test binaries built under a different tier flag (Closes #6051)

**Files**: `test/tap/tests/unit/Makefile`

The unit-test `clean` recipe removed only the binaries listed in `$(UNIT_TESTS)`, which is conditional on `PROXYSQL31` / `PROXYSQLED25519` / `PROXYSQL40` (see `test/tap/tests/unit/Makefile:441-516`). The top-level `make clean` does not propagate those flags, so binaries built under a different tier silently survived cleanup. Same root cause as the stale-object tier mismatch already documented in `CLAUDE.md` — just for unit-test binaries instead of `libproxysql.a`.

Replaced the conditional list with a `*-t` wildcard, mirroring the recipe already used by the sibling `test/tap/tests/Makefile` (`rm -f *-t || true`). The `-t` suffix is unique to unit-test binaries in this directory (no `.cpp` source files match), so the glob is safe.

**Verified on this branch**: `make clean` reclaimed **5.8 GB → 1.7 MB**, removing all 60 binaries including the 17 stale `mysqlx_*_unit-t` ones that the old recipe missed.

## Commit 2 — ci(infra): switch orchestrator source from openark to the proxysql fork (Closes #6052)

**Files**: `test/infra/docker-base/Dockerfile`, `test/infra/infra-mysql57-binlog/docker-compose.yml`

ProxySQL took over Orchestrator maintainership in 2026 — the fork at `github.com/proxysql/orchestrator` (forked from `percona/orchestrator`) is now the canonical source. It publishes its own `.deb` releases starting at v4.0.0; there is no v3.x in the fork, so a version bump from openark v3.2.6 to proxysql v4.31.1 is forced.

Two distinct images are involved — the Dockerfile installs only the orchestrator-*client* (used from the ProxySQL container); the orchestrator-*server* is in a separate historical image used by the `orc1/2/3` services.

- `test/infra/docker-base/Dockerfile`: repoint the `wget` from `github.com/openark/orchestrator/releases/download/v3.2.6/orchestrator-client_3.2.6_amd64.deb` to `github.com/proxysql/orchestrator/releases/download/v4.31.1/orchestrator-client_4.31.1_amd64.deb`.
- `test/infra/infra-mysql57-binlog/docker-compose.yml`: repoint `orc1`/`orc2`/`orc3` from `proxysql/ci-infra:openark-orchestrator` to `:percona-orchestrator`. This is the same tag the three sibling infras (`infra-mysql57`, `infra-mysql84`, `infra-mysql84-binlog`) already use, so the docker-compose is consistent across the matrix.

The CI base image workflow (`CI-push-ci-base-image.yml`) only rebuilds `proxysql/ci-infra:latest` and `:sha`; the `:openark-orchestrator` and `:percona-orchestrator` tags are historical server images that already exist in the registry and don't need rebuilding.

## Risk / things to watch

- **#6052 orchestrator client v3 → v4 jump**: this is a major version bump for the orchestrator client. The v4 client speaks the same API for the commands used by `docker-orchestrator-post.bash` (`-c clusters`, `-c discover`, `-c which-cluster`, `-c topology`), but the version was chosen at v4.31.1 (latest stable). If `CI-basictests` or `CI-mysql57-binlog` TAP groups start failing on orchestrator-version-related errors after this lands, the pin can be moved to an older v4.x.
- **#6051 tier-flag coupling**: the fix removes the only documented mechanism that distinguished per-tier unit-test outputs. If anyone is depending on `$(UNIT_TESTS)` being the source-of-truth list (e.g. for documentation or external tooling), that list is now only consultable in the `all:` / `debug:` targets — not in the cleanup recipe.

## Verification

```
$ make -C test/tap/tests/unit clean     # before fix
... only removes 52 of 60 binaries ...
$ make -C test/tap/tests/unit clean     # after fix
... 60 → 0 binaries, 5.8G → 1.7M ...

$ grep -rn openark test/infra/docker-base/ test/infra/infra-mysql57-binlog/docker-compose.yml
# (no matches)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes test cleanup and aligns CI with the maintained Orchestrator fork. Previously `make clean` in `test/tap/tests/unit` removed only `$(UNIT_TESTS)` (tier-dependent) and left cross-tier binaries; now it removes all unit-test `*-t` binaries. CI switches Orchestrator from `openark/orchestrator` v3.2.6 to `proxysql/orchestrator` v4.31.1 to match the rest of the matrix.

**Review and rollout**
- Unit-test cleanup: replace deletion of `$(UNIT_TESTS)` with a `*-t` glob so `make clean` removes all unit-test binaries across tiers; no `.cpp` uses the `-t` suffix, so the glob is safe.
- CI Orchestrator: Dockerfile downloads `orchestrator-client` v4.31.1 from `github.com/proxysql/orchestrator`; `orc1/2/3` switch from `proxysql/ci-infra:openark-orchestrator` to `proxysql/ci-infra:percona-orchestrator`. Historical server images already exist; no rebuild required.
- Risk/migration: This is a major client bump (v3→v4). Watch TAP groups that invoke Orchestrator; if failures appear, pin to an earlier v4.x. If any scripts rely on `$(UNIT_TESTS)` for cleanup, use the `*-t` suffix instead.

<sup>Written for commit a9dcda8c06265b4d3fae68a42a62664dfd650faa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to use the ProxySQL Orchestrator client version 4.31.1.
  * Updated orchestration test services to use the current ProxySQL CI image.
  * Improved unit-test cleanup to reliably remove generated test binaries and plugin libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->