### PR TITLE
fix(ci): handle tarball package builds

### DIFF
--- a/.github/workflows/ci-package-build.yml
+++ b/.github/workflows/ci-package-build.yml
@@ -168,7 +168,7 @@ jobs:
       run: |
         GIT_VERSION=$(gh release --repo ${{ github.repository }} view ${{ env.BRANCH }}-head | tr -d '*' | grep -Po "(?<=Version : ).*")
         [[ ${GIT_VERSION} == ${{ needs.clean.outputs.gitdescribe }} ]] || exit 1
-        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber ${{ env.BIN_PKG }}
+        gh release upload ${{ env.BRANCH }}-head --repo ${{ github.repository }} --clobber "$BIN_PKG"
  
     - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
       if: always()

--- a/.github/workflows/ci-package-build.yml
+++ b/.github/workflows/ci-package-build.yml
@@ -108,6 +108,11 @@ jobs:
             type: '-clang'
           - arch: 'arm64'
             type: '-dbg'
+#         tarball Compose only provides tarball_build
+          - dist: 'tarball-almalinux9'
+            type: '-clang'
+          - dist: 'tarball-almalinux9'
+            type: '-dbg'
 
     runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
     timeout-minutes: 120
@@ -142,8 +147,20 @@ jobs:
       run: |
         #[[ $(git describe --long --abbrev=7) == ${{ needs.clean.outputs.gitdescribe }} ]] || exit 1
         make ${{ matrix.dist }}${{ matrix.type }}
-        echo "BIN_PKG=$(ls -1 binaries/*[mb])" >> $GITHUB_ENV
-        echo "BIN_HASH=$(ls -1 binaries/*.id-hash)" >> $GITHUB_ENV
+        shopt -s nullglob
+        packages=(binaries/*.deb binaries/*.rpm binaries/*.tar.gz)
+        if [[ ${#packages[@]} -ne 1 ]]; then
+          echo "ERROR: expected exactly one package artifact, found ${#packages[@]}" >&2
+          printf '  %s\n' "${packages[@]:-<none>}" >&2
+          exit 1
+        fi
+        echo "BIN_PKG=${packages[0]}" >> $GITHUB_ENV
+
+    - name: Test tarball runtime
+      if: startsWith(matrix.dist, 'tarball')
+      env:
+        TARBALL_TEST_IMAGES: almalinux:9 debian:12 ubuntu:22.04
+      run: tools/test-tarball-runtime.sh
 
     - name: Push packages
       env:


### PR DESCRIPTION
## Summary
- exclude unsupported tarball debug and Clang matrix rows
- discover tarball artifacts for release upload
- run tarball runtime smoke tests in the shared package workflow

## Root cause
The generic artifact glob ignored `.tar.gz` files, and the matrix requested Compose services that do not exist.

## Validation
Not run locally; CI will exercise the workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `ci-package-build` workflow to include tarball packages and upload the discovered artifact, preventing missing `.tar.gz` releases and invalid matrix rows.

- Artifact discovery picks exactly one of `*.deb`, `*.rpm`, or `*.tar.gz` and exports `BIN_PKG`; release upload now uses `BIN_PKG`. `BIN_HASH` is no longer exported.
- Adds a conditional tarball runtime smoke test (`tools/test-tarball-runtime.sh`) for `almalinux:9`, `debian:12`, and `ubuntu:22.04`.
- Prunes unsupported tarball `-clang` and `-dbg` matrix rows to match available Compose services.

<sup>Written for commit 7b1c316d4fddc0006366bfa82845180febfc1586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package artifact validation to detect missing or duplicate package files.
  * Enhanced tarball runtime testing across supported AlmaLinux, Debian, and Ubuntu environments.
  * Prevented unsupported debug and Clang package variants from being included in AlmaLinux 9 builds.
  * Improved build artifact reporting so only the verified package is exported for release processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->