### PR TITLE
fix(ci): protect shared base image tag

### DIFF
--- a/.github/workflows/CI-push-ci-base-image.yml
+++ b/.github/workflows/CI-push-ci-base-image.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/v3.0' }}
+            type=ref,event=branch,prefix=branch-
             type=sha,prefix=
 
       - name: Build and push Docker image

--- a/test/infra/docker-base/Dockerfile
+++ b/test/infra/docker-base/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update -qq && \
         "psycopg[binary]==${PSYCOPG_VERSION}" \
         "mysql-connector-python==${MYSQL_CONNECTOR_PYTHON_VERSION}" \
         "mysqlx-connector-python==${MYSQL_CONNECTOR_PYTHON_VERSION}" \
+    && python3 -c "import psycopg; assert psycopg.__version__ == '${PSYCOPG_VERSION}'" \
     && wget https://github.com/proxysql/orchestrator/releases/download/v4.31.1/orchestrator-client_4.31.1_amd64.deb -O /tmp/orc.deb \
     && apt-get install -y /tmp/orc.deb \
     && rm -rf /var/lib/apt/lists/* /tmp/orc.deb


### PR DESCRIPTION
## Summary

- allow only `v3.0` to publish `ghcr.io/sysown/proxysql-ci-base:latest`
- publish manual feature-branch builds under branch and SHA tags instead
- fail the image build unless pinned `psycopg 3.2.13` imports successfully

## Root cause

A successful manual dispatch from a feature branch unconditionally published `latest`. That branch image omitted `psycopg`, replacing the working shared image and causing `pgsql-user-sync-t` to fail before its test logic ran.

## Recovery and validation

- rebuilt and published the current shared image from `v3.0`: https://github.com/sysown/proxysql/actions/runs/31803075762
- the recovery build installed `psycopg==3.2.13` and `psycopg-binary==3.2.13`
- parsed the modified workflow as YAML and verified the exact tag policy
- verified the pinned install/import assertion and ran `git diff --check`
- manually dispatched this branch workflow to validate that it publishes branch/SHA tags without replacing `latest`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects the shared base image `latest` tag and adds a build-time guard for `psycopg` to prevent broken test images. Previously, any feature-branch dispatch published `latest` and replaced the working image, breaking `pgsql-user-sync-t`; now only `v3.0` can publish `latest`.

- Workflow: publish `ghcr.io/sysown/proxysql-ci-base:latest` only from `v3.0`; feature-branch builds publish `branch-<branch>` and `<sha>` tags.
- Dockerfile: pin `psycopg`/`psycopg[binary]` and assert the installed version matches the pin during build.
- Migration: if you relied on feature-branch builds updating `latest`, switch consumers to `branch-<branch>` or a specific `<sha>` tag.

<sup>Written for commit 45e8b0363f52340bb5d12d0c5b074f633f44e766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image validation by confirming the installed database driver matches the expected version.
  * Updated image tagging so the `latest` tag is produced only for the `v3.0` branch.
  * Added branch-specific image tags for clearer version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->