### PR TITLE
fix(threads): repair IDLE_THREADS shutdown NULL deref and use-after-free

### DIFF
--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -25,11 +25,11 @@
 #define MIN_POLL_LEN 8
 #define MIN_POLL_DELETE_RATIO  8
 #define MY_EPOLL_THREAD_MAXEVENTS 128
+*/
 /// @brief How often wait_for_all_threads_to_exit_run_loop() logs that it is still waiting.
 #ifndef THREADS_EXIT_REPORT_INTERVAL_US
 #define THREADS_EXIT_REPORT_INTERVAL_US (10*1000*1000ULL)
 #endif
-*/
 
 #define ADMIN_HOSTGROUP	(-2)
 #define STATS_HOSTGROUP	(-3)

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -421,6 +421,8 @@ class MySQL_Threads_Handler
 {
 	private:
 	int shutdown_;
+	/// @brief Number of worker + idle threads that already left MySQL_Thread::run().
+	std::atomic<unsigned int> threads_exited_run_loop;
 	size_t stacksize;
 	pthread_attr_t attr;
 	pthread_rwlock_t rwlock;
@@ -846,6 +848,33 @@ class MySQL_Threads_Handler
 	void init(unsigned int num=0, size_t stack=0);
 	proxysql_mysql_thread_t *create_thread(unsigned int tn, void *(*start_routine) (void *), bool);
 	void shutdown_threads();
+	/**
+	 * @brief Rendezvous for all worker and idle threads before they self-delete.
+	 *
+	 * Worker and idle threads dereference each other's MySQL_Thread objects:
+	 * MySQL_Thread::run_MoveSessionsBetweenThreads() reads
+	 * mysql_threads_idles[rand()].worker, and the idle branch of
+	 * MySQL_Thread::run() reads mysql_threads[rand()].worker and then locks that
+	 * worker's myexchange mutex unconditionally. Because the peer is picked at
+	 * random and both directions exist, no pthread_join() ordering in
+	 * shutdown_threads() can make self-deletion safe -- each thread destroys its
+	 * own MySQL_Thread from its own thread function, which pthread_join() only
+	 * observes after the fact.
+	 *
+	 * Destruction must nevertheless stay on the owning thread, because
+	 * ~MySQL_Thread() frees __thread variables (mysql_thread___*) and calls
+	 * GloMyQPro->end_thread().
+	 *
+	 * Every worker and idle thread therefore calls this right after
+	 * MySQL_Thread::run() returns and before deleting its own MySQL_Thread. It
+	 * returns only once all of them have left run(), so no MySQL_Thread is ever
+	 * freed while another thread may still reach into it.
+	 *
+	 * @note The wait is unbounded, but adds no new liveness requirement:
+	 *   shutdown_threads() already pthread_join()s every one of these threads,
+	 *   and leaving run() strictly precedes the thread exit that join waits for.
+	 */
+	void wait_for_all_threads_to_exit_run_loop();
 	int listener_add(const char *iface);
 	int listener_add(const char *address, int port);
 	int listener_del(const char *iface);

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -26,10 +26,6 @@
 #define MIN_POLL_DELETE_RATIO  8
 #define MY_EPOLL_THREAD_MAXEVENTS 128
 */
-/// @brief How often wait_for_all_threads_to_exit_run_loop() logs that it is still waiting.
-#ifndef THREADS_EXIT_REPORT_INTERVAL_US
-#define THREADS_EXIT_REPORT_INTERVAL_US (10*1000*1000ULL)
-#endif
 
 #define ADMIN_HOSTGROUP	(-2)
 #define STATS_HOSTGROUP	(-3)

--- a/include/MySQL_Thread.h
+++ b/include/MySQL_Thread.h
@@ -25,6 +25,10 @@
 #define MIN_POLL_LEN 8
 #define MIN_POLL_DELETE_RATIO  8
 #define MY_EPOLL_THREAD_MAXEVENTS 128
+/// @brief How often wait_for_all_threads_to_exit_run_loop() logs that it is still waiting.
+#ifndef THREADS_EXIT_REPORT_INTERVAL_US
+#define THREADS_EXIT_REPORT_INTERVAL_US (10*1000*1000ULL)
+#endif
 */
 
 #define ADMIN_HOSTGROUP	(-2)
@@ -421,6 +425,8 @@ class MySQL_Threads_Handler
 {
 	private:
 	int shutdown_;
+	/// @brief Number of worker + idle threads that registered before entering MySQL_Thread::run().
+	std::atomic<unsigned int> threads_registered;
 	/// @brief Number of worker + idle threads that already left MySQL_Thread::run().
 	std::atomic<unsigned int> threads_exited_run_loop;
 	size_t stacksize;
@@ -866,15 +872,37 @@ class MySQL_Threads_Handler
 	 * GloMyQPro->end_thread().
 	 *
 	 * Every worker and idle thread therefore calls this right after
-	 * MySQL_Thread::run() returns and before deleting its own MySQL_Thread. It
-	 * returns only once all of them have left run(), so no MySQL_Thread is ever
-	 * freed while another thread may still reach into it.
+	 * MySQL_Thread::run() returns and before deleting its own MySQL_Thread (and
+	 * before clearing its slot in mysql_threads[], which another thread may still
+	 * be about to load). It returns only once all of them have left run(), so no
+	 * MySQL_Thread is ever freed while another thread may still reach into it.
 	 *
-	 * @note The wait is unbounded, but adds no new liveness requirement:
-	 *   shutdown_threads() already pthread_join()s every one of these threads,
-	 *   and leaving run() strictly precedes the thread exit that join waits for.
+	 * The participant count comes from register_thread_before_run_loop(), not from
+	 * num_threads: every thread that registers is exactly a thread that will call
+	 * this, so the barrier is self-consistent and does not depend on every slot of
+	 * mysql_threads[]/mysql_threads_idles[] being populated. That matters because
+	 * the rest of this class deliberately tolerates a NULL worker slot (see
+	 * signal_all_threads() and the guards in shutdown_threads()).
+	 *
+	 * @note The wait is unbounded, but adds no new liveness requirement. A thread
+	 *   that never leaves run() still holds a non-NULL slot -- it registers right
+	 *   after storing that pointer -- so shutdown_threads() would block forever in
+	 *   the pthread_join() it performs under exactly that non-NULL guard. Leaving
+	 *   run() strictly precedes the thread exit that join waits for, so any hang
+	 *   this barrier can produce is a hang the pre-existing join already produced.
+	 *   The wait logs via proxy_error() every THREADS_EXIT_REPORT_INTERVAL_US so a
+	 *   stalled shutdown is diagnosable instead of silent; it never aborts.
 	 */
 	void wait_for_all_threads_to_exit_run_loop();
+	/**
+	 * @brief Register the calling thread as a participant of the shutdown barrier.
+	 *
+	 * Must be called by each worker/idle thread function before it releases the
+	 * start-up gate (`load_`), so that the count is complete before any thread can
+	 * enter MySQL_Thread::run() and therefore before any thread can reach
+	 * wait_for_all_threads_to_exit_run_loop().
+	 */
+	void register_thread_before_run_loop();
 	int listener_add(const char *iface);
 	int listener_add(const char *address, int port);
 	int listener_del(const char *iface);

--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -40,6 +40,10 @@ constexpr const char* AUTHENTICATION_METHOD_STR[] = {
 #define MIN_POLL_DELETE_RATIO  8
 #define MY_EPOLL_THREAD_MAXEVENTS 128
 */
+/// @brief How often wait_for_all_threads_to_exit_run_loop() logs that it is still waiting.
+#ifndef THREADS_EXIT_REPORT_INTERVAL_US
+#define THREADS_EXIT_REPORT_INTERVAL_US (10*1000*1000ULL)
+#endif
 
 #define ADMIN_HOSTGROUP	(-2)
 #define STATS_HOSTGROUP	(-3)
@@ -847,6 +851,8 @@ class PgSQL_Threads_Handler
 {
 private:
 	int shutdown_;
+	/// @brief Number of worker + idle threads that registered before entering PgSQL_Thread::run().
+	std::atomic<unsigned int> threads_registered;
 	/// @brief Number of worker + idle threads that already left PgSQL_Thread::run().
 	std::atomic<unsigned int> threads_exited_run_loop;
 	size_t stacksize;
@@ -1455,15 +1461,38 @@ public:
 	 * GloPgQPro->end_thread().
 	 *
 	 * Every worker and idle thread therefore calls this right after
-	 * PgSQL_Thread::run() returns and before deleting its own PgSQL_Thread. It
-	 * returns only once all of them have left run(), so no PgSQL_Thread is ever
-	 * freed while another thread may still reach into it.
+	 * PgSQL_Thread::run() returns and before deleting its own PgSQL_Thread (and
+	 * before clearing its slot in pgsql_threads[], which another thread may still
+	 * be about to load). It returns only once all of them have left run(), so no
+	 * PgSQL_Thread is ever freed while another thread may still reach into it.
 	 *
-	 * @note The wait is unbounded, but adds no new liveness requirement:
-	 *   shutdown_threads() already pthread_join()s every one of these threads,
-	 *   and leaving run() strictly precedes the thread exit that join waits for.
+	 * The participant count comes from register_thread_before_run_loop(), not from
+	 * num_threads: every thread that registers is exactly a thread that will call
+	 * this, so the barrier is self-consistent and does not depend on every slot of
+	 * pgsql_threads[]/pgsql_threads_idles[] being populated. That matters because
+	 * the rest of this class deliberately tolerates a NULL worker slot (see
+	 * signal_all_threads() and the guards in shutdown_threads()).
+	 *
+	 * @note The wait is unbounded, but adds no new liveness requirement. A thread
+	 *   that never leaves run() still holds a non-NULL slot -- it registers right
+	 *   after storing that pointer -- so shutdown_threads() would block forever in
+	 *   the pthread_join() it performs under exactly that non-NULL guard. Leaving
+	 *   run() strictly precedes the thread exit that join waits for, so any hang
+	 *   this barrier can produce is a hang the pre-existing join already produced.
+	 *   The wait logs via proxy_error() every THREADS_EXIT_REPORT_INTERVAL_US so a
+	 *   stalled shutdown is diagnosable instead of silent; it never aborts.
 	 */
 	void wait_for_all_threads_to_exit_run_loop();
+
+	/**
+	 * @brief Register the calling thread as a participant of the shutdown barrier.
+	 *
+	 * Must be called by each worker/idle thread function before it releases the
+	 * start-up gate (`load_`), so that the count is complete before any thread can
+	 * enter PgSQL_Thread::run() and therefore before any thread can reach
+	 * wait_for_all_threads_to_exit_run_loop().
+	 */
+	void register_thread_before_run_loop();
 
 	/**
 	 * @brief Adds a new listener to the thread pool, based on an interface string.

--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -847,6 +847,8 @@ class PgSQL_Threads_Handler
 {
 private:
 	int shutdown_;
+	/// @brief Number of worker + idle threads that already left PgSQL_Thread::run().
+	std::atomic<unsigned int> threads_exited_run_loop;
 	size_t stacksize;
 	pthread_attr_t attr;
 	pthread_rwlock_t rwlock;
@@ -1434,6 +1436,34 @@ public:
 	 *
 	 */
 	void shutdown_threads();
+
+	/**
+	 * @brief Rendezvous for all worker and idle threads before they self-delete.
+	 *
+	 * Worker and idle threads dereference each other's PgSQL_Thread objects:
+	 * PgSQL_Thread::run_MoveSessionsBetweenThreads() reads
+	 * pgsql_threads_idles[rand()].worker, and the idle branch of
+	 * PgSQL_Thread::run() reads pgsql_threads[rand()].worker and then locks that
+	 * worker's myexchange mutex unconditionally. Because the peer is picked at
+	 * random and both directions exist, no pthread_join() ordering in
+	 * shutdown_threads() can make self-deletion safe -- each thread destroys its
+	 * own PgSQL_Thread from its own thread function, which pthread_join() only
+	 * observes after the fact.
+	 *
+	 * Destruction must nevertheless stay on the owning thread, because
+	 * ~PgSQL_Thread() frees __thread variables (pgsql_thread___*) and calls
+	 * GloPgQPro->end_thread().
+	 *
+	 * Every worker and idle thread therefore calls this right after
+	 * PgSQL_Thread::run() returns and before deleting its own PgSQL_Thread. It
+	 * returns only once all of them have left run(), so no PgSQL_Thread is ever
+	 * freed while another thread may still reach into it.
+	 *
+	 * @note The wait is unbounded, but adds no new liveness requirement:
+	 *   shutdown_threads() already pthread_join()s every one of these threads,
+	 *   and leaving run() strictly precedes the thread exit that join waits for.
+	 */
+	void wait_for_all_threads_to_exit_run_loop();
 
 	/**
 	 * @brief Adds a new listener to the thread pool, based on an interface string.

--- a/include/PgSQL_Thread.h
+++ b/include/PgSQL_Thread.h
@@ -40,10 +40,6 @@ constexpr const char* AUTHENTICATION_METHOD_STR[] = {
 #define MIN_POLL_DELETE_RATIO  8
 #define MY_EPOLL_THREAD_MAXEVENTS 128
 */
-/// @brief How often wait_for_all_threads_to_exit_run_loop() logs that it is still waiting.
-#ifndef THREADS_EXIT_REPORT_INTERVAL_US
-#define THREADS_EXIT_REPORT_INTERVAL_US (10*1000*1000ULL)
-#endif
 
 #define ADMIN_HOSTGROUP	(-2)
 #define STATS_HOSTGROUP	(-3)

--- a/include/proxysql_macros.h
+++ b/include/proxysql_macros.h
@@ -70,4 +70,9 @@
 #ifndef ENABLE_TIMER
 #define ENABLE_TIMER false
 #endif // ENABLE_TIMER
+
+/// @brief How often wait_for_all_threads_to_exit_run_loop() logs that it is still waiting.
+#ifndef THREADS_EXIT_REPORT_INTERVAL_US
+#define THREADS_EXIT_REPORT_INTERVAL_US (10*1000*1000ULL)
+#endif
 #endif // PROXYSQL_MACROS_H

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1277,8 +1277,8 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 #endif // IDLE_THREADS
 	stacksize=0;
 	shutdown_=0;
-	threads_registered.store(0, std::memory_order_relaxed);
-	threads_exited_run_loop.store(0, std::memory_order_relaxed);
+	threads_registered.store(0, std::memory_order_relaxed); // NOSONAR(cpp:S8417): the constructor runs before any worker/idle thread exists; no publication ordering is needed
+	threads_exited_run_loop.store(0, std::memory_order_relaxed); // NOSONAR(cpp:S8417): the constructor runs before any worker/idle thread exists; no publication ordering is needed
 	bootstrapping_listeners = true;
 	pthread_rwlock_init(&rwlock,NULL);
 	pthread_attr_init(&attr);
@@ -3201,18 +3201,18 @@ void MySQL_Threads_Handler::shutdown_threads() {
 }
 
 void MySQL_Threads_Handler::register_thread_before_run_loop() {
-	threads_registered.fetch_add(1, std::memory_order_acq_rel);
+	threads_registered.fetch_add(1, std::memory_order_acq_rel); // NOSONAR(cpp:S8417): deliberate acq_rel -- the start-up gate orders every registration before any run(), and the wait side pairs with acquire
 }
 
 void MySQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
 	// Every thread that registers also calls this, and every registration happens
 	// before the caller enters MySQL_Thread::run(), so this count is final by the
 	// time any thread can reach this point.
-	const unsigned int expected = threads_registered.load(std::memory_order_acquire);
-	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel);
+	const unsigned int expected = threads_registered.load(std::memory_order_acquire); // NOSONAR(cpp:S8417): deliberate acquire -- pairs with the acq_rel registrations, which all precede the start-up gate
+	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel); // NOSONAR(cpp:S8417): deliberate acq_rel -- the release publishes this thread's run-loop exit, the acquire pairs with the exits of peer threads
 	const unsigned long long started = monotonic_time();
 	unsigned long long next_report = started + THREADS_EXIT_REPORT_INTERVAL_US;
-	unsigned int exited = threads_exited_run_loop.load(std::memory_order_acquire);
+	unsigned int exited = threads_exited_run_loop.load(std::memory_order_acquire); // NOSONAR(cpp:S8417): deliberate acquire -- pairs with the acq_rel exit increments
 	while (exited < expected) {
 		usleep(50);
 		const unsigned long long now = monotonic_time();
@@ -3223,7 +3223,7 @@ void MySQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
 				exited, expected, (now - started) / 1000000);
 			next_report = now + THREADS_EXIT_REPORT_INTERVAL_US;
 		}
-		exited = threads_exited_run_loop.load(std::memory_order_acquire);
+		exited = threads_exited_run_loop.load(std::memory_order_acquire); // NOSONAR(cpp:S8417): deliberate acquire -- pairs with the acq_rel exit increments
 	}
 }
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1277,6 +1277,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 #endif // IDLE_THREADS
 	stacksize=0;
 	shutdown_=0;
+	threads_exited_run_loop.store(0, std::memory_order_relaxed);
 	bootstrapping_listeners = true;
 	pthread_rwlock_init(&rwlock,NULL);
 	pthread_attr_init(&attr);
@@ -3173,9 +3174,13 @@ void MySQL_Threads_Handler::shutdown_threads() {
 		if (GloVars.global.idle_threads) {
 			for (i=0; i<num_threads; i++) {
 				if (mysql_threads_idles[i].worker) {
-					pthread_mutex_lock(&mysql_threads[i].worker->thread_mutex);
+					// the guard above tests the idle thread, so the lock must be
+					// taken on the idle thread too: mysql_threads[i].worker can
+					// legitimately be NULL here (see signal_all_threads(), which
+					// explicitly tolerates not-yet-ready worker slots).
+					pthread_mutex_lock(&mysql_threads_idles[i].worker->thread_mutex);
 					mysql_threads_idles[i].worker->shutdown=1;
-					pthread_mutex_unlock(&mysql_threads[i].worker->thread_mutex);
+					pthread_mutex_unlock(&mysql_threads_idles[i].worker->thread_mutex);
 				}
 			}
 		}
@@ -3191,6 +3196,19 @@ void MySQL_Threads_Handler::shutdown_threads() {
 			}
 #endif /* IDLE_THREADS */
 		}
+	}
+}
+
+void MySQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
+	unsigned int expected = num_threads;
+#ifdef IDLE_THREADS
+	if (GloVars.global.idle_threads) {
+		expected += num_threads;
+	}
+#endif /* IDLE_THREADS */
+	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel);
+	while (threads_exited_run_loop.load(std::memory_order_acquire) < expected) {
+		usleep(50);
 	}
 }
 

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -1277,6 +1277,7 @@ MySQL_Threads_Handler::MySQL_Threads_Handler() {
 #endif // IDLE_THREADS
 	stacksize=0;
 	shutdown_=0;
+	threads_registered.store(0, std::memory_order_relaxed);
 	threads_exited_run_loop.store(0, std::memory_order_relaxed);
 	bootstrapping_listeners = true;
 	pthread_rwlock_init(&rwlock,NULL);
@@ -3199,16 +3200,30 @@ void MySQL_Threads_Handler::shutdown_threads() {
 	}
 }
 
+void MySQL_Threads_Handler::register_thread_before_run_loop() {
+	threads_registered.fetch_add(1, std::memory_order_acq_rel);
+}
+
 void MySQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
-	unsigned int expected = num_threads;
-#ifdef IDLE_THREADS
-	if (GloVars.global.idle_threads) {
-		expected += num_threads;
-	}
-#endif /* IDLE_THREADS */
+	// Every thread that registers also calls this, and every registration happens
+	// before the caller enters MySQL_Thread::run(), so this count is final by the
+	// time any thread can reach this point.
+	const unsigned int expected = threads_registered.load(std::memory_order_acquire);
 	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel);
-	while (threads_exited_run_loop.load(std::memory_order_acquire) < expected) {
+	const unsigned long long started = monotonic_time();
+	unsigned long long next_report = started + THREADS_EXIT_REPORT_INTERVAL_US;
+	unsigned int exited = threads_exited_run_loop.load(std::memory_order_acquire);
+	while (exited < expected) {
 		usleep(50);
+		const unsigned long long now = monotonic_time();
+		if (now >= next_report) {
+			// Never abort: a shutdown that is merely slow must not become a crash.
+			// Just make the stall visible, and keep waiting.
+			proxy_error("Still waiting for all MySQL worker/idle threads to leave their run loop: %u of %u exited after %llu seconds. Shutdown is stalled on a thread that has not returned from MySQL_Thread::run()\n",
+				exited, expected, (now - started) / 1000000);
+			next_report = now + THREADS_EXIT_REPORT_INTERVAL_US;
+		}
+		exited = threads_exited_run_loop.load(std::memory_order_acquire);
 	}
 }
 

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -1029,6 +1029,7 @@ PgSQL_Threads_Handler::PgSQL_Threads_Handler() {
 #endif // IDLE_THREADS
 	stacksize = 0;
 	shutdown_ = 0;
+	threads_registered.store(0, std::memory_order_relaxed);
 	threads_exited_run_loop.store(0, std::memory_order_relaxed);
 	bootstrapping_listeners = true;
 	pthread_rwlock_init(&rwlock, NULL);
@@ -2543,16 +2544,30 @@ void PgSQL_Threads_Handler::shutdown_threads() {
 	}
 }
 
+void PgSQL_Threads_Handler::register_thread_before_run_loop() {
+	threads_registered.fetch_add(1, std::memory_order_acq_rel);
+}
+
 void PgSQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
-	unsigned int expected = num_threads;
-#ifdef IDLE_THREADS
-	if (GloVars.global.idle_threads) {
-		expected += num_threads;
-	}
-#endif /* IDLE_THREADS */
+	// Every thread that registers also calls this, and every registration happens
+	// before the caller enters PgSQL_Thread::run(), so this count is final by the
+	// time any thread can reach this point.
+	const unsigned int expected = threads_registered.load(std::memory_order_acquire);
 	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel);
-	while (threads_exited_run_loop.load(std::memory_order_acquire) < expected) {
+	const unsigned long long started = monotonic_time();
+	unsigned long long next_report = started + THREADS_EXIT_REPORT_INTERVAL_US;
+	unsigned int exited = threads_exited_run_loop.load(std::memory_order_acquire);
+	while (exited < expected) {
 		usleep(50);
+		const unsigned long long now = monotonic_time();
+		if (now >= next_report) {
+			// Never abort: a shutdown that is merely slow must not become a crash.
+			// Just make the stall visible, and keep waiting.
+			proxy_error("Still waiting for all PgSQL worker/idle threads to leave their run loop: %u of %u exited after %llu seconds. Shutdown is stalled on a thread that has not returned from PgSQL_Thread::run()\n",
+				exited, expected, (now - started) / 1000000);
+			next_report = now + THREADS_EXIT_REPORT_INTERVAL_US;
+		}
+		exited = threads_exited_run_loop.load(std::memory_order_acquire);
 	}
 }
 

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -1029,6 +1029,7 @@ PgSQL_Threads_Handler::PgSQL_Threads_Handler() {
 #endif // IDLE_THREADS
 	stacksize = 0;
 	shutdown_ = 0;
+	threads_exited_run_loop.store(0, std::memory_order_relaxed);
 	bootstrapping_listeners = true;
 	pthread_rwlock_init(&rwlock, NULL);
 	pthread_attr_init(&attr);
@@ -2517,9 +2518,13 @@ void PgSQL_Threads_Handler::shutdown_threads() {
 		if (GloVars.global.idle_threads) {
 			for (i = 0; i < num_threads; i++) {
 				if (pgsql_threads_idles[i].worker) {
-					pthread_mutex_lock(&pgsql_threads[i].worker->thread_mutex);
+					// the guard above tests the idle thread, so the lock must be
+					// taken on the idle thread too: pgsql_threads[i].worker can
+					// legitimately be NULL here (see signal_all_threads(), which
+					// explicitly tolerates not-yet-ready worker slots).
+					pthread_mutex_lock(&pgsql_threads_idles[i].worker->thread_mutex);
 					pgsql_threads_idles[i].worker->shutdown = 1;
-					pthread_mutex_unlock(&pgsql_threads[i].worker->thread_mutex);
+					pthread_mutex_unlock(&pgsql_threads_idles[i].worker->thread_mutex);
 				}
 			}
 		}
@@ -2535,6 +2540,19 @@ void PgSQL_Threads_Handler::shutdown_threads() {
 			}
 #endif /* IDLE_THREADS */
 		}
+	}
+}
+
+void PgSQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
+	unsigned int expected = num_threads;
+#ifdef IDLE_THREADS
+	if (GloVars.global.idle_threads) {
+		expected += num_threads;
+	}
+#endif /* IDLE_THREADS */
+	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel);
+	while (threads_exited_run_loop.load(std::memory_order_acquire) < expected) {
+		usleep(50);
 	}
 }
 

--- a/lib/PgSQL_Thread.cpp
+++ b/lib/PgSQL_Thread.cpp
@@ -1029,8 +1029,8 @@ PgSQL_Threads_Handler::PgSQL_Threads_Handler() {
 #endif // IDLE_THREADS
 	stacksize = 0;
 	shutdown_ = 0;
-	threads_registered.store(0, std::memory_order_relaxed);
-	threads_exited_run_loop.store(0, std::memory_order_relaxed);
+	threads_registered.store(0, std::memory_order_relaxed); // NOSONAR(cpp:S8417): the constructor runs before any worker/idle thread exists; no publication ordering is needed
+	threads_exited_run_loop.store(0, std::memory_order_relaxed); // NOSONAR(cpp:S8417): the constructor runs before any worker/idle thread exists; no publication ordering is needed
 	bootstrapping_listeners = true;
 	pthread_rwlock_init(&rwlock, NULL);
 	pthread_attr_init(&attr);
@@ -2545,18 +2545,18 @@ void PgSQL_Threads_Handler::shutdown_threads() {
 }
 
 void PgSQL_Threads_Handler::register_thread_before_run_loop() {
-	threads_registered.fetch_add(1, std::memory_order_acq_rel);
+	threads_registered.fetch_add(1, std::memory_order_acq_rel); // NOSONAR(cpp:S8417): deliberate acq_rel -- the start-up gate orders every registration before any run(), and the wait side pairs with acquire
 }
 
 void PgSQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
 	// Every thread that registers also calls this, and every registration happens
 	// before the caller enters PgSQL_Thread::run(), so this count is final by the
 	// time any thread can reach this point.
-	const unsigned int expected = threads_registered.load(std::memory_order_acquire);
-	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel);
+	const unsigned int expected = threads_registered.load(std::memory_order_acquire); // NOSONAR(cpp:S8417): deliberate acquire -- pairs with the acq_rel registrations, which all precede the start-up gate
+	threads_exited_run_loop.fetch_add(1, std::memory_order_acq_rel); // NOSONAR(cpp:S8417): deliberate acq_rel -- the release publishes this thread's run-loop exit, the acquire pairs with the exits of peer threads
 	const unsigned long long started = monotonic_time();
 	unsigned long long next_report = started + THREADS_EXIT_REPORT_INTERVAL_US;
-	unsigned int exited = threads_exited_run_loop.load(std::memory_order_acquire);
+	unsigned int exited = threads_exited_run_loop.load(std::memory_order_acquire); // NOSONAR(cpp:S8417): deliberate acquire -- pairs with the acq_rel exit increments
 	while (exited < expected) {
 		usleep(50);
 		const unsigned long long now = monotonic_time();
@@ -2567,7 +2567,7 @@ void PgSQL_Threads_Handler::wait_for_all_threads_to_exit_run_loop() {
 				exited, expected, (now - started) / 1000000);
 			next_report = now + THREADS_EXIT_REPORT_INTERVAL_US;
 		}
-		exited = threads_exited_run_loop.load(std::memory_order_acquire);
+		exited = threads_exited_run_loop.load(std::memory_order_acquire); // NOSONAR(cpp:S8417): deliberate acquire -- pairs with the acq_rel exit increments
 	}
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,6 +544,9 @@ void * mysql_worker_thread_func(void *arg) {
 	proxysql_mysql_thread_t *mysql_thread=(proxysql_mysql_thread_t *)arg;
 	MySQL_Thread *worker = new MySQL_Thread();
 	mysql_thread->worker=worker;
+	// register before releasing the start-up gate below, so the shutdown barrier in
+	// wait_for_all_threads_to_exit_run_loop() has a complete participant count
+	GloMTH->register_thread_before_run_loop();
 	worker->init();
 //	worker->poll_listener_add(listen_fd);
 //	worker->poll_listener_add(socket_fd);
@@ -578,6 +581,9 @@ void * mysql_worker_thread_func_idles(void *arg) {
 	proxysql_mysql_thread_t *mysql_thread=(proxysql_mysql_thread_t *)arg;
 	MySQL_Thread *worker = new MySQL_Thread();
 	mysql_thread->worker=worker;
+	// register before releasing the start-up gate below, so the shutdown barrier in
+	// wait_for_all_threads_to_exit_run_loop() has a complete participant count
+	GloMTH->register_thread_before_run_loop();
 	worker->epoll_thread=true;
 	worker->init();
 //	worker->poll_listener_add(listen_fd);
@@ -615,6 +621,9 @@ void* pgsql_worker_thread_func(void* arg) {
 	proxysql_pgsql_thread_t* pgsql_thread = (proxysql_pgsql_thread_t*)arg;
 	PgSQL_Thread* worker = new PgSQL_Thread();
 	pgsql_thread->worker = worker;
+	// register before releasing the start-up gate below, so the shutdown barrier in
+	// wait_for_all_threads_to_exit_run_loop() has a complete participant count
+	GloPTH->register_thread_before_run_loop();
 	worker->init();
 	//	worker->poll_listener_add(listen_fd);
 	//	worker->poll_listener_add(socket_fd);
@@ -649,6 +658,9 @@ void* pgsql_worker_thread_func_idles(void* arg) {
 	proxysql_pgsql_thread_t* pgsql_thread = (proxysql_pgsql_thread_t*)arg;
 	PgSQL_Thread* worker = new PgSQL_Thread();
 	pgsql_thread->worker = worker;
+	// register before releasing the start-up gate below, so the shutdown barrier in
+	// wait_for_all_threads_to_exit_run_loop() has a complete participant count
+	GloPTH->register_thread_before_run_loop();
 	worker->epoll_thread = true;
 	worker->init();
 	//	worker->poll_listener_add(listen_fd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -552,6 +552,9 @@ void * mysql_worker_thread_func(void *arg) {
 	do { sleep_iter(++iter); } while (load_);
 
 	worker->run();
+	// worker and idle threads reach into each other's MySQL_Thread objects, so no
+	// MySQL_Thread may be destroyed until all of them have left run()
+	GloMTH->wait_for_all_threads_to_exit_run_loop();
 	//delete worker;
 	delete worker;
 	mysql_thread->worker=NULL;
@@ -584,6 +587,9 @@ void * mysql_worker_thread_func_idles(void *arg) {
 	do { sleep_iter(++iter); } while (load_);
 
 	worker->run();
+	// worker and idle threads reach into each other's MySQL_Thread objects, so no
+	// MySQL_Thread may be destroyed until all of them have left run()
+	GloMTH->wait_for_all_threads_to_exit_run_loop();
 	//delete worker;
 	delete worker;
 //	l_mem_destroy(__thr_sfp);
@@ -617,6 +623,9 @@ void* pgsql_worker_thread_func(void* arg) {
 	do { sleep_iter(++iter); } while (load_);
 
 	worker->run();
+	// worker and idle threads reach into each other's PgSQL_Thread objects, so no
+	// PgSQL_Thread may be destroyed until all of them have left run()
+	GloPTH->wait_for_all_threads_to_exit_run_loop();
 	//delete worker;
 	delete worker;
 	pgsql_thread->worker = NULL;
@@ -649,6 +658,9 @@ void* pgsql_worker_thread_func_idles(void* arg) {
 	do { sleep_iter(++iter); } while (load_);
 
 	worker->run();
+	// worker and idle threads reach into each other's PgSQL_Thread objects, so no
+	// PgSQL_Thread may be destroyed until all of them have left run()
+	GloPTH->wait_for_all_threads_to_exit_run_loop();
 	//delete worker;
 	delete worker;
 	//	l_mem_destroy(__thr_sfp);


### PR DESCRIPTION
Fixes two shutdown defects in the `IDLE_THREADS` path. Both reproduce on unmodified `v3.0`, both affect MySQL and PgSQL identically, and both are in `MySQL_Threads_Handler::shutdown_threads()`.

They were found while investigating an unrelated plugin-unload ordering problem: with `--idle-threads` enabled, ProxySQL crashed on shutdown before the behaviour under investigation became observable.

## Bug A — mismatched guard, NULL dereference

The `#ifdef IDLE_THREADS` signalling block tested one array and dereferenced another:

```c
if (mysql_threads_idles[i].worker) {                            // tests IDLE
    pthread_mutex_lock(&mysql_threads[i].worker->thread_mutex);  // derefs WORKER
    mysql_threads_idles[i].worker->shutdown = 1;
    pthread_mutex_unlock(&mysql_threads[i].worker->thread_mutex);
}
```

That single line could land in four different bad states, because the worker flag loop above it has already released those workers to exit and they self-NULL their slot (`src/main.cpp`, `worker->run(); delete worker; mysql_thread->worker = NULL;`):

- lock a live mutex — fine
- lock a mutex the worker abandoned locked when `run()` returned — **shutdown hangs forever**
- lock freed memory — **use-after-free write**
- dereference NULL — **SIGSEGV**

The fix takes the idle thread's *own* `thread_mutex`, which is also the correct lock: the idle thread reads its `shutdown` flag under that same mutex. The store previously had no mutual exclusion at all — it was made under an unrelated thread's lock.

## Bug B — use-after-free in the join loop

Threads self-delete inside their own thread function, and worker/idle peers reference each other. The join loop joined worker *i* before idle *i*, so after joining worker *i* its `MySQL_Thread` is freed while the idle thread for that slot is still running and still using the *worker's* `thread_mutex`.

**No join ordering can fix this.** The peer is selected at random in *both* directions (`rand() % num_threads`, `lib/MySQL_Thread.cpp`), and `pthread_join()` does not order the frees anyway, since each thread deletes itself inside its own thread function.

Destruction must also stay on the owning thread — `~MySQL_Thread()` frees `__thread` storage and calls `GloMyQPro->end_thread()`. So the fix changes *when* rather than *where*: a registration-counted barrier between `run()` and `delete` in all four thread functions, so no thread frees itself until every thread has left its run loop.

The barrier's participant count comes from `register_thread_before_run_loop()`, called immediately after each thread stores its `worker` pointer and before it releases the startup gate — so every registrant is exactly a barrier participant, and a NULL slot cannot cause a hang. It is deliberately not derived from `num_threads`.

The barrier also closes a second, distinct defect that had not been separately identified: it precedes the `mysql_thread->worker = NULL` store, so an idle thread can no longer load a NULLed peer slot and dereference it in `idle_thread_check_if_worker_thread_has_unprocess_resumed_sessions_and_signal_it()`, which locks before any NULL check.

## Diagnosability

If the barrier ever fails to complete, the symptom would otherwise be a silent hang on a production proxy's shutdown path. It now emits a `proxy_error()` every 10 s naming the observed and expected counts and the elapsed time, and never aborts — a shutdown that is merely slow must not become a crash.

## Verification

- **Bug A**: SIGSEGV reproduced under gdb with a forced NULL slot before the fix; clean shutdown after.
- **Bug B**: `heap-use-after-free` under ASAN in 2/2 runs before the fix, 0 sanitizer reports in 5/5 runs after, with the affected code path exercised 32× per run. The reproduction used window-widening instrumentation that parks the idle thread at the *existing* peer-access site holding the *already-loaded* pointer, and reads the same field production code reads — so ASAN was shown a race that genuinely occurs, not a synthetic one.
- **TAP**: `mysql84-g4` (including `mysql-watchdog_test-t`, which deliberately stalls a thread inside `run()` — the barrier's worst case) and `mysql84-g1`. The 10 failures observed are fixture-side and pre-existing: verified by rebuilding pristine `v3.0` in the same worktree at the same tier and re-running the same tests against the same infra, obtaining identical failure sets and counts.
- Both `PROXYSQL31=1` and `PROXYSQL40=1` builds compile clean.

## What this does not cover

- **PgSQL was never exercised under TAP.** Its fix is textually identical and the code shape was verified to match, but coverage there rests on symmetry plus local ASAN rather than a test run.
- The watchdog test proves the barrier tolerates a *bounded* stall, not that it can never deadlock on a genuinely stuck thread. That case rests on the argument above plus the 10 s diagnostic.
- Shutdown cost rose from ~15 ms to ~25 ms with 32+32 threads, bounded by one `mysql-poll_timeout` cycle. That is from Bug A's fix acquiring each idle thread's own mutex, which it previously did not.

## Recommended follow-up (not included)

`run()` returns while holding `thread_mutex` (`lib/MySQL_Thread.cpp`, `lib/PgSQL_Thread.cpp`), and the destructor never unlocks or destroys it. Any admin-thread path that locks a worker's `thread_mutex` during that window blocks forever — `SQL3_Processlist()`, `kill_session()`, `Get_Memory_Stats()`, and the PgSQL equivalents. This is pre-existing and not introduced here, but **this change widens the exposure window** from `~MySQL_Thread()` to the barrier plus the destructor. It is the highest-value follow-up and deserves its own change with its own shutdown verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two --idle-threads shutdown crashes in v3.0 for MySQL and PgSQL. Old: the signal loop locked the wrong mutex and threads self-deleted while peers still accessed them; New: lock each idle thread’s own mutex and defer self-deletion behind a counted barrier. Side effects: slightly slower shutdown and periodic “still waiting” logs.

- Lock the idle thread’s `thread_mutex` when setting `shutdown` in MySQL/PgSQL `shutdown_threads()`.
- Add `register_thread_before_run_loop()` and `wait_for_all_threads_to_exit_run_loop()`; register before releasing the start gate and wait after `run()` in all worker/idle thread functions.
- Emit progress logs every 10s while waiting; define `THREADS_EXIT_REPORT_INTERVAL_US` once in `proxysql_macros.h` so MySQL/PgSQL handlers stay consistent.
- Annotate explicit memory-order operations with `NOSONAR(cpp:S8417)` to satisfy Sonar; no behavior change.

<sup>Written for commit ea386886701e43ad46769ba8efefd50d848ce961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MySQL and PostgreSQL thread shutdown reliability.
  - Prevented thread objects from being destroyed while worker or idle threads are still running.
  - Added shutdown diagnostics that periodically report stalled thread exits without aborting.
  - Corrected idle-thread shutdown coordination to use the appropriate thread state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->