### PR TITLE
fix(mysql): require TLS for SPIFFE users (#5929)

### DIFF
--- a/lib/MySQL_Authentication.cpp
+++ b/lib/MySQL_Authentication.cpp
@@ -178,6 +178,7 @@ bool MySQL_Authentication::add(char * username, char * password, enum cred_usern
 	}
 #endif
 	uint64_t hash1, hash2;
+	bool effective_use_ssl = use_ssl;
 	SpookyHash myhash;
 	myhash.Init(1,2);
 	myhash.Update(username,strlen(username));
@@ -306,7 +307,19 @@ bool MySQL_Authentication::add(char * username, char * password, enum cred_usern
 		// FIXME: if the password is a clear text password, automatically generate sha1_pass and clear_text_password
 	}
 
-	ad->use_ssl=use_ssl;
+	if (ad->attributes && strlen(ad->attributes)) {
+		try {
+			nlohmann::json valid=nlohmann::json::parse(ad->attributes);
+			if (valid.find("spiffe_id") != valid.end()) {
+				effective_use_ssl = true;
+			}
+		}
+		catch(nlohmann::json::exception&) {
+			// Invalid attributes do not require TLS.
+		}
+	}
+
+	ad->use_ssl=effective_use_ssl;
 	ad->default_hostgroup=default_hostgroup;
 	ad->schema_locked=schema_locked;
 	ad->transaction_persistent=transaction_persistent;

--- a/test/tap/tests/unit/auth_unit-t.cpp
+++ b/test/tap/tests/unit/auth_unit-t.cpp
@@ -52,6 +52,15 @@ static bool mysql_add_frontend(MySQL_Authentication *auth,
 	);
 }
 
+static bool mysql_add_frontend_with_attributes(MySQL_Authentication *auth,
+	const char *user, bool use_ssl, const char *attributes)
+{
+	return auth->add(
+		(char *)user, (char *)"pass", USERNAME_FRONTEND,
+		use_ssl, 0, (char *)"", false, false, false,
+		100, (char *)attributes, (char *)"");
+}
+
 // ============================================================================
 // Helper: add a MySQL backend user
 // ============================================================================
@@ -449,6 +458,90 @@ static void test_mysql_frontend_backend_separation() {
 	free_account_details(be);
 }
 
+static void test_mysql_spiffe_requires_ssl() {
+	GloMyAuth->reset();
+
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "spiffe-user", false,
+		R"({"spiffe_id":"spiffe://example.org/ns/default/sa/client"})");
+	account_details_t account = GloMyAuth->lookup(
+		(char *)"spiffe-user", USERNAME_FRONTEND, { false, false, false });
+	ok(account.use_ssl, "MySQL: SPIFFE user requires TLS");
+	free_account_details(account);
+
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "spiffe-user", false,
+		R"({"spiffe_id":"spiffe://example.org/ns/default/sa/client"})");
+	account = GloMyAuth->lookup(
+		(char *)"spiffe-user", USERNAME_FRONTEND, { false, false, false });
+	ok(account.use_ssl, "MySQL: SPIFFE user remains TLS-required on update");
+	free_account_details(account);
+
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "plain-user", false, R"({"role":"client"})");
+	account = GloMyAuth->lookup(
+		(char *)"plain-user", USERNAME_FRONTEND, { false, false, false });
+	ok(!account.use_ssl, "MySQL: non-SPIFFE user preserves explicit TLS setting");
+	free_account_details(account);
+}
+
+static void test_mysql_invalid_spiffe_attributes_do_not_require_ssl() {
+	GloMyAuth->reset();
+
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "invalid-spiffe-user", false, R"({"role":"client"})");
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "invalid-spiffe-user", false,
+		R"({"spiffe_id":"spiffe://example.org/ns/default/sa/client","default-transaction_isolation":123})");
+	account_details_t account = GloMyAuth->lookup(
+		(char *)"invalid-spiffe-user", USERNAME_FRONTEND, { false, false, true });
+	ok(!account.use_ssl, "MySQL: invalid SPIFFE attributes preserve explicit TLS setting");
+	ok(account.attributes != nullptr && account.attributes[0] == '\0',
+		"MySQL: invalid SPIFFE attributes are cleared");
+	free_account_details(account);
+}
+
+static void test_mysql_spiffe_attributes_case_variant_requires_ssl() {
+	GloMyAuth->reset();
+
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "case-variant-spiffe-user", false,
+		R"({"spiffe_id":"spiffe://example.org/ns/default/sa/client"})");
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "case-variant-spiffe-user", false,
+		R"({"SPIFFE_ID":"spiffe://example.org/ns/default/sa/client"})");
+	account_details_t account = GloMyAuth->lookup(
+		(char *)"case-variant-spiffe-user", USERNAME_FRONTEND,
+		{ false, false, true });
+	ok(account.use_ssl, "MySQL: retained SPIFFE attributes require TLS");
+	ok(account.attributes != nullptr &&
+		strcmp(account.attributes,
+			R"({"spiffe_id":"spiffe://example.org/ns/default/sa/client"})") == 0,
+		"MySQL: case-variant update retains recognized SPIFFE attributes");
+	free_account_details(account);
+}
+
+static void test_mysql_spiffe_changed_attributes_toggle_ssl() {
+	GloMyAuth->reset();
+
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "changed-spiffe-user", false, R"({"role":"client"})");
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "changed-spiffe-user", false,
+		R"({"spiffe_id":"spiffe://example.org/ns/default/sa/client","role":"client"})");
+	account_details_t account = GloMyAuth->lookup(
+		(char *)"changed-spiffe-user", USERNAME_FRONTEND, { false, false, false });
+	ok(account.use_ssl, "MySQL: changed SPIFFE attributes require TLS");
+	free_account_details(account);
+
+	mysql_add_frontend_with_attributes(
+		GloMyAuth, "changed-spiffe-user", false, R"({"role":"updated"})");
+	account = GloMyAuth->lookup(
+		(char *)"changed-spiffe-user", USERNAME_FRONTEND, { false, false, false });
+	ok(!account.use_ssl, "MySQL: changed non-SPIFFE attributes clear TLS requirement");
+	free_account_details(account);
+}
+
 // ============================================================================
 // 8. PgSQL_Authentication: Core CRUD
 // ============================================================================
@@ -558,7 +651,7 @@ static void test_pgsql_inactive_pattern() {
 // ============================================================================
 
 int main() {
-	plan(60);
+	plan(69);
 
 	test_init_minimal();
 	test_init_auth();
@@ -577,6 +670,10 @@ int main() {
 	test_mysql_checksums();                  // 4 tests
 	test_mysql_memory();                     // 3 tests
 	test_mysql_frontend_backend_separation();// 4 tests
+	test_mysql_spiffe_requires_ssl();        // 3 tests
+	test_mysql_invalid_spiffe_attributes_do_not_require_ssl(); // 2 tests
+	test_mysql_spiffe_attributes_case_variant_requires_ssl(); // 2 tests
+	test_mysql_spiffe_changed_attributes_toggle_ssl(); // 2 tests
 
 	// PgSQL tests
 	test_pgsql_add_exists_lookup();          // 5 tests


### PR DESCRIPTION
## Summary
- Force the runtime MySQL `use_ssl` flag when the final retained user attributes contain `spiffe_id`.
- Preserve existing attribute validation and leave rejected attributes at the supplied TLS setting.
- Add real authentication-store coverage for initial, retained, changed, and removed SPIFFE attributes.

## Root cause
SPIFFE identity verification requires the client certificate SAN, but the authentication runtime could retain `spiffe_id` while accepting `use_ssl=0`.

## Validation
- `PROXYSQL31=1 make build_lib -j"$(nproc)"`
- `make -C test/tap/tests/unit auth_unit-t`
- `test/tap/tests/unit/auth_unit-t` (69 assertions)
- `git diff --check origin/v3.0..HEAD`

Fixes #5929

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces TLS for MySQL frontend users with SPIFFE identities. Previously the runtime could retain a `spiffe_id` while accepting `use_ssl=0`; now `use_ssl` is forced to true when retained attributes include `spiffe_id`, preventing connections without certificate SAN verification.

- Sets `ad->use_ssl` via an `effective_use_ssl` that becomes true when valid JSON attributes contain `spiffe_id`; otherwise preserves the supplied flag. Attribute validation is unchanged; invalid JSON or unknown keys leave TLS as provided. Retained valid `spiffe_id` continues to require TLS across updates.
- Adds unit tests for initial add, retained, changed, and removed SPIFFE attributes; test plan increases from 60 to 69.

**Operational impact**
- SPIFFE users must connect over TLS with a client certificate that includes the SPIFFE ID in SAN. Update client/proxy configs as needed.
- No change for users without a `spiffe_id` or with invalid attributes.

<sup>Written for commit deb0722d924bc78ad96eb8e4f5b059b30fea49e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Accounts with valid SPIFFE identities now automatically require TLS connections.
  - TLS requirements remain consistent when SPIFFE-enabled accounts are updated.
  - Changes to account attributes correctly update TLS enforcement.

- **Bug Fixes**
  - Invalid or non-SPIFFE attributes no longer incorrectly alter TLS requirements.
  - Case variations in recognized attributes are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->