### PR TITLE
fix(admin): support mysqldump session timeout SETs

### DIFF
--- a/docs/superpowers/plans/2026-08-14-issue-6010-admin-mysqldump-set.md
+++ b/docs/superpowers/plans/2026-08-14-issue-6010-admin-mysqldump-set.md
@@ -1,0 +1,272 @@
+# Issue #6010 Admin mysqldump SET Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let MySQL 8 `mysqldump --set-gtid-purged=OFF --column-statistics=0` complete an Admin backup by accepting its scoped client-timeout `SET` statement.
+
+**Architecture:** Preserve Admin configuration updates on the existing `SET`-to-`UPDATE global_variables` path. Add a narrow parser ahead of that path: scope-qualified assignments whose names appear in `mysql_variables.ignore_vars` are successful Admin no-ops; the mysqldump two-timeout statement therefore returns an OK packet without persistent state. Strip an optional `SESSION`, `LOCAL`, or `GLOBAL` token before the legacy single-assignment validation so scope text is never incorporated into a variable name.
+
+**Tech Stack:** C++17, ProxySQL Admin handler, MariaDB C client TAP test, Docker-backed TAP infrastructure.
+
+## Global Constraints
+
+- Support only the documented MySQL 8 dump command with `--set-gtid-purged=OFF --column-statistics=0`.
+- Do not add `@@GLOBAL.gtid_executed` or `information_schema.COLUMN_STATISTICS` compatibility in this issue.
+- Scoped ignored variables are no-ops and must not create or modify `global_variables` rows.
+- Preserve the current error path for unknown variables and the current translation for configured Admin variables.
+- Keep the test in `mysql84-g1`, matching the affected MySQL 8 client path.
+
+---
+
+## File Structure
+
+- `lib/Admin_Handler.cpp` — recognizes scope tokens and the existing MySQL ignored-variable set while handling Admin `SET` commands.
+- `test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp` — exercises the real Admin protocol behavior required by mysqldump.
+- `test/tap/groups/groups.json` — schedules the regression test in the MySQL 8 TAP group.
+
+### Task 1: Add a failing Admin compatibility regression
+
+**Files:**
+
+- Create: `test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp`
+- Modify: `test/tap/groups/groups.json: near the other admin tests`
+
+**Interfaces:**
+
+- Consumes: `CommandLine`, `mysql_query_t`, `tap.h`, and the Admin endpoint supplied by the TAP infrastructure.
+- Produces: `reg_test_6010_admin_mysqldump_set-t`, a standalone TAP binary with five assertions.
+
+- [ ] **Step 1: Write the failing regression source**
+
+```cpp
+#include <cstdlib>
+
+#include "mysql.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+static long long count_timeout_rows(MYSQL* admin) {
+    const char* query =
+        "SELECT COUNT(*) FROM global_variables "
+        "WHERE variable_name IN ('net_read_timeout', 'net_write_timeout')";
+    if (mysql_query_t(admin, query) != 0) return -1;
+    MYSQL_RES* result = mysql_store_result(admin);
+    MYSQL_ROW row = result ? mysql_fetch_row(result) : nullptr;
+    const long long count = row ? atoll(row[0]) : -1;
+    if (result) mysql_free_result(result);
+    return count;
+}
+
+int main() {
+    CommandLine cl;
+    if (cl.getEnv()) return EXIT_FAILURE;
+
+    MYSQL* admin = init_mysql_conn(cl.host, cl.admin_port,
+        cl.admin_username, cl.admin_password, false, false);
+    if (!admin) return EXIT_FAILURE;
+
+    plan(5);
+    const long long before = count_timeout_rows(admin);
+    ok(before == 0, "timeout variables are not Admin global variables before SET");
+
+    const int dump_set_rc = mysql_query_t(admin,
+        "SET SESSION NET_READ_TIMEOUT=86400, SESSION NET_WRITE_TIMEOUT=86400");
+    ok(dump_set_rc == 0, "mysqldump timeout SET succeeds");
+
+    const long long after = count_timeout_rows(admin);
+    ok(after == before, "mysqldump timeout SET has no persistent Admin side effect");
+
+    const int single_set_rc = mysql_query_t(admin,
+        "SET SESSION net_read_timeout=86400");
+    ok(single_set_rc == 0, "a scoped ignored timeout SET succeeds alone");
+
+    const int unknown_set_rc = mysql_query_t(admin,
+        "SET SESSION issue_6010_unknown_variable=1");
+    ok(unknown_set_rc != 0, "unknown scoped SET remains an error");
+
+    mysql_close(admin);
+    return exit_status();
+}
+```
+
+Add this scheduling entry in alphabetical position in `groups.json`:
+
+```json
+"reg_test_6010_admin_mysqldump_set-t" : [ "mysql84-g1" ],
+```
+
+- [ ] **Step 2: Build and run the regression before the handler change**
+
+Run:
+
+```bash
+make -C test/tap/tests reg_test_6010_admin_mysqldump_set-t
+export WORKSPACE=$PWD
+export INFRA_ID="issue6010-before-$(date +%s)"
+export TAP_GROUP="mysql84-g1"
+export TEST_PY_TAP_INCL="reg_test_6010_admin_mysqldump_set-t"
+export SKIP_CLUSTER_START=1
+source test/infra/common/env.sh
+./test/infra/control/ensure-infras.bash
+./test/infra/control/run-tests-isolated.bash
+./test/infra/control/stop-proxysql-isolated.bash
+```
+
+Expected: the second assertion fails because Admin reports `Unknown global variable: 'SESSION NET_READ_TIMEOUT'`.
+
+- [ ] **Step 3: Commit the test-only red state**
+
+```bash
+git add test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp test/tap/groups/groups.json
+git commit -m "test: reproduce Admin mysqldump SET failure"
+```
+
+### Task 2: Recognize scoped ignored MySQL variables in the Admin handler
+
+**Files:**
+
+- Modify: `lib/Admin_Handler.cpp: include block and admin_handler_command_set`
+- Test: `test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp`
+
+**Interfaces:**
+
+- Consumes: `mysql_variables.ignore_vars` declared by `MySQL_Protocol.h`; its members include `net_read_timeout` and `net_write_timeout`.
+- Produces: `admin_handler_command_set()` sends an Admin OK packet and returns `false` when every comma-separated assignment is a `SESSION` or `LOCAL` ignored MySQL variable; it otherwise follows the existing validation/update path.
+
+- [ ] **Step 1: Add focused parser helpers above `admin_handler_command_set`**
+
+Include `MySQL_Protocol.h`, then add helpers with these responsibilities:
+
+```cpp
+enum class admin_set_scope { implicit, session, local, global };
+
+static admin_set_scope strip_admin_set_scope(char*& variable_name) {
+    // Skip leading spaces, compare SESSION/LOCAL/GLOBAL case-insensitively,
+    // move variable_name past a matched token and its following spaces, and
+    // return the matched scope. Return implicit when no token is present.
+}
+
+static bool is_ignored_mysql_variable(const char* variable_name) {
+    return std::any_of(mysql_variables.ignore_vars.cbegin(),
+        mysql_variables.ignore_vars.cend(), [variable_name](const std::string& ignored) {
+            return strcasecmp(ignored.c_str(), variable_name) == 0;
+        });
+}
+
+static bool is_ignored_scoped_set(char* assignments) {
+    // Split only on commas between assignments, split each assignment once at
+    // '=', trim its left side, strip its scope, and return true only when the
+    // input contains at least one assignment and every assignment has SESSION
+    // or LOCAL scope and names an ignored MySQL variable.
+}
+```
+
+Use a local mutable copy of the assignment text in `is_ignored_scoped_set`;
+the original query remains available for the legacy handler. The comma loop
+must consume both timeout assignments, not stop after the first `=`.
+
+- [ ] **Step 2: Route scoped ignored assignments to an OK packet**
+
+Immediately after logging in `admin_handler_command_set`, classify the text
+after `SET `:
+
+```cpp
+if (is_ignored_scoped_set(query_no_space + sizeof("SET ") - 1)) {
+    pa->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+    return false;
+}
+```
+
+For the existing one-assignment path, call
+`strip_admin_set_scope(var_name)` after
+`trim_spaces_in_place(untrimmed_var_name)` and before
+`is_sensitive_set_variable_name()` or `is_valid_global_variable()`. This
+lets `SET GLOBAL mysql-...=...` reach the current Admin variable validation
+while leaving unscoped Admin behavior unchanged. The unknown-variable error
+branch remains unchanged.
+
+- [ ] **Step 3: Rebuild the changed server and focused TAP binary**
+
+Run:
+
+```bash
+make -j2 build_src_debug
+make -C test/tap/tests reg_test_6010_admin_mysqldump_set-t
+```
+
+Expected: both commands finish successfully; `src/proxysql` and the focused
+TAP binary exist.
+
+- [ ] **Step 4: Run the focused TAP regression against the changed server**
+
+Run:
+
+```bash
+export WORKSPACE=$PWD
+export INFRA_ID="issue6010-after-$(date +%s)"
+export TAP_GROUP="mysql84-g1"
+export TEST_PY_TAP_INCL="reg_test_6010_admin_mysqldump_set-t"
+export SKIP_CLUSTER_START=1
+source test/infra/common/env.sh
+./test/infra/control/ensure-infras.bash
+./test/infra/control/run-tests-isolated.bash
+./test/infra/control/stop-proxysql-isolated.bash
+```
+
+Expected: all five TAP assertions pass. On a failure, inspect
+`ci_infra_logs/$INFRA_ID/tests/proxysql-tester.py/tests/reg_test_6010_admin_mysqldump_set-t.log.gz`.
+
+- [ ] **Step 5: Commit the handler implementation**
+
+```bash
+git add lib/Admin_Handler.cpp
+git commit -m "fix: accept mysqldump session timeout SETs in Admin"
+```
+
+### Task 3: Verify the intended scope and final diff
+
+**Files:**
+
+- Modify: no additional source files expected
+- Test: `test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp`
+
+**Interfaces:**
+
+- Consumes: the focused TAP test and the new Admin handler classification.
+- Produces: evidence that this branch implements only the flagged mysqldump compatibility path.
+
+- [ ] **Step 1: Confirm excluded functionality has not been added**
+
+Run:
+
+```bash
+git diff origin/v3.0...HEAD -- lib/Admin_Handler.cpp test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp test/tap/groups/groups.json
+rg -n 'gtid_executed|COLUMN_STATISTICS' lib/Admin_Handler.cpp test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp
+```
+
+Expected: the diff is limited to scoped ignored-`SET` handling and the
+regression test. No new GTID or `COLUMN_STATISTICS` compatibility behavior is
+present.
+
+- [ ] **Step 2: Check formatting and repository state**
+
+Run:
+
+```bash
+git diff --check origin/v3.0...HEAD
+git status --short --branch
+git log --oneline origin/v3.0..HEAD
+```
+
+Expected: no whitespace errors, a clean worktree, and the design, test, and
+implementation commits on `fix/6010-admin-mysqldump-set`.
+
+- [ ] **Step 3: Commit only if verification requires a correction**
+
+For a needed correction, stage the exact changed files and use this message:
+
+```bash
+git commit -m "test: finalize issue 6010 coverage"
+```
+

--- a/docs/superpowers/plans/2026-08-14-issue-6010-admin-mysqldump-set.md
+++ b/docs/superpowers/plans/2026-08-14-issue-6010-admin-mysqldump-set.md
@@ -269,4 +269,3 @@ For a needed correction, stage the exact changed files and use this message:
 ```bash
 git commit -m "test: finalize issue 6010 coverage"
 ```
-

--- a/docs/superpowers/specs/2026-08-14-issue-6010-admin-mysqldump-set-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-6010-admin-mysqldump-set-design.md
@@ -1,0 +1,51 @@
+# Issue #6010: Admin mysqldump SET compatibility
+
+## Goal
+
+Allow MySQL 8 `mysqldump` to back up the ProxySQL Admin interface when invoked
+with `--set-gtid-purged=OFF --column-statistics=0`.
+
+## Scope
+
+The supported dump invocation sends:
+
+```sql
+SET SESSION NET_READ_TIMEOUT=86400, SESSION NET_WRITE_TIMEOUT=86400;
+```
+
+Admin must accept that statement without changing its persistent configuration.
+The two command-line options deliberately keep these unsupported statements out
+of scope:
+
+- `SELECT @@GLOBAL.gtid_executed`
+- queries against `information_schema.COLUMN_STATISTICS`
+
+## Design
+
+`admin_handler_command_set` will recognize and remove an optional `SESSION`,
+`LOCAL`, or `GLOBAL` scope token from each assignment before it validates the
+variable name. A scoped assignment to a known client-only MySQL variable is a
+successful no-op because ProxySQL Admin has no session state to store.
+
+The client-only variable recognition will use the existing `MySQL_Variables`
+ignored-variable list, which already includes `net_read_timeout` and
+`net_write_timeout`. Existing Admin variables will continue through the current
+`UPDATE global_variables` translation. Unknown variables will continue to
+produce an error rather than being silently accepted.
+
+The parser will process comma-separated assignments consistently, so a
+single-variable statement and a multi-variable statement follow the same
+validation rules. The implementation will not special-case one mysqldump query
+string.
+
+## Testing
+
+Add a TAP regression test that connects to Admin and verifies that:
+
+1. the exact mysqldump timeout `SET SESSION` statement succeeds;
+2. the timeout assignments do not create or alter rows in `global_variables`;
+3. scoped normal Admin assignments retain their existing persistent behavior;
+4. an unknown scoped assignment returns an error.
+
+The focused test will run with the Admin endpoint in the standard MySQL TAP
+test group. A debug build and the focused TAP test will verify the change.

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -1341,8 +1341,12 @@ bool is_valid_global_variable(const char *var_name) {
 
 enum class admin_set_scope { implicit, session, local, global };
 
+static bool is_admin_set_whitespace(char character) {
+	return character == ' ' || (character >= '\t' && character <= '\r');
+}
+
 static admin_set_scope strip_admin_set_scope(char*& variable_name) {
-	while (isspace(*variable_name)) {
+	while (is_admin_set_whitespace(*variable_name)) {
 		++variable_name;
 	}
 
@@ -1358,9 +1362,9 @@ static admin_set_scope strip_admin_set_scope(char*& variable_name) {
 
 	for (const auto& scope_token : scope_tokens) {
 		const size_t token_length = strlen(scope_token.token);
-		if (strncasecmp(variable_name, scope_token.token, token_length) == 0 && isspace(variable_name[token_length])) {
+		if (strncasecmp(variable_name, scope_token.token, token_length) == 0 && is_admin_set_whitespace(variable_name[token_length])) {
 			variable_name += token_length;
-			while (isspace(*variable_name)) {
+			while (is_admin_set_whitespace(*variable_name)) {
 				++variable_name;
 			}
 			return scope_token.scope;

--- a/lib/Admin_Handler.cpp
+++ b/lib/Admin_Handler.cpp
@@ -83,6 +83,7 @@ using json = nlohmann::json;
 #include <uuid/uuid.h>
 
 #include "PgSQL_Protocol.h"
+#include "MySQL_Protocol.h"
 #include "MySQL_Query_Cache.h"
 #include "PgSQL_Query_Cache.h"
 //#include "usual/time.h"
@@ -1338,6 +1339,99 @@ bool is_valid_global_variable(const char *var_name) {
 	}
 }
 
+enum class admin_set_scope { implicit, session, local, global };
+
+static admin_set_scope strip_admin_set_scope(char*& variable_name) {
+	while (isspace(*variable_name)) {
+		++variable_name;
+	}
+
+	struct scope_token_t {
+		const char* token;
+		admin_set_scope scope;
+	};
+	const scope_token_t scope_tokens[] = {
+		{"SESSION", admin_set_scope::session},
+		{"LOCAL", admin_set_scope::local},
+		{"GLOBAL", admin_set_scope::global},
+	};
+
+	for (const auto& scope_token : scope_tokens) {
+		const size_t token_length = strlen(scope_token.token);
+		if (strncasecmp(variable_name, scope_token.token, token_length) == 0 && isspace(variable_name[token_length])) {
+			variable_name += token_length;
+			while (isspace(*variable_name)) {
+				++variable_name;
+			}
+			return scope_token.scope;
+		}
+	}
+
+	return admin_set_scope::implicit;
+}
+
+static bool is_ignored_mysql_variable(const char* variable_name) {
+	return std::any_of(mysql_variables.ignore_vars.cbegin(), mysql_variables.ignore_vars.cend(),
+		[variable_name](const std::string& ignored) {
+			return strcasecmp(ignored.c_str(), variable_name) == 0;
+		});
+}
+
+static bool is_ignored_scoped_set(char* assignments) {
+	std::string mutable_assignments(assignments);
+	char* assignment = mutable_assignments.data();
+	bool has_assignment = false;
+	char quote = '\0';
+	int parenthesis_depth = 0;
+
+	for (char* current = assignment;; ++current) {
+		if (quote != '\0') {
+			if (*current == '\\' && quote != '`' && current[1] != '\0') {
+				++current;
+			} else if (*current == quote) {
+				quote = '\0';
+			}
+		} else if (*current == '\'' || *current == '"' || *current == '`') {
+			quote = *current;
+		} else if (*current == '(') {
+			++parenthesis_depth;
+		} else if (*current == ')') {
+			if (parenthesis_depth == 0) {
+				return false;
+			}
+			--parenthesis_depth;
+		}
+
+		if ((*current != ',' || quote != '\0' || parenthesis_depth != 0) && *current != '\0') {
+			continue;
+		}
+		if (*current == '\0' && (quote != '\0' || parenthesis_depth != 0)) {
+			return false;
+		}
+
+		const bool at_end = *current == '\0';
+		*current = '\0';
+		char* equals = strchr(assignment, '=');
+		if (equals == NULL) {
+			return false;
+		}
+		*equals = '\0';
+		char* variable_name = trim_spaces_in_place(assignment);
+		const admin_set_scope scope = strip_admin_set_scope(variable_name);
+		if ((scope != admin_set_scope::session && scope != admin_set_scope::local) || !is_ignored_mysql_variable(variable_name)) {
+			return false;
+		}
+		has_assignment = true;
+
+		if (at_end) {
+			break;
+		}
+		assignment = current + 1;
+	}
+
+	return has_assignment;
+}
+
 
 // This method translates a 'SET variable=value' command into an equivalent UPDATE. It doesn't yes support setting
 // multiple variables at once.
@@ -1359,6 +1453,11 @@ bool admin_handler_command_set(char *query_no_space, unsigned int query_no_space
 		}
 	}
 
+	if (is_ignored_scoped_set(query_no_space + sizeof("SET ") - 1)) {
+		pa->send_ok_msg_to_client(sess, NULL, 0, query_no_space);
+		return false;
+	}
+
 	// Get a pointer to the beginning of var=value entry and split to get var name and value
 	char *set_entry = query_no_space + sizeof("SET ") - 1;
 	char *untrimmed_var_name=NULL;
@@ -1367,6 +1466,7 @@ bool admin_handler_command_set(char *query_no_space, unsigned int query_no_space
 
 	// Trim spaces from var name to allow writing like 'var = value'
 	char *var_name = trim_spaces_in_place(untrimmed_var_name);
+	strip_admin_set_scope(var_name);
 
 	if (is_sensitive_set_variable_name(var_name)) {
 		proxy_info("Received SET command for %s\n", var_name);

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -300,6 +300,7 @@
   "reg_test_5790-mariadb_collation_255-t" : [ "mariadb10-galera-g1" ],
   "reg_test_5977_fast_forward_unix_socket_compression-t" : [ "legacy-g9" ],
   "reg_test_5988-caching_sha2_rsa-t" : [ "no-infra-g1","@proxysql_min_version:3.1" ],
+  "reg_test_6010_admin_mysqldump_set-t" : [ "mysql84-g1" ],
   "reg_test__ssl_client_busy_wait-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],
   "reg_test_com_change_user_malformed_packet-t" : [ "mysql84-g6","mysql95-g1" ],
   "reg_test_compression_split_packets-t" : [ "legacy-g2","mysql-auto_increment_delay_multiplex=0-g2","mysql-multiplexing=false-g2","mysql-query_digests=0-g2","mysql-query_digests_keep_comment=1-g2","mysql84-g2","mysql90-g2","mysql95-g2" ],

--- a/test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp
+++ b/test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <string>
 
 #include "mysql.h"
 #include "tap.h"
@@ -8,13 +9,25 @@
 static long long count_timeout_rows(MYSQL* admin) {
 	const char* query =
 		"SELECT COUNT(*) FROM global_variables "
-		"WHERE variable_name IN ('net_read_timeout', 'net_write_timeout')";
+		"WHERE variable_name COLLATE NOCASE IN ('net_read_timeout', 'net_write_timeout')";
 	if (mysql_query_t(admin, query) != 0) return -1;
 	MYSQL_RES* result = mysql_store_result(admin);
 	MYSQL_ROW row = result ? mysql_fetch_row(result) : nullptr;
 	const long long count = row ? atoll(row[0]) : -1;
 	if (result) mysql_free_result(result);
 	return count;
+}
+
+static std::string get_global_variable_value(MYSQL* admin, const char* variable_name) {
+	const std::string query = std::string(
+		"SELECT variable_value FROM global_variables WHERE variable_name='") +
+		variable_name + "'";
+	if (mysql_query_t(admin, query.c_str()) != 0) return {};
+	MYSQL_RES* result = mysql_store_result(admin);
+	MYSQL_ROW row = result ? mysql_fetch_row(result) : nullptr;
+	const std::string value = row ? row[0] : "";
+	if (result) mysql_free_result(result);
+	return value;
 }
 
 int main() {
@@ -25,7 +38,7 @@ int main() {
 		cl.admin_username, cl.admin_password, false, false);
 	if (!admin) return EXIT_FAILURE;
 
-	plan(5);
+	plan(10);
 	const long long before = count_timeout_rows(admin);
 	ok(before == 0, "timeout variables are not Admin global variables before SET");
 
@@ -43,6 +56,27 @@ int main() {
 	const int unknown_set_rc = mysql_query_t(admin,
 		"SET SESSION issue_6010_unknown_variable=1");
 	ok(unknown_set_rc != 0, "unknown scoped SET remains an error");
+
+	const std::string original_refresh_interval =
+		get_global_variable_value(admin, "admin-refresh_interval");
+	const std::string updated_refresh_interval =
+		original_refresh_interval == "1000" ? "1001" : "1000";
+	const int scoped_global_set_rc = mysql_query_t(admin,
+		("SET GLOBAL admin-refresh_interval=" + updated_refresh_interval).c_str());
+	const std::string changed_refresh_interval =
+		get_global_variable_value(admin, "admin-refresh_interval");
+	const int restore_refresh_interval_rc = original_refresh_interval.empty() ? -1 :
+		mysql_query_t(admin, ("SET GLOBAL admin-refresh_interval=" + original_refresh_interval).c_str());
+	const std::string restored_refresh_interval =
+		get_global_variable_value(admin, "admin-refresh_interval");
+
+	ok(!original_refresh_interval.empty(), "admin-refresh_interval has an original value");
+	ok(scoped_global_set_rc == 0, "scoped GLOBAL Admin SET succeeds");
+	ok(changed_refresh_interval == updated_refresh_interval,
+		"scoped GLOBAL Admin SET updates global_variables");
+	ok(restore_refresh_interval_rc == 0, "admin-refresh_interval restore succeeds");
+	ok(restored_refresh_interval == original_refresh_interval,
+		"admin-refresh_interval is restored after scoped GLOBAL SET");
 
 	mysql_close(admin);
 	return exit_status();

--- a/test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp
+++ b/test/tap/tests/reg_test_6010_admin_mysqldump_set-t.cpp
@@ -1,0 +1,49 @@
+#include <cstdlib>
+
+#include "mysql.h"
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+static long long count_timeout_rows(MYSQL* admin) {
+	const char* query =
+		"SELECT COUNT(*) FROM global_variables "
+		"WHERE variable_name IN ('net_read_timeout', 'net_write_timeout')";
+	if (mysql_query_t(admin, query) != 0) return -1;
+	MYSQL_RES* result = mysql_store_result(admin);
+	MYSQL_ROW row = result ? mysql_fetch_row(result) : nullptr;
+	const long long count = row ? atoll(row[0]) : -1;
+	if (result) mysql_free_result(result);
+	return count;
+}
+
+int main() {
+	CommandLine cl;
+	if (cl.getEnv()) return EXIT_FAILURE;
+
+	MYSQL* admin = init_mysql_conn(cl.host, cl.admin_port,
+		cl.admin_username, cl.admin_password, false, false);
+	if (!admin) return EXIT_FAILURE;
+
+	plan(5);
+	const long long before = count_timeout_rows(admin);
+	ok(before == 0, "timeout variables are not Admin global variables before SET");
+
+	const int dump_set_rc = mysql_query_t(admin,
+		"SET SESSION NET_READ_TIMEOUT=86400, SESSION NET_WRITE_TIMEOUT=86400");
+	ok(dump_set_rc == 0, "mysqldump timeout SET succeeds");
+
+	const long long after = count_timeout_rows(admin);
+	ok(after == before, "mysqldump timeout SET has no persistent Admin side effect");
+
+	const int single_set_rc = mysql_query_t(admin,
+		"SET SESSION net_read_timeout=86400");
+	ok(single_set_rc == 0, "a scoped ignored timeout SET succeeds alone");
+
+	const int unknown_set_rc = mysql_query_t(admin,
+		"SET SESSION issue_6010_unknown_variable=1");
+	ok(unknown_set_rc != 0, "unknown scoped SET remains an error");
+
+	mysql_close(admin);
+	return exit_status();
+}


### PR DESCRIPTION
## Summary

Fixes #6010 by accepting MySQL 8 `mysqldump`'s scoped `NET_READ_TIMEOUT` / `NET_WRITE_TIMEOUT` assignments on the Admin interface as harmless no-ops.

The Admin `SET` path now strips `SESSION`, `LOCAL`, and `GLOBAL` scope tokens before legacy validation. A comma-separated statement is accepted without persistence only when every assignment is a scoped ignored MySQL variable, preserving errors for unknown settings.

## Why

MySQL 8 `mysqldump` sends `SET SESSION NET_READ_TIMEOUT=86400, SESSION NET_WRITE_TIMEOUT=86400` before dumping. Admin previously treated `SESSION` as part of the variable name and aborted the backup.

## Validation

- `make -j2 testall`
- Focused `mysql84-g1` regression executed directly against an isolated rebuilt ProxySQL: 10/10 TAP assertions passed.
- `git diff --check origin/v3.0...HEAD`

The scope intentionally excludes GTID and column-statistics compatibility; those remain disabled by `--set-gtid-purged=OFF --column-statistics=0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts MySQL 8 mysqldump’s scoped timeout SETs on the Admin interface so backups don’t fail. Previously, Admin parsed `SESSION NET_READ_TIMEOUT`/`NET_WRITE_TIMEOUT` as unknown variables and aborted; now these scoped assignments return OK and do not persist any change.

- Strips `SESSION`/`LOCAL`/`GLOBAL` tokens before validation. Returns OK with no persistence only when every comma-separated assignment is a scoped ignored MySQL variable (e.g., `net_read_timeout`, `net_write_timeout`).
- Unknown variables still error; `SET GLOBAL <admin-var>=...` continues to update `global_variables` as before.
- Parser handles comma-separated assignments and respects quotes/parentheses.
- No GTID or `COLUMN_STATISTICS` compatibility added; use `--set-gtid-purged=OFF --column-statistics=0`.
- Adds TAP regression `reg_test_6010_admin_mysqldump_set-t` to `mysql84-g1`.

<sup>Written for commit 4e833734fa1c2aba535db99813b99929fa7e6c79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with MySQL 8 `mysqldump` timeout `SET` statements.
  * Supports `SESSION`, `LOCAL`, and `GLOBAL` variable scopes, including comma-separated assignments.
  * Recognized client-only timeout settings are accepted without persisting unsupported values.
  * Existing Admin variable updates and unknown-variable errors remain supported.

* **Tests**
  * Added regression coverage for scoped assignments, non-persistent timeout settings, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->