### PR TITLE
ci: stage mysqlbinlog into test/tap/tap/bin/ before pruning test/deps/

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -502,6 +502,43 @@ jobs:
           fi
           echo ">>> test/deps runtime-dependency check passed"
 
+          # Stage mysqlbinlog into the _test cache before the test/deps
+          # deletion below. The mysql-connector-c-8.4.0 build above produces
+          # the mysqlbinlog CLI under
+          # test/deps/mysql-connector-c-8.4.0/<mysql-8.4>/runtime_output_directory/mysqlbinlog
+          # as a side effect of `make` (cmake + the default target list).
+          # test_com_binlog_dump_enables_fast_forward-t shells out to it at
+          # runtime via system(); the test harness looks for it under
+          # ${TEST_DEPS}/mysqlbinlog. Copy the binary into
+          # test/tap/tap/bin/ (inside the _test cache's tar root) so it
+          # survives the test/deps prune below and is available to every
+          # CI-* test workflow that consumes this cache. The runner at
+          # test/infra/control/run-tests-isolated.bash will then `find` it
+          # here and symlink it into TEST_DEPS/mysqlbinlog. ~37 MB extra
+          # in the _test cache -- small compared to the existing ~700 MB
+          # saved by dropping the rest of test/deps.
+          #
+          # The bash glob `mysql-*-8.4*` matches whatever mysql source
+          # dir the upstream cmake + ln created; the build steps above
+          # always name the symlinked source dir `mysql-8.4.*` (today
+          # `mysql-8.4.0`). If multiple versions coexist, the first match
+          # is used -- which is fine because the runner only needs ONE
+          # mysqlbinlog to satisfy ${TEST_DEPS}/mysqlbinlog.
+          stage_mysqlbinlog=0
+          for src in test/deps/mysql-connector-c-8.4.0/mysql-*/runtime_output_directory/mysqlbinlog; do
+            if [ -x "${src}" ]; then
+              mkdir -p test/tap/tap/bin
+              sudo cp -f "${src}" test/tap/tap/bin/mysqlbinlog
+              sudo chmod 0755 test/tap/tap/bin/mysqlbinlog
+              echo ">>> Staged mysqlbinlog from ${src} -> test/tap/tap/bin/mysqlbinlog"
+              stage_mysqlbinlog=1
+              break
+            fi
+          done
+          if [ "${stage_mysqlbinlog}" -eq 0 ]; then
+            echo ">>> WARNING: no mysqlbinlog found under test/deps/mysql-connector-c-8.4.0/ — binlog TAP tests will fail" >&2
+          fi
+
           # sudo required: test/deps contents are owned by root (created
           # inside the docker build container). See comment above on the
           # unit test delete.


### PR DESCRIPTION
Follow-up to PR #6093 (reusables for legacy-binlog-g1 / mysql90-binlog-g1 / mysql95-binlog-g1, already merged). That PR made the workflows wire up but didn't fix the actual mysql84-binlog-g1 failure mode that the issue tracks.

### Problem

`ci-builds.yml` deletes `test/deps/` from the workspace before packing the `_test` cache to save ~700 MB. The deletion also wipes the `mysqlbinlog` binary that the mysql-connector-c-8.4.0 build produced as a side effect of `make` (output at `test/deps/mysql-connector-c-8.4.0/<src>/runtime_output_directory/mysqlbinlog`). `test_com_binlog_dump_enables_fast_forward-t` shells out to `${TEST_DEPS}/mysqlbinlog` at runtime, so it fails with `sh: 1: .../mysqlbinlog: not found`. Reproduced on PR #6094's rerun against `16c23c2f2`: the symlink was created (`lrwxrwxrwx ... -> /usr/bin/mysqlbinlog`) but `/usr/bin/mysqlbinlog` doesn't exist in the runner container because Ubuntu 24.04's `mysql-client` does not ship `mysqlbinlog` (only the `mysql`, `mysqladmin`, `mysqldump` family — `mysqlbinlog` is in `mysql-server-core-8.0`).

### Fix

Before the `sudo rm -rf test/deps` line, copy the freshly-built `mysqlbinlog` into `test/tap/tap/bin/`. `test/tap/tap/` is inside the `_test` cache's `tar -cf - test/` root, so the binary survives the cache prune. The runner at `test/infra/control/run-tests-isolated.bash` already `find`s the workspace for a `mysqlbinlog` executable and symlinks it into `${TEST_DEPS}/mysqlbinlog` — that part already works (verified on the rerun, the symlink was created); it just had nothing to symlink to before.

~37 MB extra in the `_test` cache (mysqlbinlog is a debug-mode binary). Negligible vs. the ~700 MB saved by the rest of the prune.

### Closes

#6092.

### Companion

#6094 (v3.0) lands the runner-side symlink fallback at the same time. The two land independently — this PR is purely a build-side change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stages mysqlbinlog into the `_test` cache before pruning `test/deps`, so binlog TAP tests can find it via the runner symlink. Previously, pruning removed the `mysql-connector-c-8.4.0`-built mysqlbinlog, causing `test_com_binlog_dump_enables_fast_forward-t` failures on Ubuntu 24.04; now the binary survives with a ~37 MB cache increase.

- Adds a copy step in `.github/workflows/ci-builds.yml` that glob-matches `test/deps/mysql-connector-c-8.4.0/mysql-*/runtime_output_directory/mysqlbinlog`, stages it into `test/tap/tap/bin/`, sets executable perms, and warns if not found.
- Leverages existing runner logic to find and symlink the staged binary into `${TEST_DEPS}/mysqlbinlog`; no other workflow changes.
- No migration required; all CI test jobs using the `_test` cache will have mysqlbinlog available.

<sup>Written for commit 3350038e36d4081dc9715fc0339d2249f5b6e2f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TAP test build reliability by preserving the generated `mysqlbinlog` executable for use in the test environment.
  * Added a warning when the executable cannot be found, allowing the build process to continue and provide clearer diagnostics.

* **Chores**
  * Updated continuous integration handling for generated test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->