### PR TITLE
fix(ci): hydrate LFS dependencies in builds

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -210,6 +210,7 @@ jobs:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         fetch-depth: 0
+        lfs: true
         path: 'proxysql'
 
 #    - name: Patch TAP-tests


### PR DESCRIPTION
## What changed

Enable Git LFS hydration in the reusable CI-builds checkout.

## Root cause

The AWS SDK source archive is intentionally stored in Git LFS. CI-builds checked out pull-request commits with `lfs: false`, leaving the pointer file in place. The vendored bundle checksum then failed before ProxySQL or its tests could build.

## Validation

- Reproduced the current checkout contract failure before the change.
- Parsed the updated reusable workflow and verified the checkout step has `lfs: true`.
- `git diff --check` passes.

This PR targets `GH-Actions`; it is required before rerunning the standard CI-builds jobs for PR #6048.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates Git LFS files during CI builds so the AWS SDK archive is present. Previously `actions/checkout` used lfs: false and left pointer files, causing vendored bundle checksum failures; now it sets lfs: true so builds and tests proceed.

- Adds lfs: true to the `actions/checkout` step in .github/workflows/ci-builds.yml.
- CI-only change; checkout may take longer due to LFS downloads.
- After merge, re-run CI-builds for PRs blocked by the checkout failure (e.g., #6048).

<sup>Written for commit fc4ba9d7a6ed8d55867331e3c4abf0f0c2c155c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to retrieve Git LFS-managed files during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->