### PR TITLE
ci: install mysql-server-core-8.0 in runner base image (for mysqlbinlog)

### DIFF
--- a/test/infra/docker-base/Dockerfile
+++ b/test/infra/docker-base/Dockerfile
@@ -8,6 +8,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
     mysql-client \
+    # mysql-server-core pulls in mysqlbinlog, which test_com_binlog_dump_enables_fast_forward-t
+    # shells out to at runtime. mysql-client does NOT (its core package only ships
+    # mysql / mysqladmin / mysqldump etc., not mysqlbinlog). Without this the binlog
+    # TAP tests fail with sh: 1: .../mysqlbinlog: not found even after the runner
+    # fallback in test/infra/control/run-tests-isolated.bash succeeds at creating the
+    # symlink -- the symlink target just doesn't exist. ~118 MB extra in the base
+    # image; cost is paid once and shared by every consumer. See GH issue #6092.
+    mysql-server-core-8.0 \
     mysql-shell \
     mycli \
     postgresql-client \


### PR DESCRIPTION
Companion to PR #6094. Single-file Dockerfile change so the runner base image rebuild pipeline (`CI-push-ci-base-image.yml`) picks it up automatically — that workflow only watches the v3.0 branch.

### Why this is a separate PR

`CI-push-ci-base-image.yml` rebuilds `ghcr.io/sysown/proxysql-ci-base:latest` only on pushes to `v3.0` that touch `test/infra/docker-base/Dockerfile`. My Dockerfile change in PR #6094 lives on `fix/test-deps-mysqlbinlog` and never triggers the rebuild, so even after #6094 merges the image at `ghcr.io/sysown/proxysql-ci-base:latest` still lacks `mysqlbinlog` and the binlog TAP tests stay red.

Opening this as a separate small PR so the rebuild fires the moment this lands.

### Why this matters

`mysql-client` in Ubuntu 24.04 depends on `mysql-client-core-8.0`, which ships `mysql`, `mysqladmin`, `mysqldump`, etc. — but **not `mysqlbinlog`**. `mysqlbinlog` is in `mysql-server-core-8.0`. The PR #6094 runner fallback at `test/infra/control/run-tests-isolated.bash:283-299` correctly creates the symlink at `${TEST_DEPS}/mysqlbinlog -> /usr/bin/mysqlbinlog` (visible in the artifact as `lrwxrwxrwx ... -> /usr/bin/mysqlbinlog`), but `sh` then fails with `not found` because the target doesn't exist in the image.

Reproduced against PR #6094 rerun on `16c23c2f2`: symlink created, test still fails. See GH issue #6092 for the full trace.

### Cost

`mysql-server-core-8.0` adds ~118 MB to the shared base image. Paid once; consumed by every TAP job that runs in `proxysql-ci-base:latest`.

### Closes

#6092.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs `mysql-server-core-8.0` in the CI runner base image to include `mysqlbinlog`, unblocking binlog TAP tests. Previously the image only had `mysql-client`/`mysql-client-core-8.0`; the runner created a symlink but the binary was missing, causing sh: .../`mysqlbinlog`: not found.

- Review and rollout
  - Single-file change in test/infra/docker-base/Dockerfile. Merging to `v3.0` triggers `CI-push-ci-base-image.yml` to rebuild `ghcr.io/sysown/proxysql-ci-base:latest`.
  - Adds ~118 MB to the base image; no per-test changes.
  - Companion to #6094. Closes #6092.

<sup>Written for commit 1f428ff7e74de808f3e9ee611c7d5a698fb5aaab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled binlog-related tests by adding the required MySQL server tooling to the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->