### PR TITLE
fix(tarball): bundle OpenSSL and smoke test releases

### DIFF
--- a/.github/workflows/CI-package-amd64-tarball.yml
+++ b/.github/workflows/CI-package-amd64-tarball.yml
@@ -120,6 +120,11 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }} ${{ matrix.flags }}
 
+    - name: Test tarball runtime
+      env:
+        TARBALL_TEST_IMAGES: almalinux:9 debian:12 ubuntu:22.04
+      run: tools/test-tarball-runtime.sh
+
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-tarball.yml
+++ b/.github/workflows/CI-package-arm64-tarball.yml
@@ -120,6 +120,11 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }} ${{ matrix.flags }}
 
+    - name: Test tarball runtime
+      env:
+        TARBALL_TEST_IMAGES: almalinux:9 debian:12 ubuntu:22.04
+      run: tools/test-tarball-runtime.sh
+
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/tarball-compliant/entrypoint/entrypoint.bash
@@ -37,11 +37,44 @@ ${MAKE} ${MAKEOPT} ${EXTRA} ${build_target}
 
 echo "==> Staging Tarball Files"
 mkdir -p "pkgroot/${DIR_NAME}/bin"
+mkdir -p "pkgroot/${DIR_NAME}/lib"
 mkdir -p "pkgroot/${DIR_NAME}/etc/logrotate.d"
 mkdir -p "pkgroot/${DIR_NAME}/share/proxysql/tools"
 mkdir -p "pkgroot/${DIR_NAME}/systemd/system"
 
-cp src/proxysql "pkgroot/${DIR_NAME}/bin/"
+cp src/proxysql "pkgroot/${DIR_NAME}/bin/proxysql.bin"
+cat > "pkgroot/${DIR_NAME}/bin/proxysql" <<'EOF'
+#!/bin/sh
+set -eu
+
+BIN_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export LD_LIBRARY_PATH="${BIN_DIR}/../lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+exec "${BIN_DIR}/proxysql.bin" "$@"
+EOF
+chmod 0755 "pkgroot/${DIR_NAME}/bin/proxysql"
+
+bundle_runtime_library() {
+    local soname="$1"
+    local resolved_path
+    local library_name
+
+    resolved_path=$(ldd src/proxysql | awk -v soname="${soname}" '$1 == soname && $2 == "=>" { print $3; exit }')
+    if [[ -z "${resolved_path}" || ! -f "${resolved_path}" ]]; then
+        echo "ERROR: unable to resolve ${soname} for the tarball" >&2
+        exit 1
+    fi
+
+    resolved_path=$(readlink -f "${resolved_path}")
+    library_name=$(basename "${resolved_path}")
+    cp "${resolved_path}" "pkgroot/${DIR_NAME}/lib/${library_name}"
+    if [[ "${library_name}" != "${soname}" ]]; then
+        ln -s "${library_name}" "pkgroot/${DIR_NAME}/lib/${soname}"
+    fi
+}
+
+bundle_runtime_library libssl.so.3
+bundle_runtime_library libcrypto.so.3
+
 cp etc/proxysql.cnf "pkgroot/${DIR_NAME}/etc/"
 cp etc/logrotate.d/proxysql "pkgroot/${DIR_NAME}/etc/logrotate.d/"
 cp tools/proxysql_galera_checker.sh tools/proxysql_galera_writer.pl "pkgroot/${DIR_NAME}/share/proxysql/tools/"

--- a/tools/test-tarball-runtime.sh
+++ b/tools/test-tarball-runtime.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shopt -s nullglob
+archives=(binaries/proxysql-*.tar.gz)
+if [[ ${#archives[@]} -ne 1 ]]; then
+    echo "ERROR: expected exactly one tarball in binaries/, found ${#archives[@]}" >&2
+    printf '  %s\n' "${archives[@]:-<none>}" >&2
+    exit 1
+fi
+
+archive_path=$(readlink -f "${archives[0]}")
+archive_dir=$(dirname "${archive_path}")
+archive_name=$(basename "${archive_path}")
+read -r -a images <<< "${TARBALL_TEST_IMAGES:-almalinux:9 debian:12 ubuntu:22.04}"
+
+for image in "${images[@]}"; do
+    echo "==> Testing ${archive_name} on ${image}"
+    docker run --rm \
+        --mount "type=bind,src=${archive_dir},dst=/artifacts,readonly" \
+        --entrypoint /bin/sh \
+        "${image}" \
+        -eu -c '
+            archive="/artifacts/$1"
+            workdir=$(mktemp -d)
+            trap "rm -rf \"${workdir}\"" EXIT
+            tar -xzf "${archive}" -C "${workdir}"
+
+            launcher=$(find "${workdir}" -type f -path "*/bin/proxysql" -print -quit)
+            [ -n "${launcher}" ] || { echo "ERROR: tarball launcher is missing" >&2; exit 1; }
+            root_dir=$(dirname "$(dirname "${launcher}")")
+            binary="${root_dir}/bin/proxysql.bin"
+            [ -x "${binary}" ] || { echo "ERROR: tarball binary is missing" >&2; exit 1; }
+
+            export LD_LIBRARY_PATH="${root_dir}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+            ldd "${binary}"
+            ! ldd "${binary}" | grep -q "not found"
+            "${launcher}" --version
+        ' sh "${archive_name}"
+done

--- a/tools/test-tarball-runtime.sh
+++ b/tools/test-tarball-runtime.sh
@@ -40,7 +40,7 @@ for image in "${images[@]}"; do
                 resolved_path=
                 while IFS= read -r dependency; do
                     case "${dependency}" in
-                        "${library} => "*)
+                        *"${library} => "*)
                             resolved_path=${dependency#*=> }
                             resolved_path=${resolved_path%% *}
                             break

--- a/tools/test-tarball-runtime.sh
+++ b/tools/test-tarball-runtime.sh
@@ -33,8 +33,30 @@ for image in "${images[@]}"; do
             [ -x "${binary}" ] || { echo "ERROR: tarball binary is missing" >&2; exit 1; }
 
             export LD_LIBRARY_PATH="${root_dir}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-            ldd "${binary}"
-            ! ldd "${binary}" | grep -q "not found"
+            ldd_output=$(ldd "${binary}")
+            printf "%s\\n" "${ldd_output}"
+            ! printf "%s\\n" "${ldd_output}" | grep -q "not found"
+            for library in libssl.so.3 libcrypto.so.3; do
+                resolved_path=
+                while IFS= read -r dependency; do
+                    case "${dependency}" in
+                        "${library} => "*)
+                            resolved_path=${dependency#*=> }
+                            resolved_path=${resolved_path%% *}
+                            break
+                            ;;
+                    esac
+                done <<EOF
+${ldd_output}
+EOF
+                case "${resolved_path}" in
+                    "${root_dir}"/lib/*) ;;
+                    *)
+                        echo "ERROR: ${library} did not resolve from the tarball" >&2
+                        exit 1
+                        ;;
+                esac
+            done
             "${launcher}" --version
         ' sh "${archive_name}"
 done


### PR DESCRIPTION
## Summary
- bundle the OpenSSL runtime libraries used by Linux tarballs
- launch the binary with its packaged library path
- smoke-test extracted tarballs on AlmaLinux 9, Debian 12, and Ubuntu 22.04 before release upload

## Validation
Not run locally; the added GitHub Actions smoke test provides CI validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundle OpenSSL in Linux tarballs and add cross‑distro smoke tests to prevent releases that fail to start. Previously tarballs depended on system OpenSSL and could crash; now they include `libssl.so.3`/`libcrypto.so.3` and launch with a configured library path.

- Tarball now contains `lib/` with OpenSSL libs and a `bin/proxysql` launcher that sets `LD_LIBRARY_PATH` and execs `bin/proxysql.bin`.
- CI runs `tools/test-tarball-runtime.sh` on amd64 and arm64 for AlmaLinux 9, Debian 12, and Ubuntu 22.04; it asserts `ldd` resolves `libssl.so.3`/`libcrypto.so.3` from the tarball `lib/`, tolerates indented `ldd` output, runs `bin/proxysql --version`, and blocks upload on failure.
- Required migration: if you hardcode the binary path, call `bin/proxysql` (supported entry point), not `bin/proxysql.bin`.

<sup>Written for commit ac98d1f0043cb8e60c3ddb104d408a4171b7c800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tarball packages now include required runtime libraries for improved portability.
  * Added a launcher that automatically configures bundled libraries when starting the application.

* **Bug Fixes**
  * Improved tarball startup reliability across supported Linux environments.
  * Added validation to detect missing binaries, libraries, or unusable packages.

* **Tests**
  * Tarballs are now tested on AlmaLinux 9, Debian 12, and Ubuntu 22.04 for both AMD64 and ARM64 builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->