### PR TITLE
ci: add reusables for legacy-binlog-g1, mysql90-binlog-g1, mysql95-binlog-g1

### DIFF
--- a/.github/workflows/ci-legacy-binlog-g1.yml
+++ b/.github/workflows/ci-legacy-binlog-g1.yml
@@ -1,0 +1,22 @@
+name: CI-legacy-binlog-g1
+
+on:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  id-token: write
+  packages: read
+
+jobs:
+  tests:
+    uses: sysown/proxysql/.github/workflows/ci-ai-gcov.yml@GH-Actions
+    with:
+      trigger: ${{ inputs.trigger }}
+      tap_group: legacy-binlog-g1
+      infra_id: ci-legacy-binlog-g1

--- a/.github/workflows/ci-mysql90-binlog-g1.yml
+++ b/.github/workflows/ci-mysql90-binlog-g1.yml
@@ -1,0 +1,22 @@
+name: CI-mysql90-binlog-g1
+
+on:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  id-token: write
+  packages: read
+
+jobs:
+  tests:
+    uses: sysown/proxysql/.github/workflows/ci-ai-gcov.yml@GH-Actions
+    with:
+      trigger: ${{ inputs.trigger }}
+      tap_group: mysql90-binlog-g1
+      infra_id: ci-mysql90-binlog-g1

--- a/.github/workflows/ci-mysql95-binlog-g1.yml
+++ b/.github/workflows/ci-mysql95-binlog-g1.yml
@@ -1,0 +1,22 @@
+name: CI-mysql95-binlog-g1
+
+on:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  id-token: write
+  packages: read
+
+jobs:
+  tests:
+    uses: sysown/proxysql/.github/workflows/ci-ai-gcov.yml@GH-Actions
+    with:
+      trigger: ${{ inputs.trigger }}
+      tap_group: mysql95-binlog-g1
+      infra_id: ci-mysql95-binlog-g1


### PR DESCRIPTION
This adds the GH-Actions-branch half of CI coverage for the three binlog groups that were already registered in `test/tap/groups/groups.json` but had no CI workflow before PR #6086 (which added `mysql84-binlog-g1`):

- `legacy-binlog-g1` — backend infra-dbdeployer-mysql57-binlog
- `mysql90-binlog-g1` — backend infra-dbdeployer-mysql90-binlog
- `mysql95-binlog-g1` — backend infra-dbdeployer-mysql95-binlog

### What this PR does

1. Adds three shim reusables that delegate to the existing `ci-ai-gcov.yml` reusable (added in PR #6089) with the per-group `tap_group` / `infra_id`. Mirrors the `ci-ai-g1.yml` / `ci-ai-g2.yml` pattern extracted in the same PR.

```yaml
# ci-legacy-binlog-g1.yml (etc.)
jobs:
  tests:
    uses: sysown/proxysql/.github/workflows/ci-ai-gcov.yml@GH-Actions
    with:
      trigger: ${{ inputs.trigger }}
      tap_group: legacy-binlog-g1
      infra_id: ci-legacy-binlog-g1
```

2. Stages the `mysqlbinlog` CLI (built by the mysql-connector-c-8.4.0 build as a side effect of `make`) into `test/tap/tap/bin/` BEFORE the test/deps/ deletion. Without this, the `mysql84-binlog-g1` group fails at runtime because the binary is gone after the cache prune (see #6092). ~37 MB extra in the _test cache; the runner at `test/infra/control/run-tests-isolated.bash` already `find`s the workspace and symlinks it into `${TEST_DEPS}/mysqlbinlog`.

### Companion

The caller side lives on v3.0 in PR #6094 (branch `fix/test-deps-mysqlbinlog`). This PR **must land first** — the v3.0 callers invoke `ci-<group>.yml@GH-Actions`, so resolving the ref requires the files to already exist on `GH-Actions`. Merging the v3.0 PR before this one would red CI with "Could not find workflow reference".

### Issue

Closes #6092 (the first of the issue's two follow-ups; the v3.0 PR also lands the runner fallback that fixes the failing mysqbilnog lookup in mysql84-binlog-g1).

### Notes

- Uses the parameterized `ci-ai-gcov.yml` shim rather than a dedicated `ci-<group>.yml` standalone reusable (like `ci-mysql84-binlog-g1.yml` is). The shim is bit-identical to ai-g1/ai-g2 vs. mysql84-binlog-g1's standalone reusable, so the new workflows inherit the bug fixes (the codecov retry triad, the harness NULLable permissions, etc.) PR #6089 brought into `ci-ai-gcov.yml` without per-group duplication.
- The actual MySQL backend for each group is selected by `test/tap/groups/<group>/infras.lst`, already wired up on v3.0.
- `matrix.infradb` is hardcoded to `mysql84` in `ci-ai-gcov.yml`, so the check name for these three workflows will read `CI-AI-GCOV / tests (mysql84,genai-gcov)` — a label artifact, not the actual backend. The workflow / group name in the GitHub UI is the source of truth. Worth parameterizing `matrix.infradb` in a follow-up if reviewers want cosmetic accuracy.