### PR TITLE
fix(ci): install Git LFS on self-hosted builds

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -203,6 +203,21 @@ jobs:
           exit 1
         fi
 
+    # actions/checkout performs LFS smudging on the runner, before the
+    # Docker build container starts. Keep this guard on the self-hosted pool:
+    # GitHub-hosted images already provide git-lfs, while ci-vm-1 does not.
+    - name: Install Git LFS when absent (self-hosted)
+      if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
+      run: |
+        set -euo pipefail
+        if command -v git-lfs >/dev/null 2>&1; then
+          git-lfs --version
+          exit 0
+        fi
+        sudo -n apt-get update
+        sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install --yes git-lfs
+        git-lfs --version
+
     - name: Checkout repository
       if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4


### PR DESCRIPTION
## Summary

Install `git-lfs` on a self-hosted CI runner only when it is absent, before `actions/checkout` performs LFS smudging.

## Root cause

All CI-builds matrix legs stopped during checkout on `ci-vm-1` because the workflow enables `lfs: true` while that runner image lacks the `git-lfs` executable. The Docker build container never starts before checkout.

## Validation

- Parsed `.github/workflows/ci-builds.yml` as YAML.
- Asserted the guarded install step precedes checkout and invokes `apt-get install --yes git-lfs`.
- `git diff --check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs `git-lfs` on self-hosted CI runners when missing, before `actions/checkout` smudges LFS. Previously, builds on `ci-vm-1` failed during checkout due to missing `git-lfs`; now checkout completes and Docker builds start.

**Review notes**
- Adds a pre-checkout step gated to `self-hosted` runners with `inputs.trusted` and when `steps.cache-check.outputs.cache-hit` is not true.
- The step no-ops if `git-lfs` exists; otherwise runs `apt-get update` and installs `git-lfs` via `sudo` non-interactively.
- GitHub-hosted runners are unchanged; they already include `git-lfs`.

<sup>Written for commit 51aae4c1cbd6eba96aafc64fb1e289903c89820e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved self-hosted build setup by automatically installing Git LFS when it is unavailable.
  * Added verification to confirm the installed Git LFS version before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->