### PR TITLE
ci: fix mysqlbinlog lookup + add callers for 3 missing binlog groups

### DIFF
--- a/.github/workflows/CI-legacy-binlog-g1.yml
+++ b/.github/workflows/CI-legacy-binlog-g1.yml
@@ -1,0 +1,23 @@
+name: CI-legacy-binlog-g1
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ completed ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # The reusable workflow mints a Codecov OIDC token.  Permissions are
+    # intersected across caller and callee, so the caller also grants write-all.
+    permissions: write-all
+    uses: sysown/proxysql/.github/workflows/ci-legacy-binlog-g1.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-mysql90-binlog-g1.yml
+++ b/.github/workflows/CI-mysql90-binlog-g1.yml
@@ -1,0 +1,23 @@
+name: CI-mysql90-binlog-g1
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ completed ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # The reusable workflow mints a Codecov OIDC token.  Permissions are
+    # intersected across caller and callee, so the caller also grants write-all.
+    permissions: write-all
+    uses: sysown/proxysql/.github/workflows/ci-mysql90-binlog-g1.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}

--- a/.github/workflows/CI-mysql95-binlog-g1.yml
+++ b/.github/workflows/CI-mysql95-binlog-g1.yml
@@ -1,0 +1,23 @@
+name: CI-mysql95-binlog-g1
+run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }} ${{ github.workflow }} ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}'
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ CI-trigger ]
+    types: [ completed ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run && github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    # The reusable workflow mints a Codecov OIDC token.  Permissions are
+    # intersected across caller and callee, so the caller also grants write-all.
+    permissions: write-all
+    uses: sysown/proxysql/.github/workflows/ci-mysql95-binlog-g1.yml@GH-Actions
+    secrets: inherit
+    with:
+      trigger: ${{ toJson(github) }}

--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -280,7 +280,23 @@ mkdir -p "${TESTS_LOGS_PATH_HOST}"
 chmod 777 "${TESTS_LOGS_PATH_HOST}"
 
 # Find binaries
+#
+# ci-builds.yml explicitly deletes test/deps/ from the cached workspace after
+# the TAP binaries are built (see "Delete test/deps" block in ci-builds.yml).
+# The libmariadbclient.a / libmysqlclient.a archives are statically linked
+# into the *-t binaries, but the mysqlbinlog *executable* is invoked at
+# runtime by test_com_binlog_dump_enables_fast_forward-t via system() and
+# therefore is NOT carried in the cache. Fall back to whatever the runner
+# container provides on PATH (test/infra/docker-base/Dockerfile installs
+# mysql-client, which depends on mysql-server-core-8.0 and ships
+# /usr/bin/mysqlbinlog) so the symlink at TEST_DEPS/mysqlbinlog resolves
+# even when nothing in the workspace matches.
+#
+# See GH issue #6092 for the full failure trace.
 MYSQL_BINLOG_BIN=$(find "${WORKSPACE}" -path "${WORKSPACE}/ci_infra_logs" -prune -o -path "${WORKSPACE}/.git" -prune -o -name "mysqlbinlog" -type f -executable -print | head -n 1)
+if [ -z "${MYSQL_BINLOG_BIN}" ]; then
+    MYSQL_BINLOG_BIN="$(command -v mysqlbinlog 2>/dev/null || true)"
+fi
 
 # Execution: run the container
 docker run \

--- a/test/infra/docker-base/Dockerfile
+++ b/test/infra/docker-base/Dockerfile
@@ -8,6 +8,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
     mysql-client \
+    # mysql-server-core pulls in mysqlbinlog, which test_com_binlog_dump_enables_fast_forward-t
+    # shells out to at runtime. mysql-client does NOT (its core package only ships
+    # mysql / mysqladmin / mysqldump etc., not mysqlbinlog). Without this the binlog
+    # TAP tests fail with sh: 1: .../mysqlbinlog: not found even after the runner
+    # fallback in test/infra/control/run-tests-isolated.bash succeeds at creating the
+    # symlink -- the symlink target just doesn't exist. ~118 MB extra in the base
+    # image; cost is paid once and shared by every consumer. See GH issue #6092.
+    mysql-server-core-8.0 \
     mysql-shell \
     mycli \
     postgresql-client \


### PR DESCRIPTION
Two related changes that both stem from the infra defect surfaced by `CI-mysql84-binlog-g1` failing on PR #6087 (`fix(threads): repair IDLE_THREADS shutdown NULL deref and use-after-free`). Neither change is related to the thread-shutdown fix; both are pure CI infra.

### 1. Runner fallback for \`mysqlbinlog\`

`test/infra/control/run-tests-isolated.bash:283` resolves the mysqlbinlog path by `find`ing the workspace. After `ci-builds.yml` deletes `test/deps/` from the cache (to save ~700 MB), `find` returns nothing, the runtime symlink at `${TEST_DEPS}/mysqlbinlog` is never created, and `test_com_binlog_dump_enables_fast_forward-t` fails with `sh: 1: .../mysqlbinlog: not found` / exit code 32512.

The runner container (`test/infra/docker-base/Dockerfile`) already installs `mysql-client`, which depends on `mysql-server-core-8.0` and ships `/usr/bin/mysqlbinlog`. Fall back to `command -v mysqlbinlog` when `find` returns nothing:

```bash
MYSQL_BINLOG_BIN=$(find "${WORKSPACE}" ... -name "mysqlbinlog" -type f -executable -print | head -n 1)
if [ -z "${MYSQL_BINLOG_BIN}" ]; then
    MYSQL_BINLOG_BIN="$(command -v mysqlbinlog 2>/dev/null || true)"
fi
```

The `BINLOG_READER_BIN` lookup (companion to `MYSQL_BINLOG_BIN` for `test_binlog_reader-t`) doesn't currently exist in `run-tests-isolated.bash` on v3.0 — skipping it here; will revisit if/when that helper is reintroduced.

### 2. Callers for the three missing binlog groups

`mysql84-binlog-g1` was added in PR #6086. The three sibling groups (`legacy-binlog-g1`, `mysql90-binlog-g1`, `mysql95-binlog-g1`) are already registered in `test/tap/groups/groups.json` and have their `env.sh` + `infras.lst` + infra definitions, but no CI workflow. Without this, the same mysqlbinlog defect would bite them silently when they eventually get coverage.

New callers:
- `.github/workflows/CI-legacy-binlog-g1.yml`
- `.github/workflows/CI-mysql90-binlog-g1.yml`
- `.github/workflows/CI-mysql95-binlog-g1.yml`

Each mirrors `CI-mysql84-binlog-g1.yml` (the existing caller) with the workflow / reusable name swapped.

### Companion

The reusable side lives on `GH-Actions` in PR #6093 (branch `fix/ghactions-binlog-shards`). **Land that PR first** — the v3.0 callers invoke `ci-<group>.yml@GH-Actions`, so resolving the ref requires the reusables to already exist on `GH-Actions`.

### Issue

Closes #6092.

### Verification

- `git diff origin/v3.0..HEAD test/infra/control/run-tests-isolated.bash`: 16 added lines (the `find` lookback + comment block). No behavior change for the existing happy path (workspace mysqlbinlog still preferred); just an additional fallback.
- `git diff origin/v3.0..HEAD .github/workflows/CI-*.yml`: 3 new files, each 23 lines (mirrors `CI-mysql84-binlog-g1.yml` byte-for-byte with the workflow name and the reusable path swapped).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI “mysqlbinlog: not found” failures and adds CI coverage for three missing binlog groups. Tests now resolve `mysqlbinlog` from the workspace (staged by the GH-Actions build) or fall back to `/usr/bin/mysqlbinlog`, so binlog TAP runs succeed.

- `run-tests-isolated.bash` still prefers the workspace binary; if absent, it uses `command -v mysqlbinlog` to create the symlink.
- Runner base image installs `mysql-server-core-8.0` (Ubuntu 24.04 `mysql-client` does not ship `mysqlbinlog`), ensuring `/usr/bin/mysqlbinlog` exists.
- Adds caller workflows: `CI-legacy-binlog-g1.yml`, `CI-mysql90-binlog-g1.yml`, `CI-mysql95-binlog-g1.yml` (mirror `CI-mysql84-binlog-g1.yml`); reusables on `GH-Actions` are merged and resolve.
- Closes #6092.

<sup>Written for commit c24ebfdb1e397e4416e8dbc4551dfc78a65c5d7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated CI workflows for legacy binlog testing and MySQL 9.0 and 9.5 binlog group 1 validation.
  * Workflows can be triggered manually or following successful CI preparation, with outdated runs automatically canceled.

* **Bug Fixes**
  * Test setup now automatically uses the available `mysqlbinlog` executable when a workspace copy is unavailable.
  * Test environments now include the required `mysqlbinlog` utility, improving binlog test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->