### PR TITLE
fix(genai): restore complete and reliable AI TAP coverage

### DIFF
--- a/doc/PLUGIN_API.md
+++ b/doc/PLUGIN_API.md
@@ -103,7 +103,7 @@ All types are defined in `include/ProxySQL_Plugin.h`:
 ```cpp
 struct ProxySQL_PluginDescriptor {
     const char *name;                         // Human-readable plugin name
-    uint32_t abi_version;                     // PROXYSQL_PLUGIN_ABI_VERSION (1, 2, or 3)
+    uint32_t abi_version;                     // PROXYSQL_PLUGIN_ABI_VERSION (currently 5)
     proxysql_plugin_init_cb init;             // bool (*)(ProxySQL_PluginServices *)
     proxysql_plugin_start_cb start;           // bool (*)()
     proxysql_plugin_stop_cb stop;             // bool (*)()
@@ -115,7 +115,7 @@ struct ProxySQL_PluginDescriptor {
 | Field              | Type          | Description                                               |
 |--------------------|---------------|-----------------------------------------------------------|
 | `name`             | `const char*` | Plugin identifier, used in logging.                        |
-| `abi_version`      | `uint32_t`    | Set from `PROXYSQL_PLUGIN_ABI_VERSION`.  Value `1` = pre-chassis descriptor (six fields).  Value `2` = adds `register_schemas` (four-phase lifecycle).  Value `3` = same descriptor layout as `2`; `ProxySQL_PluginServices` adds a tail-appended `register_runtime_view`.  A v3/v3.1 ProxySQL core rejects `abi_version > 1`; the current PROXYSQL40 core accepts `[1, 3]`. |
+| `abi_version`      | `uint32_t`    | Set from `PROXYSQL_PLUGIN_ABI_VERSION`. Value `1` is the pre-chassis descriptor; `2` adds `register_schemas`; `3` adds `register_runtime_view`; `4` appends `db_kind` to runtime views; `5` appends optional Admin-mutex handoff callbacks to `ProxySQL_PluginCommandContext`. The current PROXYSQL40 core accepts `[1, 5]`. |
 | `init`             | callback      | Phase D — called with live services; register tables and commands here (or finish context setup if `register_schemas` already did it). |
 | `start`            | callback      | Phase E — start threads, open sockets, load config.        |
 | `stop`             | callback      | Called on shutdown.  Pairs with `init`, not `start`: if `init` returned true and `start` later failed, `stop` is still called so the plugin can release resources it allocated in `init`. |
@@ -128,16 +128,15 @@ Return `true` on success, `false` on failure. A `false` return from
 
 #### ABI version
 
-`include/ProxySQL_Plugin.h` exposes `PROXYSQL_PLUGIN_ABI_VERSION` (3 under
-PROXYSQL40, undefined in pre-chassis builds — the descriptor is then a
-legacy six-field struct with `abi_version = 1`).  Plugins MUST assign
+`include/ProxySQL_Plugin.h` exposes `PROXYSQL_PLUGIN_ABI_VERSION` (currently 5
+under PROXYSQL40, undefined in pre-chassis builds — the descriptor is then a
+legacy six-field struct with `abi_version = 1`). Plugins MUST assign
 `abi_version` from this macro rather than hard-coding a literal; the
 core's loader uses it to detect layout skew and reject plugins built
-for an unsupported ABI.  ABI 3 keeps the descriptor layout identical to
-ABI 2 — the only addition is a tail-appended `register_runtime_view`
-field on `ProxySQL_PluginServices` — so plugins that compile against
-ABI 2 still load on the current core; the trailing services field is
-simply invisible to them.  See `ProxySQL_Plugin.h` for the exact rules.
+for an unsupported ABI. All changes since ABI 2 have been tail additions or
+changes to tail-extensible callback payloads, so older plugins retain the
+prefix they were compiled against. See `ProxySQL_Plugin.h` for the exact
+rules.
 
 ### The Entry Point
 
@@ -322,10 +321,18 @@ struct ProxySQL_PluginCommandContext {
     SQLite3DB *admindb;
     SQLite3DB *configdb;
     SQLite3DB *statsdb;
+    void *admin_mutex_context;                 // ABI 5, optional
+    void (*release_admin_mutex)(void *);       // ABI 5, optional
+    void (*acquire_admin_mutex)(void *);       // ABI 5, optional
 };
 ```
 
 Passed to every command callback. Provides direct access to the three databases.
+Commands that can wait for another Admin-interface consumer may use the three
+ABI-5 fields to release the Admin global mutex for the blocking interval. Such
+commands must call `acquire_admin_mutex(admin_mutex_context)` before returning.
+The callbacks are null outside production Admin dispatch and must be checked as
+a complete triplet. Ordinary commands should leave them unused.
 
 ### Result
 
@@ -542,7 +549,7 @@ void register_stats_table(ProxySQL_PluginServices& services,
 - **No dependency resolution**: Plugins are loaded in the order listed in
   `proxysql.cnf`. If one plugin depends on another, the dependency must be
   listed first.
-- **ABI version range**: The current core accepts `abi_version` values in `[1, 3]`. Newly built plugins should set `abi_version = PROXYSQL_PLUGIN_ABI_VERSION`.
+- **ABI version range**: The current core accepts `abi_version` values in `[1, 5]`. Newly built plugins should set `abi_version = PROXYSQL_PLUGIN_ABI_VERSION`.
 - **Compiler coupling**: Plugins must match the ProxySQL core's C++ compiler
   and standard library due to `std::string` in `ProxySQL_PluginCommandResult`.
 

--- a/doc/plugin-chassis/ABI.md
+++ b/doc/plugin-chassis/ABI.md
@@ -59,8 +59,8 @@ The chassis (`lib/ProxySQL_PluginManager.cpp:324–383`) enforces:
 ### Current ABI version
 
 ```c
-#define PROXYSQL_PLUGIN_ABI_VERSION       4
-#define PROXYSQL_PLUGIN_ABI_VERSION_MAX   4
+#define PROXYSQL_PLUGIN_ABI_VERSION       5
+#define PROXYSQL_PLUGIN_ABI_VERSION_MAX   5
 ```
 
 ABI evolution so far:
@@ -68,6 +68,11 @@ ABI evolution so far:
 - **ABI 1 → ABI 2:** appends `register_schemas` to the descriptor (four-phase lifecycle). ABI-1 plugins skip Phase B entirely.
 - **ABI 2 → ABI 3:** descriptor layout is **unchanged**. The single addition is a `register_runtime_view` callback at the **tail of `ProxySQL_PluginServices`** (see §3 below). ABI-2 plugins keep loading on an ABI-3 core: their compiled-against `ProxySQL_PluginServices` simply ends one field earlier, and core never dereferences the trailing field for them. The accept range remains `[1, PROXYSQL_PLUGIN_ABI_VERSION_MAX]`.
 - **ABI 3 → ABI 4:** `ProxySQL_PluginDescriptor` and `ProxySQL_PluginServices` layouts are **unchanged**. The change is in `ProxySQL_PluginRuntimeView`, which gains a `db_kind` field (`ProxySQL_PluginDBKind`) **appended at the tail** of the struct. The chassis now dispatches the correct DB handle (admindb/configdb/statsdb) to the refresh callback based on `db_kind`. ABI-3 plugins that initialize `ProxySQL_PluginRuntimeView` with `{table_name, refresh, opaque}` (3-field aggregate init) automatically get `db_kind = admin_db` (value 0) via zero-initialization of the trailing field — matching the pre-ABI-4 behaviour without any detection code.
+- **ABI 4 → ABI 5:** `ProxySQL_PluginCommandContext` appends three optional
+  Admin global-mutex handoff fields. A command that can wait for another Admin
+  consumer may release the mutex during that wait and reacquire it before
+  returning. ABI-4 plugins see the unchanged `{admindb, configdb, statsdb}`
+  prefix and continue to load without using the new callbacks.
 
 Future ABI versions append fields. The chassis bumps `PROXYSQL_PLUGIN_ABI_VERSION_MAX` and gates each new field's read on `abi_version >= N`.
 
@@ -103,7 +108,7 @@ Reasons:
 
 ### Field stability
 
-The services struct is **tail-extensible**. The chassis fills the struct in declaration order and the plugin reads what it knows about. A plugin compiled against ABI 2 still loads on the current ABI-3 chassis: its compiled-against `ProxySQL_PluginServices` ends at `register_command_alias` and the chassis simply doesn't dereference the trailing `register_runtime_view` for that plugin. Same rule applies for any future ABI-N additions.
+The services struct is **tail-extensible**. The chassis fills the struct in declaration order and the plugin reads what it knows about. A plugin compiled against ABI 2 still loads on the current chassis: its compiled-against `ProxySQL_PluginServices` ends at `register_command_alias` and the chassis simply doesn't dereference the trailing `register_runtime_view` for that plugin. Same rule applies for any future ABI-N additions.
 
 The reverse — a future plugin trying to call a field that doesn't exist on the current chassis — would crash. The chassis prevents this by rejecting plugins whose `abi_version > PROXYSQL_PLUGIN_ABI_VERSION_MAX`.
 
@@ -196,7 +201,7 @@ The chassis follows these rules for ABI evolution:
 2. **Append, never insert.** New fields go at the end of the relevant struct.
 3. **Gate every new field's read.** When the chassis dereferences a field that's only valid for `abi_version >= N`, the read must be inside `if (descriptor->abi_version >= Nu)`.
 4. **Plugins set their own `abi_version` to whatever their compile-time header had.** This is the contract for "what fields I have". The chassis's `PROXYSQL_PLUGIN_ABI_VERSION_MAX` is the contract for "what fields I know how to read".
-5. **A future ABI 3 must not change the layout of fields that exist at ABI 2.** Otherwise an ABI-2 plugin stops being loadable.
+5. **A future ABI N must not change the layout of fields that exist at ABI N-1.** Otherwise an older plugin stops being loadable.
 
 The current public API surface (`ProxySQL_PluginDescriptor` + `ProxySQL_PluginServices` + the query-hook payload/result/action types) is **not yet versioned individually**. A future change might (e.g.) add a `ProxySQL_PluginServices_v3` for the second wave of services. The chassis is structured so this addition is a tail-append on the descriptor (`new_services` field) rather than a new struct.
 
@@ -252,7 +257,7 @@ static bool my_stop(const ProxySQL_PluginServices* services) {
 
 static const ProxySQL_PluginDescriptor descriptor = {
     "my_plugin",                          // name
-    PROXYSQL_PLUGIN_ABI_VERSION,          // abi_version (= 4)
+    PROXYSQL_PLUGIN_ABI_VERSION,          // abi_version (= 5)
     my_init,                              // init   (Phase D)
     my_start,                             // start  (Phase E)
     my_stop,                              // stop

--- a/docs/superpowers/plans/2026-08-17-ai-tap-shards-reliability.md
+++ b/docs/superpowers/plans/2026-08-17-ai-tap-shards-reliability.md
@@ -1,0 +1,446 @@
+# AI TAP Shards Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Keep each
+> checkbox test-first and commit only after the listed verification is green.
+
+**Goal:** Make `CI-ai-g1` and `CI-ai-g2` trustworthy and green under the
+label-selected ASAN integration build while retaining every one of their 22
+registered tests.
+
+**Architecture:** Treat the failures as one end-to-end contract. The central
+build must hand off every declared executable; the runner must reject missing
+or duplicate programs; the AI group must establish one authenticated HTTP MCP
+baseline; production must atomically publish loaded MCP variables; and each
+registered test must exercise the current interface deterministically.
+
+**Tech stack:** C++17, GNU Make, SQLite, libcurl, Bash, Python `unittest`, TAP,
+and the repository's Docker-isolated TAP runner.
+
+## Global constraints
+
+- Preserve the exact 22 `ai-g1` and 22 `ai-g2` entries in
+  `test/tap/groups/groups.json`.
+- Do not remove, silently omit, or unconditionally skip a registered test.
+- A full shard succeeds only when declared = discovered = executed = passed.
+- Use `PROXYSQL40=1` consistently for all relevant builds.
+- Run integration programs only through `test/scripts/run-tests-isolated.bash`.
+- Keep `.github/workflows/CI-unit-tests-asan-coverage.yml` unchanged.
+- Do not include MySQL 9.0/9.5 binlog failures in this PR.
+
+## Task 1: Publish MCP runtime variables atomically
+
+**Files:**
+
+- Modify: `test/tap/tests/unit/genai_plugin_load_unit-t.cpp`
+- Modify: `plugins/genai/src/plugin_main.cpp`
+- Modify: `plugins/genai/include/genai_plugin.h`
+
+### Steps
+
+- [ ] Extend the lifecycle fixture schema with
+  `runtime_global_variables(variable_name TEXT PRIMARY KEY, variable_value TEXT)`
+  and seed an unrelated `mysql-threads` row.
+- [ ] Add lifecycle TAP assertions for this sequence:
+  1. load `mcp-timeout_ms=45000` and observe all 14 `mcp-*` rows;
+  2. reload `mcp-timeout_ms=46000` and observe exactly 14 rows, with no
+     duplicate and with `mysql-threads` unchanged;
+  3. install an aborting SQLite trigger for the timeout insert, attempt a load
+     of `47000`, and observe a command error plus the previous `46000` runtime
+     view and active handler value.
+- [ ] Force a clean rebuild and run the unit binary before production changes:
+
+  ```bash
+  make -C test/tap/tests/unit PROXYSQL40=1 genai_plugin_load_unit-t -B
+  test/tap/tests/unit/genai_plugin_load_unit-t
+  ```
+
+  Expected RED: only the new runtime-publication/rollback assertions fail.
+
+- [ ] In `mcp_load_variables_from_admindb`, collect the complete desired
+  `mcp-*` snapshot and the previous handler snapshot as owned
+  `std::vector<std::pair<std::string, std::string>>` values.
+- [ ] Apply every desired value through `MCP_Threads_Handler::set_variable()`
+  and reject the load if any value is invalid.
+- [ ] Publish values read back from the handler in one SQLite transaction:
+  delete only `mcp-*` rows, bind and insert the complete snapshot, and commit
+  only after every statement succeeds.
+- [ ] On either handler application or SQL publication failure, restore all
+  previous handler values. Let SQLite roll back the uncommitted runtime view.
+- [ ] Update the declaration comment to state the atomic handler/runtime-table
+  contract and failure behavior.
+- [ ] Rebuild and run the affected and adjacent suites:
+
+  ```bash
+  make -C test/tap/tests/unit PROXYSQL40=1 \
+    genai_plugin_load_unit-t genai_thread_unit-t genai_mcp_thread_unit-t -B
+  test/tap/tests/unit/genai_plugin_load_unit-t
+  test/tap/tests/unit/genai_thread_unit-t
+  test/tap/tests/unit/genai_mcp_thread_unit-t
+  ```
+
+  Expected GREEN: every TAP assertion passes and all three processes exit 0.
+
+- [ ] Commit:
+
+  ```bash
+  git add plugins/genai test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+  git commit -m "fix(mcp): publish loaded runtime variables atomically"
+  ```
+
+## Task 2: Make MCP readiness authenticated and protocol-aware
+
+**Files:**
+
+- Create: `test/tap/tests/unit/mcp_client_unit-t.cpp`
+- Modify: `test/tap/tests/unit/Makefile`
+- Modify: `test/tap/tap/mcp_client.cpp`
+
+### Steps
+
+- [ ] Add a loopback fixture that binds an ephemeral port, accepts one HTTP
+  request, records its headers, and returns a caller-provided status/body.
+- [ ] Add three TAP cases for `MCPClient::check_server()`:
+  authenticated HTTP 200 JSON-RPC success sends
+  `Authorization: Bearer tap-token`; HTTP 401 returns false; malformed JSON at
+  HTTP 200 returns false.
+- [ ] Register a focused Makefile target linking `mcp_client.cpp`, libcurl,
+  pthreads, and the existing JSON dependency.
+- [ ] Build and run before changing the client:
+
+  ```bash
+  make -C test/tap/tests/unit PROXYSQL40=1 mcp_client_unit-t -B
+  test/tap/tests/unit/mcp_client_unit-t
+  ```
+
+  Expected RED: the header and HTTP-status assertions fail.
+
+- [ ] Reuse the same bearer-header construction used by normal tool calls in
+  `check_server()` whenever `auth_token` is non-empty.
+- [ ] Require `CURLE_OK`, HTTP status 200, valid JSON, matching JSON-RPC id, and
+  a `result` member; log transport, HTTP, parse, and protocol failures
+  separately.
+- [ ] Rebuild and rerun the unit target; all cases must pass.
+- [ ] Commit:
+
+  ```bash
+  git add test/tap/tap/mcp_client.cpp test/tap/tests/unit/Makefile \
+    test/tap/tests/unit/mcp_client_unit-t.cpp
+  git commit -m "fix(tap): authenticate MCP readiness probes"
+  ```
+
+## Task 3: Establish one authenticated AI MCP baseline
+
+**Files:**
+
+- Modify: `test/tap/groups/test_ai_group_shards.py`
+- Modify: `test/tap/groups/ai/mcp-config.sql`
+- Modify: `test/tap/groups/ai/env.sh`
+- Modify: `test/tap/groups/ai-g1/env.sh`
+- Modify: `test/tap/groups/ai-g2/env.sh`
+- Modify: `test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp`
+- Modify: `test/tap/tests/mcp_mysql_concurrency_stress-t.cpp`
+- Modify: `test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp`
+- Modify: `test/tap/tests/mcp_mixed_stats_cap_churn-t.cpp`
+- Modify: `test/tap/tests/mcp_mixed_stats_profile_matrix-t.cpp`
+- Modify: `test/tap/tests/mcp_query_rules-t.cpp`
+- Modify: `test/tap/tests/mcp_query_run_sql_readonly-t.cpp`
+- Modify: `test/tap/tests/mcp_query_run_sql_readonly_bypass-t.cpp`
+- Modify: `test/tap/tests/mcp_show_connections_commands_inmemory-t.cpp`
+- Modify: `test/tap/tests/mcp_show_queries_topk-t.cpp`
+- Modify: `test/tap/tests/mcp_stats_refresh-t.cpp`
+- Modify: `test/tap/tests/test_stats_mcp_tables-t.cpp`
+
+### Steps
+
+- [ ] Extend the Python contract test to assert exact unchanged shard
+  membership, HTTP (`mcp-use_ssl=false`), one non-empty token applied to all
+  endpoint-auth variables, both `TAP_MCP_PORT`/`TAP_MCPPORT`, and
+  `TAP_MCP_AUTH_TOKEN` in every inherited environment.
+- [ ] Run:
+
+  ```bash
+  python3 -m unittest test/tap/groups/test_ai_group_shards.py -v
+  ```
+
+  Expected RED: the transport/token/environment assertions fail while exact
+  membership remains green.
+
+- [ ] Export one stable test token and both port spellings from the AI group;
+  keep shard env files consistent with the parent.
+- [ ] In `mcp-config.sql`, set HTTP plus that token for config, stats, query,
+  admin, cache, AI, and RAG endpoints before enabling MCP and saving to disk.
+- [ ] Update each listed client test to set `cl.mcp_auth_token`, configure the
+  endpoint it calls with the escaped canonical token, and restore the disk
+  baseline during cleanup rather than clearing authentication.
+- [ ] Preserve negative-auth coverage by replacing credentials only for the
+  negative case and restoring the canonical value on every exit path.
+- [ ] Remove automatic HTTP-to-HTTPS probing from non-TLS tests; use the group
+  HTTP endpoint directly.
+- [ ] Rerun the Python contract test, then build the affected TAP binaries:
+
+  ```bash
+  python3 -m unittest test/tap/groups/test_ai_group_shards.py -v
+  make -C test/tap PROXYSQL40=1 \
+    mcp_query_rules-t mcp_query_run_sql_readonly-t \
+    mcp_query_run_sql_readonly_bypass-t test_stats_mcp_tables-t
+  ```
+
+- [ ] Run each affected program through the isolated runner with the matching
+  AI group and require process/TAP success.
+- [ ] Commit:
+
+  ```bash
+  git add test/tap/groups test/tap/tests
+  git commit -m "fix(tap): standardize authenticated AI MCP setup"
+  ```
+
+## Task 4: Restore maintained shell-test prerequisites
+
+**Files:**
+
+- Create: `test/tap/tests/mcp_rules_testing/mcp_test_helpers.sh`
+- Create: `test/tap/groups/test_ai_shell_contract.py`
+- Modify: `test/tap/tests/test_mcp_claude_headless_flow-t.sh`
+- Modify: `test/tap/tests/test_mcp_llm_discovery_phaseb-t.sh`
+- Modify: `test/tap/tests/test_mcp_rag_metrics-t.sh`
+- Modify: `test/tap/tests/test_mcp_static_harvest-t.sh`
+- Modify files under: `test/tap/tests/mcp_headless_testing/`
+- Modify files under: `test/tap/tests/rag_stats_testing/`
+
+### Steps
+
+- [ ] Add static contract tests proving the shared helper exists, uses
+  `TAP_ADMINHOST`, accepts either MCP port spelling, emits a bearer header,
+  defaults to HTTP, has no hard-coded admin `127.0.0.1`, has no `sqlite3`
+  executable dependency, and refers only to fixtures below `test/tap/tests`.
+- [ ] Run the new unittest and record the expected missing-helper/path/SQLite
+  failures.
+- [ ] Restore the helper at the path all four programs source. Provide TAP
+  planning/results, admin SQL, authenticated JSON-RPC calls, readiness checks,
+  and explicit prerequisite diagnostics.
+- [ ] Move or recreate the headless dry-run fixtures below
+  `test/tap/tests/mcp_headless_testing`; default to the isolated `proxysql`
+  host. Keep live Claude execution opt-in while ensuring the local dry-run
+  remains a real passing assertion path.
+- [ ] Make discovery, RAG, and static-harvest scripts consume the canonical
+  group host/scheme/token/profile contract and restore modified state.
+- [ ] Replace the RAG fixture's `sqlite3` CLI calls with an embedded Python
+  `sqlite3` script that returns nonzero on schema/data failure.
+- [ ] Rerun the contract test and `bash -n` over the helper and four programs.
+- [ ] Execute all four through the isolated AI shard runner and require every
+  declared TAP assertion to pass.
+- [ ] Commit:
+
+  ```bash
+  git add test/tap/groups/test_ai_shell_contract.py \
+    test/tap/tests/mcp_rules_testing test/tap/tests/mcp_headless_testing \
+    test/tap/tests/rag_stats_testing test/tap/tests/test_mcp_*-t.sh
+  git commit -m "fix(tap): restore portable MCP shell fixtures"
+  ```
+
+## Task 5: Align stale GenAI, NL2SQL, and vector feature tests
+
+**Files:**
+
+- Modify: `test/tap/tests/genai_module-t.cpp`
+- Modify: `test/tap/tests/nl2sql_unit_base-t.cpp`
+- Modify: `test/tap/tests/vector_features-t.cpp`
+
+### Steps
+
+- [ ] Rewrite `genai_module-t` expectations around the canonical `genai-*`
+  variables: exact current count, representative defaults, supported
+  `LOAD/SAVE GENAI VARIABLES` aliases, value changes, and persistence. Delete
+  all `genai-var1`/`genai-var2` compatibility expectations.
+- [ ] Replace NL2SQL suffix concatenation with full canonical names:
+  `genai-llm_enabled`, `genai-llm_provider`,
+  `genai-llm_provider_model`, `genai-llm_cache_similarity_threshold`, and
+  `genai-llm_timeout_ms`. Validate the runtime values through supported admin
+  commands and remove the placeholder manager-exists assertion.
+- [ ] Replace removed `mysql_servers.ai_*` checks in `vector_features-t` with
+  canonical vector-path/dimension, cache, similarity, and anomaly variables;
+  assert load/save persistence and reject tautologies or empty-as-success.
+- [ ] Build all three before changing their expectations and preserve the
+  existing failures as RED evidence, then rebuild after each rewrite.
+- [ ] Execute each program with the isolated runner and require exact TAP plan
+  completion with exit 0.
+- [ ] Commit:
+
+  ```bash
+  git add test/tap/tests/genai_module-t.cpp \
+    test/tap/tests/nl2sql_unit_base-t.cpp test/tap/tests/vector_features-t.cpp
+  git commit -m "fix(tap): test current GenAI and vector interfaces"
+  ```
+
+## Task 6: Make vector performance coverage deterministic
+
+**Files:**
+
+- Modify: `test/tap/tests/vector_db_performance-t.cpp`
+
+### Steps
+
+- [ ] Add a focused regression showing that the existing four-byte mock hash
+  can produce a false high-similarity match for a distinct query, and retain
+  the current relative-timing assertions long enough to observe their failure.
+- [ ] Replace the mock embedding with a deterministic full-dimension generator
+  seeded by a stable FNV-1a hash and advanced with a fixed integer PRNG.
+- [ ] Assert exact-query result correctness, unrelated-query miss at `0.99`,
+  vector/result shape, successful representative small/medium/large workloads,
+  and only broad absolute completion bounds. Remove relative timing ordering.
+- [ ] Build and run through the isolated runner twice to prove deterministic
+  success.
+- [ ] Commit:
+
+  ```bash
+  git add test/tap/tests/vector_db_performance-t.cpp
+  git commit -m "fix(tap): make vector performance checks deterministic"
+  ```
+
+## Task 7: Reconcile declared tests across the complete handoff
+
+**Files:**
+
+- Create: `test/scripts/lib/group_reconciliation.py`
+- Create: `test/scripts/tests/test_group_reconciliation.py`
+- Modify: `test/scripts/bin/proxysql-tester.py`
+
+### Steps
+
+- [ ] Add pure Python unit cases for: 22 declared/16 discovered reports six
+  exact missing names; duplicate basenames report duplicates; a result with no
+  exit status reports skipped; nonzero reports failed; all passing is clean;
+  and an explicit selected subset validates only that subset.
+- [ ] Define a `GroupReconciliation` dataclass with `passed`, `failed`,
+  `skipped`, `missing`, `duplicates`, and an `ok` property, plus:
+
+  ```python
+  reconcile_group_results(
+      declared: set[str],
+      discovered: list[str],
+      results: list[tuple[str, int | None]],
+  ) -> GroupReconciliation
+  ```
+
+- [ ] Run:
+
+  ```bash
+  python3 -m unittest test/scripts/tests/test_group_reconciliation.py -v
+  ```
+
+  Expected RED: import/module failure before implementation.
+
+- [ ] Accumulate discovered basenames and execution results across every
+  `tap_tests_*` work directory in `proxysql-tester.py`, then reconcile once
+  against the group membership after version/include/exclude selection.
+- [ ] Log exact sorted sets for missing, duplicate, skipped, and failed tests;
+  increment the run status for any nonempty error set. Remove the current
+  per-directory expectation intersection that hides globally missing programs.
+- [ ] Run the unit suite plus `python3 -m py_compile` on the runner.
+- [ ] Commit:
+
+  ```bash
+  git add test/scripts/lib/group_reconciliation.py \
+    test/scripts/tests/test_group_reconciliation.py \
+    test/scripts/bin/proxysql-tester.py
+  git commit -m "fix(tap): fail shards with missing test programs"
+  ```
+
+## Task 8: Build and stage all eleven declared GenAI units
+
+**Files:**
+
+- Create: `test/tap/groups/test_ai_unit_handoff.py`
+- Modify: `test/tap/tests/unit/Makefile`
+- Modify: `test/tap/Makefile`
+- Create during the build: `test/tap/tap_tests_ai_unit/manifest.txt`
+
+### Steps
+
+- [ ] Parse `groups.json` in the new contract test and assert that the staged
+  manifest/Makefile contract names exactly these eleven group-declared units:
+  `genai_config_query_unit-t`, `genai_discovery_schema_unit-t`,
+  `genai_fts_string_unit-t`, `genai_llm_clients_unit-t`,
+  `genai_mcp_endpoint_unit-t`, `genai_mcp_thread_unit-t`,
+  `genai_mysql_catalog_unit-t`, `genai_query_handler_unit-t`,
+  `genai_rag_fetch_from_source_unit-t`, `genai_stats_parsing_unit-t`, and
+  `genai_thread_unit-t`.
+- [ ] Also assert the stage path matches `tap_tests_*` and that the three
+  unrelated GenAI unit binaries are absent.
+- [ ] Run the contract test before Makefile changes and observe RED.
+- [ ] Refactor common GenAI plugin source compilation into path-preserving
+  object files and one static archive that inherits `OPT`, coverage, sanitizer,
+  and debug flags.
+- [ ] Link only the eleven declared programs against that archive in a
+  sequential `ai_genai_unit_tests` target; do not re-enable the complete
+  `unit_tests` GenAI set.
+- [ ] Under `PROXYSQL40=1 WITHGCOV=1 SKIP_GENAI_UNIT_TESTS=1`, make the top-level
+  TAP build invoke that target, stage executable hardlinks/copies under
+  `test/tap/tap_tests_ai_unit`, write the sorted manifest, and compare it to
+  the expected list before succeeding.
+- [ ] Run the contract test and a clean forced build of the focused target:
+
+  ```bash
+  python3 -m unittest test/tap/groups/test_ai_unit_handoff.py -v
+  make -C test/tap PROXYSQL40=1 WITHGCOV=1 SKIP_GENAI_UNIT_TESTS=1 \
+    ai_genai_unit_tests -B -j1
+  find test/tap/tap_tests_ai_unit -maxdepth 1 -type f -printf '%f\n' | sort
+  ```
+
+  Expected GREEN: exactly eleven executables plus `manifest.txt`, with all
+  executable names matching the AI group contract.
+- [ ] Run all eleven staged units and require exit 0/TAP completion.
+- [ ] Commit:
+
+  ```bash
+  git add test/tap/Makefile test/tap/tests/unit/Makefile \
+    test/tap/groups/test_ai_unit_handoff.py
+  git commit -m "build(tap): hand off declared GenAI unit tests"
+  ```
+
+## Task 9: Verify the consolidated repair and update PR #6107
+
+**Files:**
+
+- Modify if needed: files from Tasks 1–8 only
+- Update remotely: PR #6107 title and description
+
+### Steps
+
+- [ ] Run all static/unit contract suites:
+
+  ```bash
+  python3 -m unittest \
+    test/tap/groups/test_ai_group_shards.py \
+    test/tap/groups/test_ai_shell_contract.py \
+    test/tap/groups/test_ai_unit_handoff.py \
+    test/scripts/tests/test_group_reconciliation.py -v
+  git diff --check
+  ```
+
+- [ ] Force-rebuild and execute the production-adjacent GenAI/MCP unit suites,
+  the MCP client unit, and all eleven staged group units.
+- [ ] Run every directly repaired integration program through
+  `run-tests-isolated.bash`; do not invoke a test binary against shared/manual
+  Docker infrastructure.
+- [ ] Run the full unfiltered `ai-g1` and `ai-g2` groups and capture the final
+  reconciliation. Both must report 22 declared, 22 discovered, 22 executed,
+  and 22 passed.
+- [ ] Inspect output for `AddressSanitizer`, `LeakSanitizer`, `runtime error:`,
+  and incomplete TAP plans. Treat any occurrence as a failure to investigate.
+- [ ] Confirm the central build diff does not touch
+  `CI-unit-tests-asan-coverage` and does not include MySQL 9.0/9.5 binlog code.
+- [ ] Retitle PR #6107 to
+  `fix(genai): make AI TAP shards complete and reliable` and rewrite its body to
+  explain the six repaired layers, exact shard totals, local verification,
+  ASAN status, issue coverage, and excluded binlog scope. Close an older issue
+  only when every failure recorded in it is resolved.
+- [ ] Push the complete branch, preserve the `ci:asan` label, and trigger the
+  intended labeled pipeline with an empty commit only after the label is
+  present if a deliberate rerun is required.
+- [ ] Inspect all required PR checks and logs. Do not describe a failure as
+  pre-existing; either fix an in-scope AI failure or document a concrete,
+  evidence-backed out-of-scope cause.
+

--- a/docs/superpowers/plans/2026-08-17-ai-tap-shards-reliability.md
+++ b/docs/superpowers/plans/2026-08-17-ai-tap-shards-reliability.md
@@ -443,4 +443,3 @@ and the repository's Docker-isolated TAP runner.
 - [ ] Inspect all required PR checks and logs. Do not describe a failure as
   pre-existing; either fix an in-scope AI failure or document a concrete,
   evidence-backed out-of-scope cause.
-

--- a/docs/superpowers/plans/2026-08-17-genai-variable-default-seeding.md
+++ b/docs/superpowers/plans/2026-08-17-genai-variable-default-seeding.md
@@ -34,7 +34,7 @@
 
 **Interfaces:**
 - Consumes: existing `ProxySQL_PluginManager::init_all()` / `start_all()` lifecycle, `SQLite3DB::return_one_int()`, handler variable enumeration APIs, and plugin-service database getters.
-- Produces: a 57-assertion lifecycle regression plus startup helpers that seed exactly 14 MCP and 32 GenAI variables in each database while preserving pre-existing values.
+- Produces: a 60-assertion lifecycle regression plus startup helpers that seed exactly 14 MCP and 32 GenAI variables in each database while preserving pre-existing values.
 
 - [ ] **Step 1: Give configdb the minimal schema used by the seeding contract**
 
@@ -76,7 +76,7 @@ for (SQLite3DB* db : {g_configdb, g_admindb}) {
 
 - [ ] **Step 3: Add post-start persistence and preservation assertions**
 
-Change `plan(45)` to `plan(57)`. Immediately after `start_all()` succeeds, run six assertions for each database:
+Change `plan(45)` to `plan(60)`. Immediately after `start_all()` succeeds, run six assertions for each database:
 
 ```cpp
 struct VariableDatabase {
@@ -117,6 +117,8 @@ for (const VariableDatabase& target : {
 ```
 
 The primary key on `variable_name` and exact counts jointly prove that startup creates one row per supported variable without duplicates.
+
+Final review adds three assertions around `genai-llm_cache_enabled`: the config database receives its compiled `true` default, `SAVE GENAI VARIABLES TO MEMORY` succeeds, and an Admin database value persisted as `false` is loaded and preserved by that save.
 
 - [ ] **Step 4: Build and run the test to establish RED**
 
@@ -250,7 +252,7 @@ make -C test/tap/tests/unit genai_plugin_load_unit-t
 test/tap/tests/unit/genai_plugin_load_unit-t
 ```
 
-Expected: `1..57`, all 57 assertions pass, and the process exits 0.
+Expected: `1..60`, all 60 assertions pass, and the process exits 0.
 
 - [ ] **Step 6: Review the diff and commit the behavior with its regression**
 
@@ -287,7 +289,7 @@ make -C test/tap/tests/unit -B genai_plugin_load_unit-t
 test/tap/tests/unit/genai_plugin_load_unit-t
 ```
 
-Expected: clean plugin rebuild succeeds and all 57 assertions pass.
+Expected: clean plugin rebuild succeeds and all 60 assertions pass.
 
 - [ ] **Step 2: Run adjacent GenAI handler unit tests**
 

--- a/docs/superpowers/plans/2026-08-17-genai-variable-default-seeding.md
+++ b/docs/superpowers/plans/2026-08-17-genai-variable-default-seeding.md
@@ -1,0 +1,317 @@
+# GenAI Plugin Variable Default Seeding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore persistent, non-destructive startup seeding for all MCP and GenAI plugin variables tracked by issue #6099.
+
+**Architecture:** During `genai_start()`, collect names and constructor-default values from the two plugin-owned handlers, then insert missing rows into the persistent config database and in-memory Admin database before loading runtime state. A single database writer handles both variable families and uses one transaction plus `INSERT OR IGNORE`, so existing operator values win and partial installations are repaired idempotently.
+
+**Tech Stack:** C++17, ProxySQL plugin ABI, `SQLite3DB`, bundled SQLite prepared-statement API, TAP unit tests, GNU Make.
+
+## Global Constraints
+
+- Persist defaults in both configdb and admindb; do not implement a memory-only fix.
+- Preserve every existing operator value with `INSERT OR IGNORE`; never use `REPLACE` in the seeding path.
+- Seed variables before `mcp_load_variables_from_admindb()` and `genai_load_variables_from_admindb()` run.
+- Keep `runtime_global_variables` out of this change; issue #6100 owns runtime projection.
+- Do not change variable names, compiled defaults, validation, plugin ABI, endpoint authentication, or CI workflow definitions.
+- Leave `CI-unit-tests-asan-coverage` unchanged.
+
+---
+
+## File map
+
+- `test/tap/tests/unit/genai_plugin_load_unit-t.cpp`: extend the real plugin lifecycle test with fresh/partial-install persistence and preservation assertions.
+- `plugins/genai/src/plugin_main.cpp`: collect handler defaults, seed both databases transactionally, and call the seeding path before runtime loads.
+- `docs/superpowers/specs/2026-08-17-genai-variable-default-seeding-design.md`: approved design; no further edits expected unless implementation exposes a contradiction.
+
+### Task 1: Add the failing lifecycle regression
+
+**Files:**
+- Modify: `test/tap/tests/unit/genai_plugin_load_unit-t.cpp:20-110`
+
+**Interfaces:**
+- Consumes: existing `ProxySQL_PluginManager::init_all()` / `start_all()` lifecycle and `SQLite3DB::return_one_int()`.
+- Produces: a 57-assertion lifecycle test that requires exactly 14 persisted MCP variables and 32 persisted GenAI variables in each database while preserving pre-existing values.
+
+- [ ] **Step 1: Give configdb the minimal schema used by the seeding contract**
+
+Extract the existing `global_variables` DDL into a helper and invoke it for both database handles. Keep the MCP table DDLs Admin-only:
+
+```cpp
+void setup_global_variables_schema(SQLite3DB* db) {
+	db->execute("CREATE TABLE IF NOT EXISTS global_variables ("
+	            " variable_name TEXT PRIMARY KEY, variable_value TEXT)");
+}
+
+void setup_admindb_schema(SQLite3DB* db) {
+	setup_global_variables_schema(db);
+	// Existing mcp_auth_profiles, mcp_target_profiles, runtime tables,
+	// and mcp_query_rules DDLs remain here unchanged.
+}
+```
+
+After opening the three in-memory databases, initialize both schemas:
+
+```cpp
+setup_admindb_schema(g_admindb);
+setup_global_variables_schema(g_configdb);
+```
+
+- [ ] **Step 2: Model persisted operator values before plugin startup**
+
+Immediately after schema setup, seed a partial configuration into both databases. These values deliberately differ from constructor defaults:
+
+```cpp
+for (SQLite3DB* db : {g_configdb, g_admindb}) {
+	if (!db->execute(
+		"INSERT INTO global_variables(variable_name, variable_value) VALUES"
+		" ('mcp-port','7123'),('genai-threads','7')")) {
+		BAIL_OUT("failed to seed persisted GenAI plugin variables");
+	}
+}
+```
+
+- [ ] **Step 3: Add post-start persistence and preservation assertions**
+
+Change `plan(45)` to `plan(57)`. Immediately after `start_all()` succeeds, run six assertions for each database:
+
+```cpp
+struct VariableDatabase {
+	SQLite3DB* db;
+	const char* name;
+};
+
+for (const VariableDatabase& target : {
+	VariableDatabase{g_configdb, "configdb"},
+	VariableDatabase{g_admindb, "admindb"}
+}) {
+	const int mcp_count = target.db->return_one_int(
+		"SELECT COUNT(*) FROM global_variables WHERE variable_name LIKE 'mcp-%'");
+	const int genai_count = target.db->return_one_int(
+		"SELECT COUNT(*) FROM global_variables WHERE variable_name LIKE 'genai-%'");
+
+	ok(mcp_count == 14, "%s contains all 14 MCP variables (got %d)",
+	   target.name, mcp_count);
+	ok(genai_count == 32, "%s contains all 32 GenAI variables (got %d)",
+	   target.name, genai_count);
+	ok(target.db->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='mcp-port' AND variable_value='7123'") == 1,
+	   "%s preserves persisted mcp-port", target.name);
+	ok(target.db->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='genai-threads' AND variable_value='7'") == 1,
+	   "%s preserves persisted genai-threads", target.name);
+	ok(target.db->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='mcp-timeout_ms' AND variable_value='30000'") == 1,
+	   "%s persists missing mcp-timeout_ms default", target.name);
+	ok(target.db->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='genai-rag_timeout_ms' AND variable_value='2000'") == 1,
+	   "%s persists missing genai-rag_timeout_ms default", target.name);
+}
+```
+
+The primary key on `variable_name` and exact counts jointly prove that startup creates one row per supported variable without duplicates.
+
+- [ ] **Step 4: Build and run the test to establish RED**
+
+Run:
+
+```bash
+make -C test/tap/tests/unit genai_plugin_load_unit-t
+test/tap/tests/unit/genai_plugin_load_unit-t
+```
+
+Expected: the existing 45 lifecycle assertions remain successful; the new row-count and missing-default assertions fail because each database still contains only the two pre-seeded rows. The four preservation assertions pass, proving the failure is specifically missing default seeding.
+
+### Task 2: Seed both variable families transactionally at plugin start
+
+**Files:**
+- Modify: `plugins/genai/src/plugin_main.cpp:50-100`
+- Modify: `plugins/genai/src/plugin_main.cpp:675-698`
+
+**Interfaces:**
+- Consumes: `MCP_Threads_Handler::get_variables_list()`, `get_variable_string()`, `GenAI_Threads_Handler::get_variables_list()`, `get_variable()`, and plugin-service `get_admindb()` / `get_configdb()`.
+- Produces: anonymous-namespace helpers `collect_variable_defaults(GenAIPluginContext&, VariableDefaults&)`, `seed_variable_defaults(SQLite3DB*, const VariableDefaults&, const char*)`, and `seed_plugin_variable_defaults(GenAIPluginContext&)`.
+
+- [ ] **Step 1: Add a value type and a single variable-list cleanup helper**
+
+Add `<utility>` and `<vector>` explicitly, then define these anonymous-namespace utilities near `embed_query_via_glogath`:
+
+```cpp
+using VariableDefaults = std::vector<std::pair<std::string, std::string>>;
+
+void free_variable_names(char** names) {
+	if (names == nullptr) return;
+	for (int i = 0; names[i] != nullptr; ++i) free(names[i]);
+	free(names);
+}
+```
+
+- [ ] **Step 2: Collect the complete MCP and GenAI default set before touching either database**
+
+Implement one collector that appends qualified names and current constructor values. On any read/allocation failure, free owned memory and return false without starting a transaction:
+
+```cpp
+bool collect_variable_defaults(GenAIPluginContext& ctx, VariableDefaults& defaults) {
+	if (ctx.mcp == nullptr || GloGATH == nullptr) return false;
+
+	char** mcp_names = ctx.mcp->get_variables_list();
+	if (mcp_names == nullptr) return false;
+	for (int i = 0; mcp_names[i] != nullptr; ++i) {
+		std::string value;
+		if (!ctx.mcp->get_variable_string(mcp_names[i], value)) {
+			free_variable_names(mcp_names);
+			return false;
+		}
+		defaults.emplace_back(std::string("mcp-") + mcp_names[i], std::move(value));
+	}
+	free_variable_names(mcp_names);
+
+	char** genai_names = GloGATH->get_variables_list();
+	if (genai_names == nullptr) return false;
+	for (int i = 0; genai_names[i] != nullptr; ++i) {
+		char* value = GloGATH->get_variable(genai_names[i]);
+		defaults.emplace_back(
+			std::string("genai-") + genai_names[i], value != nullptr ? value : "");
+		free(value);
+	}
+	free_variable_names(genai_names);
+	return true;
+}
+```
+
+- [ ] **Step 3: Implement the transactional `INSERT OR IGNORE` writer**
+
+Prepare exactly this statement so existing rows can never be replaced:
+
+```cpp
+"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)"
+```
+
+`seed_variable_defaults()` must:
+
+1. reject a null database;
+2. prepare the statement and log the database label plus SQLite return code on failure;
+3. begin one transaction;
+4. bind the qualified name and value with `SQLITE_TRANSIENT`;
+5. require `proxy_sqlite3_step()` to return `SQLITE_DONE`;
+6. clear bindings and reset after every row;
+7. roll back and log the failing variable on any bind, step, clear, reset, or commit failure;
+8. return true only after commit succeeds.
+
+Use the bundled function pointers already used by `mcp_save_variables_to_admindb()`:
+
+```cpp
+(*proxy_sqlite3_bind_text)(statement, 1, item.first.c_str(), -1, SQLITE_TRANSIENT);
+(*proxy_sqlite3_bind_text)(statement, 2, item.second.c_str(), -1, SQLITE_TRANSIENT);
+(*proxy_sqlite3_step)(statement);
+(*proxy_sqlite3_clear_bindings)(statement);
+(*proxy_sqlite3_reset)(statement);
+```
+
+Do not use `SAFE_SQLITE3_STEP2` here: the seeding path must roll back and return a controlled plugin-start failure rather than assert.
+
+- [ ] **Step 4: Seed configdb and admindb before runtime loads**
+
+Implement the orchestration helper:
+
+```cpp
+bool seed_plugin_variable_defaults(GenAIPluginContext& ctx) {
+	if (ctx.services == nullptr ||
+	    ctx.services->get_configdb == nullptr ||
+	    ctx.services->get_admindb == nullptr) {
+		return false;
+	}
+
+	VariableDefaults defaults;
+	if (!collect_variable_defaults(ctx, defaults)) return false;
+
+	SQLite3DB* configdb = ctx.services->get_configdb();
+	SQLite3DB* admindb = ctx.services->get_admindb();
+	return seed_variable_defaults(configdb, defaults, "configdb") &&
+	       seed_variable_defaults(admindb, defaults, "admindb");
+}
+```
+
+At the start of `genai_start()`, after `ctx.started = true` and before `mcp_load_variables_from_admindb(ctx)`, call the helper. On failure, log `genai plugin: failed to seed MCP/GenAI variable defaults`, reset `ctx.started`, and return false.
+
+- [ ] **Step 5: Rebuild and verify GREEN**
+
+Run:
+
+```bash
+make -C test/tap/tests/unit genai_plugin_load_unit-t
+test/tap/tests/unit/genai_plugin_load_unit-t
+```
+
+Expected: `1..57`, all 57 assertions pass, and the process exits 0.
+
+- [ ] **Step 6: Review the diff and commit the behavior with its regression**
+
+Run:
+
+```bash
+git diff --check
+git diff -- plugins/genai/src/plugin_main.cpp test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+```
+
+Confirm the diff contains no `REPLACE`, no `runtime_global_variables`, and no workflow changes. Then commit:
+
+```bash
+git add plugins/genai/src/plugin_main.cpp test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+git commit -m "fix(genai): persist missing plugin variable defaults"
+```
+
+### Task 3: Verify #6099 and prepare the branch for review
+
+**Files:**
+- Verify only; no planned source changes.
+
+**Interfaces:**
+- Consumes: the completed lifecycle regression and branch diff.
+- Produces: fresh build/test evidence and a reviewable three-commit branch (design, plan, then implementation).
+
+- [ ] **Step 1: Force a clean targeted rebuild**
+
+Run:
+
+```bash
+make -C plugins/genai clean
+make -C test/tap/tests/unit -B genai_plugin_load_unit-t
+test/tap/tests/unit/genai_plugin_load_unit-t
+```
+
+Expected: clean plugin rebuild succeeds and all 57 assertions pass.
+
+- [ ] **Step 2: Run adjacent GenAI handler unit tests**
+
+Run:
+
+```bash
+make -C test/tap/tests/unit genai_mcp_thread_unit-t genai_thread_unit-t
+test/tap/tests/unit/genai_mcp_thread_unit-t
+test/tap/tests/unit/genai_thread_unit-t
+```
+
+Expected: both binaries exit 0 with no TAP failures.
+
+- [ ] **Step 3: Verify repository and scope state**
+
+Run:
+
+```bash
+git status --short --branch
+git diff origin/v3.0...HEAD --check
+git diff --stat origin/v3.0...HEAD
+git log --oneline origin/v3.0..HEAD
+```
+
+Expected: the worktree is clean; the branch contains the design, plan, and implementation commits; changed paths are limited to the design, plan, `plugin_main.cpp`, and `genai_plugin_load_unit-t.cpp`.
+
+- [ ] **Step 4: Apply completion verification before publishing**
+
+Invoke `superpowers:verification-before-completion`, re-read the fresh command outputs, and report any unverified integration behavior explicitly. Do not claim that the full AI TAP shards pass until GitHub Actions runs them.

--- a/docs/superpowers/plans/2026-08-17-genai-variable-default-seeding.md
+++ b/docs/superpowers/plans/2026-08-17-genai-variable-default-seeding.md
@@ -25,14 +25,16 @@
 - `plugins/genai/src/plugin_main.cpp`: collect handler defaults, seed both databases transactionally, and call the seeding path before runtime loads.
 - `docs/superpowers/specs/2026-08-17-genai-variable-default-seeding-design.md`: approved design; no further edits expected unless implementation exposes a contradiction.
 
-### Task 1: Add the failing lifecycle regression
+### Task 1: Add the lifecycle regression and persistent startup seeding
 
 **Files:**
 - Modify: `test/tap/tests/unit/genai_plugin_load_unit-t.cpp:20-110`
+- Modify: `plugins/genai/src/plugin_main.cpp:50-100`
+- Modify: `plugins/genai/src/plugin_main.cpp:675-698`
 
 **Interfaces:**
-- Consumes: existing `ProxySQL_PluginManager::init_all()` / `start_all()` lifecycle and `SQLite3DB::return_one_int()`.
-- Produces: a 57-assertion lifecycle test that requires exactly 14 persisted MCP variables and 32 persisted GenAI variables in each database while preserving pre-existing values.
+- Consumes: existing `ProxySQL_PluginManager::init_all()` / `start_all()` lifecycle, `SQLite3DB::return_one_int()`, handler variable enumeration APIs, and plugin-service database getters.
+- Produces: a 57-assertion lifecycle regression plus startup helpers that seed exactly 14 MCP and 32 GenAI variables in each database while preserving pre-existing values.
 
 - [ ] **Step 1: Give configdb the minimal schema used by the seeding contract**
 
@@ -127,7 +129,7 @@ test/tap/tests/unit/genai_plugin_load_unit-t
 
 Expected: the existing 45 lifecycle assertions remain successful; the new row-count and missing-default assertions fail because each database still contains only the two pre-seeded rows. The four preservation assertions pass, proving the failure is specifically missing default seeding.
 
-### Task 2: Seed both variable families transactionally at plugin start
+#### Production implementation after the RED checkpoint
 
 **Files:**
 - Modify: `plugins/genai/src/plugin_main.cpp:50-100`
@@ -266,7 +268,7 @@ git add plugins/genai/src/plugin_main.cpp test/tap/tests/unit/genai_plugin_load_
 git commit -m "fix(genai): persist missing plugin variable defaults"
 ```
 
-### Task 3: Verify #6099 and prepare the branch for review
+### Task 2: Verify #6099 and prepare the branch for review
 
 **Files:**
 - Verify only; no planned source changes.

--- a/docs/superpowers/specs/2026-08-17-ai-tap-shards-reliability-design.md
+++ b/docs/superpowers/specs/2026-08-17-ai-tap-shards-reliability-design.md
@@ -1,0 +1,240 @@
+# AI TAP Shards Reliability Design
+
+## Purpose
+
+PR #6107 will become the consolidated repair for the GenAI/MCP failures exposed
+by `CI-ai-g1` and `CI-ai-g2` under the label-selected ASAN build. The work covers
+the complete configuration and test-execution contract represented by parent
+issue #6098, rather than stopping after the first variable-initialization defect
+in #6099.
+
+The final pull request must make the two AI shards trustworthy: a green result
+means every declared test was present and passed, while a missing, stale, or
+broken test remains a visible failure. MySQL 9.0 and 9.5 binlog-reader failures
+are unrelated and remain outside this design.
+
+## Non-Negotiable Test Visibility
+
+The 22 entries currently assigned to `ai-g1` and the 22 entries currently
+assigned to `ai-g2` remain registered. No test may be removed, silently omitted,
+or converted into an unconditional skip to make CI green.
+
+For an unfiltered shard run, the harness must reconcile all of these counts:
+
+- 22 tests declared by `groups.json`;
+- 22 corresponding executable test programs discovered across the configured
+  TAP work directories;
+- 22 programs executed;
+- 22 programs passed.
+
+Any mismatch is a hard failure that lists the exact missing, skipped, or failed
+programs. Developer runs that explicitly select tests with include/exclude or
+shuffle controls validate the selected subset instead of requiring all 22.
+
+Tests whose assumptions refer to deleted helpers or obsolete interfaces are
+updated to exercise the supported replacement. Compatibility aliases are not
+added to production merely to preserve an obsolete test vocabulary.
+
+## Observed Failure Layers
+
+The failures form a single ordered contract:
+
+1. A fresh plugin database lacked canonical `mcp-*` and `genai-*` rows, making
+   `SET` an ineffective update. The existing #6107 commits repair this layer by
+   seeding missing defaults without overwriting operator values.
+2. Once `SET mcp-enabled=true` works, the MCP listener starts, but common health
+   probes omit bearer authentication and several tests disagree with the group
+   TLS configuration.
+3. `LOAD MCP VARIABLES TO RUNTIME` changes plugin state without publishing the
+   active MCP snapshot in `runtime_global_variables`.
+4. Shell tests depend on a deleted helper, a host-only loopback address, a path
+   excluded from the AI sparse checkout, or an unavailable `sqlite3` CLI.
+5. GenAI, NL2SQL, and vector tests assert obsolete names, schemas, timing order,
+   or model-dependent similarity outcomes.
+6. Eleven GenAI unit tests remain declared in the groups but are intentionally
+   not built by the central GenAI handoff, and the harness currently validates
+   only executables it happened to discover.
+
+Fixing only an earlier layer leaves the same test program failing at the next
+layer. PR #6107 therefore covers all six layers and validates them together.
+
+## Runtime Variable Contract
+
+Plugin startup continues to seed missing MCP and GenAI defaults into configdb
+and admindb using transactional `INSERT OR IGNORE`. Existing operator values
+remain authoritative, retries are idempotent, and any failed seed transaction
+rolls back.
+
+`LOAD MCP VARIABLES TO RUNTIME` gains a second, atomic publication step:
+
+1. Read and validate the complete MCP configuration from admindb.
+2. Apply it to the plugin's runtime handler.
+3. In a transaction on admindb, replace the `mcp-*` rows in
+   `runtime_global_variables` with values read back from the successfully loaded
+   handler.
+4. Commit the runtime view only after every row has been bound and inserted.
+
+If validation, handler application, SQL preparation, binding, stepping, or
+commit fails, the command reports failure and must not expose a partially
+updated runtime view. Repeated loads replace old MCP rows without duplicates.
+Unrelated runtime variables are untouched.
+
+The same helper used by the admin command is exercised through the real plugin
+lifecycle unit fixture. Tests cover initial publication, changed values,
+repeated load, and rollback behavior.
+
+## Canonical MCP Test Configuration
+
+The AI group owns a canonical MCP baseline that is saved to disk and restored by
+the existing per-test ProxySQL reconfiguration:
+
+- MCP listens on the environment-provided port, normally 6071;
+- HTTP is the default transport for integration tests;
+- both config and query endpoints receive an explicit, non-empty test bearer
+  token;
+- MySQL and PostgreSQL target/auth profiles use the isolated infrastructure
+  hostnames and credentials;
+- MCP is enabled only after variables and profiles are complete.
+
+The token is exported through the AI group environment so C++, shell, and
+helper-based clients share one source of truth. Tests that exercise negative
+authentication temporarily replace or clear the token and restore the
+canonical baseline before exit. Tests that exercise TLS explicitly opt into it
+for that case and restore HTTP afterward.
+
+`MCPClient::check_server()` continues to probe `/mcp/config`, but it sends the
+same `Authorization: Bearer ...` header as normal tool calls when a token is
+configured. Its response check uses the HTTP/JSON-RPC result rather than a
+substring that cannot distinguish authentication and protocol failures. Client
+unit coverage proves that authenticated readiness includes the header and that
+missing or incorrect credentials remain rejected by endpoint tests.
+
+## Maintained Integration Tests
+
+The existing test names and shard memberships remain stable while their
+internals are aligned with the supported interfaces:
+
+- `genai_module-t` validates canonical GenAI variables, loading, saving, and
+  persistence instead of the removed `genai-var1`/`genai-var2` sample surface.
+- `mcp_runtime_variables-t` validates exact MCP runtime projection and reload
+  behavior rather than tolerating an absent view.
+- MCP concurrency, query, stats, and show tests use the canonical authenticated
+  client/setup and leave the shared runtime state recoverable.
+- `nl2sql_unit_base-t` uses the names exported by the current GenAI variable
+  handler and validates their current defaults and accepted values.
+- `vector_features-t` addresses the current vector store schema and APIs rather
+  than removed `ai_*` columns.
+- `vector_db_performance-t` retains representative small/medium/large workloads
+  but replaces relative timing and model-semantic assertions with deterministic
+  insert/search correctness, result-shape, and bounded-completion assertions.
+
+The four shell tests keep their current registered names. A maintained helper is
+provided at the shared path they source. It centralizes TAP output, admin SQL,
+authenticated MCP calls, endpoint readiness, and environment-derived host/port
+selection. The Claude headless fixture uses `proxysql`, not container-local
+`127.0.0.1`, and validates a repository-owned test configuration without
+requiring a real external Claude invocation. Tests needing SQLite use Python's
+standard `sqlite3` module, already present in the runner, rather than adding an
+undeclared CLI dependency. Required MCP fixtures live under paths already
+included in the AI checkout/handoff.
+
+Missing prerequisites fail once with a precise message identifying the path,
+command, or environment value; they do not cascade into misleading endpoint
+failures.
+
+## Complete GenAI Unit-Test Handoff
+
+The eleven GenAI unit programs registered in `ai-g1` or `ai-g2` must survive the
+central build handoff. The reusable workflow deliberately sets
+`SKIP_GENAI_UNIT_TESTS=1` to protect disk-constrained runners, so the source-side
+build introduces a narrowly scoped AI-shard target instead of re-enabling all
+fourteen large GenAI unit binaries for every ProxySQL 4.0 matrix variant.
+
+For the ProxySQL 4.0 GCOV TAP build, that target:
+
+1. compiles the common GenAI implementation objects once with the build's
+   sanitizer/coverage/debug flags instead of compiling 30-plus sources once per
+   test;
+2. links only the eleven unit programs declared by the AI shards, sequentially
+   to cap peak disk and memory usage;
+3. stages the resulting executables in a regular `tap_tests_*` work directory
+   under `test/tap/`, outside the workflow's broad deletion of
+   `test/tap/tests/unit/*-t`;
+4. preserves symbols needed for sanitizer diagnostics while using compressed
+   debug information where supported;
+5. emits and verifies a manifest naming every staged program before the test
+   handoff is packed.
+
+The test runner discovers that staged work directory through its existing
+`tap_tests_*` mechanism. The manifest is also checked against `groups.json`, so
+adding a future GenAI unit test to an AI shard without updating the build
+contract fails during the central build rather than disappearing from CI.
+
+## Harness Reconciliation
+
+`proxysql-tester.py` accumulates discovery and result state across every regular
+TAP work directory before validating a group. It compares the union of
+discovered basenames with the group members selected after version and explicit
+developer filters.
+
+The summary distinguishes:
+
+- declared and executed successfully;
+- declared and executed unsuccessfully;
+- declared but missing from the handoff;
+- explicitly filtered by a developer;
+- unexpected duplicate executables with the same basename.
+
+Missing and duplicate programs are failures in an unfiltered CI shard.
+Validation no longer limits expectations to the binaries found in the current
+directory, which is the behavior that hid the eleven missing GenAI tests.
+
+## Error Handling and Isolation
+
+All SQL changes are checked and transactional at the narrowest database
+boundary. Test helpers report transport, HTTP authentication, JSON-RPC, and MCP
+tool errors separately so a refused request is not mislabeled as an absent
+listener.
+
+Each integration test starts from the disk-backed canonical group configuration
+that the harness reloads before execution. Tests modifying MCP variables,
+profiles, rules, or endpoint tokens use scoped cleanup paths that run on both
+success and failure. The group cleanup hook remains a final safety net, not the
+primary isolation mechanism.
+
+No production behavior is weakened to accommodate tests: endpoint tokens remain
+mandatory, negative authentication remains covered, and TLS verification is
+changed only in test clients using locally generated certificates.
+
+## Verification
+
+Implementation follows a red-green cycle for each boundary:
+
+- lifecycle unit regression for startup seeding and runtime projection;
+- MCP client unit regression proving authenticated readiness requests;
+- group setup contract tests for transport, token, host, and profile values;
+- shell-test fixture tests for helper availability and environment-derived
+  targets;
+- harness tests proving missing and duplicate group executables fail;
+- Makefile/handoff contract tests proving all eleven AI GenAI unit executables
+  are staged without enabling the three unrelated GenAI unit programs;
+- focused local execution of every repaired integration test through
+  `run-tests-isolated.bash`;
+- full local or CI execution of `ai-g1` and `ai-g2`, each reporting 22/22;
+- final label-selected ASAN CI run with no sanitizer diagnostics.
+
+Adjacent GenAI plugin unit suites and the normal non-ASAN build remain green.
+The existing `CI-unit-tests-asan-coverage` workflow is not changed.
+
+## Pull Request and Issue Scope
+
+PR #6107 is retitled and rewritten after the consolidated implementation is
+coherent. It covers parent #6098 and work items #6099 through #6103, plus the
+applicable failures recorded in #5531 through #5533. An older issue is closed
+only if all of its recorded failures are actually resolved; otherwise the PR
+links the addressed portion and leaves the residual issue open.
+
+The final PR description reports exact per-shard execution totals, targeted test
+totals, sanitizer status, and any external behavior intentionally left for a
+separate scope. MySQL 9.0/9.5 binlog-reader readiness is explicitly identified
+as unrelated and is neither modified nor claimed as fixed.

--- a/docs/superpowers/specs/2026-08-17-genai-variable-default-seeding-design.md
+++ b/docs/superpowers/specs/2026-08-17-genai-variable-default-seeding-design.md
@@ -1,0 +1,144 @@
+# GenAI Plugin Variable Default Seeding Design
+
+**Status:** Approved design; implementation plan pending
+**Issue:** #6099
+**Branch:** `fix/6099-genai-variable-defaults`
+**Base:** `v3.0` at `94b3c8260`
+**Date:** 2026-08-17
+
+## Problem
+
+The GenAI plugin constructs `MCP_Threads_Handler` and
+`GenAI_Threads_Handler` with compiled-in defaults, but plugin startup then
+loads `mcp-*` and `genai-*` values from `main.global_variables` without first
+seeding those rows. On a fresh installation both queries return no rows.
+Subsequent admin statements such as `SET mcp-enabled=true` translate to an
+update of a row that does not exist, leaving the handler on its constructor
+default and making AI TAP behavior depend on test order.
+
+Before the plugin carve-out, Admin startup wrote handler defaults to both the
+persistent config database and the in-memory Admin database with
+`INSERT OR IGNORE`, then loaded the in-memory values into the handlers. The
+carve-out retained the load path but lost the seeding step.
+
+## Goals
+
+- Restore persistent default seeding for every supported MCP and GenAI
+  variable.
+- Preserve all operator-provided values during first start, restart, and
+  upgrades.
+- Add newly introduced variables to an existing installation without
+  requiring a manual save command.
+- Make plugin startup independent of AI TAP execution order.
+- Cover the lifecycle contract with the existing plugin-load unit test.
+
+## Non-goals
+
+- Populating `runtime_global_variables`; issue #6100 owns that projection.
+- Changing variable names, defaults, validation, or endpoint authentication.
+- Adding a generic variable-registration service to the plugin ABI.
+- Modifying `CI-unit-tests-asan-coverage` or AI workflow definitions.
+
+## Considered approaches
+
+### Seed from the plugin during startup — selected
+
+The GenAI plugin enumerates the variables owned by its two handlers and
+inserts missing rows into both database layers before loading runtime state.
+This restores the previous lifecycle contract within the component that now
+owns the variables.
+
+### Add a generic plugin-variable API to the chassis
+
+A new ABI service could register names and defaults before Admin bootstrap.
+That may be useful for multiple future plugins, but it expands core and ABI
+scope unnecessarily for a defect isolated to the GenAI carve-out.
+
+### Seed variables in AI test setup
+
+The TAP setup could insert the missing rows directly. That would make the
+current shards pass while leaving fresh production installations with the
+same broken lifecycle, so it is not an acceptable fix.
+
+## Design
+
+### Source of truth
+
+The handlers remain the single source of truth for supported names and
+compiled-in defaults:
+
+- `MCP_Threads_Handler::get_variables_list()` and
+  `get_variable_string()` expose 14 MCP variables.
+- `GenAI_Threads_Handler::get_variables_list()` and `get_variable()` expose
+  32 GenAI variables.
+
+Startup must enumerate those APIs instead of maintaining a second defaults
+table in plugin glue. Consequently, adding a handler variable automatically
+causes it to be seeded on the next start.
+
+### Startup order
+
+`genai_start()` will perform these operations in order:
+
+1. Seed missing `mcp-*` and `genai-*` rows in the persistent config
+   database returned by `get_configdb()`.
+2. Seed the same missing rows in `main.global_variables` through the Admin
+   database returned by `get_admindb()`.
+3. Load MCP values from `main.global_variables` into
+   `MCP_Threads_Handler`.
+4. Load GenAI values from `main.global_variables` into
+   `GenAI_Threads_Handler`.
+5. Continue the existing runtime-component refresh and listener startup.
+
+Both seeding passes use `INSERT OR IGNORE`. Existing rows always win over
+constructor defaults, whether they came from disk, config, or an operator
+update. Missing variables are added individually, so a partial variable set
+is repaired without resetting the rows that already exist.
+
+### Transaction and failure behavior
+
+Each database is seeded in its own transaction because the plugin receives
+separate database handles. A failed prepare, bind, step, or commit rolls back
+that database and makes `genai_start()` return false with a specific log
+message. If persistent seeding commits and in-memory seeding later fails, the
+next start safely retries: `INSERT OR IGNORE` makes every operation
+idempotent.
+
+Allocated variable lists and values are released on every success and error
+path. No handler write lock is needed because `genai_start()` runs before
+plugin worker threads and only reads constructor state.
+
+## Testing
+
+Extend `test/tap/tests/unit/genai_plugin_load_unit-t.cpp`, which already
+drives the real shared object through schema registration, initialization,
+start, and stop against SQLite databases.
+
+The fixture will create `global_variables` in both the Admin and config
+databases. Before plugin startup it will seed distinct non-default values for
+one MCP variable and one GenAI variable in both databases, modeling values
+loaded from a previous run.
+
+After startup, assertions will verify:
+
+- the persistent and in-memory databases each contain exactly 14 `mcp-*`
+  rows and 32 `genai-*` rows;
+- representative constructor defaults have been inserted in both databases;
+- the pre-existing MCP and GenAI values remain unchanged in both databases;
+- every variable name is unique, enforced by the existing
+  `global_variables` primary key;
+- startup succeeds with a partially populated persistent configuration,
+  demonstrating restart and upgrade behavior.
+
+The test fails on the current implementation because neither database is
+seeded. It will be run once before the production change to establish the
+red phase, then after the minimal implementation and again with the relevant
+plugin unit-test suite.
+
+## Compatibility and risk
+
+The change restores behavior that existed before the plugin carve-out. It
+does not overwrite configured values, publish runtime rows, alter plugin ABI,
+or enable MCP/GenAI features by default. The primary risk is startup failure
+on a database error; failing explicitly is preferable to starting with an
+incomplete and misleading configuration surface.

--- a/include/ProxySQL_Plugin.h
+++ b/include/ProxySQL_Plugin.h
@@ -36,8 +36,12 @@ namespace prometheus { class Registry; }
 //          struct with {table_name, refresh, opaque} automatically get
 //          db_kind = admin_db (value 0) via zero-initialization of the
 //          trailing field — matching the pre-ABI-4 behaviour.
-constexpr unsigned int PROXYSQL_PLUGIN_ABI_VERSION = 4u;
-constexpr unsigned int PROXYSQL_PLUGIN_ABI_VERSION_MAX = 4u;
+//   ABI 5: ProxySQL_PluginCommandContext appends optional Admin global-mutex
+//          handoff callbacks. Plugins use them only around work that can wait
+//          for another Admin consumer; older plugins continue to use the
+//          unchanged three DB-handle prefix.
+constexpr unsigned int PROXYSQL_PLUGIN_ABI_VERSION = 5u;
+constexpr unsigned int PROXYSQL_PLUGIN_ABI_VERSION_MAX = 5u;
 
 enum class ProxySQL_PluginDBKind : uint8_t {
 	admin_db = 0,
@@ -59,6 +63,17 @@ struct ProxySQL_PluginCommandContext {
 	SQLite3DB *admindb;
 	SQLite3DB *configdb;
 	SQLite3DB *statsdb;
+
+	// Optional handoff for commands that must wait for work which can itself
+	// enter the Admin interface.  Admin_Handler holds its global query mutex
+	// while dispatching plugin commands; a callback that drains worker threads
+	// while retaining that mutex can deadlock with a worker already waiting for
+	// Admin.  Such callbacks may release the mutex for the blocking portion and
+	// must reacquire it before returning.  Direct/unit-test dispatchers leave
+	// these null, in which case the callback must not attempt a handoff.
+	void *admin_mutex_context { nullptr };
+	void (*release_admin_mutex)(void *) { nullptr };
+	void (*acquire_admin_mutex)(void *) { nullptr };
 };
 
 // NOTE: ProxySQL_PluginCommandResult contains std::string. Plugins MUST

--- a/include/ProxySQL_Statistics.hpp
+++ b/include/ProxySQL_Statistics.hpp
@@ -240,6 +240,7 @@ class ProxySQL_Statistics {
 		time_t from,
 		time_t to,
 		const std::string& aggregation = "");
+	SQLite3_result* list_tsdb_metric_names();
 	// Backend health queries
 	SQLite3_result* get_backend_health_metrics(time_t from, time_t to, int hostgroup = -1);
 	// Status
@@ -281,7 +282,7 @@ class ProxySQL_Statistics {
 	private:
 #ifdef PROXYSQLTSDB
 	/** Serialize compound operations performed through the shared TSDB SQLite connection. */
-	std::mutex tsdb_mutex;
+	pthread_mutex_t tsdb_mutex = PTHREAD_MUTEX_INITIALIZER;
 	void insert_tsdb_metric_unlocked(const std::string& metric_name,
 		const std::map<std::string, std::string>& labels,
 		double value,

--- a/include/ProxySQL_Statistics.hpp
+++ b/include/ProxySQL_Statistics.hpp
@@ -279,6 +279,20 @@ class ProxySQL_Statistics {
 	bool knows_variable_name(const std::string & variable_name) const;
 
 	private:
+#ifdef PROXYSQLTSDB
+	/** Serialize compound operations performed through the shared TSDB SQLite connection. */
+	std::mutex tsdb_mutex;
+	void insert_tsdb_metric_unlocked(const std::string& metric_name,
+		const std::map<std::string, std::string>& labels,
+		double value,
+		time_t timestamp);
+	void insert_backend_health_unlocked(int hostgroup,
+		const std::string& hostname,
+		int port,
+		bool probe_up,
+		int connect_ms,
+		time_t timestamp);
+#endif
 	/** @brief Map with the key being the variable_name and the value being the variable_id, used for history_mysql_variables data. Matches the history_mysql_variables_lookup. */
 	std::map<std::string, int64_t> variable_name_id_map;
 	std::mutex mu;

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -7527,10 +7527,11 @@ char* PgSQL_Session::get_current_query(int max_length) {
 
 	if (query_len > 0) {
 		res = (char *) malloc(query_len + 1);
-		if (trunc_query) {
-			// for truncated queries, add three dots at the end
-			memcpy(res, query_ptr, query_len - 3);
-			memcpy(res + (query_len - 3), "...", 3);
+		if (trunc_query && query_len >= 4) {
+			// for truncated queries, add three dots at the end when they fit
+			size_t cp_len = static_cast<size_t>(query_len) - 3;
+			memcpy(res, query_ptr, cp_len);
+			memcpy(res + cp_len, "...", 3);
 		} else {
 			memcpy(res, query_ptr, query_len);
 		}

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -6346,7 +6346,20 @@ void ProxySQL_Admin::send_error_msg_to_client(S* sess, const char *msg, uint16_t
 #ifdef PROXYSQL40
 template <typename S>
 bool ProxySQL_Admin::dispatch_plugin_admin_command(S* sess, const char* sql) {
-	ProxySQL_PluginCommandContext ctx { admindb, configdb, statsdb };
+	ProxySQL_PluginCommandContext ctx {
+		admindb,
+		configdb,
+		statsdb,
+		this,
+		[](void* opaque) {
+			auto* admin = static_cast<ProxySQL_Admin*>(opaque);
+			pthread_mutex_unlock(&admin->sql_query_global_mutex);
+		},
+		[](void* opaque) {
+			auto* admin = static_cast<ProxySQL_Admin*>(opaque);
+			pthread_mutex_lock(&admin->sql_query_global_mutex);
+		}
+	};
 	ProxySQL_PluginCommandResult result { 0, 0, "" };
 	if (!proxysql_dispatch_configured_plugin_admin_command(ctx, sql, result)) {
 		return false;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1787,7 +1787,9 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 		if (admin) {
 			if (dump_global_variables) {
 				pthread_mutex_lock(&GloVars.checksum_mutex);
-				admindb->execute("DELETE FROM runtime_global_variables");	// extra
+				// Each core variable flusher below replaces its own namespace.
+				// Preserve rows published by plugins under namespaces core does
+				// not own (for example mcp-*).
 				flush_admin_variables___runtime_to_database(admindb, false, false, false, true);
 				flush_mysql_variables___runtime_to_database(admindb, false, false, false, true);
 #ifdef PROXYSQLTSDB

--- a/lib/ProxySQL_RESTAPI_Server.cpp
+++ b/lib/ProxySQL_RESTAPI_Server.cpp
@@ -365,22 +365,15 @@ public:
                 return response;
             }
             
-            char *error = NULL;
-            int cols, rows;
-            SQLite3_result *res = NULL;
-            GloProxyStats->statsdb_disk->execute_statement("SELECT DISTINCT metric_name FROM tsdb_metrics", &error, &cols, &rows, &res);
-            
-            if (error) {
-                j_resp = json {{"error", error}};
-                free(error);
+            SQLite3_result *res = GloProxyStats->list_tsdb_metric_names();
+            if (!res) {
+                j_resp = json {{"error", "Unable to list TSDB metrics"}};
             } else {
                 std::vector<string> metrics;
-                if (res) {
-                    for (int i = 0; i < res->rows_count; i++) {
-                        metrics.push_back(res->rows[i]->fields[0]);
-                    }
-                    delete res;
+                for (int i = 0; i < res->rows_count; i++) {
+                    metrics.push_back(res->rows[i]->fields[0]);
                 }
+                delete res;
                 j_resp = metrics;
             }
         } else if (req_path == "/api/tsdb/query") {

--- a/lib/ProxySQL_Statistics.cpp
+++ b/lib/ProxySQL_Statistics.cpp
@@ -22,9 +22,30 @@ using json = nlohmann::json;
 #include <sstream>
 #include <netdb.h>
 #include <future>
+#include <cassert>
 
 #ifdef PROXYSQLTSDB
 namespace {
+class PthreadMutexGuard {
+public:
+	explicit PthreadMutexGuard(pthread_mutex_t& mutex) : mutex_(mutex) {
+		const int rc = pthread_mutex_lock(&mutex_);
+		assert(rc == 0);
+		(void)rc;
+	}
+	~PthreadMutexGuard() {
+		const int rc = pthread_mutex_unlock(&mutex_);
+		assert(rc == 0);
+		(void)rc;
+	}
+
+	PthreadMutexGuard(const PthreadMutexGuard&) = delete;
+	PthreadMutexGuard& operator=(const PthreadMutexGuard&) = delete;
+
+private:
+	pthread_mutex_t& mutex_;
+};
+
 std::string escape_sql_string_literal(const std::string& value) {
 	std::string escaped;
 	escaped.reserve(value.size() + 8);
@@ -240,6 +261,7 @@ ProxySQL_Statistics::~ProxySQL_Statistics() {
 	if (stmt_insert_backend_health) {
 		(*proxy_sqlite3_finalize)(stmt_insert_backend_health);
 	}
+	pthread_mutex_destroy(&tsdb_mutex);
 #endif
 	drop_tables_defs(tables_defs_statsdb_mem);
 	delete tables_defs_statsdb_mem;
@@ -1471,7 +1493,7 @@ void ProxySQL_Statistics::insert_tsdb_metric(const std::string& metric_name,
                                              const std::map<std::string, std::string>& labels,
                                              double value,
                                              time_t timestamp) {
-    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    PthreadMutexGuard lock(tsdb_mutex);
     insert_tsdb_metric_unlocked(metric_name, labels, value, timestamp);
 }
 
@@ -1518,7 +1540,7 @@ void ProxySQL_Statistics::insert_backend_health(int hostgroup,
                                                 bool probe_up,
                                                 int connect_ms,
                                                 time_t timestamp) {
-    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    PthreadMutexGuard lock(tsdb_mutex);
     insert_backend_health_unlocked(hostgroup, hostname, port, probe_up, connect_ms, timestamp);
 }
 
@@ -1560,7 +1582,7 @@ void ProxySQL_Statistics::tsdb_downsample_metrics() {
     if (!variables.tsdb_enabled) return;
     if (!statsdb_disk) return;
 
-    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    PthreadMutexGuard lock(tsdb_mutex);
 
     time_t ts = time(NULL);
     time_t current_hour = (ts / 3600) * 3600;
@@ -1613,7 +1635,7 @@ void ProxySQL_Statistics::tsdb_retention_cleanup() {
     if (!variables.tsdb_enabled) return;
     if (!statsdb_disk) return;
 
-    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    PthreadMutexGuard lock(tsdb_mutex);
 
     time_t ts = time(NULL);
     const int retention_days = std::max(1, variables.tsdb_retention_days);
@@ -1644,7 +1666,7 @@ ProxySQL_Statistics::tsdb_status_t ProxySQL_Statistics::get_tsdb_status() {
 
     if (!statsdb_disk) return status;
 
-    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    PthreadMutexGuard lock(tsdb_mutex);
 
     char *error = NULL;
     int cols = 0;
@@ -1757,6 +1779,26 @@ bool ProxySQL_Statistics::tsdb_retention_timetoget(unsigned long long curtime) {
     return false;
 }
 
+SQLite3_result* ProxySQL_Statistics::list_tsdb_metric_names() {
+    if (!statsdb_disk) return NULL;
+    PthreadMutexGuard lock(tsdb_mutex);
+
+    char* error = NULL;
+    int cols = 0;
+    int affected_rows = 0;
+    SQLite3_result* resultset = NULL;
+    statsdb_disk->execute_statement(
+        "SELECT DISTINCT metric_name FROM tsdb_metrics ORDER BY metric_name",
+        &error, &cols, &affected_rows, &resultset);
+    if (error) {
+        proxy_error("list_tsdb_metric_names failed: %s\n", error);
+        free(error);
+        if (resultset) delete resultset;
+        return NULL;
+    }
+    return resultset;
+}
+
 // TSDB Query with Label Filtering
 SQLite3_result* ProxySQL_Statistics::query_tsdb_metrics(
         const std::string& metric_name,
@@ -1767,7 +1809,7 @@ SQLite3_result* ProxySQL_Statistics::query_tsdb_metrics(
 
     if (!statsdb_disk) return NULL;
 
-    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    PthreadMutexGuard lock(tsdb_mutex);
 
     if (to < from) {
         std::swap(from, to);
@@ -1829,7 +1871,7 @@ SQLite3_result* ProxySQL_Statistics::query_tsdb_metrics(
 SQLite3_result* ProxySQL_Statistics::get_backend_health_metrics(time_t from, time_t to, int hostgroup) {
     if (!statsdb_disk) return NULL;
 
-    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    PthreadMutexGuard lock(tsdb_mutex);
 
     if (to < from) {
         std::swap(from, to);
@@ -1872,7 +1914,7 @@ void ProxySQL_Statistics::tsdb_sampler_loop() {
         update_modules_metrics();
         auto metrics = GloVars.prometheus_registry->Collect();
         time_t now = time(NULL);
-        std::lock_guard<std::mutex> lock(tsdb_mutex);
+        PthreadMutexGuard lock(tsdb_mutex);
         statsdb_disk->execute("BEGIN");
         for (const auto& family : metrics) {
             for (const auto& metric : family.metric) {
@@ -2043,7 +2085,7 @@ void ProxySQL_Statistics::tsdb_monitor_loop() {
 			}
 		}
 
-		std::lock_guard<std::mutex> lock(tsdb_mutex);
+		PthreadMutexGuard lock(tsdb_mutex);
 		statsdb_disk->execute("BEGIN");
 		for (const probe_result_t& res : batch_results) {
 			insert_backend_health_unlocked(

--- a/lib/ProxySQL_Statistics.cpp
+++ b/lib/ProxySQL_Statistics.cpp
@@ -1471,6 +1471,14 @@ void ProxySQL_Statistics::insert_tsdb_metric(const std::string& metric_name,
                                              const std::map<std::string, std::string>& labels,
                                              double value,
                                              time_t timestamp) {
+    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    insert_tsdb_metric_unlocked(metric_name, labels, value, timestamp);
+}
+
+void ProxySQL_Statistics::insert_tsdb_metric_unlocked(const std::string& metric_name,
+                                                      const std::map<std::string, std::string>& labels,
+                                                      double value,
+                                                      time_t timestamp) {
     if (!statsdb_disk) return;
     sqlite3 *mydb3 = statsdb_disk->get_db();
     int rc;
@@ -1510,6 +1518,16 @@ void ProxySQL_Statistics::insert_backend_health(int hostgroup,
                                                 bool probe_up,
                                                 int connect_ms,
                                                 time_t timestamp) {
+    std::lock_guard<std::mutex> lock(tsdb_mutex);
+    insert_backend_health_unlocked(hostgroup, hostname, port, probe_up, connect_ms, timestamp);
+}
+
+void ProxySQL_Statistics::insert_backend_health_unlocked(int hostgroup,
+                                                         const std::string& hostname,
+                                                         int port,
+                                                         bool probe_up,
+                                                         int connect_ms,
+                                                         time_t timestamp) {
     if (!statsdb_disk) return;
     sqlite3 *mydb3 = statsdb_disk->get_db();
     int rc;
@@ -1542,6 +1560,8 @@ void ProxySQL_Statistics::tsdb_downsample_metrics() {
     if (!variables.tsdb_enabled) return;
     if (!statsdb_disk) return;
 
+    std::lock_guard<std::mutex> lock(tsdb_mutex);
+
     time_t ts = time(NULL);
     time_t current_hour = (ts / 3600) * 3600;
 
@@ -1564,8 +1584,10 @@ void ProxySQL_Statistics::tsdb_downsample_metrics() {
     }
     if (resultset) delete resultset;
 
-    // Process new hours
-    if (last_hour < current_hour - 3600) {
+    // Reprocess the latest completed bucket as well as new buckets. Metrics can
+    // arrive just after an hourly pass has committed, and INSERT OR REPLACE
+    // makes refreshing that boundary bucket idempotent.
+    if (last_hour <= current_hour - 3600) {
         char buf[2048];
         snprintf(buf, sizeof(buf),
             "INSERT OR REPLACE INTO tsdb_metrics_hour "
@@ -1580,7 +1602,7 @@ void ProxySQL_Statistics::tsdb_downsample_metrics() {
             "FROM tsdb_metrics "
             "WHERE timestamp >= %ld AND timestamp < %ld "
             "GROUP BY bucket, metric_name, labels",
-            last_hour > 0 ? last_hour + 3600 : 0,
+            last_hour > 0 ? last_hour : 0,
             current_hour);
 
         statsdb_disk->execute(buf);
@@ -1590,6 +1612,8 @@ void ProxySQL_Statistics::tsdb_downsample_metrics() {
 void ProxySQL_Statistics::tsdb_retention_cleanup() {
     if (!variables.tsdb_enabled) return;
     if (!statsdb_disk) return;
+
+    std::lock_guard<std::mutex> lock(tsdb_mutex);
 
     time_t ts = time(NULL);
     const int retention_days = std::max(1, variables.tsdb_retention_days);
@@ -1619,6 +1643,8 @@ ProxySQL_Statistics::tsdb_status_t ProxySQL_Statistics::get_tsdb_status() {
     tsdb_status_t status = {0, 0, 0, 0, 0};
 
     if (!statsdb_disk) return status;
+
+    std::lock_guard<std::mutex> lock(tsdb_mutex);
 
     char *error = NULL;
     int cols = 0;
@@ -1740,6 +1766,9 @@ SQLite3_result* ProxySQL_Statistics::query_tsdb_metrics(
         const std::string& aggregation) {
 
     if (!statsdb_disk) return NULL;
+
+    std::lock_guard<std::mutex> lock(tsdb_mutex);
+
     if (to < from) {
         std::swap(from, to);
     }
@@ -1799,6 +1828,9 @@ SQLite3_result* ProxySQL_Statistics::query_tsdb_metrics(
 // TSDB Backend Health Query
 SQLite3_result* ProxySQL_Statistics::get_backend_health_metrics(time_t from, time_t to, int hostgroup) {
     if (!statsdb_disk) return NULL;
+
+    std::lock_guard<std::mutex> lock(tsdb_mutex);
+
     if (to < from) {
         std::swap(from, to);
     }
@@ -1840,6 +1872,7 @@ void ProxySQL_Statistics::tsdb_sampler_loop() {
         update_modules_metrics();
         auto metrics = GloVars.prometheus_registry->Collect();
         time_t now = time(NULL);
+        std::lock_guard<std::mutex> lock(tsdb_mutex);
         statsdb_disk->execute("BEGIN");
         for (const auto& family : metrics) {
             for (const auto& metric : family.metric) {
@@ -1849,28 +1882,28 @@ void ProxySQL_Statistics::tsdb_sampler_loop() {
                 }
                 switch (family.type) {
                     case prometheus::MetricType::Counter:
-                        insert_tsdb_metric(family.name, labels, metric.counter.value, now);
+                        insert_tsdb_metric_unlocked(family.name, labels, metric.counter.value, now);
                         break;
                     case prometheus::MetricType::Gauge:
-                        insert_tsdb_metric(family.name, labels, metric.gauge.value, now);
+                        insert_tsdb_metric_unlocked(family.name, labels, metric.gauge.value, now);
                         break;
                     case prometheus::MetricType::Summary: {
-                        insert_tsdb_metric(family.name + "_count", labels, static_cast<double>(metric.summary.sample_count), now);
-                        insert_tsdb_metric(family.name + "_sum", labels, metric.summary.sample_sum, now);
+                        insert_tsdb_metric_unlocked(family.name + "_count", labels, static_cast<double>(metric.summary.sample_count), now);
+                        insert_tsdb_metric_unlocked(family.name + "_sum", labels, metric.summary.sample_sum, now);
                         for (const auto& q : metric.summary.quantile) {
                             std::map<std::string, std::string> q_labels(labels);
                             q_labels["quantile"] = format_prometheus_label_double(q.quantile);
-                            insert_tsdb_metric(family.name, q_labels, q.value, now);
+                            insert_tsdb_metric_unlocked(family.name, q_labels, q.value, now);
                         }
                         break;
                     }
                     case prometheus::MetricType::Histogram: {
-                        insert_tsdb_metric(family.name + "_count", labels, static_cast<double>(metric.histogram.sample_count), now);
-                        insert_tsdb_metric(family.name + "_sum", labels, metric.histogram.sample_sum, now);
+                        insert_tsdb_metric_unlocked(family.name + "_count", labels, static_cast<double>(metric.histogram.sample_count), now);
+                        insert_tsdb_metric_unlocked(family.name + "_sum", labels, metric.histogram.sample_sum, now);
                         for (const auto& b : metric.histogram.bucket) {
                             std::map<std::string, std::string> b_labels(labels);
                             b_labels["le"] = format_prometheus_label_double(b.upper_bound);
-                            insert_tsdb_metric(
+                            insert_tsdb_metric_unlocked(
                                 family.name + "_bucket",
                                 b_labels,
                                 static_cast<double>(b.cumulative_count),
@@ -1880,11 +1913,11 @@ void ProxySQL_Statistics::tsdb_sampler_loop() {
                         break;
                     }
                     case prometheus::MetricType::Info:
-                        insert_tsdb_metric(family.name, labels, metric.info.value, now);
+                        insert_tsdb_metric_unlocked(family.name, labels, metric.info.value, now);
                         break;
                     case prometheus::MetricType::Untyped:
                     default:
-                        insert_tsdb_metric(family.name, labels, metric.untyped.value, now);
+                        insert_tsdb_metric_unlocked(family.name, labels, metric.untyped.value, now);
                         break;
                 }
             }
@@ -1995,14 +2028,26 @@ void ProxySQL_Statistics::tsdb_monitor_loop() {
 		for (size_t j = i; j < batch_end; ++j) {
 			batch_futures.push_back(std::async(std::launch::async, probe_backend, targets[j].hg, targets[j].host, targets[j].port, now));
 		}
-		statsdb_disk->execute("BEGIN");
+
+		// Network completion is independent of SQLite. Collect every result
+		// before taking the TSDB mutex so an unreachable backend cannot block
+		// samplers, status queries, downsampling, or retention for the probe
+		// timeout.
+		std::vector<probe_result_t> batch_results;
+		batch_results.reserve(batch_futures.size());
 		for (auto& f : batch_futures) {
 			try {
-				probe_result_t res = f.get();
-				insert_backend_health(res.hg, res.host, res.port, res.probe_up, res.connect_ms, res.timestamp);
+				batch_results.push_back(f.get());
 			} catch (const std::exception& e) {
 				proxy_error("TSDB monitor probe failed: %s\n", e.what());
 			}
+		}
+
+		std::lock_guard<std::mutex> lock(tsdb_mutex);
+		statsdb_disk->execute("BEGIN");
+		for (const probe_result_t& res : batch_results) {
+			insert_backend_health_unlocked(
+				res.hg, res.host, res.port, res.probe_up, res.connect_ms, res.timestamp);
 		}
 		statsdb_disk->execute("COMMIT");
 	}

--- a/plugins/genai/README.md
+++ b/plugins/genai/README.md
@@ -176,11 +176,13 @@ the chassis writes to `proxysql.log`.
 - **`MCP_Threads_Handler` variable accessors** (`get_variable`,
   `set_variable`, `has_variable`, `get_variables_list`) all serialize
   on the handler's `pthread_rwlock`.
-- **`genai_refresh_runtime_components`** is currently called from the
-  admin SQL thread without quiescing readers — operators triggering
-  `LOAD GENAI VARIABLES TO RUNTIME` while traffic is hot should expect
-  brief reload-window blips. Tracked as a follow-up — see the
-  detailed contract comment on the declaration in `genai_plugin.h`.
+- **`genai_refresh_runtime_components`** takes an exclusive lifecycle lock
+  while replacing the GenAI resources its AI/RAG handlers borrow, then rebinds
+  the persistent handlers before admitting another request. Admin command
+  callbacks yield the Admin global mutex before waiting for this lock, avoiding
+  a lock inversion with MCP config/stats requests. Other readers, especially
+  the anomaly-detector query hook, are not yet covered by the same lifecycle
+  lock; see the detailed contract comment in `genai_plugin.h`.
 - **Profile triplet**: `install_profiles_from_admin` and
   `save_profiles_to_admin_table` are *atomic across both tables*: one
   wrlock for both swaps + one BEGIN/COMMIT for both writes, FK-aware
@@ -215,8 +217,9 @@ the most worth closing given vector-storage complexity.
 
 ## 10. Known gaps
 
-- **`genai_refresh_runtime_components` race**: see Concurrency notes
-  above; needs a proper rwlock around `GloGATH`/`GloAI` consumers.
+- **Non-MCP `genai_refresh_runtime_components` race**: see Concurrency notes
+  above; needs a proper rwlock around the remaining `GloGATH`/`GloAI`
+  consumers.
 - **Tool-handler unit tests**: see Testing section.
 
 ## 11. History

--- a/plugins/genai/include/AI_Tool_Handler.h
+++ b/plugins/genai/include/AI_Tool_Handler.h
@@ -73,6 +73,9 @@ public:
 	 */
 	int init() override;
 
+	/** Rebind the borrowed bridge after a GenAI runtime reload. */
+	void set_llm_bridge(LLM_Bridge* llm) { llm_bridge = llm; }
+
 	/**
 	 * @brief Close and cleanup
 	 */

--- a/plugins/genai/include/MCP_Endpoint.h
+++ b/plugins/genai/include/MCP_Endpoint.h
@@ -6,11 +6,11 @@
 #include "proxysql.h"
 #include <string>
 #include <memory>
-#include <shared_mutex>
 
 // Forward declarations
 class MCP_Threads_Handler;
 class MCP_Tool_Handler;
+class GenAIRWLock;
 
 // Include httpserver after proxysql.h
 #include "httpserver.hpp"
@@ -37,7 +37,7 @@ private:
 	MCP_Threads_Handler* handler;       ///< Pointer to MCP handler for variable access
 	MCP_Tool_Handler* tool_handler;     ///< Pointer to endpoint's dedicated tool handler
 	std::string endpoint_name;           ///< Endpoint name (config, query, admin, etc.)
-	std::shared_mutex* runtime_dependencies_mutex; ///< Optional guard for borrowed GenAI runtime state
+	GenAIRWLock* runtime_dependencies_mutex; ///< Optional guard for borrowed GenAI runtime state
 
 	/**
 	 * @brief Authenticate the incoming request
@@ -162,7 +162,7 @@ public:
 		MCP_Threads_Handler* h,
 		MCP_Tool_Handler* th,
 		const std::string& name,
-		std::shared_mutex* dependencies_mutex = nullptr
+		GenAIRWLock* dependencies_mutex = nullptr
 	);
 
 	/**

--- a/plugins/genai/include/MCP_Endpoint.h
+++ b/plugins/genai/include/MCP_Endpoint.h
@@ -6,6 +6,7 @@
 #include "proxysql.h"
 #include <string>
 #include <memory>
+#include <shared_mutex>
 
 // Forward declarations
 class MCP_Threads_Handler;
@@ -36,6 +37,7 @@ private:
 	MCP_Threads_Handler* handler;       ///< Pointer to MCP handler for variable access
 	MCP_Tool_Handler* tool_handler;     ///< Pointer to endpoint's dedicated tool handler
 	std::string endpoint_name;           ///< Endpoint name (config, query, admin, etc.)
+	std::shared_mutex* runtime_dependencies_mutex; ///< Optional guard for borrowed GenAI runtime state
 
 	/**
 	 * @brief Authenticate the incoming request
@@ -153,8 +155,15 @@ public:
 	 * @param h Pointer to the MCP_Threads_Handler instance
 	 * @param th Pointer to the endpoint's dedicated tool handler
 	 * @param name The name of this endpoint (e.g., "config", "query")
+	 * @param dependencies_mutex Optional lifecycle guard for handlers that
+	 *        borrow replaceable GenAI runtime resources
 	 */
-	MCP_JSONRPC_Resource(MCP_Threads_Handler* h, MCP_Tool_Handler* th, const std::string& name);
+	MCP_JSONRPC_Resource(
+		MCP_Threads_Handler* h,
+		MCP_Tool_Handler* th,
+		const std::string& name,
+		std::shared_mutex* dependencies_mutex = nullptr
+	);
 
 	/**
 	 * @brief Destructor

--- a/plugins/genai/include/RAG_Tool_Handler.h
+++ b/plugins/genai/include/RAG_Tool_Handler.h
@@ -407,6 +407,13 @@ public:
 	int init() override;
 
 	/**
+	 * Refresh borrowed runtime resources and the configuration snapshot after
+	 * LOAD GENAI VARIABLES.  The caller must hold the plugin runtime dependency
+	 * mutex exclusively.
+	 */
+	void refresh_runtime_dependencies(AI_Features_Manager* ai_mgr);
+
+	/**
 	 * @brief Close and cleanup
 	 *
 	 * Cleans up resources and closes database connections. Called automatically

--- a/plugins/genai/include/genai_plugin.h
+++ b/plugins/genai/include/genai_plugin.h
@@ -120,16 +120,19 @@ GenAIPluginContext& genai_context();
 void genai_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
 /**
- * @brief Push admin DB's `mcp-*` global_variables values into the
- *        running MCP_Threads_Handler.
+ * @brief Validate and push the complete admin DB `mcp-*` configuration into
+ *        the running MCP_Threads_Handler, then atomically publish the
+ *        normalized active snapshot to `runtime_global_variables`.
  *
  * Defined in plugin_main.cpp.  Called from `genai_start()` (initial
  * read at plugin start) and from the `LOAD MCP VARIABLES TO RUNTIME`
  * admin command (in plugin_commands.cpp) — both go through this one
  * helper to keep behavior consistent.
  *
- * @return true on success; false if admindb is unavailable or the
- *         lookup query errored out.
+ * @return true on success; false if the configuration is incomplete/invalid,
+ *         admindb access or publication fails, or the previous handler state
+ *         cannot be retained.  A failed load leaves the prior committed
+ *         runtime snapshot visible and restores the prior handler values.
  */
 bool mcp_load_variables_from_admindb(GenAIPluginContext& ctx);
 

--- a/plugins/genai/include/genai_plugin.h
+++ b/plugins/genai/include/genai_plugin.h
@@ -58,7 +58,26 @@ private:
 /** SharedMutex wrapper backed by the project's pthread rwlock primitive. */
 class GenAIRWLock {
 public:
-	GenAIRWLock() = default;
+	GenAIRWLock() noexcept {
+		pthread_rwlockattr_t attr;
+		int rc = pthread_rwlockattr_init(&attr);
+		assert(rc == 0);
+		(void)rc;
+#if defined(__GLIBC__)
+		// The query hook is a continuous stream of readers. Prefer a queued
+		// writer so reload and shutdown cannot starve behind that hot path.
+		rc = pthread_rwlockattr_setkind_np(
+			&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+		assert(rc == 0);
+		(void)rc;
+#endif
+		rc = pthread_rwlock_init(&rwlock_, &attr);
+		assert(rc == 0);
+		(void)rc;
+		rc = pthread_rwlockattr_destroy(&attr);
+		assert(rc == 0);
+		(void)rc;
+	}
 	~GenAIRWLock() { pthread_rwlock_destroy(&rwlock_); }
 
 	void lock() noexcept {
@@ -82,7 +101,7 @@ public:
 	GenAIRWLock& operator=(const GenAIRWLock&) = delete;
 
 private:
-	pthread_rwlock_t rwlock_ = PTHREAD_RWLOCK_INITIALIZER;
+	pthread_rwlock_t rwlock_;
 };
 
 /**

--- a/plugins/genai/include/genai_plugin.h
+++ b/plugins/genai/include/genai_plugin.h
@@ -21,6 +21,8 @@
 #include "ProxySQL_Plugin.h"
 
 #include <atomic>
+#include <mutex>
+#include <shared_mutex>
 
 namespace prometheus { class Counter; }
 class Anomaly_Detector;
@@ -63,6 +65,20 @@ struct GenAIPluginContext {
 	/// See plugins/genai/src/MCP_Thread.cpp for the listener
 	/// implementation.
 	MCP_Threads_Handler* mcp { nullptr };
+
+	/// Serializes every GenAI plugin Admin command. Commands normally enter
+	/// with Admin's global query mutex held, but runtime reloads must yield that
+	/// mutex while draining MCP work. A second plugin command releases Admin
+	/// before waiting here, so it cannot mutate plugin runtime state during the
+	/// yielded interval and cannot form a command-mutex/Admin lock inversion.
+	std::mutex admin_command_mutex;
+
+	/// Protects MCP AI/RAG calls while their borrowed GloGATH/GloAI
+	/// dependencies are replaced.  Runtime reloads and MCP listener
+	/// construction take the exclusive side; endpoint calls take the shared
+	/// side.  Admin command callbacks release the Admin global mutex before
+	/// waiting for this lock, preventing an Admin/MCP lock inversion.
+	std::shared_mutex runtime_dependencies_mutex;
 };
 
 /**
@@ -75,25 +91,24 @@ struct GenAIPluginContext {
  * provider configuration.
  *
  * @par Concurrency contract
- * Caller MUST guarantee no other thread is dereferencing `GloGATH` or
- * `GloAI` while this runs.  The teardown calls `delete`-equivalent
- * `shutdown()` methods on both globals; concurrent reads from MCP
- * listener threads, tool-handler workers, or the anomaly-detector hot
- * path would observe a half-destroyed handler.  Today the function is
- * called from:
+ * MCP AI/RAG calls share `runtime_dependencies_mutex`; this function takes
+ * its exclusive side while replacing runtime resources, then rebinds the
+ * persistent endpoint handlers before allowing another call through.  The
+ * listener remains alive, so an in-flight Config/Stats handler waiting for
+ * the Admin mutex cannot be trapped behind a synchronous listener join.
+ * Other callers of `GloGATH` / `GloAI` (notably the anomaly-detector query
+ * hook) are not quiesced here; callers must still account for that wider
+ * concurrency contract.  Today the function is called from:
  *
  *   1. `genai_start()` — single-threaded plugin lifecycle, no traffic
  *      yet, always safe.
  *   2. `LOAD GENAI VARIABLES TO RUNTIME` admin command — runs on the
- *      admin SQL thread while MCP listener / tool handlers may be
- *      actively serving requests.  Currently this is racy; the
- *      practical mitigation is operator-side: quiesce traffic before
- *      issuing the LOAD command, or accept the brief reload window.
+ *      admin SQL thread.  The callback releases the Admin mutex before
+ *      entering this function so an active MCP request can finish first.
  *   3. `LOAD GENAI VARIABLES FROM CONFIG` — same constraint as (2).
  *
- * Adding a proper rwlock-around-GloGATH/GloAI is a follow-up tracked
- * separately; it touches every consumer of those globals (not just
- * the reload path) and is too large for this carve-out PR.
+ * Extending this lifecycle lock to the remaining GloGATH/GloAI consumers is
+ * tracked separately; it touches more than the MCP reload path covered here.
  */
 bool genai_refresh_runtime_components(GenAIPluginContext& ctx);
 

--- a/plugins/genai/include/genai_plugin.h
+++ b/plugins/genai/include/genai_plugin.h
@@ -21,13 +21,69 @@
 #include "ProxySQL_Plugin.h"
 
 #include <atomic>
+#include <cassert>
 #include <mutex>
 #include <shared_mutex>
+#include <pthread.h>
 
 namespace prometheus { class Counter; }
 class Anomaly_Detector;
 class MCP_Threads_Handler;
 class GenAI_Threads_Handler;
+
+/** BasicLockable wrapper backed by the project's pthread mutex primitive. */
+class GenAIMutex {
+public:
+	GenAIMutex() = default;
+	~GenAIMutex() { pthread_mutex_destroy(&mutex_); }
+
+	void lock() noexcept {
+		const int rc = pthread_mutex_lock(&mutex_);
+		assert(rc == 0);
+		(void)rc;
+	}
+	void unlock() noexcept {
+		const int rc = pthread_mutex_unlock(&mutex_);
+		assert(rc == 0);
+		(void)rc;
+	}
+
+	GenAIMutex(const GenAIMutex&) = delete;
+	GenAIMutex& operator=(const GenAIMutex&) = delete;
+
+private:
+	pthread_mutex_t mutex_ = PTHREAD_MUTEX_INITIALIZER;
+};
+
+/** SharedMutex wrapper backed by the project's pthread rwlock primitive. */
+class GenAIRWLock {
+public:
+	GenAIRWLock() = default;
+	~GenAIRWLock() { pthread_rwlock_destroy(&rwlock_); }
+
+	void lock() noexcept {
+		const int rc = pthread_rwlock_wrlock(&rwlock_);
+		assert(rc == 0);
+		(void)rc;
+	}
+	void unlock() noexcept {
+		const int rc = pthread_rwlock_unlock(&rwlock_);
+		assert(rc == 0);
+		(void)rc;
+	}
+	void lock_shared() noexcept {
+		const int rc = pthread_rwlock_rdlock(&rwlock_);
+		assert(rc == 0);
+		(void)rc;
+	}
+	void unlock_shared() noexcept { unlock(); }
+
+	GenAIRWLock(const GenAIRWLock&) = delete;
+	GenAIRWLock& operator=(const GenAIRWLock&) = delete;
+
+private:
+	pthread_rwlock_t rwlock_ = PTHREAD_RWLOCK_INITIALIZER;
+};
 
 /**
  * @brief Process-wide state shared across the plugin's translation units.
@@ -71,14 +127,14 @@ struct GenAIPluginContext {
 	/// mutex while draining MCP work. A second plugin command releases Admin
 	/// before waiting here, so it cannot mutate plugin runtime state during the
 	/// yielded interval and cannot form a command-mutex/Admin lock inversion.
-	std::mutex admin_command_mutex;
+	GenAIMutex admin_command_mutex;
 
 	/// Protects MCP AI/RAG calls while their borrowed GloGATH/GloAI
 	/// dependencies are replaced.  Runtime reloads and MCP listener
 	/// construction take the exclusive side; endpoint calls take the shared
 	/// side.  Admin command callbacks release the Admin global mutex before
 	/// waiting for this lock, preventing an Admin/MCP lock inversion.
-	std::shared_mutex runtime_dependencies_mutex;
+	GenAIRWLock runtime_dependencies_mutex;
 };
 
 /**
@@ -96,9 +152,9 @@ struct GenAIPluginContext {
  * persistent endpoint handlers before allowing another call through.  The
  * listener remains alive, so an in-flight Config/Stats handler waiting for
  * the Admin mutex cannot be trapped behind a synchronous listener join.
- * Other callers of `GloGATH` / `GloAI` (notably the anomaly-detector query
- * hook) are not quiesced here; callers must still account for that wider
- * concurrency contract.  Today the function is called from:
+ * The anomaly-detector query hook, stats runtime view, and MCP AI/RAG calls
+ * all hold the shared side while using replaceable runtime objects. Today the
+ * function is called from:
  *
  *   1. `genai_start()` — single-threaded plugin lifecycle, no traffic
  *      yet, always safe.
@@ -107,8 +163,6 @@ struct GenAIPluginContext {
  *      entering this function so an active MCP request can finish first.
  *   3. `LOAD GENAI VARIABLES FROM CONFIG` — same constraint as (2).
  *
- * Extending this lifecycle lock to the remaining GloGATH/GloAI consumers is
- * tracked separately; it touches more than the MCP reload path covered here.
  */
 bool genai_refresh_runtime_components(GenAIPluginContext& ctx);
 

--- a/plugins/genai/src/Discovery_Schema.cpp
+++ b/plugins/genai/src/Discovery_Schema.cpp
@@ -1312,6 +1312,8 @@ int Discovery_Schema::rebuild_fts_index(int run_id) {
 				} catch (...) {
 					// Ignore parse errors
 				}
+			}
+			if (prof_result) {
 				delete prof_result;
 			}
 

--- a/plugins/genai/src/GenAI_Thread.cpp
+++ b/plugins/genai/src/GenAI_Thread.cpp
@@ -432,6 +432,9 @@ char* GenAI_Threads_Handler::get_variable(char* name) {
 		snprintf(buf, sizeof(buf), "%d", variables.genai_llm_cache_similarity_threshold);
 		return strdup(buf);
 	}
+	if (!strcmp(name, "llm_cache_enabled")) {
+		return strdup(variables.genai_llm_cache_enabled ? "true" : "false");
+	}
 	if (!strcmp(name, "llm_timeout_ms")) {
 		char buf[64];
 		snprintf(buf, sizeof(buf), "%d", variables.genai_llm_timeout_ms);
@@ -616,6 +619,10 @@ bool GenAI_Threads_Handler::set_variable(char* name, const char* value) {
 			return false;
 		}
 		variables.genai_llm_cache_similarity_threshold = val;
+		return true;
+	}
+	if (!strcmp(name, "llm_cache_enabled")) {
+		variables.genai_llm_cache_enabled = (strcmp(value, "true") == 0);
 		return true;
 	}
 	if (!strcmp(name, "llm_timeout_ms")) {

--- a/plugins/genai/src/MCP_Endpoint.cpp
+++ b/plugins/genai/src/MCP_Endpoint.cpp
@@ -15,8 +15,16 @@ using json = nlohmann::json;
 
 using namespace httpserver;
 
-MCP_JSONRPC_Resource::MCP_JSONRPC_Resource(MCP_Threads_Handler* h, MCP_Tool_Handler* th, const std::string& name)
-	: handler(h), tool_handler(th), endpoint_name(name)
+MCP_JSONRPC_Resource::MCP_JSONRPC_Resource(
+	MCP_Threads_Handler* h,
+	MCP_Tool_Handler* th,
+	const std::string& name,
+	std::shared_mutex* dependencies_mutex
+)
+	: handler(h),
+	  tool_handler(th),
+	  endpoint_name(name),
+	  runtime_dependencies_mutex(dependencies_mutex)
 {
 	proxy_debug(PROXY_DEBUG_GENERIC, 3, "Created MCP JSON-RPC resource for endpoint '%s'\n", name.c_str());
 }
@@ -506,6 +514,15 @@ json MCP_JSONRPC_Resource::handle_tools_call(const json& req_json) {
 	proxy_info("MCP TOOL CALL: endpoint='%s' tool='%s'\n", endpoint_name.c_str(), tool_name.c_str());
 	proxy_debug(PROXY_DEBUG_GENERIC, 2, "MCP tool call: %s with args: %s\n", tool_name.c_str(), arguments.dump().c_str());
 
+	// AI/RAG handlers borrow the vector DB, LLM bridge, and GenAI worker
+	// manager.  LOAD GENAI VARIABLES replaces those resources in place.  Hold
+	// the shared side only across the handler call so the reload can wait for
+	// current users and rebind the persistent handler before admitting the
+	// next request.
+	std::shared_lock<std::shared_mutex> runtime_guard;
+	if (runtime_dependencies_mutex != nullptr) {
+		runtime_guard = std::shared_lock<std::shared_mutex>(*runtime_dependencies_mutex);
+	}
 	json response = tool_handler->execute_tool(tool_name, arguments);
 
 	// Check if this is a ProxySQL tool response with success/result wrapper

--- a/plugins/genai/src/MCP_Endpoint.cpp
+++ b/plugins/genai/src/MCP_Endpoint.cpp
@@ -7,6 +7,7 @@ using json = nlohmann::json;
 #define PROXYJSON
 
 #include "MCP_Endpoint.h"
+#include "genai_plugin.h"
 #include "MCP_Thread.h"
 #include "MySQL_Tool_Handler.h"
 #include "MCP_Tool_Handler.h"
@@ -19,7 +20,7 @@ MCP_JSONRPC_Resource::MCP_JSONRPC_Resource(
 	MCP_Threads_Handler* h,
 	MCP_Tool_Handler* th,
 	const std::string& name,
-	std::shared_mutex* dependencies_mutex
+	GenAIRWLock* dependencies_mutex
 )
 	: handler(h),
 	  tool_handler(th),
@@ -519,9 +520,9 @@ json MCP_JSONRPC_Resource::handle_tools_call(const json& req_json) {
 	// the shared side only across the handler call so the reload can wait for
 	// current users and rebind the persistent handler before admitting the
 	// next request.
-	std::shared_lock<std::shared_mutex> runtime_guard;
+	std::shared_lock<GenAIRWLock> runtime_guard;
 	if (runtime_dependencies_mutex != nullptr) {
-		runtime_guard = std::shared_lock<std::shared_mutex>(*runtime_dependencies_mutex);
+		runtime_guard = std::shared_lock<GenAIRWLock>(*runtime_dependencies_mutex);
 	}
 	json response = tool_handler->execute_tool(tool_name, arguments);
 

--- a/plugins/genai/src/ProxySQL_MCP_Server.cpp
+++ b/plugins/genai/src/ProxySQL_MCP_Server.cpp
@@ -19,6 +19,7 @@ using json = nlohmann::json;
 #include "AI_Tool_Handler.h"
 #include "RAG_Tool_Handler.h"
 #include "AI_Features_Manager.h"
+#include "genai_plugin.h"
 #include "proxysql_utils.h"
 
 using namespace httpserver;
@@ -181,7 +182,9 @@ ProxySQL_MCP_Server::ProxySQL_MCP_Server(int p, MCP_Threads_Handler* h)
 	// 6. AI endpoint (for LLM and other AI features).
 	if (handler->ai_tool_handler) {
 		std::unique_ptr<httpserver::http_resource> ai_resource =
-			std::unique_ptr<httpserver::http_resource>(new MCP_JSONRPC_Resource(handler, handler->ai_tool_handler, "ai"));
+			std::unique_ptr<httpserver::http_resource>(new MCP_JSONRPC_Resource(
+				handler, handler->ai_tool_handler, "ai",
+				&genai_context().runtime_dependencies_mutex));
 		ws->register_resource("/mcp/ai", ai_resource.get(), true);
 		_endpoints.push_back({"/mcp/ai", std::move(ai_resource)});
 	}
@@ -194,7 +197,9 @@ ProxySQL_MCP_Server::ProxySQL_MCP_Server(int p, MCP_Threads_Handler* h)
 		handler->rag_tool_handler = new RAG_Tool_Handler(GloAI, catalog_path);
 		if (handler->rag_tool_handler->init() == 0) {
 			std::unique_ptr<httpserver::http_resource> rag_resource =
-				std::unique_ptr<httpserver::http_resource>(new MCP_JSONRPC_Resource(handler, handler->rag_tool_handler, "rag"));
+				std::unique_ptr<httpserver::http_resource>(new MCP_JSONRPC_Resource(
+					handler, handler->rag_tool_handler, "rag",
+					&genai_context().runtime_dependencies_mutex));
 			ws->register_resource("/mcp/rag", rag_resource.get(), true);
 			_endpoints.push_back({"/mcp/rag", std::move(rag_resource)});
 			proxy_info("RAG Tool Handler initialized\n");

--- a/plugins/genai/src/plugin_commands.cpp
+++ b/plugins/genai/src/plugin_commands.cpp
@@ -117,7 +117,8 @@ ProxySQL_PluginCommandResult load_mcp_variables_to_runtime(
 	(void)cmd_ctx; (void)sql;
 	GenAIPluginContext& ctx = genai_context();
 	if (!mcp_load_variables_from_admindb(ctx)) {
-		return err_result("LOAD MCP VARIABLES TO RUNTIME: failed reading global_variables");
+		return err_result(
+			"LOAD MCP VARIABLES TO RUNTIME: failed applying or publishing global_variables");
 	}
 	mcp_start_listener_if_enabled(ctx);
 	return ok_result("MCP variables loaded to runtime");

--- a/plugins/genai/src/plugin_commands.cpp
+++ b/plugins/genai/src/plugin_commands.cpp
@@ -42,6 +42,87 @@ extern ProxySQL_Admin* GloAdmin;
 
 namespace {
 
+/**
+ * Temporarily yield Admin's global query mutex around work that can wait for
+ * MCP callbacks.  Production Admin dispatch supplies the handoff callbacks;
+ * direct unit-test dispatch leaves them null and therefore remains a no-op.
+ */
+class AdminMutexHandoff {
+public:
+	explicit AdminMutexHandoff(const ProxySQL_PluginCommandContext& command_context)
+		: command_context_(command_context), released_(false) {}
+
+	void release() {
+		if (released_ || command_context_.admin_mutex_context == nullptr ||
+		    command_context_.release_admin_mutex == nullptr ||
+		    command_context_.acquire_admin_mutex == nullptr) {
+			return;
+		}
+		command_context_.release_admin_mutex(command_context_.admin_mutex_context);
+		released_ = true;
+	}
+
+	~AdminMutexHandoff() {
+		if (released_) {
+			command_context_.acquire_admin_mutex(command_context_.admin_mutex_context);
+		}
+	}
+
+private:
+	const ProxySQL_PluginCommandContext& command_context_;
+	bool released_;
+};
+
+/**
+ * Serialize the complete GenAI Admin command, including any interval where
+ * the callback yields Admin's global mutex. Waiting for this plugin mutex
+ * while retaining Admin would invert the order used by a reload that is
+ * finishing its yielded work, so production dispatch releases Admin before
+ * lock() and reacquires it immediately after entering the serialized region.
+ */
+class SerializedAdminCommand {
+public:
+	SerializedAdminCommand(
+		const ProxySQL_PluginCommandContext& command_context,
+		std::mutex& command_mutex
+	) : command_context_(command_context), command_mutex_(command_mutex), handed_off_(false) {
+		if (command_context_.admin_mutex_context != nullptr &&
+		    command_context_.release_admin_mutex != nullptr &&
+		    command_context_.acquire_admin_mutex != nullptr) {
+			command_context_.release_admin_mutex(command_context_.admin_mutex_context);
+			handed_off_ = true;
+		}
+
+		command_mutex_.lock();
+
+		if (handed_off_) {
+			command_context_.acquire_admin_mutex(command_context_.admin_mutex_context);
+		}
+	}
+
+	~SerializedAdminCommand() {
+		command_mutex_.unlock();
+	}
+
+	SerializedAdminCommand(const SerializedAdminCommand&) = delete;
+	SerializedAdminCommand& operator=(const SerializedAdminCommand&) = delete;
+
+private:
+	const ProxySQL_PluginCommandContext& command_context_;
+	std::mutex& command_mutex_;
+	bool handed_off_;
+};
+
+template <proxysql_plugin_admin_command_cb Callback>
+ProxySQL_PluginCommandResult serialized_admin_command(
+	const ProxySQL_PluginCommandContext& cmd_ctx,
+	const char* sql
+) {
+	GenAIPluginContext& ctx = genai_context();
+	SerializedAdminCommand command_guard(cmd_ctx, ctx.admin_command_mutex);
+	return Callback(cmd_ctx, sql);
+}
+
 /// Build a successful PluginCommandResult.  Uniform helper so all
 /// callbacks return the same shape.
 ProxySQL_PluginCommandResult ok_result(const char* msg) {
@@ -78,7 +159,6 @@ ProxySQL_PluginCommandResult load_variables_from_config(
 	const char* ok_msg,
 	const char* err_msg
 ) {
-	(void)cmd_ctx;
 	if (GloAdmin == nullptr || GloVars.configfile_open == false || GloVars.confFile == nullptr) {
 		return err_result("Config file unknown");
 	}
@@ -92,10 +172,14 @@ ProxySQL_PluginCommandResult load_variables_from_config(
 	}
 	GenAIPluginContext& ctx = genai_context();
 	if (std::strcmp(prefix, "genai") == 0) {
+		AdminMutexHandoff handoff(cmd_ctx);
+		handoff.release();
 		if (!genai_refresh_runtime_components(ctx)) {
 			return err_result("LOAD GENAI VARIABLES FROM CONFIG: failed reloading runtime components");
 		}
 	} else if (std::strcmp(prefix, "mcp") == 0) {
+		AdminMutexHandoff handoff(cmd_ctx);
+		handoff.release();
 		mcp_start_listener_if_enabled(ctx);
 	}
 	ProxySQL_PluginCommandResult r = ok_result(ok_msg);
@@ -120,6 +204,8 @@ ProxySQL_PluginCommandResult load_mcp_variables_to_runtime(
 		return err_result(
 			"LOAD MCP VARIABLES TO RUNTIME: failed applying or publishing global_variables");
 	}
+	AdminMutexHandoff handoff(cmd_ctx);
+	handoff.release();
 	mcp_start_listener_if_enabled(ctx);
 	return ok_result("MCP variables loaded to runtime");
 }
@@ -137,7 +223,7 @@ ProxySQL_PluginCommandResult save_mcp_variables_to_memory(
 	const ProxySQL_PluginCommandContext& cmd_ctx,
 	const char* sql
 ) {
-	(void)cmd_ctx; (void)sql;
+	(void)sql;
 	GenAIPluginContext& ctx = genai_context();
 	if (!mcp_save_variables_to_admindb(ctx)) {
 		return err_result("SAVE MCP VARIABLES TO MEMORY: failed writing global_variables");
@@ -169,6 +255,8 @@ ProxySQL_PluginCommandResult load_mcp_variables_from_disk(
 	if (!mcp_load_variables_from_admindb(ctx)) {
 		return err_result("LOAD MCP VARIABLES FROM DISK: failed to refresh runtime");
 	}
+	AdminMutexHandoff handoff(cmd_ctx);
+	handoff.release();
 	mcp_start_listener_if_enabled(ctx);
 	return ok_result("MCP variables loaded from disk");
 }
@@ -204,11 +292,13 @@ ProxySQL_PluginCommandResult load_genai_variables_to_runtime(
 	const ProxySQL_PluginCommandContext& cmd_ctx,
 	const char* sql
 ) {
-	(void)cmd_ctx; (void)sql;
+	(void)sql;
 	GenAIPluginContext& ctx = genai_context();
 	if (!genai_load_variables_from_admindb(ctx)) {
 		return err_result("LOAD GENAI VARIABLES TO RUNTIME: failed reading global_variables");
 	}
+	AdminMutexHandoff handoff(cmd_ctx);
+	handoff.release();
 	if (!genai_refresh_runtime_components(ctx)) {
 		return err_result("LOAD GENAI VARIABLES TO RUNTIME: failed reloading runtime components");
 	}
@@ -225,7 +315,7 @@ ProxySQL_PluginCommandResult save_genai_variables_to_memory(
 	const ProxySQL_PluginCommandContext& cmd_ctx,
 	const char* sql
 ) {
-	(void)cmd_ctx; (void)sql;
+	(void)sql;
 	GenAIPluginContext& ctx = genai_context();
 	if (!genai_save_variables_to_admindb(ctx)) {
 		return err_result("SAVE GENAI VARIABLES TO MEMORY: failed writing global_variables");
@@ -264,7 +354,7 @@ ProxySQL_PluginCommandResult save_mcp_query_rules_to_memory(
 	const ProxySQL_PluginCommandContext& cmd_ctx,
 	const char* sql
 ) {
-	(void)cmd_ctx; (void)sql;
+	(void)sql;
 	GenAIPluginContext& ctx = genai_context();
 	if (!mcp_save_query_rules_from_runtime(ctx, /*runtime=*/false)) {
 		return err_result("SAVE MCP QUERY RULES TO MEMORY: failed (is the MCP listener running?)");
@@ -285,11 +375,13 @@ ProxySQL_PluginCommandResult load_mcp_profiles_to_runtime(
 	const ProxySQL_PluginCommandContext& cmd_ctx,
 	const char* sql
 ) {
-	(void)cmd_ctx; (void)sql;
+	(void)sql;
 	GenAIPluginContext& ctx = genai_context();
 	if (!mcp_load_target_auth_map_from_admindb(ctx)) {
 		return err_result("LOAD MCP PROFILES TO RUNTIME: failed reading mcp_*_profiles");
 	}
+	AdminMutexHandoff handoff(cmd_ctx);
+	handoff.release();
 	mcp_start_listener_if_enabled(ctx);
 	return ok_result("MCP profiles loaded to runtime");
 }
@@ -359,6 +451,8 @@ ProxySQL_PluginCommandResult load_mcp_profiles_from_disk(
 	if (!mcp_load_target_auth_map_from_admindb(ctx)) {
 		return err_result("LOAD MCP PROFILES FROM DISK: failed to refresh runtime");
 	}
+	AdminMutexHandoff handoff(cmd_ctx);
+	handoff.release();
 	mcp_start_listener_if_enabled(ctx);
 	return ok_result("MCP profiles loaded from disk");
 }
@@ -452,76 +546,76 @@ void genai_register_admin_commands(ProxySQL_PluginServices* services) {
 	// "LOAD X TO RUNTIME" is canonical; users can also type
 	// "LOAD X FROM MEMORY" / "LOAD X FROM MEM" / "LOAD X TO RUN".
 	// Alias set mirrors mysqlx's convention.
-	reg("LOAD MCP VARIABLES TO RUNTIME", &load_mcp_variables_to_runtime, {
+	reg("LOAD MCP VARIABLES TO RUNTIME", &serialized_admin_command<load_mcp_variables_to_runtime>, {
 		"LOAD MCP VARIABLES FROM MEMORY",
 		"LOAD MCP VARIABLES FROM MEM",
 		"LOAD MCP VARIABLES TO RUN",
 	});
 
-	reg("LOAD MCP VARIABLES FROM DISK", &load_mcp_variables_from_disk, {
+	reg("LOAD MCP VARIABLES FROM DISK", &serialized_admin_command<load_mcp_variables_from_disk>, {
 		"LOAD MCP VARIABLES TO MEMORY",
 		"LOAD MCP VARIABLES TO MEM",
 	});
 
-	reg("LOAD MCP VARIABLES FROM CONFIG", &load_mcp_variables_from_config, {});
+	reg("LOAD MCP VARIABLES FROM CONFIG", &serialized_admin_command<load_mcp_variables_from_config>, {});
 
-	reg("SAVE MCP VARIABLES TO MEMORY", &save_mcp_variables_to_memory, {
+	reg("SAVE MCP VARIABLES TO MEMORY", &serialized_admin_command<save_mcp_variables_to_memory>, {
 		"SAVE MCP VARIABLES TO MEM",
 		"SAVE MCP VARIABLES FROM RUNTIME",
 		"SAVE MCP VARIABLES FROM RUN",
 	});
 
-	reg("SAVE MCP VARIABLES TO DISK", &save_mcp_variables_to_disk, {
+	reg("SAVE MCP VARIABLES TO DISK", &serialized_admin_command<save_mcp_variables_to_disk>, {
 		"SAVE MCP VARIABLES FROM MEMORY",
 		"SAVE MCP VARIABLES FROM MEM",
 	});
 
-	reg("LOAD MCP PROFILES TO RUNTIME", &load_mcp_profiles_to_runtime, {
+	reg("LOAD MCP PROFILES TO RUNTIME", &serialized_admin_command<load_mcp_profiles_to_runtime>, {
 		"LOAD MCP PROFILES FROM MEMORY",
 		"LOAD MCP PROFILES FROM MEM",
 		"LOAD MCP PROFILES TO RUN",
 	});
 
-	reg("LOAD MCP PROFILES FROM DISK", &load_mcp_profiles_from_disk, {
+	reg("LOAD MCP PROFILES FROM DISK", &serialized_admin_command<load_mcp_profiles_from_disk>, {
 		"LOAD MCP PROFILES TO MEMORY",
 	});
 
-	reg("SAVE MCP PROFILES TO MEMORY", &save_mcp_profiles_from_runtime, {
+	reg("SAVE MCP PROFILES TO MEMORY", &serialized_admin_command<save_mcp_profiles_from_runtime>, {
 		"SAVE MCP PROFILES TO MEM",
 		"SAVE MCP PROFILES FROM RUNTIME",
 		"SAVE MCP PROFILES FROM RUN",
 	});
 
-	reg("SAVE MCP PROFILES TO DISK", &save_mcp_profiles_to_disk, {});
+	reg("SAVE MCP PROFILES TO DISK", &serialized_admin_command<save_mcp_profiles_to_disk>, {});
 
-	reg("LOAD MCP QUERY RULES TO RUNTIME", &load_mcp_query_rules_to_runtime, {
+	reg("LOAD MCP QUERY RULES TO RUNTIME", &serialized_admin_command<load_mcp_query_rules_to_runtime>, {
 		"LOAD MCP QUERY RULES FROM MEMORY",
 		"LOAD MCP QUERY RULES FROM MEM",
 		"LOAD MCP QUERY RULES TO RUN",
 	});
 
-	reg("LOAD MCP QUERY RULES FROM DISK", &load_mcp_query_rules_from_disk, {
+	reg("LOAD MCP QUERY RULES FROM DISK", &serialized_admin_command<load_mcp_query_rules_from_disk>, {
 		"LOAD MCP QUERY RULES TO MEMORY",
 	});
 
-	reg("SAVE MCP QUERY RULES TO MEMORY", &save_mcp_query_rules_to_memory, {
+	reg("SAVE MCP QUERY RULES TO MEMORY", &serialized_admin_command<save_mcp_query_rules_to_memory>, {
 		"SAVE MCP QUERY RULES TO MEM",
 		"SAVE MCP QUERY RULES FROM RUNTIME",
 		"SAVE MCP QUERY RULES FROM RUN",
 	});
 
-	reg("SAVE MCP QUERY RULES TO DISK", &save_mcp_query_rules_to_disk, {});
+	reg("SAVE MCP QUERY RULES TO DISK", &serialized_admin_command<save_mcp_query_rules_to_disk>, {});
 
 	// genai-* variables: same alias scheme as the MCP verbs above.
-	reg("LOAD GENAI VARIABLES TO RUNTIME", &load_genai_variables_to_runtime, {
+	reg("LOAD GENAI VARIABLES TO RUNTIME", &serialized_admin_command<load_genai_variables_to_runtime>, {
 		"LOAD GENAI VARIABLES FROM MEMORY",
 		"LOAD GENAI VARIABLES FROM MEM",
 		"LOAD GENAI VARIABLES TO RUN",
 	});
 
-	reg("LOAD GENAI VARIABLES FROM CONFIG", &load_genai_variables_from_config, {});
+	reg("LOAD GENAI VARIABLES FROM CONFIG", &serialized_admin_command<load_genai_variables_from_config>, {});
 
-	reg("SAVE GENAI VARIABLES TO MEMORY", &save_genai_variables_to_memory, {
+	reg("SAVE GENAI VARIABLES TO MEMORY", &serialized_admin_command<save_genai_variables_to_memory>, {
 		"SAVE GENAI VARIABLES TO MEM",
 		"SAVE GENAI VARIABLES FROM RUNTIME",
 		"SAVE GENAI VARIABLES FROM RUN",

--- a/plugins/genai/src/plugin_commands.cpp
+++ b/plugins/genai/src/plugin_commands.cpp
@@ -84,7 +84,7 @@ class SerializedAdminCommand {
 public:
 	SerializedAdminCommand(
 		const ProxySQL_PluginCommandContext& command_context,
-		std::mutex& command_mutex
+		GenAIMutex& command_mutex
 	) : command_context_(command_context), command_mutex_(command_mutex), handed_off_(false) {
 		if (command_context_.admin_mutex_context != nullptr &&
 		    command_context_.release_admin_mutex != nullptr &&
@@ -109,7 +109,7 @@ public:
 
 private:
 	const ProxySQL_PluginCommandContext& command_context_;
-	std::mutex& command_mutex_;
+	GenAIMutex& command_mutex_;
 	bool handed_off_;
 };
 

--- a/plugins/genai/src/plugin_hooks.cpp
+++ b/plugins/genai/src/plugin_hooks.cpp
@@ -37,6 +37,7 @@ extern GenAI_Threads_Handler* GloGATH;
 
 ProxySQL_PluginQueryHookResult genai_query_hook(const ProxySQL_PluginQueryHookPayload& payload) {
 	GenAIPluginContext& ctx = genai_context();
+	std::shared_lock<GenAIRWLock> runtime_guard(ctx.runtime_dependencies_mutex);
 
 	// Detector not yet up (init failed, or hook fired between stop and
 	// final unload): always allow.  The lock-free

--- a/plugins/genai/src/plugin_main.cpp
+++ b/plugins/genai/src/plugin_main.cpp
@@ -696,7 +696,7 @@ bool genai_refresh_runtime_components(GenAIPluginContext& ctx) {
 	// next endpoint call can enter.  Command callbacks release the Admin mutex
 	// before reaching this lock, so a request already waiting for Admin cannot
 	// form Admin -> reload -> request -> Admin lock inversion.
-	std::unique_lock<std::shared_mutex> runtime_guard(ctx.runtime_dependencies_mutex);
+	std::unique_lock<GenAIRWLock> runtime_guard(ctx.runtime_dependencies_mutex);
 
 	if (GloGATH != nullptr) {
 		GloGATH->shutdown();
@@ -904,7 +904,7 @@ void mcp_start_listener_if_enabled(GenAIPluginContext& ctx) {
 	// Serialize listener construction/destruction with GenAI reloads.  The
 	// server constructor snapshots GloAI/GloGATH dependencies for its AI/RAG
 	// handlers, and its destructor drains those handlers before freeing them.
-	std::unique_lock<std::shared_mutex> runtime_guard(ctx.runtime_dependencies_mutex);
+	std::unique_lock<GenAIRWLock> runtime_guard(ctx.runtime_dependencies_mutex);
 	if (!ctx.mcp->variables.mcp_enabled) {
 		if (ctx.mcp->mcp_server != nullptr) {
 			delete ctx.mcp->mcp_server;
@@ -1011,21 +1011,16 @@ bool genai_start() {
  *
  * Tear-down order is the reverse of construction in genai_init() so
  * that consumers go away before producers:
- *   1. flip `started` to false — the query-hook adapter switches to
- *      ALLOW-everything once this flips, draining in-flight readers
- *      that observed `started == true` before the flip.
- *   2. delete MCP_Threads_Handler — its destructor stops the
- *      ProxySQL_MCP_Server (joining accept + worker threads), so by
- *      the time we move on no listener thread is still alive that
- *      could touch GloGATH/GloAI.
- *   3. delete AI_Features_Manager and GenAI_Threads_Handler — safe
- *      now because the listener / tool handlers (their only callers)
- *      are gone.
- *   4. clear the embedding hook ATOMICALLY before deleting the
- *      anomaly detector, so any straggling hot-path reader (the
- *      query hook ran concurrently with step 1) sees a null pointer
- *      and short-circuits, not a dangling GenAI handler.
- *   5. delete the anomaly detector itself.
+ *   1. flip `started` to false — new query-hook calls become no-ops.
+ *   2. stop the MCP server without holding runtime_dependencies_mutex.
+ *      Its destructor joins accept + worker threads, including workers
+ *      that may already hold the shared side of that mutex. Taking the
+ *      writer first would deadlock while waiting for those workers.
+ *   3. take the exclusive runtime lock. This drains any query-hook or
+ *      stats-view reader that entered before step 1 and prevents another
+ *      runtime consumer from observing teardown in progress.
+ *   4. clear the embedding callback, then destroy the MCP handler,
+ *      AI/GenAI runtime objects, and anomaly detector in reverse order.
  *
  * Prometheus counters stay registered: prometheus-cpp has no
  * Unregister API and re-registering them on a future load+start of
@@ -1037,14 +1032,24 @@ bool genai_start() {
 bool genai_stop() {
 	GenAIPluginContext& ctx = genai_context();
 	ctx.started = false;
+
+	// The server owns threads whose AI/RAG calls take the shared runtime lock.
+	// Drain them before requesting the exclusive side below.
 	if (ctx.mcp != nullptr) {
-		// MCP listener teardown.  ~MCP_Threads_Handler stops the
-		// embedded ProxySQL_MCP_Server (if running) and joins worker
-		// threads.  Mirrors the pre-4.C `delete GloMCPH` in main.cpp.
+		ctx.mcp->shutdown();
+	}
+
+	std::unique_lock<GenAIRWLock> runtime_guard(ctx.runtime_dependencies_mutex);
+	if (ctx.mcp != nullptr) {
 		delete ctx.mcp;
 		ctx.mcp = nullptr;
 		GloMCPH = nullptr;
 	}
+
+	// No shared runtime consumer can retain the embedding callback after the
+	// exclusive lock was acquired, so clear it before deleting GloGATH.
+	genai_anomaly_embed_fn.store(nullptr, std::memory_order_release);
+
 	// Step 5: tear down AI_Features_Manager and GenAI_Threads_Handler
 	// in reverse construction order.  Mirrors the pre-Step-5 shutdown
 	// in src/main.cpp.
@@ -1057,16 +1062,6 @@ bool genai_stop() {
 		GloGATH = nullptr;
 	}
 	if (ctx.anomaly_detector != nullptr) {
-		// Clear the embedding hook before deleting the detector so
-		// any in-flight hot-path call sees a null pointer rather
-		// than a dangling GenAI_Threads_Handler reference.  Release
-		// ordering pairs with the acquire load in
-		// Anomaly_Detector::get_query_embedding so subsequent
-		// readers either observe the null (and short-circuit)
-		// before the GloGATH delete becomes visible, or observe
-		// the prior non-null pointer paired with the
-		// still-live GloGATH from genai_init.
-		genai_anomaly_embed_fn.store(nullptr, std::memory_order_release);
 		ctx.anomaly_detector->close();
 		delete ctx.anomaly_detector;
 		ctx.anomaly_detector = nullptr;

--- a/plugins/genai/src/plugin_main.cpp
+++ b/plugins/genai/src/plugin_main.cpp
@@ -51,6 +51,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <utility>
+#include <vector>
 
 class ProxySQL_Admin;
 extern ProxySQL_Admin* GloAdmin;
@@ -83,6 +85,14 @@ extern std::atomic<genai_anomaly_embed_fn_t> genai_anomaly_embed_fn;
 
 namespace {
 
+using VariableDefaults = std::vector<std::pair<std::string, std::string>>;
+
+void free_variable_names(char** names) {
+	if (names == nullptr) return;
+	for (int i = 0; names[i] != nullptr; ++i) free(names[i]);
+	free(names);
+}
+
 std::vector<float> embed_query_via_glogath(const std::string& query) {
 	if (GloGATH == nullptr) return {};
 	std::vector<std::string> docs { query };
@@ -91,6 +101,123 @@ std::vector<float> embed_query_via_glogath(const std::string& query) {
 		return {};
 	}
 	return std::vector<float>(res.data, res.data + res.embedding_size);
+}
+
+bool collect_variable_defaults(GenAIPluginContext& ctx, VariableDefaults& defaults) {
+	if (ctx.mcp == nullptr || GloGATH == nullptr) return false;
+
+	char** mcp_names = ctx.mcp->get_variables_list();
+	if (mcp_names == nullptr) return false;
+	for (int i = 0; mcp_names[i] != nullptr; ++i) {
+		std::string value;
+		if (!ctx.mcp->get_variable_string(mcp_names[i], value)) {
+			free_variable_names(mcp_names);
+			return false;
+		}
+		defaults.emplace_back(std::string("mcp-") + mcp_names[i], std::move(value));
+	}
+	free_variable_names(mcp_names);
+
+	char** genai_names = GloGATH->get_variables_list();
+	if (genai_names == nullptr) return false;
+	for (int i = 0; genai_names[i] != nullptr; ++i) {
+		char* value = GloGATH->get_variable(genai_names[i]);
+		defaults.emplace_back(
+			std::string("genai-") + genai_names[i], value != nullptr ? value : "");
+		free(value);
+	}
+	free_variable_names(genai_names);
+	return true;
+}
+
+bool seed_variable_defaults(SQLite3DB* db, const VariableDefaults& defaults,
+		const char* database_name) {
+	if (db == nullptr) {
+		genai_log(6, "genai plugin: cannot seed defaults in %s: null database\n", database_name);
+		return false;
+	}
+
+	auto [prep_rc, stmt] = db->prepare_v2(
+		"INSERT OR IGNORE INTO global_variables(variable_name, variable_value) VALUES(?1, ?2)"
+	);
+	if (prep_rc != SQLITE_OK) {
+		genai_log(6, "genai plugin: failed to prepare default seeding for %s (rc=%d)\n",
+		          database_name, prep_rc);
+		return false;
+	}
+	sqlite3_stmt* statement = stmt.get();
+
+	if (!db->execute("BEGIN")) {
+		genai_log(6, "genai plugin: failed to begin default seeding transaction for %s\n",
+		          database_name);
+		return false;
+	}
+
+	for (const auto& item : defaults) {
+		int rc = (*proxy_sqlite3_bind_text)(statement, 1, item.first.c_str(), -1, SQLITE_TRANSIENT);
+		if (rc != SQLITE_OK) {
+			genai_log(6, "genai plugin: failed to bind default %s for %s (rc=%d)\n",
+			          item.first.c_str(), database_name, rc);
+			db->execute("ROLLBACK");
+			return false;
+		}
+
+		rc = (*proxy_sqlite3_bind_text)(statement, 2, item.second.c_str(), -1, SQLITE_TRANSIENT);
+		if (rc != SQLITE_OK) {
+			genai_log(6, "genai plugin: failed to bind default %s for %s (rc=%d)\n",
+			          item.first.c_str(), database_name, rc);
+			db->execute("ROLLBACK");
+			return false;
+		}
+
+		rc = (*proxy_sqlite3_step)(statement);
+		if (rc != SQLITE_DONE) {
+			genai_log(6, "genai plugin: failed to seed default %s for %s (rc=%d)\n",
+			          item.first.c_str(), database_name, rc);
+			db->execute("ROLLBACK");
+			return false;
+		}
+
+		rc = (*proxy_sqlite3_clear_bindings)(statement);
+		if (rc != SQLITE_OK) {
+			genai_log(6, "genai plugin: failed to clear default bindings for %s in %s (rc=%d)\n",
+			          item.first.c_str(), database_name, rc);
+			db->execute("ROLLBACK");
+			return false;
+		}
+
+		rc = (*proxy_sqlite3_reset)(statement);
+		if (rc != SQLITE_OK) {
+			genai_log(6, "genai plugin: failed to reset default statement for %s in %s (rc=%d)\n",
+			          item.first.c_str(), database_name, rc);
+			db->execute("ROLLBACK");
+			return false;
+		}
+	}
+
+	if (!db->execute("COMMIT")) {
+		genai_log(6, "genai plugin: failed to commit default seeding transaction for %s\n",
+		          database_name);
+		db->execute("ROLLBACK");
+		return false;
+	}
+	return true;
+}
+
+bool seed_plugin_variable_defaults(GenAIPluginContext& ctx) {
+	if (ctx.services == nullptr ||
+	    ctx.services->get_configdb == nullptr ||
+	    ctx.services->get_admindb == nullptr) {
+		return false;
+	}
+
+	VariableDefaults defaults;
+	if (!collect_variable_defaults(ctx, defaults)) return false;
+
+	SQLite3DB* configdb = ctx.services->get_configdb();
+	SQLite3DB* admindb = ctx.services->get_admindb();
+	return seed_variable_defaults(configdb, defaults, "configdb") &&
+	       seed_variable_defaults(admindb, defaults, "admindb");
 }
 
 } // namespace
@@ -675,6 +802,12 @@ void mcp_start_listener_if_enabled(GenAIPluginContext& ctx) {
 bool genai_start() {
 	GenAIPluginContext& ctx = genai_context();
 	ctx.started = true;
+
+	if (!seed_plugin_variable_defaults(ctx)) {
+		genai_log(6, "genai plugin: failed to seed MCP/GenAI variable defaults\n");
+		ctx.started = false;
+		return false;
+	}
 
 	if (!mcp_load_variables_from_admindb(ctx)) {
 		genai_log(6, "genai plugin: failed to load MCP variables at startup\n");

--- a/plugins/genai/src/plugin_main.cpp
+++ b/plugins/genai/src/plugin_main.cpp
@@ -39,6 +39,8 @@
 #include "Discovery_Schema.h"     // load_mcp_query_rules / get_mcp_query_rules
 #include "GenAI_Thread.h"
 #include "AI_Features_Manager.h"
+#include "AI_Tool_Handler.h"
+#include "RAG_Tool_Handler.h"
 #include "sqlite3db.h"
 #include "proxysql_utils.h"
 #include "proxysql.h"
@@ -52,6 +54,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -687,7 +690,14 @@ bool genai_load_variables_from_admindb(GenAIPluginContext& ctx) {
  * bridge from the refreshed GenAI configuration.
  */
 bool genai_refresh_runtime_components(GenAIPluginContext& ctx) {
-	(void)ctx;
+	// AI/RAG endpoint resources persist across a GenAI reload, but their tool
+	// handlers borrow objects owned by GloGATH/GloAI.  Wait for current AI/RAG
+	// calls, rebuild the owners, and rebind those borrowed pointers before the
+	// next endpoint call can enter.  Command callbacks release the Admin mutex
+	// before reaching this lock, so a request already waiting for Admin cannot
+	// form Admin -> reload -> request -> Admin lock inversion.
+	std::unique_lock<std::shared_mutex> runtime_guard(ctx.runtime_dependencies_mutex);
+
 	if (GloGATH != nullptr) {
 		GloGATH->shutdown();
 		GloGATH->init();
@@ -695,9 +705,23 @@ bool genai_refresh_runtime_components(GenAIPluginContext& ctx) {
 	if (GloAI != nullptr) {
 		GloAI->shutdown();
 		if (GloAI->init() != 0) {
+			if (ctx.mcp != nullptr && ctx.mcp->ai_tool_handler != nullptr) {
+				ctx.mcp->ai_tool_handler->set_llm_bridge(nullptr);
+			}
+			if (ctx.mcp != nullptr && ctx.mcp->rag_tool_handler != nullptr) {
+				ctx.mcp->rag_tool_handler->refresh_runtime_dependencies(GloAI);
+			}
 			genai_log(6, "genai plugin: AI_Features_Manager::init() failed during reload\n");
 			return false;
 		}
+	}
+
+	if (ctx.mcp != nullptr && ctx.mcp->ai_tool_handler != nullptr) {
+		ctx.mcp->ai_tool_handler->set_llm_bridge(
+			GloAI != nullptr ? GloAI->get_llm_bridge() : nullptr);
+	}
+	if (ctx.mcp != nullptr && ctx.mcp->rag_tool_handler != nullptr) {
+		ctx.mcp->rag_tool_handler->refresh_runtime_dependencies(GloAI);
 	}
 	return true;
 }
@@ -877,6 +901,10 @@ bool mcp_save_target_auth_map_to_admindb(GenAIPluginContext& ctx) {
  */
 void mcp_start_listener_if_enabled(GenAIPluginContext& ctx) {
 	if (ctx.mcp == nullptr) return;
+	// Serialize listener construction/destruction with GenAI reloads.  The
+	// server constructor snapshots GloAI/GloGATH dependencies for its AI/RAG
+	// handlers, and its destructor drains those handlers before freeing them.
+	std::unique_lock<std::shared_mutex> runtime_guard(ctx.runtime_dependencies_mutex);
 	if (!ctx.mcp->variables.mcp_enabled) {
 		if (ctx.mcp->mcp_server != nullptr) {
 			delete ctx.mcp->mcp_server;

--- a/plugins/genai/src/plugin_main.cpp
+++ b/plugins/genai/src/plugin_main.cpp
@@ -122,8 +122,13 @@ bool collect_variable_defaults(GenAIPluginContext& ctx, VariableDefaults& defaul
 	if (genai_names == nullptr) return false;
 	for (int i = 0; genai_names[i] != nullptr; ++i) {
 		char* value = GloGATH->get_variable(genai_names[i]);
-		defaults.emplace_back(
-			std::string("genai-") + genai_names[i], value != nullptr ? value : "");
+		if (value == nullptr) {
+			genai_log(6, "genai plugin: failed to read default for genai-%s\n",
+			          genai_names[i]);
+			free_variable_names(genai_names);
+			return false;
+		}
+		defaults.emplace_back(std::string("genai-") + genai_names[i], value);
 		free(value);
 	}
 	free_variable_names(genai_names);

--- a/plugins/genai/src/plugin_main.cpp
+++ b/plugins/genai/src/plugin_main.cpp
@@ -51,6 +51,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -87,11 +88,16 @@ namespace {
 
 using VariableDefaults = std::vector<std::pair<std::string, std::string>>;
 
-void free_variable_names(char** names) {
-	if (names == nullptr) return;
-	for (int i = 0; names[i] != nullptr; ++i) free(names[i]);
-	free(names);
-}
+struct VariableNamesDeleter {
+	void operator()(char** names) const {
+		if (names == nullptr) return;
+		free_deleter release;
+		for (int i = 0; names[i] != nullptr; ++i) release(names[i]);
+		release(names);
+	}
+};
+
+using VariableNamesOwner = std::unique_ptr<char*, VariableNamesDeleter>;
 
 std::vector<float> embed_query_via_glogath(const std::string& query) {
 	if (GloGATH == nullptr) return {};
@@ -106,32 +112,25 @@ std::vector<float> embed_query_via_glogath(const std::string& query) {
 bool collect_variable_defaults(GenAIPluginContext& ctx, VariableDefaults& defaults) {
 	if (ctx.mcp == nullptr || GloGATH == nullptr) return false;
 
-	char** mcp_names = ctx.mcp->get_variables_list();
-	if (mcp_names == nullptr) return false;
-	for (int i = 0; mcp_names[i] != nullptr; ++i) {
+	VariableNamesOwner mcp_names { ctx.mcp->get_variables_list() };
+	if (!mcp_names) return false;
+	for (int i = 0; mcp_names.get()[i] != nullptr; ++i) {
 		std::string value;
-		if (!ctx.mcp->get_variable_string(mcp_names[i], value)) {
-			free_variable_names(mcp_names);
-			return false;
-		}
-		defaults.emplace_back(std::string("mcp-") + mcp_names[i], std::move(value));
+		if (!ctx.mcp->get_variable_string(mcp_names.get()[i], value)) return false;
+		defaults.emplace_back(std::string("mcp-") + mcp_names.get()[i], std::move(value));
 	}
-	free_variable_names(mcp_names);
 
-	char** genai_names = GloGATH->get_variables_list();
-	if (genai_names == nullptr) return false;
-	for (int i = 0; genai_names[i] != nullptr; ++i) {
-		char* value = GloGATH->get_variable(genai_names[i]);
-		if (value == nullptr) {
+	VariableNamesOwner genai_names { GloGATH->get_variables_list() };
+	if (!genai_names) return false;
+	for (int i = 0; genai_names.get()[i] != nullptr; ++i) {
+		mf_unique_ptr<char> value { GloGATH->get_variable(genai_names.get()[i]) };
+		if (!value) {
 			genai_log(6, "genai plugin: failed to read default for genai-%s\n",
-			          genai_names[i]);
-			free_variable_names(genai_names);
+			          genai_names.get()[i]);
 			return false;
 		}
-		defaults.emplace_back(std::string("genai-") + genai_names[i], value);
-		free(value);
+		defaults.emplace_back(std::string("genai-") + genai_names.get()[i], value.get());
 	}
-	free_variable_names(genai_names);
 	return true;
 }
 

--- a/plugins/genai/src/plugin_main.cpp
+++ b/plugins/genai/src/plugin_main.cpp
@@ -87,6 +87,7 @@ extern std::atomic<genai_anomaly_embed_fn_t> genai_anomaly_embed_fn;
 namespace {
 
 using VariableDefaults = std::vector<std::pair<std::string, std::string>>;
+using VariableValues = std::vector<std::pair<std::string, std::string>>;
 
 struct VariableNamesDeleter {
 	void operator()(char** names) const {
@@ -372,14 +373,116 @@ bool genai_register_schemas(ProxySQL_PluginServices* services) {
 //               externally visible, declared in genai_plugin.h, and
 //               called from plugin_commands.cpp.)
 
+namespace {
+
+bool collect_mcp_handler_values(MCP_Threads_Handler* handler, VariableValues& values) {
+	values.clear();
+	if (handler == nullptr) return false;
+
+	VariableNamesOwner names { handler->get_variables_list() };
+	if (!names) return false;
+
+	for (int i = 0; names.get()[i] != nullptr; ++i) {
+		std::string value;
+		if (!handler->get_variable_string(names.get()[i], value)) {
+			genai_log(6, "genai plugin: failed to read active mcp-%s\n", names.get()[i]);
+			return false;
+		}
+		values.emplace_back(names.get()[i], std::move(value));
+	}
+	return !values.empty();
+}
+
+bool apply_mcp_handler_values(MCP_Threads_Handler* handler, const VariableValues& values,
+		const char* operation) {
+	for (const auto& item : values) {
+		if (handler->set_variable(item.first.c_str(), item.second.c_str()) != 0) {
+			// Endpoint-auth values are credentials.  Name the rejected setting
+			// without echoing its value into proxysql.log.
+			genai_log(6, "genai plugin: %s rejected mcp-%s\n", operation,
+			          item.first.c_str());
+			return false;
+		}
+	}
+	return true;
+}
+
+bool contains_mcp_variable(const VariableValues& values, const std::string& name) {
+	for (const auto& item : values) {
+		if (item.first == name) return true;
+	}
+	return false;
+}
+
+bool publish_mcp_runtime_values(SQLite3DB* admindb, const VariableValues& values) {
+	auto [prep_rc, stmt] = admindb->prepare_v2(
+		"INSERT INTO main.runtime_global_variables(variable_name, variable_value)"
+		" VALUES(?1, ?2)"
+	);
+	if (prep_rc != SQLITE_OK) {
+		genai_log(6, "genai plugin: failed to prepare MCP runtime publication (rc=%d)\n",
+		          prep_rc);
+		return false;
+	}
+
+	if (!admindb->execute("BEGIN")) {
+		genai_log(6, "genai plugin: failed to begin MCP runtime publication\n");
+		return false;
+	}
+
+	if (!admindb->execute(
+			"DELETE FROM main.runtime_global_variables WHERE variable_name LIKE 'mcp-%'")) {
+		genai_log(6, "genai plugin: failed to clear the prior MCP runtime snapshot\n");
+		admindb->execute("ROLLBACK");
+		return false;
+	}
+
+	sqlite3_stmt* statement = stmt.get();
+	for (const auto& item : values) {
+		const std::string qualified = std::string("mcp-") + item.first;
+		int rc = (*proxy_sqlite3_bind_text)(
+			statement, 1, qualified.c_str(), -1, SQLITE_TRANSIENT);
+		if (rc == SQLITE_OK) {
+			rc = (*proxy_sqlite3_bind_text)(
+				statement, 2, item.second.c_str(), -1, SQLITE_TRANSIENT);
+		}
+		if (rc == SQLITE_OK) rc = (*proxy_sqlite3_step)(statement);
+		if (rc != SQLITE_DONE) {
+			genai_log(6, "genai plugin: failed to publish runtime %s (rc=%d)\n",
+			          qualified.c_str(), rc);
+			admindb->execute("ROLLBACK");
+			return false;
+		}
+
+		rc = (*proxy_sqlite3_clear_bindings)(statement);
+		if (rc == SQLITE_OK) rc = (*proxy_sqlite3_reset)(statement);
+		if (rc != SQLITE_OK) {
+			genai_log(6, "genai plugin: failed to reset MCP runtime publication"
+			          " for %s (rc=%d)\n", qualified.c_str(), rc);
+			admindb->execute("ROLLBACK");
+			return false;
+		}
+	}
+
+	if (!admindb->execute("COMMIT")) {
+		genai_log(6, "genai plugin: failed to commit MCP runtime publication\n");
+		admindb->execute("ROLLBACK");
+		return false;
+	}
+	return true;
+}
+
+} // namespace
+
 /**
- * @brief Push admin DB's mcp-* variables into the running
- *        MCP_Threads_Handler.  Mirrors the pre-4.C
- *        flush_mcp_variables___database_to_runtime in core.
+ * @brief Validate and push admin DB's complete mcp-* configuration into the
+ *        running handler, then atomically publish the normalized active values
+ *        to runtime_global_variables.
  *
  * @param ctx  Plugin context (provides services + ctx.mcp).
- * @return true on success; false on SQL error (logged and propagated
- *         to caller).
+ * @return true on success; false on an incomplete/invalid configuration or a
+ *         SQL error.  Failures restore the previous handler values and leave
+ *         the previously committed runtime table snapshot visible.
  */
 bool mcp_load_variables_from_admindb(GenAIPluginContext& ctx) {
 	if (ctx.services == nullptr || ctx.services->get_admindb == nullptr || ctx.mcp == nullptr) {
@@ -401,15 +504,55 @@ bool mcp_load_variables_from_admindb(GenAIPluginContext& ctx) {
 		if (rs != nullptr) delete rs;
 		return false;
 	}
+
+	VariableValues previous;
+	if (!collect_mcp_handler_values(ctx.mcp, previous)) {
+		if (rs != nullptr) delete rs;
+		return false;
+	}
+
+	VariableValues desired;
 	if (rs != nullptr) {
 		for (auto* row : rs->rows) {
 			const char* qualified = row->fields[0];
 			const char* value = row->fields[1];
-			if (qualified != nullptr && std::strncmp(qualified, "mcp-", 4) == 0) {
-				ctx.mcp->set_variable(qualified + 4, value ? value : "");
+			if (qualified == nullptr || std::strncmp(qualified, "mcp-", 4) != 0 ||
+				!ctx.mcp->has_variable(qualified + 4)) {
+				genai_log(6, "genai plugin: unknown MCP variable %s\n",
+				          qualified ? qualified : "(null)");
+				delete rs;
+				return false;
 			}
+			desired.emplace_back(qualified + 4, value ? value : "");
 		}
 		delete rs;
+	}
+
+	if (desired.size() != previous.size()) {
+		genai_log(6, "genai plugin: incomplete MCP variable set: expected %zu, got %zu\n",
+		          previous.size(), desired.size());
+		return false;
+	}
+	for (const auto& item : previous) {
+		if (!contains_mcp_variable(desired, item.first)) {
+			genai_log(6, "genai plugin: missing mcp-%s from global_variables\n",
+			          item.first.c_str());
+			return false;
+		}
+	}
+
+	if (!apply_mcp_handler_values(ctx.mcp, desired, "LOAD")) {
+		apply_mcp_handler_values(ctx.mcp, previous, "rollback");
+		return false;
+	}
+
+	VariableValues active;
+	if (!collect_mcp_handler_values(ctx.mcp, active) ||
+		!publish_mcp_runtime_values(admindb, active)) {
+		if (!apply_mcp_handler_values(ctx.mcp, previous, "rollback")) {
+			genai_log(3, "genai plugin: failed to restore MCP handler after LOAD failure\n");
+		}
+		return false;
 	}
 	return true;
 }

--- a/plugins/genai/src/plugin_tables.cpp
+++ b/plugins/genai/src/plugin_tables.cpp
@@ -27,6 +27,7 @@
 #include "AI_Features_Manager.h"
 #include "ProxySQL_Admin_Tables_Definitions.h"
 #include "Query_Tool_Handler.h"
+#include "RAG_Tool_Handler.h"
 #include "Discovery_Schema.h"
 
 #include <cstdio>
@@ -222,56 +223,66 @@ void refresh_stats_mcp_query_rules(SQLite3DB* db, void*) {
 	delete result; result = nullptr;
 }
 
-void refresh_stats_mcp_query_tools_counters(SQLite3DB* db, void*) {
-	if (db == nullptr) return;
-	MCP_Threads_Handler* mcp = genai_context().mcp;
-	if (mcp == nullptr) return;
-	Query_Tool_Handler* qth = mcp->query_tool_handler;
-	if (qth == nullptr) return;
-	SQLite3_result* result = qth->get_tool_usage_stats_resultset(false);
-	if (result == nullptr) return;
-	if (!db->execute("BEGIN")) { delete result; result = nullptr; return; }
-	if (!db->execute("DELETE FROM stats_mcp_query_tools_counters")) { db->execute("ROLLBACK"); delete result; result = nullptr; return; }
+bool insert_tool_counter_rows(
+	SQLite3DB* db,
+	const char* table_name,
+	SQLite3_result* result
+) {
+	if (result == nullptr) return true;
 	for (int i = 0; i < result->rows_count; i++) {
 		char** row = result->rows[i]->fields;
 		char* q = sqlite3_mprintf(
-			"INSERT INTO stats_mcp_query_tools_counters"
+			"INSERT INTO %s"
 			" (endpoint, tool, schema, count, first_seen,"
 			"  last_seen, sum_time, min_time, max_time)"
 			" VALUES('%q','%q','%q','%q','%q','%q','%q','%q','%q')",
+			table_name,
 			row[0], row[1], row[2], row[3], row[4],
 			row[5], row[6], row[7], row[8]);
-		db->execute(q);
+		const bool inserted = db->execute(q);
+		sqlite3_free(q);
+		if (!inserted) return false;
+	}
+	return true;
+}
+
+void refresh_stats_mcp_tool_counters(SQLite3DB* db, bool reset) {
+	if (db == nullptr) return;
+	MCP_Threads_Handler* mcp = genai_context().mcp;
+	if (mcp == nullptr) return;
+
+	SQLite3_result* query_result = mcp->query_tool_handler
+		? mcp->query_tool_handler->get_tool_usage_stats_resultset(reset)
+		: nullptr;
+	SQLite3_result* rag_result = mcp->rag_tool_handler
+		? mcp->rag_tool_handler->get_tool_usage_stats_resultset(reset)
+		: nullptr;
+	const char* table_name = reset
+		? "stats_mcp_query_tools_counters_reset"
+		: "stats_mcp_query_tools_counters";
+
+	const bool transaction_started = db->execute("BEGIN");
+	bool success = transaction_started;
+	if (success) {
+		char* q = sqlite3_mprintf("DELETE FROM %s", table_name);
+		success = db->execute(q);
 		sqlite3_free(q);
 	}
-	if (!db->execute("COMMIT")) { delete result; result = nullptr; return; }
-	delete result; result = nullptr;
+	if (success) success = insert_tool_counter_rows(db, table_name, query_result);
+	if (success) success = insert_tool_counter_rows(db, table_name, rag_result);
+	if (success) success = db->execute("COMMIT");
+	if (!success && transaction_started) db->execute("ROLLBACK");
+
+	delete query_result;
+	delete rag_result;
+}
+
+void refresh_stats_mcp_query_tools_counters(SQLite3DB* db, void*) {
+	refresh_stats_mcp_tool_counters(db, false);
 }
 
 void refresh_stats_mcp_query_tools_counters_reset(SQLite3DB* db, void*) {
-	if (db == nullptr) return;
-	MCP_Threads_Handler* mcp = genai_context().mcp;
-	if (mcp == nullptr) return;
-	Query_Tool_Handler* qth = mcp->query_tool_handler;
-	if (qth == nullptr) return;
-	SQLite3_result* result = qth->get_tool_usage_stats_resultset(true);
-	if (result == nullptr) return;
-	if (!db->execute("BEGIN")) { delete result; result = nullptr; return; }
-	if (!db->execute("DELETE FROM stats_mcp_query_tools_counters_reset")) { db->execute("ROLLBACK"); delete result; result = nullptr; return; }
-	for (int i = 0; i < result->rows_count; i++) {
-		char** row = result->rows[i]->fields;
-		char* q = sqlite3_mprintf(
-			"INSERT INTO stats_mcp_query_tools_counters_reset"
-			" (endpoint, tool, schema, count, first_seen,"
-			"  last_seen, sum_time, min_time, max_time)"
-			" VALUES('%q','%q','%q','%q','%q','%q','%q','%q','%q')",
-			row[0], row[1], row[2], row[3], row[4],
-			row[5], row[6], row[7], row[8]);
-		db->execute(q);
-		sqlite3_free(q);
-	}
-	if (!db->execute("COMMIT")) { delete result; result = nullptr; return; }
-	delete result; result = nullptr;
+	refresh_stats_mcp_tool_counters(db, true);
 }
 
 void refresh_stats_genai_global(SQLite3DB* db, void*) {

--- a/plugins/genai/src/plugin_tables.cpp
+++ b/plugins/genai/src/plugin_tables.cpp
@@ -287,6 +287,8 @@ void refresh_stats_mcp_query_tools_counters_reset(SQLite3DB* db, void*) {
 
 void refresh_stats_genai_global(SQLite3DB* db, void*) {
 	if (db == nullptr) return;
+	GenAIPluginContext& ctx = genai_context();
+	std::shared_lock<GenAIRWLock> runtime_guard(ctx.runtime_dependencies_mutex);
 
 	std::vector<std::pair<std::string, std::string>> all_vars;
 
@@ -294,8 +296,8 @@ void refresh_stats_genai_global(SQLite3DB* db, void*) {
 		auto vars = GloGATH->collect_status_variables();
 		all_vars.insert(all_vars.end(), vars.begin(), vars.end());
 	}
-	if (genai_context().mcp) {
-		auto vars = genai_context().mcp->collect_status_variables();
+	if (ctx.mcp) {
+		auto vars = ctx.mcp->collect_status_variables();
 		all_vars.insert(all_vars.end(), vars.begin(), vars.end());
 	}
 	if (GloAI) {

--- a/plugins/genai/src/tool_handlers/RAG_Tool_Handler.cpp
+++ b/plugins/genai/src/tool_handlers/RAG_Tool_Handler.cpp
@@ -349,17 +349,9 @@ RAG_Tool_Handler::RAG_Tool_Handler(AI_Features_Manager* ai_mgr, const std::strin
 	  response_max_bytes(5000000),
 	  timeout_ms(2000)
 {
-	// Initialize configuration from GenAI_Thread if available
-	if (ai_manager && GloGATH) {
-		k_max = GloGATH->variables.genai_rag_k_max;
-		candidates_max = GloGATH->variables.genai_rag_candidates_max;
-		query_max_bytes = GloGATH->variables.genai_rag_query_max_bytes;
-		response_max_bytes = GloGATH->variables.genai_rag_response_max_bytes;
-		timeout_ms = GloGATH->variables.genai_rag_timeout_ms;
-	}
-
 	// Initialize counters mutex
 	pthread_mutex_init(&counters_lock, NULL);
+	refresh_runtime_dependencies(ai_mgr);
 
 	proxy_debug(PROXY_DEBUG_GENAI, 3, "RAG_Tool_Handler created\n");
 }
@@ -394,9 +386,7 @@ RAG_Tool_Handler::~RAG_Tool_Handler() {
  * @see ai_manager
  */
 int RAG_Tool_Handler::init() {
-	if (ai_manager) {
-		vector_db = ai_manager->get_vector_db();
-	}
+	refresh_runtime_dependencies(ai_manager);
 
 	if (!vector_db) {
 		proxy_error("RAG_Tool_Handler: Vector database not available\n");
@@ -418,6 +408,19 @@ int RAG_Tool_Handler::init() {
 
 	proxy_info("RAG_Tool_Handler initialized\n");
 	return 0;
+}
+
+void RAG_Tool_Handler::refresh_runtime_dependencies(AI_Features_Manager* ai_mgr) {
+	ai_manager = ai_mgr;
+	vector_db = ai_manager ? ai_manager->get_vector_db() : NULL;
+
+	if (GloGATH) {
+		k_max = GloGATH->variables.genai_rag_k_max;
+		candidates_max = GloGATH->variables.genai_rag_candidates_max;
+		query_max_bytes = GloGATH->variables.genai_rag_query_max_bytes;
+		response_max_bytes = GloGATH->variables.genai_rag_response_max_bytes;
+		timeout_ms = GloGATH->variables.genai_rag_timeout_ms;
+	}
 }
 
 /**
@@ -1641,6 +1644,9 @@ json RAG_Tool_Handler::get_tool_description(const std::string& tool_name) {
  */
 json RAG_Tool_Handler::execute_tool(const std::string& tool_name, const json& arguments) {
 	proxy_debug(PROXY_DEBUG_GENAI, 3, "RAG_Tool_Handler: execute_tool(%s)\n", tool_name.c_str());
+	if (!vector_db) {
+		return create_error_response("Vector database not available");
+	}
 
 	// Record start time for timing stats
 	auto start_time = std::chrono::high_resolution_clock::now();

--- a/plugins/genai/src/tool_handlers/Stats_Tool_Handler.cpp
+++ b/plugins/genai/src/tool_handlers/Stats_Tool_Handler.cpp
@@ -1495,15 +1495,15 @@ json Stats_Tool_Handler::handle_show_processlist(const json& arguments) {
 	processlist_config_t base_cfg {};
 #ifdef IDLE_THREADS
 	base_cfg.show_idle_session = is_pgsql
-		? GloPTH->variables.session_idle_show_processlist
-		: GloMTH->variables.session_idle_show_processlist;
+		? GloPTH->get_variable_int("session_idle_show_processlist")
+		: GloMTH->get_variable_int("session_idle_show_processlist");
 #endif
 	base_cfg.show_extended = is_pgsql
-		? GloPTH->variables.show_processlist_extended
-		: GloMTH->variables.show_processlist_extended;
+		? GloPTH->get_variable_int("show_processlist_extended")
+		: GloMTH->get_variable_int("show_processlist_extended");
 	base_cfg.max_query_length = is_pgsql
-		? GloPTH->variables.processlist_max_query_length
-		: GloMTH->variables.processlist_max_query_length;
+		? GloPTH->get_variable_int("processlist_max_query_length")
+		: GloMTH->get_variable_int("processlist_max_query_length");
 	base_cfg.query_options = query_opts;
 
 	/**

--- a/test/scripts/bin/proxysql-tester.py
+++ b/test/scripts/bin/proxysql-tester.py
@@ -1100,8 +1100,16 @@ CREATE TABLE stats_history.mysql_server_read_only_log (
         tap_group = os.environ.get('TAP_GROUP', '')
         if tap_group:
             groups_json_path = f"{WORKSPACE}/test/tap/groups/groups.json"
-            with open(groups_json_path) as groups_file:
-                groups = json.load(groups_file)
+            try:
+                with open(groups_json_path) as groups_file:
+                    groups = json.load(groups_file)
+            except (OSError, ValueError) as error:
+                log.critical(
+                    f"TAP_GROUP '{tap_group}' reconciliation cannot read "
+                    f"'{groups_json_path}': {error}"
+                )
+                groups = {}
+                ret_rc = max(ret_rc, 1)
 
             declared_tests = {
                 test_name

--- a/test/scripts/bin/proxysql-tester.py
+++ b/test/scripts/bin/proxysql-tester.py
@@ -26,6 +26,7 @@ from structlog import get_logger, configure
 # import custom libs
 lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'lib'))
 sys.path.append(lib_path)
+from group_reconciliation import reconcile_group_results
 import utils
 
 script = os.path.basename(__file__)
@@ -979,38 +980,6 @@ CREATE TABLE stats_history.mysql_server_read_only_log (
             if rc and int(os.environ['TEST_PY_EXIT_ON_FAIL_TEST']):
                 sys.exit(1)
 
-        # Validate that all expected tests for this group passed
-        # If TAP_GROUP is set and group_has_tests, we expect ALL tests in groups.json to pass
-        # NOTE: Only validate tests that actually exist in the current workdir to avoid
-        # false positives when processing secondary workdirs (e.g., deprecate_eof_support)
-        if TAP_GROUP and group_has_tests and groups:
-            # Get tests that exist in the current workdir and belong to TAP_GROUP
-            available_tests = set(os.path.basename(t) for t in tap_tests)
-            expected_in_workdir = set(test_name for test_name, test_groups in groups.items()
-                                       if TAP_GROUP in test_groups and test_name in available_tests)
-
-            # Only validate if this workdir has tests for our group
-            if expected_in_workdir:
-                passed_tests = set(os.path.basename(cmd) for cmd, rc_val in summary if rc_val == 0)
-                failed_tests = set(os.path.basename(cmd) for cmd, rc_val in summary if rc_val is not None and rc_val != 0)
-                skipped_tests = set(os.path.basename(cmd) for cmd, rc_val in summary if rc_val is None)
-
-                # Differentiate skipped tests from truly missing tests
-                # Skipped tests are intentionally excluded (version filter, group membership, etc.)
-                # Missing tests are expected but never encountered during execution
-                expected_runnable = expected_in_workdir - skipped_tests
-                missing_tests = expected_runnable - passed_tests - failed_tests
-
-                if missing_tests:
-                    log.critical(f"TAP_GROUP '{TAP_GROUP}': {len(missing_tests)} expected tests did not run: {sorted(missing_tests)}")
-                    rc = rc + len(missing_tests)
-
-                if len(passed_tests) != len(expected_runnable):
-                    log.critical(f"TAP_GROUP '{TAP_GROUP}': Expected {len(expected_runnable)} runnable tests to pass, but only {len(passed_tests)} passed. Failed: {len(failed_tests)}, Missing: {len(missing_tests)}, Skipped: {len(skipped_tests)}")
-                    # Ensure rc is non-zero to indicate failure
-                    if rc == 0:
-                        rc = len(expected_runnable) - len(passed_tests)
-
         return rc, logs, summary
 
     def collect_tap_workdirs(self, tap_workdir):
@@ -1102,6 +1071,11 @@ CREATE TABLE stats_history.mysql_server_read_only_log (
         ret_summary = []
 #        tap_workdirs = os.environ['TAP_WORKDIRS'].strip('() ').split()
         tap_workdirs = self.collect_tap_workdirs(os.environ['TAP_WORKDIRS'])
+        discovered_tests = [
+            os.path.basename(test_path)
+            for tap_dir in tap_workdirs
+            for test_path in sorted(glob.glob(tap_dir.rstrip('/') + '/*-t'))
+        ]
         log.info("Discovering workdirs ...")
         for tap_dir in tap_workdirs:
             log.info("TAP_WORKDIR: " + tap_dir.replace(WORKSPACE, '').rstrip('/') + '/')
@@ -1122,6 +1096,76 @@ CREATE TABLE stats_history.mysql_server_read_only_log (
                 display_test_summary(os.path.basename(tap_dir.rstrip('/')), rc, summary)
 #                log.info(f"ret_rc = {ret_rc}    rc = {rc}")
         self.execute_hooks('post-*')
+
+        tap_group = os.environ.get('TAP_GROUP', '')
+        if tap_group:
+            groups_json_path = f"{WORKSPACE}/test/tap/groups/groups.json"
+            with open(groups_json_path) as groups_file:
+                groups = json.load(groups_file)
+
+            declared_tests = {
+                test_name
+                for test_name, test_groups in groups.items()
+                if tap_group in test_groups
+            }
+            declared_tests = {
+                test_name
+                for test_name in declared_tests
+                if not self.filtered_by_version(
+                    test_name, getattr(self, 'padmin_vers', '9999.0.0'), groups
+                )[0]
+                and self.filtered_by_regex(test_name, 'TEST_PY_TAP_INCL')[0]
+                and not self.filtered_by_regex(test_name, 'TEST_PY_TAP_EXCL')[0]
+            }
+
+            # A shuffle limit deliberately selects a random subset from the
+            # discovered programs. Reconcile only the names selected by that
+            # mode; an unfiltered group still reconciles every declaration.
+            if int(os.environ.get('TEST_PY_TAP_SHUFFLE_LIMIT', 0)) > 0:
+                selected_names = {
+                    os.path.basename(test_path)
+                    for test_path, _ in ret_summary
+                }
+                declared_tests &= selected_names
+
+            result_basenames = [
+                (os.path.basename(test_path), status)
+                for test_path, status in ret_summary
+            ]
+            reconciliation = reconcile_group_results(
+                declared_tests, discovered_tests, result_basenames
+            )
+            discovered_declared = {
+                name for name in discovered_tests if name in declared_tests
+            }
+            executed = reconciliation.passed | reconciliation.failed
+            log.info(
+                f"TAP_GROUP '{tap_group}' reconciliation: "
+                f"declared={len(declared_tests)}, "
+                f"discovered={len(discovered_declared)}, "
+                f"executed={len(executed)}, "
+                f"passed={len(reconciliation.passed)}"
+            )
+
+            error_sets = {
+                'missing': reconciliation.missing,
+                'duplicates': reconciliation.duplicates,
+                'skipped': reconciliation.skipped,
+                'failed': reconciliation.failed,
+            }
+            for category, names in error_sets.items():
+                message = (
+                    f"TAP_GROUP '{tap_group}' reconciliation {category}: "
+                    f"{sorted(names)}"
+                )
+                if names:
+                    log.critical(message)
+                else:
+                    log.info(message)
+
+            if not reconciliation.ok:
+                distinct_errors = set().union(*error_sets.values())
+                ret_rc += max(1, len(distinct_errors))
 
         # Restore the original environment config
         os.environ['TAP_WORKDIR'] = orig_workdir

--- a/test/scripts/lib/group_reconciliation.py
+++ b/test/scripts/lib/group_reconciliation.py
@@ -1,0 +1,61 @@
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GroupReconciliation:
+    passed: set[str]
+    failed: set[str]
+    skipped: set[str]
+    missing: set[str]
+    duplicates: set[str]
+
+    @property
+    def ok(self) -> bool:
+        return (
+            not self.failed
+            and not self.skipped
+            and not self.missing
+            and not self.duplicates
+        )
+
+
+def reconcile_group_results(
+    declared: set[str],
+    discovered: list[str],
+    results: list[tuple[str, int | None]],
+) -> GroupReconciliation:
+    """Reconcile one selected TAP group across all discovered workdirs."""
+    selected_discovered = [name for name in discovered if name in declared]
+    discovered_counts = Counter(selected_discovered)
+    discovered_names = set(selected_discovered)
+
+    duplicates = {
+        name for name, count in discovered_counts.items() if count > 1
+    }
+    missing = declared - discovered_names
+
+    statuses_by_name: dict[str, list[int | None]] = defaultdict(list)
+    for name, status in results:
+        if name in declared:
+            statuses_by_name[name].append(status)
+
+    passed: set[str] = set()
+    failed: set[str] = set()
+    skipped: set[str] = set()
+    for name in discovered_names:
+        statuses = statuses_by_name.get(name, [])
+        if any(status is not None and status != 0 for status in statuses):
+            failed.add(name)
+        elif not statuses or any(status is None for status in statuses):
+            skipped.add(name)
+        else:
+            passed.add(name)
+
+    return GroupReconciliation(
+        passed=passed,
+        failed=failed,
+        skipped=skipped,
+        missing=missing,
+        duplicates=duplicates,
+    )

--- a/test/scripts/tests/test_group_reconciliation.py
+++ b/test/scripts/tests/test_group_reconciliation.py
@@ -1,0 +1,86 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+from group_reconciliation import reconcile_group_results
+
+
+class GroupReconciliationTests(unittest.TestCase):
+    def test_reports_every_declared_but_undiscovered_test(self):
+        declared = {f"test-{index:02d}-t" for index in range(1, 23)}
+        discovered = [f"test-{index:02d}-t" for index in range(1, 17)]
+        results = [(name, 0) for name in discovered]
+
+        report = reconcile_group_results(declared, discovered, results)
+
+        self.assertEqual(
+            report.missing,
+            {f"test-{index:02d}-t" for index in range(17, 23)},
+        )
+        self.assertFalse(report.ok)
+
+    def test_reports_duplicate_discovered_basenames(self):
+        report = reconcile_group_results(
+            {"alpha-t", "beta-t"},
+            ["alpha-t", "alpha-t", "beta-t"],
+            [("alpha-t", 0), ("beta-t", 0)],
+        )
+
+        self.assertEqual(report.duplicates, {"alpha-t"})
+        self.assertFalse(report.ok)
+
+    def test_result_without_exit_status_is_skipped(self):
+        report = reconcile_group_results(
+            {"alpha-t"}, ["alpha-t"], [("alpha-t", None)]
+        )
+
+        self.assertEqual(report.skipped, {"alpha-t"})
+        self.assertFalse(report.ok)
+
+    def test_nonzero_exit_status_is_failed(self):
+        report = reconcile_group_results(
+            {"alpha-t"}, ["alpha-t"], [("alpha-t", 7)]
+        )
+
+        self.assertEqual(report.failed, {"alpha-t"})
+        self.assertFalse(report.ok)
+
+    def test_all_declared_tests_passing_is_clean(self):
+        report = reconcile_group_results(
+            {"alpha-t", "beta-t"},
+            ["alpha-t", "beta-t"],
+            [("alpha-t", 0), ("beta-t", 0)],
+        )
+
+        self.assertEqual(report.passed, {"alpha-t", "beta-t"})
+        self.assertEqual(report.failed, set())
+        self.assertEqual(report.skipped, set())
+        self.assertEqual(report.missing, set())
+        self.assertEqual(report.duplicates, set())
+        self.assertTrue(report.ok)
+
+    def test_selected_subset_ignores_unselected_programs(self):
+        report = reconcile_group_results(
+            {"alpha-t"},
+            ["alpha-t", "beta-t", "beta-t"],
+            [("alpha-t", 0), ("beta-t", 9), ("beta-t", 9)],
+        )
+
+        self.assertEqual(report.passed, {"alpha-t"})
+        self.assertEqual(report.duplicates, set())
+        self.assertTrue(report.ok)
+
+    def test_empty_selected_subset_is_clean(self):
+        report = reconcile_group_results(
+            set(), ["alpha-t"], [("alpha-t", 0)]
+        )
+
+        self.assertTrue(report.ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tap/Makefile
+++ b/test/tap/Makefile
@@ -1,5 +1,27 @@
 #!/bin/make -f
 
+AI_GENAI_UNIT_TESTS := \
+	genai_config_query_unit-t \
+	genai_discovery_schema_unit-t \
+	genai_fts_string_unit-t \
+	genai_llm_clients_unit-t \
+	genai_mcp_endpoint_unit-t \
+	genai_mcp_thread_unit-t \
+	genai_mysql_catalog_unit-t \
+	genai_query_handler_unit-t \
+	genai_rag_fetch_from_source_unit-t \
+	genai_stats_parsing_unit-t \
+	genai_thread_unit-t
+AI_GENAI_STAGE_DIR := tap_tests_ai_unit
+
+AI_GENAI_HANDOFF_ENABLED := 0
+ifeq ($(PROXYSQL40),1)
+ifeq ($(WITHGCOV),1)
+ifeq ($(SKIP_GENAI_UNIT_TESTS),1)
+AI_GENAI_HANDOFF_ENABLED := 1
+endif
+endif
+endif
 
 .DEFAULT: all
 .PHONY: all
@@ -61,6 +83,31 @@ tests_with_deps: tap test_deps
 .PHONY: unit_tests
 unit_tests: tap test_deps
 	cd tests/unit && CC=${CC} CXX=${CXX} ${MAKE} $(MAKECMDGOALS)
+	@if [ "$(AI_GENAI_HANDOFF_ENABLED)" = "1" ]; then \
+		$(MAKE) ai_genai_unit_tests; \
+	fi
+
+
+.PHONY: ai_genai_unit_tests stage_ai_genai_unit_tests
+.NOTPARALLEL: ai_genai_unit_tests
+ai_genai_unit_tests: tap test_deps
+	cd tests/unit && CC=${CC} CXX=${CXX} ${MAKE} ai_genai_unit_tests
+	$(MAKE) stage_ai_genai_unit_tests
+
+stage_ai_genai_unit_tests:
+	@set -eu; \
+		rm -rf "$(AI_GENAI_STAGE_DIR)"; \
+		mkdir -p "$(AI_GENAI_STAGE_DIR)"; \
+		for test_name in $(AI_GENAI_UNIT_TESTS); do \
+			test -x "tests/unit/$$test_name"; \
+			ln "tests/unit/$$test_name" "$(AI_GENAI_STAGE_DIR)/$$test_name"; \
+		done; \
+		printf '%s\n' $(AI_GENAI_UNIT_TESTS) | LC_ALL=C sort > "$(AI_GENAI_STAGE_DIR)/manifest.txt"; \
+		find "$(AI_GENAI_STAGE_DIR)" -maxdepth 1 -type f ! -name manifest.txt -printf '%f\n' \
+			| LC_ALL=C sort | cmp -s "$(AI_GENAI_STAGE_DIR)/manifest.txt" -; \
+		for test_name in $(AI_GENAI_UNIT_TESTS); do \
+			rm -f "tests/unit/$$test_name"; \
+		done
 
 
 .PHONY: clean_utils
@@ -75,7 +122,7 @@ clean:
 	cd tests && ${MAKE} -s clean
 	cd tests_with_deps && ${MAKE} -s clean
 	cd tests/unit && ${MAKE} -s clean
-	rm -rf pgsql_user_sync
+	rm -rf pgsql_user_sync $(AI_GENAI_STAGE_DIR)
 
 .PHONY: cleanall
 .SILENT: cleanall
@@ -85,3 +132,4 @@ cleanall:
 	cd tests && ${MAKE} -s clean
 	cd tests_with_deps && ${MAKE} -s clean
 	cd tests/unit && ${MAKE} -s clean
+	rm -rf $(AI_GENAI_STAGE_DIR)

--- a/test/tap/groups/ai-g1/env.sh
+++ b/test/tap/groups/ai-g1/env.sh
@@ -4,7 +4,9 @@
 export DEFAULT_MYSQL_INFRA="infra-mysql84"
 export DEFAULT_PGSQL_INFRA="docker-pgsql16-single"
 
-export TAP_MCPPORT="${TAP_MCPPORT:-6071}"
+export TAP_MCP_PORT="${TAP_MCP_PORT:-${TAP_MCPPORT:-6071}}"
+export TAP_MCPPORT="${TAP_MCP_PORT}"
+export TAP_MCP_AUTH_TOKEN="${TAP_MCP_AUTH_TOKEN:-tap-mcp-token}"
 export MCP_TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
 export MCP_AUTH_PROFILE_ID="${MCP_AUTH_PROFILE_ID:-tap_mysql_auth}"
 export MCP_PGSQL_TARGET_ID="${MCP_PGSQL_TARGET_ID:-tap_pgsql_default}"

--- a/test/tap/groups/ai-g2/env.sh
+++ b/test/tap/groups/ai-g2/env.sh
@@ -4,7 +4,9 @@
 export DEFAULT_MYSQL_INFRA="infra-mysql84"
 export DEFAULT_PGSQL_INFRA="docker-pgsql16-single"
 
-export TAP_MCPPORT="${TAP_MCPPORT:-6071}"
+export TAP_MCP_PORT="${TAP_MCP_PORT:-${TAP_MCPPORT:-6071}}"
+export TAP_MCPPORT="${TAP_MCP_PORT}"
+export TAP_MCP_AUTH_TOKEN="${TAP_MCP_AUTH_TOKEN:-tap-mcp-token}"
 export MCP_TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
 export MCP_AUTH_PROFILE_ID="${MCP_AUTH_PROFILE_ID:-tap_mysql_auth}"
 export MCP_PGSQL_TARGET_ID="${MCP_PGSQL_TARGET_ID:-tap_pgsql_default}"

--- a/test/tap/groups/ai/cleanup.sql
+++ b/test/tap/groups/ai/cleanup.sql
@@ -2,6 +2,14 @@
 -- Removes MCP configuration after tests complete
 -- Variables are substituted using envsubst before execution
 
+SET mcp-enabled='false';
+LOAD MCP VARIABLES TO RUNTIME;
+SAVE MCP VARIABLES TO DISK;
+
+SET genai-enabled='false';
+LOAD GENAI VARIABLES TO RUNTIME;
+SAVE GENAI VARIABLES TO DISK;
+
 DELETE FROM mcp_target_profiles WHERE target_id IN ('${MCP_TARGET_ID}', '${MCP_PGSQL_TARGET_ID}');
 DELETE FROM mcp_auth_profiles WHERE auth_profile_id IN ('${MCP_AUTH_PROFILE_ID}', '${MCP_PGSQL_AUTH_PROFILE_ID}');
 LOAD MCP PROFILES TO RUNTIME;

--- a/test/tap/groups/ai/env.sh
+++ b/test/tap/groups/ai/env.sh
@@ -5,8 +5,12 @@
 export DEFAULT_MYSQL_INFRA="infra-mysql84"
 export DEFAULT_PGSQL_INFRA="docker-pgsql16-single"
 
-# MCP-specific environment variables for AI tests
-export TAP_MCPPORT="${TAP_MCPPORT:-6071}"
+# MCP-specific environment variables for AI tests.  C++ CommandLine consumes
+# TAP_MCP_PORT while older shell tests consume TAP_MCPPORT; keep one canonical
+# value visible through both names.
+export TAP_MCP_PORT="${TAP_MCP_PORT:-${TAP_MCPPORT:-6071}}"
+export TAP_MCPPORT="${TAP_MCP_PORT}"
+export TAP_MCP_AUTH_TOKEN="${TAP_MCP_AUTH_TOKEN:-tap-mcp-token}"
 export MCP_TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
 export MCP_AUTH_PROFILE_ID="${MCP_AUTH_PROFILE_ID:-tap_mysql_auth}"
 export MCP_PGSQL_TARGET_ID="${MCP_PGSQL_TARGET_ID:-tap_pgsql_default}"

--- a/test/tap/groups/ai/mcp-config.sql
+++ b/test/tap/groups/ai/mcp-config.sql
@@ -16,6 +16,12 @@ SET mcp-enabled='false';
 LOAD MCP VARIABLES TO RUNTIME;
 SAVE MCP VARIABLES TO DISK;
 
+-- Initialize the AI feature manager before the MCP listener constructs the
+-- AI and RAG endpoint handlers.
+SET genai-enabled='true';
+LOAD GENAI VARIABLES TO RUNTIME;
+SAVE GENAI VARIABLES TO DISK;
+
 -- Configure MySQL servers for MCP
 DELETE FROM mysql_servers WHERE hostgroup_id IN (0, ${MCP_MYSQL_HOSTGROUP_ID});
 INSERT INTO mysql_servers (hostgroup_id, hostname, port, status, weight, comment)

--- a/test/tap/groups/ai/mcp-config.sql
+++ b/test/tap/groups/ai/mcp-config.sql
@@ -5,13 +5,13 @@
 -- Configure MCP variables
 SET mcp-port='${TAP_MCP_PORT}';
 SET mcp-use_ssl='false';
-SET mcp-config_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
-SET mcp-stats_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
-SET mcp-query_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
-SET mcp-admin_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
-SET mcp-cache_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
-SET mcp-ai_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
-SET mcp-rag_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
+SET mcp-config_endpoint_auth='${TAP_MCP_AUTH_TOKEN_SQL}';
+SET mcp-stats_endpoint_auth='${TAP_MCP_AUTH_TOKEN_SQL}';
+SET mcp-query_endpoint_auth='${TAP_MCP_AUTH_TOKEN_SQL}';
+SET mcp-admin_endpoint_auth='${TAP_MCP_AUTH_TOKEN_SQL}';
+SET mcp-cache_endpoint_auth='${TAP_MCP_AUTH_TOKEN_SQL}';
+SET mcp-ai_endpoint_auth='${TAP_MCP_AUTH_TOKEN_SQL}';
+SET mcp-rag_endpoint_auth='${TAP_MCP_AUTH_TOKEN_SQL}';
 SET mcp-enabled='false';
 LOAD MCP VARIABLES TO RUNTIME;
 SAVE MCP VARIABLES TO DISK;

--- a/test/tap/groups/ai/mcp-config.sql
+++ b/test/tap/groups/ai/mcp-config.sql
@@ -3,8 +3,15 @@
 -- Variables are substituted using envsubst before execution
 
 -- Configure MCP variables
-SET mcp-port='${TAP_MCPPORT}';
-SET mcp-use_ssl='true';
+SET mcp-port='${TAP_MCP_PORT}';
+SET mcp-use_ssl='false';
+SET mcp-config_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
+SET mcp-stats_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
+SET mcp-query_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
+SET mcp-admin_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
+SET mcp-cache_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
+SET mcp-ai_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
+SET mcp-rag_endpoint_auth='${TAP_MCP_AUTH_TOKEN}';
 SET mcp-enabled='false';
 LOAD MCP VARIABLES TO RUNTIME;
 SAVE MCP VARIABLES TO DISK;

--- a/test/tap/groups/ai/setup-infras.bash
+++ b/test/tap/groups/ai/setup-infras.bash
@@ -72,6 +72,7 @@ echo ">>> AI post-infras hook: Configuring MCP..."
 
 # Set MCP-specific environment variables (with defaults)
 export TAP_MCPPORT="${TAP_MCPPORT:-6071}"
+export TAP_MCP_AUTH_TOKEN="${TAP_MCP_AUTH_TOKEN:-tap-mcp-token}"
 export MCP_TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
 export MCP_AUTH_PROFILE_ID="${MCP_AUTH_PROFILE_ID:-tap_mysql_auth}"
 export MCP_PGSQL_TARGET_ID="${MCP_PGSQL_TARGET_ID:-tap_pgsql_default}"
@@ -90,6 +91,13 @@ export TAP_PGSQLSERVER_HOST="pgsql1.${DEFAULT_PGSQL_INFRA}"
 export TAP_PGSQLSERVER_PORT="5432"
 export TAP_PGSQLSERVER_USERNAME="postgres"
 export TAP_PGSQLSERVER_PASSWORD="${ROOT_PASSWORD}"
+
+# envsubst is a textual renderer, so publish a separate value that is safe
+# inside a single-quoted Admin SQL literal. ProxySQL's Admin parser accepts
+# doubled quotes and backslashes in the same form as the MySQL client API.
+TAP_MCP_AUTH_TOKEN_SQL="${TAP_MCP_AUTH_TOKEN//\\/\\\\}"
+TAP_MCP_AUTH_TOKEN_SQL="${TAP_MCP_AUTH_TOKEN_SQL//\'/\'\'}"
+export TAP_MCP_AUTH_TOKEN_SQL
 
 # Apply MCP configuration
 MCP_CONFIG_SQL="${SCRIPT_DIR}/mcp-config.sql"

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -71,6 +71,7 @@
   "llm_bridge_accuracy-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
   "log_utils_unit-t" : [ "unit-tests-g1" ],
   "max_connections_ff-t" : [ "legacy-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql90-g1","mysql95-g1" ],
+  "mcp_client_unit-t" : [ "unit-tests-g1","@proxysql_min_version:4.0" ],
   "mcp_mixed_mysql_pgsql_concurrency_stress-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
   "mcp_mixed_stats_cap_churn-t" : [ "ai-g1","@proxysql_min_version:4.0" ],
   "mcp_mixed_stats_profile_matrix-t" : [ "ai-g1","@proxysql_min_version:4.0" ],

--- a/test/tap/groups/test_ai_group_shards.py
+++ b/test/tap/groups/test_ai_group_shards.py
@@ -186,10 +186,14 @@ class AiGroupShardTest(unittest.TestCase):
         self.assertTrue(environment["TAP_MCP_AUTH_TOKEN"])
 
         disabled_at = rendered.index("SET mcp-enabled='false';")
+        genai_enabled_at = rendered.index("SET genai-enabled='true';")
+        genai_loaded_at = rendered.index("LOAD GENAI VARIABLES TO RUNTIME;")
         profiles_at = rendered.index("LOAD MCP PROFILES TO RUNTIME;")
         enabled_at = rendered.rindex("SET mcp-enabled='true';")
         self.assertLess(disabled_at, profiles_at)
         self.assertLess(profiles_at, enabled_at)
+        self.assertLess(genai_enabled_at, genai_loaded_at)
+        self.assertLess(genai_loaded_at, enabled_at)
 
 
 if __name__ == "__main__":

--- a/test/tap/groups/test_ai_group_shards.py
+++ b/test/tap/groups/test_ai_group_shards.py
@@ -163,6 +163,7 @@ class AiGroupShardTest(unittest.TestCase):
                 "TAP_PGSQLSERVER_PASSWORD": "postgres",
             }
         )
+        environment["TAP_MCP_AUTH_TOKEN_SQL"] = environment["TAP_MCP_AUTH_TOKEN"]
         rendered = subprocess.run(
             ["envsubst"],
             input=(AI_GROUP_DIR / "mcp-config.sql").read_text(encoding="utf-8"),
@@ -194,6 +195,28 @@ class AiGroupShardTest(unittest.TestCase):
         self.assertLess(profiles_at, enabled_at)
         self.assertLess(genai_enabled_at, genai_loaded_at)
         self.assertLess(genai_loaded_at, enabled_at)
+
+    def test_rendered_ai_mcp_config_uses_sql_escaped_auth_token(self):
+        environment = self.source_group_environment(AI_GROUP_DIR / "env.sh")
+        environment.update(
+            {
+                "TAP_MCP_AUTH_TOKEN": "quote'and\\backslash",
+                "TAP_MCP_AUTH_TOKEN_SQL": "quote''and\\\\backslash",
+            }
+        )
+        rendered = subprocess.run(
+            ["envsubst"],
+            input=(AI_GROUP_DIR / "mcp-config.sql").read_text(encoding="utf-8"),
+            text=True,
+            check=True,
+            capture_output=True,
+            env=environment,
+        ).stdout
+        self.assertIn(
+            "SET mcp-config_endpoint_auth='quote''and\\\\backslash';",
+            rendered,
+        )
+        self.assertNotIn("${TAP_MCP_AUTH_TOKEN_SQL}", rendered)
 
 
 if __name__ == "__main__":

--- a/test/tap/groups/test_ai_group_shards.py
+++ b/test/tap/groups/test_ai_group_shards.py
@@ -2,12 +2,26 @@
 """Regression contract for the balanced, CI-wired AI TAP shards."""
 
 import json
+import os
+import re
+import subprocess
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[3]
 GROUPS_JSON = ROOT / "test/tap/groups/groups.json"
+AI_GROUP_DIR = ROOT / "test/tap/groups/ai"
+
+MCP_AUTH_VARIABLES = {
+    "config_endpoint_auth",
+    "stats_endpoint_auth",
+    "query_endpoint_auth",
+    "admin_endpoint_auth",
+    "cache_endpoint_auth",
+    "ai_endpoint_auth",
+    "rag_endpoint_auth",
+}
 
 EXPECTED_G1 = {
     "ai_llm_retry_scenarios-t",
@@ -69,6 +83,29 @@ class AiGroupShardTest(unittest.TestCase):
     def members(self, group):
         return {name for name, tags in self.groups.items() if group in tags}
 
+    def source_group_environment(self, path):
+        clean_env = {
+            "PATH": os.environ["PATH"],
+            "WORKSPACE": str(ROOT),
+        }
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'set -a; source "$1"; env -0',
+                "bash",
+                str(path),
+            ],
+            check=True,
+            capture_output=True,
+            env=clean_env,
+        )
+        return dict(
+            item.split("=", 1)
+            for item in result.stdout.decode().split("\0")
+            if "=" in item
+        )
+
     def test_groups_are_balanced_and_disjoint(self):
         g1 = self.members("ai-g1")
         g2 = self.members("ai-g2")
@@ -97,6 +134,62 @@ class AiGroupShardTest(unittest.TestCase):
                 f".github/workflows/ci-{group}.yml@GH-Actions",
                 caller.read_text(encoding="utf-8"),
             )
+
+    def test_ai_environments_export_one_mcp_connection_contract(self):
+        environments = []
+        for relative_path in ("ai/env.sh", "ai-g1/env.sh", "ai-g2/env.sh"):
+            environment = self.source_group_environment(
+                ROOT / "test/tap/groups" / relative_path
+            )
+            environments.append(environment)
+            self.assertEqual(environment["TAP_MCPPORT"], "6071", relative_path)
+            self.assertEqual(environment["TAP_MCP_PORT"], "6071", relative_path)
+            self.assertTrue(environment["TAP_MCP_AUTH_TOKEN"], relative_path)
+
+        tokens = {environment["TAP_MCP_AUTH_TOKEN"] for environment in environments}
+        self.assertEqual(len(tokens), 1)
+
+    def test_rendered_ai_mcp_config_is_authenticated_http(self):
+        environment = self.source_group_environment(AI_GROUP_DIR / "env.sh")
+        environment.update(
+            {
+                "TAP_MYSQLHOST": "infra-mysql84",
+                "TAP_MYSQLPORT": "3306",
+                "TAP_MYSQLUSERNAME": "root",
+                "TAP_MYSQLPASSWORD": "root",
+                "TAP_PGSQLSERVER_HOST": "docker-pgsql16-single",
+                "TAP_PGSQLSERVER_PORT": "5432",
+                "TAP_PGSQLSERVER_USERNAME": "postgres",
+                "TAP_PGSQLSERVER_PASSWORD": "postgres",
+            }
+        )
+        rendered = subprocess.run(
+            ["envsubst"],
+            input=(AI_GROUP_DIR / "mcp-config.sql").read_text(encoding="utf-8"),
+            text=True,
+            check=True,
+            capture_output=True,
+            env=environment,
+        ).stdout
+        self.assertNotIn("${", rendered)
+
+        assignments = dict(
+            re.findall(r"SET mcp-([A-Za-z0-9_]+)='([^']*)';", rendered)
+        )
+        self.assertEqual(assignments["port"], environment["TAP_MCP_PORT"])
+        self.assertEqual(assignments["use_ssl"], "false")
+        self.assertSetEqual(MCP_AUTH_VARIABLES, MCP_AUTH_VARIABLES & assignments.keys())
+        self.assertSetEqual(
+            {assignments[name] for name in MCP_AUTH_VARIABLES},
+            {environment["TAP_MCP_AUTH_TOKEN"]},
+        )
+        self.assertTrue(environment["TAP_MCP_AUTH_TOKEN"])
+
+        disabled_at = rendered.index("SET mcp-enabled='false';")
+        profiles_at = rendered.index("LOAD MCP PROFILES TO RUNTIME;")
+        enabled_at = rendered.rindex("SET mcp-enabled='true';")
+        self.assertLess(disabled_at, profiles_at)
+        self.assertLess(profiles_at, enabled_at)
 
 
 if __name__ == "__main__":

--- a/test/tap/groups/test_ai_shell_contract.py
+++ b/test/tap/groups/test_ai_shell_contract.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Behavioral contract for shell programs registered in the AI TAP shards."""
+
+import json
+import os
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+TESTS_DIR = ROOT / "test/tap/tests"
+HELPER = TESTS_DIR / "mcp_rules_testing/mcp_test_helpers.sh"
+HEADLESS_DIR = TESTS_DIR / "mcp_headless_testing"
+RAG_DIR = TESTS_DIR / "rag_stats_testing"
+
+SHELL_PROGRAMS = (
+    TESTS_DIR / "test_mcp_claude_headless_flow-t.sh",
+    TESTS_DIR / "test_mcp_llm_discovery_phaseb-t.sh",
+    TESTS_DIR / "test_mcp_rag_metrics-t.sh",
+    TESTS_DIR / "test_mcp_static_harvest-t.sh",
+)
+
+
+class AiShellContractTest(unittest.TestCase):
+    def run_bash(self, script, *, env=None, check=True):
+        return subprocess.run(
+            ["bash", "-c", script],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=check,
+        )
+
+    def helper_environment(self, overrides):
+        env = {
+            "PATH": os.environ["PATH"],
+            "TAP_ADMINHOST": "admin.example",
+            "TAP_ADMINPORT": "16032",
+            "TAP_ADMINUSERNAME": "radmin",
+            "TAP_ADMINPASSWORD": "radmin",
+            "TAP_MCP_AUTH_TOKEN": "contract-token",
+        }
+        env.update(overrides)
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; printf "%s\\n" "$PROXYSQL_ADMIN_HOST" "$MCP_HOST" "$MCP_PORT" "$MCP_SCHEME"',
+                "bash",
+                str(HELPER),
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return result.stdout.splitlines()
+
+    def test_helper_uses_canonical_admin_mcp_environment(self):
+        self.assertTrue(HELPER.is_file())
+        values = self.helper_environment(
+            {"TAP_MCP_PORT": "16071", "TAP_MCPPORT": "26071"}
+        )
+        self.assertEqual(values, ["admin.example", "admin.example", "16071", "http"])
+
+        legacy_values = self.helper_environment({"TAP_MCPPORT": "36071"})
+        self.assertEqual(legacy_values[2], "36071")
+
+    def test_helper_sends_bearer_authenticated_http(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            capture = temporary_path / "curl.args"
+            fake_curl = temporary_path / "curl"
+            fake_curl.write_text(
+                "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"$CURL_CAPTURE\"\nprintf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}'\n",
+                encoding="utf-8",
+            )
+            fake_curl.chmod(0o755)
+            env = {
+                "PATH": f"{temporary}:{os.environ['PATH']}",
+                "CURL_CAPTURE": str(capture),
+                "TAP_ADMINHOST": "mcp.example",
+                "TAP_MCP_PORT": "16071",
+                "TAP_MCP_AUTH_TOKEN": "contract-token",
+            }
+            subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; mcp_request config \'{"jsonrpc":"2.0","method":"ping","id":1}\' >/dev/null',
+                    "bash",
+                    str(HELPER),
+                ],
+                cwd=ROOT,
+                env=env,
+                check=True,
+            )
+            arguments = capture.read_text(encoding="utf-8").splitlines()
+            self.assertIn("http://mcp.example:16071/mcp/config", arguments)
+            self.assertIn("Authorization: Bearer contract-token", arguments)
+
+    def test_helper_admin_sql_targets_configured_host(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            capture = temporary_path / "mysql.args"
+            fake_mysql = temporary_path / "mysql"
+            fake_mysql.write_text(
+                "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"$MYSQL_CAPTURE\"\n",
+                encoding="utf-8",
+            )
+            fake_mysql.chmod(0o755)
+            env = {
+                "PATH": f"{temporary}:{os.environ['PATH']}",
+                "MYSQL_CAPTURE": str(capture),
+                "TAP_ADMINHOST": "admin.example",
+                "TAP_ADMINPORT": "16032",
+                "TAP_ADMINUSERNAME": "radmin",
+                "TAP_ADMINPASSWORD": "radmin",
+                "TAP_MCP_AUTH_TOKEN": "contract-token",
+            }
+            subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; exec_admin_silent "SELECT 1" >/dev/null',
+                    "bash",
+                    str(HELPER),
+                ],
+                cwd=ROOT,
+                env=env,
+                check=True,
+            )
+            arguments = capture.read_text(encoding="utf-8").splitlines()
+            self.assertIn("admin.example", arguments)
+            self.assertNotIn("127.0.0.1", arguments)
+
+    def test_registered_programs_use_shared_portable_helper(self):
+        for program in SHELL_PROGRAMS:
+            source = program.read_text(encoding="utf-8")
+            self.assertIn("mcp_test_helpers.sh", source, program.name)
+            self.assertNotIn("scripts/mcp/", source, program.name)
+            self.assertNotIn("-h 127.0.0.1", source, program.name)
+            self.assertNotIn("https://${", source, program.name)
+
+    def test_headless_dry_run_fixtures_are_self_contained(self):
+        static_harvest = HEADLESS_DIR / "static_harvest.sh"
+        two_phase = HEADLESS_DIR / "two_phase_discovery.py"
+        config = HEADLESS_DIR / "mcp_config.example.json"
+        for fixture in (static_harvest, two_phase, config):
+            self.assertTrue(fixture.is_file(), fixture)
+            self.assertTrue(fixture.resolve().is_relative_to(TESTS_DIR.resolve()))
+
+        parsed_config = json.loads(config.read_text(encoding="utf-8"))
+        self.assertIn("proxysql", parsed_config["mcpServers"])
+        result = subprocess.run(
+            [
+                "python3",
+                str(two_phase),
+                "--mcp-config",
+                str(config),
+                "--target-id",
+                "tap_mysql_default",
+                "--schema",
+                "test",
+                "--run-id",
+                "42",
+                "--dry-run",
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertIn("[DRY RUN]", result.stdout)
+        self.assertIn("Target ID: tap_mysql_default", result.stdout)
+
+    def test_rag_database_fixture_needs_only_python_stdlib(self):
+        prepare = RAG_DIR / "prepare_test_db.sh"
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            db_path = temporary_path / "rag.db"
+            bin_path = temporary_path / "bin"
+            bin_path.mkdir()
+            (bin_path / "python3").symlink_to(Path(os.environ.get("PYTHON", "/usr/bin/python3")))
+            env = {
+                "PATH": str(bin_path),
+                "RAG_DB_PATH": str(db_path),
+                "WORKSPACE": str(ROOT),
+            }
+            subprocess.run(["/bin/bash", str(prepare)], env=env, check=True)
+            with sqlite3.connect(db_path) as connection:
+                self.assertEqual(
+                    connection.execute("SELECT COUNT(*) FROM rag_documents").fetchone()[0],
+                    1,
+                )
+                self.assertEqual(
+                    connection.execute("SELECT COUNT(*) FROM rag_chunks").fetchone()[0],
+                    1,
+                )
+
+    def test_all_shell_sources_parse(self):
+        sources = list(SHELL_PROGRAMS)
+        sources.extend(
+            (
+                HELPER,
+                HEADLESS_DIR / "static_harvest.sh",
+                RAG_DIR / "prepare_test_db.sh",
+                RAG_DIR / "test_rag_search_log.sh",
+                RAG_DIR / "test_rag_tool_counters.sh",
+            )
+        )
+        for source in sources:
+            result = subprocess.run(
+                ["bash", "-n", str(source)],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, f"{source}: {result.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tap/groups/test_ai_shell_contract.py
+++ b/test/tap/groups/test_ai_shell_contract.py
@@ -103,6 +103,44 @@ class AiShellContractTest(unittest.TestCase):
             arguments = capture.read_text(encoding="utf-8").splitlines()
             self.assertIn("http://mcp.example:16071/mcp/config", arguments)
             self.assertIn("Authorization: Bearer contract-token", arguments)
+            self.assertIn("--connect-timeout", arguments)
+            self.assertIn("--max-time", arguments)
+
+    def test_helper_https_uses_configured_ca_by_default(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            capture = temporary_path / "curl.args"
+            fake_curl = temporary_path / "curl"
+            fake_curl.write_text(
+                "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"$CURL_CAPTURE\"\nprintf '%s\\n' '{}'\n",
+                encoding="utf-8",
+            )
+            fake_curl.chmod(0o755)
+            ca_file = temporary_path / "test-ca.pem"
+            ca_file.write_text("test CA", encoding="utf-8")
+            env = {
+                "PATH": f"{temporary}:{os.environ['PATH']}",
+                "CURL_CAPTURE": str(capture),
+                "TAP_MCP_SCHEME": "https",
+                "TAP_MCP_CA_CERT": str(ca_file),
+                "TAP_MCP_AUTH_TOKEN": "contract-token",
+            }
+            subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; mcp_request config \'{}\' >/dev/null',
+                    "bash",
+                    str(HELPER),
+                ],
+                cwd=ROOT,
+                env=env,
+                check=True,
+            )
+            arguments = capture.read_text(encoding="utf-8").splitlines()
+            self.assertIn("--cacert", arguments)
+            self.assertIn(str(ca_file), arguments)
+            self.assertNotIn("--insecure", arguments)
 
     def test_helper_admin_sql_targets_configured_host(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/test/tap/groups/test_ai_unit_handoff.py
+++ b/test/tap/groups/test_ai_unit_handoff.py
@@ -1,0 +1,106 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+TAP_ROOT = Path(__file__).resolve().parents[1]
+GROUPS_JSON = TAP_ROOT / "groups" / "groups.json"
+TOP_MAKEFILE = TAP_ROOT / "Makefile"
+UNIT_MAKEFILE = TAP_ROOT / "tests" / "unit" / "Makefile"
+
+UNRELATED_GENAI_UNITS = {
+    "genai_plugin_anomaly_unit-t",
+    "genai_plugin_backend_client_unit-t",
+    "genai_plugin_load_unit-t",
+}
+
+
+def parse_make_list(makefile_text: str, variable: str) -> list[str]:
+    lines = makefile_text.splitlines()
+    values: list[str] = []
+    collecting = False
+    for line in lines:
+        if not collecting:
+            match = re.match(rf"^{re.escape(variable)}\s*:?=\s*(.*)$", line)
+            if match is None:
+                continue
+            remainder = match.group(1)
+            collecting = True
+        else:
+            remainder = line.strip()
+
+        continued = remainder.endswith("\\")
+        if continued:
+            remainder = remainder[:-1]
+        values.extend(remainder.split())
+        if not continued:
+            break
+    return values
+
+
+class AIUnitHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.groups = json.loads(GROUPS_JSON.read_text())
+        cls.top_makefile = TOP_MAKEFILE.read_text()
+        cls.unit_makefile = UNIT_MAKEFILE.read_text()
+        cls.expected = {
+            name
+            for name, memberships in cls.groups.items()
+            if name.startswith("genai_")
+            and name.endswith("_unit-t")
+            and ({"ai-g1", "ai-g2"} & set(memberships))
+        }
+
+    def test_group_contract_contains_exactly_eleven_genai_units(self):
+        self.assertEqual(len(self.expected), 11)
+
+    def test_unit_makefile_build_contract_matches_group_declarations(self):
+        configured = set(
+            parse_make_list(self.unit_makefile, "AI_GENAI_UNIT_TESTS")
+        )
+        self.assertEqual(configured, self.expected)
+        self.assertTrue(configured.isdisjoint(UNRELATED_GENAI_UNITS))
+        self.assertRegex(
+            self.unit_makefile, r"(?m)^ai_genai_unit_tests:\s*\$\(AI_GENAI_UNIT_TESTS\)"
+        )
+
+    def test_top_level_stage_contract_is_runner_discoverable(self):
+        configured = set(
+            parse_make_list(self.top_makefile, "AI_GENAI_UNIT_TESTS")
+        )
+        self.assertEqual(configured, self.expected)
+        self.assertTrue(configured.isdisjoint(UNRELATED_GENAI_UNITS))
+
+        stage_values = parse_make_list(
+            self.top_makefile, "AI_GENAI_STAGE_DIR"
+        )
+        self.assertEqual(len(stage_values), 1)
+        self.assertRegex(Path(stage_values[0]).name, r"^tap_tests_.+")
+        self.assertRegex(
+            self.top_makefile, r"(?m)^ai_genai_unit_tests:\s*"
+        )
+
+    def test_built_manifest_and_stage_match_contract_when_present(self):
+        stage_values = parse_make_list(
+            self.top_makefile, "AI_GENAI_STAGE_DIR"
+        )
+        if not stage_values:
+            self.fail("AI_GENAI_STAGE_DIR is not declared")
+
+        stage_dir = TAP_ROOT / stage_values[0]
+        manifest = stage_dir / "manifest.txt"
+        if not manifest.exists():
+            return
+
+        manifest_names = {
+            line.strip() for line in manifest.read_text().splitlines() if line.strip()
+        }
+        self.assertEqual(manifest_names, self.expected)
+        staged_files = {path.name for path in stage_dir.iterdir() if path.is_file()}
+        self.assertEqual(staged_files, self.expected | {"manifest.txt"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tap/tap/mcp_client.cpp
+++ b/test/tap/tap/mcp_client.cpp
@@ -374,10 +374,11 @@ MCPResponse MCPClient::call_tool(
 // ============================================================================
 
 bool MCPClient::check_server() {
+    const unsigned int ping_id = request_id_++;
     json ping_request = {
         {"jsonrpc", "2.0"},
         {"method", "ping"},
-        {"id", request_id_++}
+        {"id", ping_id}
     };
 
     std::string url = build_url("config");
@@ -386,6 +387,10 @@ bool MCPClient::check_server() {
 
     struct curl_slist* headers = nullptr;
     headers = curl_slist_append(headers, "Content-Type: application/json");
+    if (!auth_token_.empty()) {
+        const std::string auth_header = "Authorization: Bearer " + auth_token_;
+        headers = curl_slist_append(headers, auth_header.c_str());
+    }
 
     curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl_, CURLOPT_POST, 1L);
@@ -394,6 +399,8 @@ bool MCPClient::check_server() {
     curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &response_body);
 
     CURLcode res = curl_easy_perform(curl_);
+    long http_code = 0;
+    curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &http_code);
 
     curl_slist_free_all(headers);
 
@@ -402,6 +409,27 @@ bool MCPClient::check_server() {
         return false;
     }
 
-    // Check for valid response (contains "result")
-    return response_body.find("\"result\"") != std::string::npos;
+    if (http_code != 200) {
+        last_error_ = "HTTP error: " + std::to_string(http_code);
+        return false;
+    }
+
+    json response;
+    try {
+        response = json::parse(response_body);
+    } catch (const json::parse_error& e) {
+        last_error_ = "JSON parse error: " + std::string(e.what());
+        return false;
+    }
+
+    if (!response.is_object() ||
+        !response.contains("jsonrpc") || response["jsonrpc"] != "2.0" ||
+        !response.contains("id") || response["id"] != ping_id ||
+        !response.contains("result")) {
+        last_error_ = "Invalid JSON-RPC readiness response";
+        return false;
+    }
+
+    last_error_.clear();
+    return true;
 }

--- a/test/tap/tap/mcp_client.h
+++ b/test/tap/tap/mcp_client.h
@@ -311,7 +311,8 @@ public:
     /**
      * @brief Check if MCP server is accessible
      *
-     * Sends a ping request to /mcp/config endpoint.
+     * Sends a ping request to /mcp/config with the configured bearer token and
+     * requires HTTP 200 plus a matching JSON-RPC result response.
      *
      * @return true if server responds successfully
      */

--- a/test/tap/tests/genai_module-t.cpp
+++ b/test/tap/tests/genai_module-t.cpp
@@ -1,376 +1,153 @@
 /**
  * @file genai_module-t.cpp
- * @brief TAP test for the GenAI module
- *
- * This test verifies the functionality of the GenAI (Generative AI) module in ProxySQL.
- * It tests:
- *   - LOAD/SAVE commands for GenAI variables across all variants
- *   - Variable access (SET and SELECT) for genai-var1 and genai-var2
- *   - Variable persistence across storage layers (memory, disk, runtime)
- *   - CHECKSUM commands for GenAI variables
- *   - SHOW VARIABLES for GenAI module
- *
- * @date 2025-01-08
+ * @brief Verify the current GenAI variable and persistence contract.
  */
 
-#include <algorithm>
+#include <cstdlib>
 #include <string>
-#include <string.h>
-#include <stdio.h>
-#include <unistd.h>
 #include <vector>
-#include <tuple>
 
 #include "mysql.h"
-#include "mysqld_error.h"
 
-#include "tap.h"
 #include "command_line.h"
-#include "utils.h"
+#include "tap.h"
 
 using std::string;
 
-/**
- * @brief Helper function to add LOAD/SAVE command variants for GenAI module
- *
- * This function generates all the standard LOAD/SAVE command variants that
- * ProxySQL supports for module variables. It follows the same pattern used
- * for other modules like MYSQL, PGSQL, etc.
- *
- * @param queries Vector to append the generated commands to
- */
-void add_genai_load_save_commands(std::vector<std::string>& queries) {
-	// LOAD commands - Memory variants
-	queries.push_back("LOAD GENAI VARIABLES TO MEMORY");
-	queries.push_back("LOAD GENAI VARIABLES TO MEM");
+namespace {
 
-	// LOAD from disk
-	queries.push_back("LOAD GENAI VARIABLES FROM DISK");
-
-	// LOAD from memory
-	queries.push_back("LOAD GENAI VARIABLES FROM MEMORY");
-	queries.push_back("LOAD GENAI VARIABLES FROM MEM");
-
-	// LOAD to runtime
-	queries.push_back("LOAD GENAI VARIABLES TO RUNTIME");
-	queries.push_back("LOAD GENAI VARIABLES TO RUN");
-
-	// SAVE from memory
-	queries.push_back("SAVE GENAI VARIABLES FROM MEMORY");
-	queries.push_back("SAVE GENAI VARIABLES FROM MEM");
-
-	// SAVE to disk
-	queries.push_back("SAVE GENAI VARIABLES TO DISK");
-
-	// SAVE to memory
-	queries.push_back("SAVE GENAI VARIABLES TO MEMORY");
-	queries.push_back("SAVE GENAI VARIABLES TO MEM");
-
-	// SAVE from runtime
-	queries.push_back("SAVE GENAI VARIABLES FROM RUNTIME");
-	queries.push_back("SAVE GENAI VARIABLES FROM RUN");
+bool execute_admin(MYSQL* admin, const string& sql) {
+	if (mysql_query(admin, sql.c_str()) != 0) {
+		diag("Admin command failed: %s: %s", sql.c_str(), mysql_error(admin));
+		return false;
+	}
+	MYSQL_RES* result = mysql_store_result(admin);
+	if (result != nullptr) mysql_free_result(result);
+	return true;
 }
 
-/**
- * @brief Get the value of a GenAI variable as a string
- *
- * @param admin MySQL connection to admin interface
- * @param var_name Variable name (without genai- prefix)
- * @return std::string The variable value, or empty string on error
- */
-std::string get_genai_variable(MYSQL* admin, const std::string& var_name) {
-	std::string query = "SELECT @@genai-" + var_name;
-	if (mysql_query(admin, query.c_str()) != 0) {
-		return "";
+bool query_scalar(MYSQL* admin, const string& sql, string& value) {
+	value.clear();
+	if (mysql_query(admin, sql.c_str()) != 0) {
+		diag("Admin query failed: %s: %s", sql.c_str(), mysql_error(admin));
+		return false;
 	}
-
-	MYSQL_RES* res = mysql_store_result(admin);
-	if (!res) {
-		return "";
+	MYSQL_RES* result = mysql_store_result(admin);
+	if (result == nullptr) {
+		diag("Admin query returned no result: %s", sql.c_str());
+		return false;
 	}
-
-	MYSQL_ROW row = mysql_fetch_row(res);
-	std::string value = row && row[0] ? row[0] : "";
-
-	mysql_free_result(res);
-	return value;
+	MYSQL_ROW row = mysql_fetch_row(result);
+	const bool found = row != nullptr && row[0] != nullptr;
+	if (found) value = row[0];
+	mysql_free_result(result);
+	return found;
 }
 
-/**
- * @brief Test variable access operations (SET and SELECT)
- *
- * Tests setting and retrieving GenAI variables to ensure they work correctly.
- */
-int test_variable_access(MYSQL* admin) {
-	int test_num = 0;
-
-	// Test 1: Get default value of genai-var1
-	std::string var1_default = get_genai_variable(admin, "var1");
-	ok(var1_default == "default_value_1",
-	   "Default value of genai-var1 is 'default_value_1', got '%s'", var1_default.c_str());
-
-	// Test 2: Get default value of genai-var2
-	std::string var2_default = get_genai_variable(admin, "var2");
-	ok(var2_default == "100", 
-	   "Default value of genai-var2 is '100', got '%s'", var2_default.c_str());
-
-	// Test 3: Set genai-var1 to a new value
-	MYSQL_QUERY(admin, "SET genai-var1='test_value_123'");
-	std::string var1_new = get_genai_variable(admin, "var1");
-	ok(var1_new == "test_value_123", 
-	   "After SET, genai-var1 is 'test_value_123', got '%s'", var1_new.c_str());
-
-	// Test 4: Set genai-var2 to a new integer value
-	MYSQL_QUERY(admin, "SET genai-var2=42");
-	std::string var2_new = get_genai_variable(admin, "var2");
-	ok(var2_new == "42", 
-	   "After SET, genai-var2 is '42', got '%s'", var2_new.c_str());
-
-	// Test 5: Set genai-var1 with special characters
-	MYSQL_QUERY(admin, "SET genai-var1='test with spaces'");
-	std::string var1_special = get_genai_variable(admin, "var1");
-	ok(var1_special == "test with spaces", 
-	   "genai-var1 with spaces is 'test with spaces', got '%s'", var1_special.c_str());
-
-	// Test 6: Verify SHOW VARIABLES LIKE pattern
-	MYSQL_QUERY(admin, "SHOW VARIABLES LIKE 'genai-%'");
-	MYSQL_RES* res = mysql_store_result(admin);
-	int num_rows = static_cast<int>(mysql_num_rows(res));
-	ok(num_rows == 2, 
-	   "SHOW VARIABLES LIKE 'genai-%%' returns 2 rows, got %d", num_rows);
-	mysql_free_result(res);
-
-	// Test 7: Restore default values
-	MYSQL_QUERY(admin, "SET genai-var1='default_value_1'");
-	MYSQL_QUERY(admin, "SET genai-var2=100");
-	ok(1,  "Restored default values for genai-var1 and genai-var2");
-
-	return test_num;
+string quote_value(MYSQL* admin, const string& value) {
+	string escaped(value.size() * 2 + 1, '\0');
+	const unsigned long length = mysql_real_escape_string(
+		admin, escaped.data(), value.c_str(), static_cast<unsigned long>(value.size()));
+	escaped.resize(length);
+	return "'" + escaped + "'";
 }
 
-/**
- * @brief Test variable persistence across storage layers
- *
- * Tests that variables are correctly copied between:
- * - Memory (main.global_variables)
- * - Disk (disk.global_variables)
- * - Runtime (GloGATH handler object)
- */
-int test_variable_persistence(MYSQL* admin) {
-	int test_num = 0;
-
-	// Test 1: Set values and save to disk
-	diag("Testing variable persistence: Set values, save to disk, modify, load from disk");
-	MYSQL_QUERY(admin, "SET genai-var1='disk_test_value'");
-	MYSQL_QUERY(admin, "SET genai-var2=999");
-	MYSQL_QUERY(admin, "SAVE GENAI VARIABLES TO DISK");
-	ok(1,  "Set genai-var1='disk_test_value', genai-var2=999 and saved to disk");
-
-	// Test 2: Modify values in memory
-	MYSQL_QUERY(admin, "SET genai-var1='memory_value'");
-	MYSQL_QUERY(admin, "SET genai-var2=111");
-	std::string var1_mem = get_genai_variable(admin, "var1");
-	std::string var2_mem = get_genai_variable(admin, "var2");
-	ok(var1_mem == "memory_value" && var2_mem == "111", 
-	   "Modified in memory: genai-var1='memory_value', genai-var2='111'");
-
-	// Test 3: Load from disk and verify original values restored
-	MYSQL_QUERY(admin, "LOAD GENAI VARIABLES FROM DISK");
-	std::string var1_disk = get_genai_variable(admin, "var1");
-	std::string var2_disk = get_genai_variable(admin, "var2");
-	ok(var1_disk == "disk_test_value" && var2_disk == "999", 
-	   "After LOAD FROM DISK: genai-var1='disk_test_value', genai-var2='999'");
-
-	// Test 4: Save to memory and verify
-	MYSQL_QUERY(admin, "SAVE GENAI VARIABLES TO MEMORY");
-	ok(1,  "SAVE GENAI VARIABLES TO MEMORY executed");
-
-	// Test 5: Load from memory
-	MYSQL_QUERY(admin, "LOAD GENAI VARIABLES FROM MEMORY");
-	ok(1,  "LOAD GENAI VARIABLES FROM MEMORY executed");
-
-	// Test 6: Test SAVE from runtime
-	MYSQL_QUERY(admin, "SAVE GENAI VARIABLES FROM RUNTIME");
-	ok(1,  "SAVE GENAI VARIABLES FROM RUNTIME executed");
-
-	// Test 7: Test LOAD to runtime
-	MYSQL_QUERY(admin, "LOAD GENAI VARIABLES TO RUNTIME");
-	ok(1,  "LOAD GENAI VARIABLES TO RUNTIME executed");
-
-	// Test 8: Restore default values
-	MYSQL_QUERY(admin, "SET genai-var1='default_value_1'");
-	MYSQL_QUERY(admin, "SET genai-var2=100");
-	MYSQL_QUERY(admin, "SAVE GENAI VARIABLES TO DISK");
-	ok(1,  "Restored default values and saved to disk");
-
-	return test_num;
+bool set_variable(MYSQL* admin, const string& name, const string& value) {
+	return execute_admin(admin, "SET " + name + "=" + quote_value(admin, value));
 }
 
-/**
- * @brief Test CHECKSUM commands for GenAI variables
- *
- * Tests all CHECKSUM variants to ensure they work correctly.
- */
-int test_checksum_commands(MYSQL* admin) {
-	int test_num = 0;
-
-	// Test 1: CHECKSUM DISK GENAI VARIABLES
-	diag("Testing CHECKSUM commands for GenAI variables");
-	int rc1 = mysql_query(admin, "CHECKSUM DISK GENAI VARIABLES");
-	ok(rc1 == 0,  "CHECKSUM DISK GENAI VARIABLES");
-	if (rc1 == 0) {
-		MYSQL_RES* res = mysql_store_result(admin);
-		int num_rows = static_cast<int>(mysql_num_rows(res));
-		ok(num_rows == 1,  "CHECKSUM DISK GENAI VARIABLES returns 1 row");
-		mysql_free_result(res);
-	} else {
-		skip(1, "Skipping row count check due to error");
-	}
-
-	// Test 2: CHECKSUM MEM GENAI VARIABLES
-	int rc2 = mysql_query(admin, "CHECKSUM MEM GENAI VARIABLES");
-	ok(rc2 == 0,  "CHECKSUM MEM GENAI VARIABLES");
-	if (rc2 == 0) {
-		MYSQL_RES* res = mysql_store_result(admin);
-		int num_rows = static_cast<int>(mysql_num_rows(res));
-		ok(num_rows == 1,  "CHECKSUM MEM GENAI VARIABLES returns 1 row");
-		mysql_free_result(res);
-	} else {
-		skip(1, "Skipping row count check due to error");
-	}
-
-	// Test 3: CHECKSUM MEMORY GENAI VARIABLES (alias for MEM)
-	int rc3 = mysql_query(admin, "CHECKSUM MEMORY GENAI VARIABLES");
-	ok(rc3 == 0,  "CHECKSUM MEMORY GENAI VARIABLES");
-	if (rc3 == 0) {
-		MYSQL_RES* res = mysql_store_result(admin);
-		int num_rows = static_cast<int>(mysql_num_rows(res));
-		ok(num_rows == 1,  "CHECKSUM MEMORY GENAI VARIABLES returns 1 row");
-		mysql_free_result(res);
-	} else {
-		skip(1, "Skipping row count check due to error");
-	}
-
-	// Test 4: CHECKSUM GENAI VARIABLES (defaults to DISK)
-	int rc4 = mysql_query(admin, "CHECKSUM GENAI VARIABLES");
-	ok(rc4 == 0,  "CHECKSUM GENAI VARIABLES");
-	if (rc4 == 0) {
-		MYSQL_RES* res = mysql_store_result(admin);
-		int num_rows = static_cast<int>(mysql_num_rows(res));
-		ok(num_rows == 1,  "CHECKSUM GENAI VARIABLES returns 1 row");
-		mysql_free_result(res);
-	} else {
-		skip(1, "Skipping row count check due to error");
-	}
-
-	return test_num;
+bool read_variable(MYSQL* admin, const string& name, string& value) {
+	return query_scalar(
+		admin,
+		"SELECT variable_value FROM global_variables WHERE variable_name=" +
+			quote_value(admin, name),
+		value);
 }
 
-/**
- * @brief Main test function
- *
- * Orchestrates all GenAI module tests.
- */
+void expect_variable(MYSQL* admin, const string& name, const string& expected) {
+	string value;
+	const bool found = read_variable(admin, name, value);
+	ok(found && value == expected,
+	   "%s is '%s' (got '%s')", name.c_str(), expected.c_str(), value.c_str());
+}
+
+} // namespace
+
 int main() {
 	CommandLine cl;
-
 	if (cl.getEnv()) {
-		diag("Failed to get the required environmental variables.");
+		diag("Failed to read TAP environment");
 		return EXIT_FAILURE;
 	}
 
-	// Initialize connection to admin interface
-	MYSQL* admin = mysql_init(NULL);
-	if (!admin) {
-		fprintf(stderr, "File %s, line %d, Error: mysql_init failed\n", __FILE__, __LINE__);
+	MYSQL* admin = mysql_init(nullptr);
+	if (admin == nullptr ||
+	    mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+	                       nullptr, cl.admin_port, nullptr, 0) == nullptr) {
+		diag("Failed to connect to ProxySQL admin: %s", admin ? mysql_error(admin) : "mysql_init failed");
+		if (admin != nullptr) mysql_close(admin);
 		return EXIT_FAILURE;
 	}
 
-	if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
-		NULL, cl.admin_port, NULL, 0)) {
-		fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
-		return EXIT_FAILURE;
+	plan(37);
+
+	string variable_count;
+	const bool count_found = query_scalar(
+		admin,
+		"SELECT COUNT(*) FROM global_variables WHERE variable_name LIKE 'genai-%'",
+		variable_count);
+	ok(count_found && variable_count == "32",
+	   "GenAI exposes exactly 32 canonical variables (got '%s')", variable_count.c_str());
+
+	expect_variable(admin, "genai-threads", "4");
+	expect_variable(admin, "genai-embedding_uri", "http://127.0.0.1:8013/embedding");
+	expect_variable(admin, "genai-llm_provider", "openai");
+	expect_variable(admin, "genai-llm_provider_model", "llama3.2");
+	expect_variable(admin, "genai-llm_cache_similarity_threshold", "85");
+	expect_variable(admin, "genai-vector_db_path", "/var/lib/proxysql/ai_features.db");
+	expect_variable(admin, "genai-vector_dimension", "1536");
+	expect_variable(admin, "genai-rag_k_max", "50");
+
+	const std::vector<string> supported_aliases {
+		"LOAD GENAI VARIABLES TO MEMORY",
+		"LOAD GENAI VARIABLES TO MEM",
+		"LOAD GENAI VARIABLES FROM DISK",
+		"LOAD GENAI VARIABLES FROM MEMORY",
+		"LOAD GENAI VARIABLES FROM MEM",
+		"LOAD GENAI VARIABLES TO RUNTIME",
+		"LOAD GENAI VARIABLES TO RUN",
+		"SAVE GENAI VARIABLES FROM MEMORY",
+		"SAVE GENAI VARIABLES FROM MEM",
+		"SAVE GENAI VARIABLES TO DISK",
+		"SAVE GENAI VARIABLES TO MEMORY",
+		"SAVE GENAI VARIABLES TO MEM",
+		"SAVE GENAI VARIABLES FROM RUNTIME",
+		"SAVE GENAI VARIABLES FROM RUN",
+	};
+	for (const string& command : supported_aliases) {
+		ok(execute_admin(admin, command), "supported alias succeeds: %s", command.c_str());
 	}
 
-	diag("Connected to ProxySQL admin interface at %s:%d", cl.host, cl.admin_port);
+	const string variable = "genai-llm_timeout_ms";
+	string original;
+	if (!read_variable(admin, variable, original)) original = "30000";
 
-	// Build the list of LOAD/SAVE commands to test
-	std::vector<std::string> queries;
-	add_genai_load_save_commands(queries);
+	ok(set_variable(admin, variable, "45000"), "set canonical GenAI variable in memory");
+	expect_variable(admin, variable, "45000");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME"), "load GenAI memory into runtime");
+	ok(set_variable(admin, variable, "46000"), "change memory without changing runtime");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES FROM RUNTIME"), "save GenAI runtime back to memory");
+	expect_variable(admin, variable, "45000");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES TO DISK"), "save GenAI memory to disk");
+	ok(set_variable(admin, variable, "47000"), "change memory after disk save");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES FROM DISK"), "load GenAI variables from disk");
+	expect_variable(admin, variable, "45000");
 
-	// Each command test = 2 tests (execution + optional result check)
-	// LOAD/SAVE commands: 14 commands
-	// Variable access tests: 7 tests
-	// Persistence tests: 8 tests
-	// CHECKSUM tests: 8 tests (4 commands × 2)
-	int num_load_save_tests = (int)queries.size() * 2; // Each command + result check
-	int total_tests = num_load_save_tests + 7 + 8 + 8;
+	ok(set_variable(admin, variable, original), "restore original GenAI timeout in memory");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME"), "restore original GenAI timeout in runtime");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES TO DISK"), "restore original GenAI timeout on disk");
+	expect_variable(admin, variable, original);
 
-	plan(total_tests);
-
-	int test_count = 0;
-
-	// ============================================================================
-	// Part 1: Test LOAD/SAVE commands
-	// ============================================================================
-	diag("=== Part 1: Testing LOAD/SAVE GENAI VARIABLES commands ===");
-	for (const auto& query : queries) {
-		MYSQL* admin_local = mysql_init(NULL);
-		if (!admin_local) {
-			diag("Failed to initialize MySQL connection");
-			continue;
-		}
-
-		if (!mysql_real_connect(admin_local, cl.host, cl.admin_username, cl.admin_password,
-			NULL, cl.admin_port, NULL, 0)) {
-			diag("Failed to connect to admin interface");
-			mysql_close(admin_local);
-			continue;
-		}
-
-		int rc = run_q(admin_local, query.c_str());
-		ok(rc == 0,  "Command executed successfully: %s", query.c_str());
-
-		// For SELECT/SHOW/CHECKSUM style commands, verify result set
-		if (strncasecmp(query.c_str(), "SELECT ", 7) == 0 ||
-			strncasecmp(query.c_str(), "SHOW ", 5) == 0 ||
-			strncasecmp(query.c_str(), "CHECKSUM ", 9) == 0) {
-			MYSQL_RES* res = mysql_store_result(admin_local);
-			unsigned long long num_rows = mysql_num_rows(res);
-			ok(num_rows != 0,  "Command returned rows: %s", query.c_str());
-			mysql_free_result(res);
-		} else {
-			// For non-query commands, just mark the test as passed
-			ok(1,  "Command completed: %s", query.c_str());
-		}
-
-		mysql_close(admin_local);
-	}
-
-	// ============================================================================
-	// Part 2: Test variable access (SET and SELECT)
-	// ============================================================================
-	diag("=== Part 2: Testing variable access (SET and SELECT) ===");
-	test_variable_access(admin);
-
-	// ============================================================================
-	// Part 3: Test variable persistence across layers
-	// ============================================================================
-	diag("=== Part 3: Testing variable persistence across storage layers ===");
-	test_variable_persistence(admin);
-
-	// ============================================================================
-	// Part 4: Test CHECKSUM commands
-	// ============================================================================
-	diag("=== Part 4: Testing CHECKSUM commands ===");
-	test_checksum_commands(admin);
-
-	// ============================================================================
-	// Cleanup
-	// ============================================================================
 	mysql_close(admin);
-
-	diag("=== All GenAI module tests completed ===");
-
 	return exit_status();
 }

--- a/test/tap/tests/mcp_headless_testing/mcp_config.example.json
+++ b/test/tap/tests/mcp_headless_testing/mcp_config.example.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "proxysql": {
+      "type": "http",
+      "url": "http://proxysql:6071/mcp/query",
+      "headers": {
+        "Authorization": "Bearer tap-mcp-token"
+      }
+    }
+  }
+}

--- a/test/tap/tests/mcp_headless_testing/static_harvest.sh
+++ b/test/tap/tests/mcp_headless_testing/static_harvest.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Deterministic phase-A discovery wrapper used by the headless TAP smoke test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../mcp_rules_testing/mcp_test_helpers.sh"
+
+ENDPOINT="${PROXYSQL_MCP_ENDPOINT:-$(get_endpoint_url query)}"
+TARGET_ID="${MCP_TARGET_ID:-}"
+SCHEMA_FILTER=""
+NOTES=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --endpoint)
+            ENDPOINT="$2"
+            shift 2
+            ;;
+        --target-id)
+            TARGET_ID="$2"
+            shift 2
+            ;;
+        --schema)
+            SCHEMA_FILTER="$2"
+            shift 2
+            ;;
+        --notes)
+            NOTES="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 --target-id ID [--schema NAME] [--notes TEXT] [--endpoint URL]"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "${TARGET_ID}" ]]; then
+    echo "--target-id is required" >&2
+    exit 2
+fi
+if [[ -z "${MCP_AUTH_TOKEN}" ]]; then
+    echo "TAP_MCP_AUTH_TOKEN is required" >&2
+    exit 2
+fi
+require_command curl
+require_command jq
+
+arguments="$(jq -cn \
+    --arg target_id "${TARGET_ID}" \
+    --arg schema "${SCHEMA_FILTER}" \
+    --arg notes "${NOTES}" \
+    '{target_id:$target_id}
+     + (if $schema == "" then {} else {schema_filter:$schema} end)
+     + (if $notes == "" then {} else {notes:$notes} end)')"
+request="$(jq -cn --argjson arguments "${arguments}" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"discovery.run_static",arguments:$arguments}}')"
+
+echo "=== Phase 1: Static Harvest ==="
+echo "Endpoint: ${ENDPOINT}"
+echo "Target ID: ${TARGET_ID}"
+response="$(mcp_request_url "${ENDPOINT}" "${request}")"
+echo "${response}" | jq .
+
+if echo "${response}" | jq -e 'has("error") or (.result.isError == true)' >/dev/null; then
+    echo "MCP static harvest returned an error" >&2
+    exit 1
+fi
+
+inner="$(echo "${response}" | jq -er '.result.content[0].text')"
+run_id="$(echo "${inner}" | jq -er '.run_id')"
+echo "Run ID: ${run_id}"

--- a/test/tap/tests/mcp_headless_testing/two_phase_discovery.py
+++ b/test/tap/tests/mcp_headless_testing/two_phase_discovery.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Launch the optional semantic phase after a deterministic MCP harvest."""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SYSTEM_PROMPT = """You are analyzing one database schema through ProxySQL MCP.
+Use only the configured ProxySQL MCP tools. Read catalog objects for the supplied
+target and run identifiers, then persist concise summaries through the LLM tools.
+Do not use local files or shell commands for database discovery.
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mcp-config", required=True)
+    parser.add_argument("--target-id", required=True)
+    parser.add_argument("--schema", required=True)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--model", default="claude-sonnet-4-5")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--dangerously-skip-permissions", action="store_true")
+    return parser.parse_args()
+
+
+def materialize_config(config_path):
+    with config_path.open(encoding="utf-8") as stream:
+        config = json.load(stream)
+    servers = config.get("mcpServers", {})
+    if "proxysql" not in servers:
+        raise ValueError("MCP config must define mcpServers.proxysql")
+
+    endpoint = os.environ.get("PROXYSQL_MCP_ENDPOINT")
+    token = os.environ.get("TAP_MCP_AUTH_TOKEN") or os.environ.get(
+        "PROXYSQL_MCP_TOKEN"
+    )
+    server = servers["proxysql"]
+    if endpoint:
+        server["url"] = endpoint
+    if token:
+        server.setdefault("headers", {})["Authorization"] = f"Bearer {token}"
+
+    temporary = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", encoding="utf-8", delete=False
+    )
+    with temporary:
+        json.dump(config, temporary)
+    return Path(temporary.name)
+
+
+def main():
+    args = parse_args()
+    config_path = Path(args.mcp_config)
+    if not config_path.is_file():
+        print(f"MCP config does not exist: {config_path}", file=sys.stderr)
+        return 2
+    try:
+        with config_path.open(encoding="utf-8") as stream:
+            config = json.load(stream)
+        if "proxysql" not in config.get("mcpServers", {}):
+            raise ValueError("missing mcpServers.proxysql")
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Invalid MCP config: {error}", file=sys.stderr)
+        return 2
+
+    user_prompt = (
+        f"Analyze schema {args.schema!r} for target {args.target_id!r} using "
+        f"catalog run_id {args.run_id}. Persist the resulting semantic summary."
+    )
+    if args.dry_run:
+        print("[DRY RUN] Two-Phase Database Discovery")
+        print(f"  MCP Config: {config_path}")
+        print(f"  Schema: {args.schema}")
+        print(f"  Target ID: {args.target_id}")
+        print(f"  Run ID: {args.run_id}")
+        print(f"  Model: {args.model}")
+        print(f"  Prompt: {user_prompt}")
+        return 0
+
+    claude = shutil.which("claude")
+    if not claude:
+        print("claude CLI is required when dry-run is disabled", file=sys.stderr)
+        return 2
+
+    rendered_config = materialize_config(config_path)
+    try:
+        command = [
+            claude,
+            "--mcp-config",
+            str(rendered_config),
+            "--model",
+            args.model,
+            "--system-prompt",
+            SYSTEM_PROMPT,
+            "--allowed-tools",
+            "mcp__proxysql__*",
+            "--print",
+        ]
+        if args.dangerously_skip_permissions:
+            command.append("--dangerously-skip-permissions")
+        result = subprocess.run(command, input=user_prompt, text=True, check=False)
+        return result.returncode
+    finally:
+        rendered_config.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
@@ -244,13 +244,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
-std::string escape_sql_literal(const char* input) {
-	std::string escaped = input ? input : "";
-	size_t pos = 0;
-	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
-		escaped.insert(pos, 1, '\'');
-		pos += 2;
-	}
+std::string escape_sql_literal(MYSQL* admin, const char* input) {
+	if (input == nullptr) return {};
+	const size_t input_length = std::strlen(input);
+	std::string escaped(input_length * 2 + 1, '\0');
+	const unsigned long escaped_length = mysql_real_escape_string(
+		admin, escaped.data(), input, static_cast<unsigned long>(input_length));
+	escaped.resize(escaped_length);
 	return escaped;
 }
 
@@ -267,7 +267,8 @@ bool configure_mcp_runtime(
 	int processlist_cap,
 	int show_queries_cap
 ) {
-	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
+	if (admin == nullptr) return false;
+	const std::string auth_token = escape_sql_literal(admin, cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",

--- a/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
@@ -244,6 +244,16 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
+std::string escape_sql_literal(const char* input) {
+	std::string escaped = input ? input : "";
+	size_t pos = 0;
+	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
+		escaped.insert(pos, 1, '\'');
+		pos += 2;
+	}
+	return escaped;
+}
+
 /**
  * @brief Configure MCP runtime for concurrent cross-protocol stats polling.
  *
@@ -257,11 +267,13 @@ bool configure_mcp_runtime(
 	int processlist_cap,
 	int show_queries_cap
 ) {
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
-		"SET mcp-stats_endpoint_auth=''",
+		"SET mcp-config_endpoint_auth='" + auth_token + "'",
+		"SET mcp-stats_endpoint_auth='" + auth_token + "'",
 		"SET mcp-stats_show_processlist_max_rows=" + std::to_string(processlist_cap),
 		"SET mcp-stats_show_queries_max_rows=" + std::to_string(show_queries_cap),
 		"LOAD MCP VARIABLES TO RUNTIME"
@@ -284,11 +296,7 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
-	run_q(admin, "SET mcp-stats_show_processlist_max_rows=200");
-	run_q(admin, "SET mcp-stats_show_queries_max_rows=200");
-	run_q(admin, "SET mcp-stats_endpoint_auth=''");
-	run_q(admin, "SET mcp-enabled=false");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 }
 
 /**

--- a/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
@@ -165,6 +165,16 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
+std::string escape_sql_literal(const char* input) {
+	std::string escaped = input ? input : "";
+	size_t pos = 0;
+	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
+		escaped.insert(pos, 1, '\'');
+		pos += 2;
+	}
+	return escaped;
+}
+
 /**
  * @brief Configure MCP runtime for concurrent stats polling.
  *
@@ -173,11 +183,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
  * @return true if all setup statements succeeded.
  */
 bool configure_mcp_runtime(MYSQL* admin, const CommandLine& cl) {
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
-		"SET mcp-stats_endpoint_auth=''",
+		"SET mcp-config_endpoint_auth='" + auth_token + "'",
+		"SET mcp-stats_endpoint_auth='" + auth_token + "'",
 		"SET mcp-stats_show_processlist_max_rows=" + std::to_string(k_processlist_cap),
 		"SET mcp-stats_show_queries_max_rows=" + std::to_string(k_show_queries_cap),
 		"LOAD MCP VARIABLES TO RUNTIME"
@@ -200,11 +212,7 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
-	run_q(admin, "SET mcp-stats_show_processlist_max_rows=200");
-	run_q(admin, "SET mcp-stats_show_queries_max_rows=200");
-	run_q(admin, "SET mcp-stats_endpoint_auth=''");
-	run_q(admin, "SET mcp-enabled=false");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 }
 
 /**

--- a/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
@@ -165,13 +165,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
-std::string escape_sql_literal(const char* input) {
-	std::string escaped = input ? input : "";
-	size_t pos = 0;
-	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
-		escaped.insert(pos, 1, '\'');
-		pos += 2;
-	}
+std::string escape_sql_literal(MYSQL* admin, const char* input) {
+	if (input == nullptr) return {};
+	const size_t input_length = std::strlen(input);
+	std::string escaped(input_length * 2 + 1, '\0');
+	const unsigned long escaped_length = mysql_real_escape_string(
+		admin, escaped.data(), input, static_cast<unsigned long>(input_length));
+	escaped.resize(escaped_length);
 	return escaped;
 }
 
@@ -183,7 +183,8 @@ std::string escape_sql_literal(const char* input) {
  * @return true if all setup statements succeeded.
  */
 bool configure_mcp_runtime(MYSQL* admin, const CommandLine& cl) {
-	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
+	if (admin == nullptr) return false;
+	const std::string auth_token = escape_sql_literal(admin, cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",

--- a/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
@@ -161,13 +161,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
-std::string escape_sql_literal(const char* input) {
-	std::string escaped = input ? input : "";
-	size_t pos = 0;
-	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
-		escaped.insert(pos, 1, '\'');
-		pos += 2;
-	}
+std::string escape_sql_literal(MYSQL* admin, const char* input) {
+	if (input == nullptr) return {};
+	const size_t input_length = std::strlen(input);
+	std::string escaped(input_length * 2 + 1, '\0');
+	const unsigned long escaped_length = mysql_real_escape_string(
+		admin, escaped.data(), input, static_cast<unsigned long>(input_length));
+	escaped.resize(escaped_length);
 	return escaped;
 }
 
@@ -179,7 +179,8 @@ std::string escape_sql_literal(const char* input) {
  * @return true if all setup statements succeeded.
  */
 bool configure_mcp_runtime(MYSQL* admin, const CommandLine& cl) {
-	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
+	if (admin == nullptr) return false;
+	const std::string auth_token = escape_sql_literal(admin, cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",

--- a/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
@@ -161,6 +161,16 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
+std::string escape_sql_literal(const char* input) {
+	std::string escaped = input ? input : "";
+	size_t pos = 0;
+	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
+		escaped.insert(pos, 1, '\'');
+		pos += 2;
+	}
+	return escaped;
+}
+
 /**
  * @brief Configure MCP runtime for concurrent stats polling.
  *
@@ -169,11 +179,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
  * @return true if all setup statements succeeded.
  */
 bool configure_mcp_runtime(MYSQL* admin, const CommandLine& cl) {
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
-		"SET mcp-stats_endpoint_auth=''",
+		"SET mcp-config_endpoint_auth='" + auth_token + "'",
+		"SET mcp-stats_endpoint_auth='" + auth_token + "'",
 		"SET mcp-stats_show_processlist_max_rows=" + std::to_string(k_processlist_cap),
 		"SET mcp-stats_show_queries_max_rows=" + std::to_string(k_show_queries_cap),
 		"LOAD MCP VARIABLES TO RUNTIME"
@@ -196,11 +208,7 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
-	run_q(admin, "SET mcp-stats_show_processlist_max_rows=200");
-	run_q(admin, "SET mcp-stats_show_queries_max_rows=200");
-	run_q(admin, "SET mcp-stats_endpoint_auth=''");
-	run_q(admin, "SET mcp-enabled=false");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 }
 
 /**

--- a/test/tap/tests/mcp_query_rules-t.cpp
+++ b/test/tap/tests/mcp_query_rules-t.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <algorithm>
+#include <cstring>
 #include <string>
 #include <vector>
 #include <unistd.h>
@@ -23,11 +24,24 @@ static const char* k_auth_profile_id = "tap_mcp_rules_auth";
 // Helper Functions
 // ============================================================================
 
+std::string escape_sql_literal(const char* input) {
+	std::string escaped = input ? input : "";
+	size_t pos = 0;
+	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
+		escaped.insert(pos, 1, '\'');
+		pos += 2;
+	}
+	return escaped;
+}
+
 bool configure_mcp_for_rules_test(MYSQL* admin, const CommandLine& cl) {
 	diag("Configuring MCP for rules test");
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 
-	run_q(admin, "SET mcp-port=6071");
+	run_q(admin, ("SET mcp-port=" + std::to_string(cl.mcp_port)).c_str());
 	run_q(admin, "SET mcp-use_ssl=false");
+	run_q(admin, ("SET mcp-config_endpoint_auth='" + auth_token + "'").c_str());
+	run_q(admin, ("SET mcp-query_endpoint_auth='" + auth_token + "'").c_str());
 	run_q(admin, "SET mcp-enabled=true");
 
 	// Clean up existing test data
@@ -200,7 +214,10 @@ int main(int argc, char** argv) {
 		return exit_status();
 	}
 
-	MCPClient mcp(cl.admin_host, 6071);
+	MCPClient mcp(cl.admin_host, cl.mcp_port);
+	if (strlen(cl.mcp_auth_token) > 0) {
+		mcp.set_auth_token(cl.mcp_auth_token);
+	}
 	if (!mcp.check_server()) {
 		diag("MCP server not accessible");
 		mysql_close(admin);
@@ -213,6 +230,7 @@ int main(int argc, char** argv) {
 	diag("Final cleanup");
 	run_q(admin, "DELETE FROM mcp_query_rules WHERE rule_id >= 1000");
 	run_q(admin, "LOAD MCP QUERY RULES TO RUNTIME");
+	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 	ok(true, "Cleanup completed");
 
 	mysql_close(admin);

--- a/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
@@ -70,10 +70,15 @@ bool configure_mcp_for_test(MYSQL* admin, const CommandLine& cl) {
 	const std::string mysql_user = escape_sql_literal(cl.mysql_username);
 	const std::string mysql_password = escape_sql_literal(cl.mysql_password);
 	const std::string default_schema = escape_sql_literal(k_test_schema);
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 
 	const std::string q1 = "SET mcp-port=" + std::to_string(cl.mcp_port);
 	const std::string q2 = "SET mcp-use_ssl=false";
 	const std::string q3 = "SET mcp-enabled=true";
+	const std::string q_config_auth =
+		"SET mcp-config_endpoint_auth='" + auth_token + "'";
+	const std::string q_query_auth =
+		"SET mcp-query_endpoint_auth='" + auth_token + "'";
 	const std::string q4 = "DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'";
 	const std::string q5 = "DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'";
 	const std::string q6 =
@@ -93,6 +98,8 @@ bool configure_mcp_for_test(MYSQL* admin, const CommandLine& cl) {
 	return run_q(admin, q1.c_str()) == 0 &&
 	       run_q(admin, q2.c_str()) == 0 &&
 	       run_q(admin, q3.c_str()) == 0 &&
+	       run_q(admin, q_config_auth.c_str()) == 0 &&
+	       run_q(admin, q_query_auth.c_str()) == 0 &&
 	       run_q(admin, q4.c_str()) == 0 &&
 	       run_q(admin, q5.c_str()) == 0 &&
 	       run_q(admin, q6.c_str()) == 0 &&
@@ -216,6 +223,7 @@ cleanup:
 		mysql_close(mysql);
 	}
 	if (admin) {
+		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 		run_q(admin, ("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());

--- a/test/tap/tests/mcp_query_run_sql_readonly_bypass-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly_bypass-t.cpp
@@ -153,6 +153,7 @@ bool configure_mcp_for_test(MYSQL* admin, const CommandLine& cl, const std::stri
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
+		"SET mcp-config_endpoint_auth='" + escape_sql_literal(query_token) + "'",
 		"SET mcp-query_endpoint_auth='" + escape_sql_literal(query_token) + "'",
 		"DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'",
 		"DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'",
@@ -320,8 +321,7 @@ cleanup:
 		run_q(admin, ("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());
-		run_q(admin, "SET mcp-query_endpoint_auth=''");
-		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 		run_q(admin, "LOAD MCP PROFILES TO RUNTIME");
 		run_q(admin, "LOAD MYSQL SERVERS TO RUNTIME");
 		mysql_close(admin);

--- a/test/tap/tests/mcp_rules_testing/mcp_test_helpers.sh
+++ b/test/tap/tests/mcp_rules_testing/mcp_test_helpers.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Shared connection, TAP, and request helpers for MCP shell tests.
+
+# ProxySQL admin connection.  The isolated runner exposes ProxySQL through its
+# Docker DNS name; callers can override every field through the standard TAP
+# environment.
+PROXYSQL_ADMIN_HOST="${TAP_ADMINHOST:-${PROXYSQL_ADMIN_HOST:-proxysql}}"
+PROXYSQL_ADMIN_PORT="${TAP_ADMINPORT:-${PROXYSQL_ADMIN_PORT:-6032}}"
+PROXYSQL_ADMIN_USER="${TAP_ADMINUSERNAME:-${PROXYSQL_ADMIN_USER:-radmin}}"
+PROXYSQL_ADMIN_PASSWORD="${TAP_ADMINPASSWORD:-${PROXYSQL_ADMIN_PASSWORD:-radmin}}"
+
+# Backend connection used by discovery fixtures.
+MYSQL_HOST="${TAP_MYSQLHOST:-${MYSQL_HOST:-mysql}}"
+MYSQL_PORT="${TAP_MYSQLPORT:-${MYSQL_PORT:-3306}}"
+MYSQL_USER="${TAP_MYSQLUSERNAME:-${MYSQL_USER:-root}}"
+MYSQL_PASSWORD="${TAP_MYSQLPASSWORD:-${MYSQL_PASSWORD:-none}}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-${TEST_DB_NAME:-test}}"
+
+# MCP uses the admin host by default because both listeners belong to the same
+# ProxySQL instance.  TAP_MCP_PORT is canonical; TAP_MCPPORT remains supported
+# for older callers.
+MCP_HOST="${TAP_MCP_HOST:-${TAP_ADMINHOST:-${MCP_HOST:-proxysql}}}"
+MCP_PORT="${TAP_MCP_PORT:-${TAP_MCPPORT:-${MCP_PORT:-6071}}}"
+MCP_SCHEME="${TAP_MCP_SCHEME:-${MCP_SCHEME:-http}}"
+MCP_AUTH_TOKEN="${TAP_MCP_AUTH_TOKEN:-${PROXYSQL_MCP_TOKEN:-}}"
+MCP_TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
+
+PLAN="${PLAN:-0}"
+DONE="${DONE:-0}"
+FAIL="${FAIL:-0}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+log_test() { echo -e "${GREEN}[TEST]${NC} $*" >&2; }
+log_verbose() { echo -e "${YELLOW}[VERBOSE]${NC} $*" >&2; }
+
+tap_plan() {
+    PLAN="$1"
+    echo "msg: 1..${PLAN}"
+}
+
+tap_ok() {
+    DONE=$((DONE + 1))
+    echo "msg: ok ${DONE} - $1"
+}
+
+tap_not_ok() {
+    DONE=$((DONE + 1))
+    FAIL=$((FAIL + 1))
+    echo "msg: not ok ${DONE} - $1"
+    if [[ $# -gt 1 && -n "$2" ]]; then
+        while IFS= read -r line; do
+            echo "msg: # ${line}"
+        done <<< "$2"
+    fi
+}
+
+tap_skip() {
+    DONE=$((DONE + 1))
+    echo "msg: ok ${DONE} - $1 # SKIP $2"
+}
+
+tap_finish() {
+    if [[ "${DONE}" -ne "${PLAN}" ]]; then
+        echo "msg: # planned ${PLAN} assertions but ran ${DONE}"
+        return 1
+    fi
+    if [[ "${FAIL}" -ne 0 ]]; then
+        echo "msg: # FAILURES=${FAIL}/${PLAN}"
+        return 1
+    fi
+    return 0
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        log_error "required command is unavailable: $1"
+        return 1
+    fi
+}
+
+require_mcp_prerequisites() {
+    local failed=0
+    local command_name
+    for command_name in mysql curl jq; do
+        require_command "${command_name}" || failed=1
+    done
+    if [[ -z "${MCP_AUTH_TOKEN}" ]]; then
+        log_error "TAP_MCP_AUTH_TOKEN is required for the authenticated AI TAP groups"
+        failed=1
+    fi
+    case "${MCP_SCHEME}" in
+        http|https) ;;
+        *)
+            log_error "TAP_MCP_SCHEME must be http or https (got: ${MCP_SCHEME})"
+            failed=1
+            ;;
+    esac
+    return "${failed}"
+}
+
+mysql_command() {
+    local host="$1"
+    local port="$2"
+    local user="$3"
+    local password="$4"
+    local query="$5"
+    shift 5
+
+    local -a arguments=("$@" -h "${host}" -P "${port}" -u "${user}" -e "${query}")
+    if [[ -z "${password}" || "${password}" == "none" ]]; then
+        mysql "${arguments[@]}"
+    else
+        MYSQL_PWD="${password}" mysql "${arguments[@]}"
+    fi
+}
+
+exec_admin() {
+    mysql_command \
+        "${PROXYSQL_ADMIN_HOST}" "${PROXYSQL_ADMIN_PORT}" \
+        "${PROXYSQL_ADMIN_USER}" "${PROXYSQL_ADMIN_PASSWORD}" "$1"
+}
+
+exec_admin_silent() {
+    local output
+    local status
+    if output="$(mysql_command \
+        "${PROXYSQL_ADMIN_HOST}" "${PROXYSQL_ADMIN_PORT}" \
+        "${PROXYSQL_ADMIN_USER}" "${PROXYSQL_ADMIN_PASSWORD}" "$1" -B -N 2>&1)"; then
+        status=0
+    else
+        status=$?
+    fi
+    if [[ -n "${output}" ]]; then
+        printf '%s\n' "${output}" | sed '/^mysql: \[Warning\].* insecure\.$/d'
+    fi
+    return "${status}"
+}
+
+exec_mysql() {
+    local -a database_argument=()
+    if [[ -n "${MYSQL_DATABASE}" ]]; then
+        database_argument=(-D "${MYSQL_DATABASE}")
+    fi
+    mysql_command \
+        "${MYSQL_HOST}" "${MYSQL_PORT}" "${MYSQL_USER}" "${MYSQL_PASSWORD}" \
+        "$1" "${database_argument[@]}"
+}
+
+exec_mysql_silent() {
+    local output
+    local status
+    local -a database_argument=()
+    if [[ -n "${MYSQL_DATABASE}" ]]; then
+        database_argument=(-D "${MYSQL_DATABASE}")
+    fi
+    if output="$(mysql_command \
+        "${MYSQL_HOST}" "${MYSQL_PORT}" "${MYSQL_USER}" "${MYSQL_PASSWORD}" \
+        "$1" -B -N "${database_argument[@]}" 2>&1)"; then
+        status=0
+    else
+        status=$?
+    fi
+    if [[ -n "${output}" ]]; then
+        printf '%s\n' "${output}" | sed '/^mysql: \[Warning\].* insecure\.$/d'
+    fi
+    return "${status}"
+}
+
+get_endpoint_url() {
+    printf '%s://%s:%s/mcp/%s\n' "${MCP_SCHEME}" "${MCP_HOST}" "${MCP_PORT}" "$1"
+}
+
+mcp_request_url() {
+    local url="$1"
+    local payload="$2"
+    local -a curl_arguments=(
+        --silent --show-error --fail-with-body
+        --request POST "${url}"
+        --header "Content-Type: application/json"
+        --header "Authorization: Bearer ${MCP_AUTH_TOKEN}"
+        --data "${payload}"
+    )
+    if [[ "${url}" == https://* ]]; then
+        curl_arguments=(--insecure "${curl_arguments[@]}")
+    fi
+    curl "${curl_arguments[@]}"
+}
+
+mcp_request() {
+    mcp_request_url "$(get_endpoint_url "$1")" "$2"
+}
+
+check_proxysql_admin() {
+    exec_admin_silent "SELECT 1" >/dev/null 2>&1
+}
+
+check_mcp_server() {
+    local response
+    response="$(mcp_request config '{"jsonrpc":"2.0","method":"ping","id":1}')" || return 1
+    jq -e \
+        '.jsonrpc == "2.0" and .id == 1 and has("result") and (has("error") | not)' \
+        >/dev/null 2>&1 <<< "${response}"
+}
+
+check_mysql_backend() {
+    exec_mysql_silent "SELECT 1" >/dev/null 2>&1
+}
+
+get_rule_hits() {
+    exec_admin_silent "SELECT hits FROM stats_mcp_query_rules WHERE rule_id = $1;"
+}
+
+restore_mcp_group_baseline() {
+    exec_admin_silent \
+        "LOAD MCP VARIABLES FROM DISK; LOAD MCP PROFILES FROM DISK; LOAD MCP QUERY RULES FROM DISK;" \
+        >/dev/null
+}
+
+export PROXYSQL_ADMIN_HOST PROXYSQL_ADMIN_PORT PROXYSQL_ADMIN_USER PROXYSQL_ADMIN_PASSWORD
+export MYSQL_HOST MYSQL_PORT MYSQL_USER MYSQL_PASSWORD MYSQL_DATABASE
+export MCP_HOST MCP_PORT MCP_SCHEME MCP_AUTH_TOKEN MCP_TARGET_ID
+export -f log_info log_error log_test log_verbose
+export -f tap_plan tap_ok tap_not_ok tap_skip tap_finish
+export -f require_command require_mcp_prerequisites
+export -f mysql_command exec_admin exec_admin_silent exec_mysql exec_mysql_silent
+export -f get_endpoint_url mcp_request_url mcp_request check_proxysql_admin check_mcp_server check_mysql_backend
+export -f get_rule_hits restore_mcp_group_baseline

--- a/test/tap/tests/mcp_rules_testing/mcp_test_helpers.sh
+++ b/test/tap/tests/mcp_rules_testing/mcp_test_helpers.sh
@@ -24,6 +24,10 @@ MCP_PORT="${TAP_MCP_PORT:-${TAP_MCPPORT:-${MCP_PORT:-6071}}}"
 MCP_SCHEME="${TAP_MCP_SCHEME:-${MCP_SCHEME:-http}}"
 MCP_AUTH_TOKEN="${TAP_MCP_AUTH_TOKEN:-${PROXYSQL_MCP_TOKEN:-}}"
 MCP_TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
+MCP_CONNECT_TIMEOUT="${TAP_MCP_CONNECT_TIMEOUT:-5}"
+MCP_REQUEST_TIMEOUT="${TAP_MCP_REQUEST_TIMEOUT:-30}"
+MCP_CA_CERT="${TAP_MCP_CA_CERT:-}"
+MCP_TLS_INSECURE="${TAP_MCP_TLS_INSECURE:-0}"
 
 PLAN="${PLAN:-0}"
 DONE="${DONE:-0}"
@@ -101,6 +105,12 @@ require_mcp_prerequisites() {
             failed=1
             ;;
     esac
+    if [[ "${MCP_SCHEME}" == "https" && "${MCP_TLS_INSECURE}" != "1" ]]; then
+        if [[ -z "${MCP_CA_CERT}" || ! -f "${MCP_CA_CERT}" ]]; then
+            log_error "TAP_MCP_CA_CERT must name a readable test CA for HTTPS (or set TAP_MCP_TLS_INSECURE=1 explicitly)"
+            failed=1
+        fi
+    fi
     return "${failed}"
 }
 
@@ -181,13 +191,22 @@ mcp_request_url() {
     local payload="$2"
     local -a curl_arguments=(
         --silent --show-error --fail-with-body
+        --connect-timeout "${MCP_CONNECT_TIMEOUT}"
+        --max-time "${MCP_REQUEST_TIMEOUT}"
         --request POST "${url}"
         --header "Content-Type: application/json"
         --header "Authorization: Bearer ${MCP_AUTH_TOKEN}"
         --data "${payload}"
     )
     if [[ "${url}" == https://* ]]; then
-        curl_arguments=(--insecure "${curl_arguments[@]}")
+        if [[ "${MCP_TLS_INSECURE}" == "1" ]]; then
+            curl_arguments=(--insecure "${curl_arguments[@]}")
+        elif [[ -n "${MCP_CA_CERT}" && -f "${MCP_CA_CERT}" ]]; then
+            curl_arguments=(--cacert "${MCP_CA_CERT}" "${curl_arguments[@]}")
+        else
+            log_error "HTTPS MCP request requires TAP_MCP_CA_CERT or explicit TAP_MCP_TLS_INSECURE=1"
+            return 2
+        fi
     fi
     curl "${curl_arguments[@]}"
 }
@@ -225,6 +244,7 @@ restore_mcp_group_baseline() {
 export PROXYSQL_ADMIN_HOST PROXYSQL_ADMIN_PORT PROXYSQL_ADMIN_USER PROXYSQL_ADMIN_PASSWORD
 export MYSQL_HOST MYSQL_PORT MYSQL_USER MYSQL_PASSWORD MYSQL_DATABASE
 export MCP_HOST MCP_PORT MCP_SCHEME MCP_AUTH_TOKEN MCP_TARGET_ID
+export MCP_CONNECT_TIMEOUT MCP_REQUEST_TIMEOUT MCP_CA_CERT MCP_TLS_INSECURE
 export -f log_info log_error log_test log_verbose
 export -f tap_plan tap_ok tap_not_ok tap_skip tap_finish
 export -f require_command require_mcp_prerequisites

--- a/test/tap/tests/mcp_show_connections_commands_inmemory-t.cpp
+++ b/test/tap/tests/mcp_show_connections_commands_inmemory-t.cpp
@@ -66,6 +66,16 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
+std::string escape_sql_literal(const char* input) {
+	std::string escaped = input ? input : "";
+	size_t pos = 0;
+	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
+		escaped.insert(pos, 1, '\'');
+		pos += 2;
+	}
+	return escaped;
+}
+
 /**
  * @brief Configure MCP runtime for stats tool tests.
  *
@@ -76,11 +86,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
  * @return true if all setup statements succeeded.
  */
 bool configure_mcp_runtime(MYSQL* admin, const CommandLine& cl) {
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
-		"SET mcp-stats_endpoint_auth=''",
+		"SET mcp-config_endpoint_auth='" + auth_token + "'",
+		"SET mcp-stats_endpoint_auth='" + auth_token + "'",
 		"SET mcp-stats_enable_debug_tools=false",
 		"LOAD MCP VARIABLES TO RUNTIME"
 	};
@@ -101,10 +113,7 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
-	run_q(admin, "SET mcp-stats_enable_debug_tools=false");
-	run_q(admin, "SET mcp-stats_endpoint_auth=''");
-	run_q(admin, "SET mcp-enabled=false");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 }
 
 /**

--- a/test/tap/tests/mcp_show_queries_topk-t.cpp
+++ b/test/tap/tests/mcp_show_queries_topk-t.cpp
@@ -59,6 +59,16 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
+std::string escape_sql_literal(const char* input) {
+	std::string escaped = input ? input : "";
+	size_t pos = 0;
+	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
+		escaped.insert(pos, 1, '\'');
+		pos += 2;
+	}
+	return escaped;
+}
+
 /**
  * @brief Configure MCP stats endpoint and runtime cap for show_queries.
  *
@@ -67,11 +77,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
  * @return true if all setup statements succeeded.
  */
 bool configure_mcp_stats(MYSQL* admin, const CommandLine& cl) {
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
-		"SET mcp-stats_endpoint_auth=''",
+		"SET mcp-config_endpoint_auth='" + auth_token + "'",
+		"SET mcp-stats_endpoint_auth='" + auth_token + "'",
 		"SET mcp-stats_show_queries_max_rows=" + std::to_string(k_show_queries_cap),
 		"LOAD MCP VARIABLES TO RUNTIME"
 	};
@@ -391,10 +403,7 @@ int main(int argc, char** argv) {
 
 	if (admin) {
 		run_q(admin, "PROXYSQLTEST 4");
-		run_q(admin, "SET mcp-stats_show_queries_max_rows=200");
-		run_q(admin, "SET mcp-stats_endpoint_auth=''");
-		run_q(admin, "SET mcp-enabled=false");
-		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 		mysql_close(admin);
 	}
 	if (mcp) {

--- a/test/tap/tests/mcp_stats_refresh-t.cpp
+++ b/test/tap/tests/mcp_stats_refresh-t.cpp
@@ -45,6 +45,16 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
 	return true;
 }
 
+std::string escape_sql_literal(const char* input) {
+	std::string escaped = input ? input : "";
+	size_t pos = 0;
+	while ((pos = escaped.find('\'', pos)) != std::string::npos) {
+		escaped.insert(pos, 1, '\'');
+		pos += 2;
+	}
+	return escaped;
+}
+
 /**
  * @brief Configure MCP runtime variables required by this test.
  *
@@ -53,11 +63,13 @@ bool run_admin_stmt(MYSQL* admin, const std::string& query, const char* context)
  * @return true if all configuration statements succeeded.
  */
 bool configure_mcp_stats_endpoint(MYSQL* admin, const CommandLine& cl) {
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 	const std::vector<std::string> statements = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
-		"SET mcp-stats_endpoint_auth=''",
+		"SET mcp-config_endpoint_auth='" + auth_token + "'",
+		"SET mcp-stats_endpoint_auth='" + auth_token + "'",
 		"LOAD MCP VARIABLES TO RUNTIME"
 	};
 
@@ -208,38 +220,21 @@ int main(int argc, char** argv) {
 	}
 
 	bool mcp_reachable = false;
-	bool using_ssl = false;
 	if (can_continue) {
 		// Retry loop: MCP server may need a moment to start after LOAD MCP VARIABLES TO RUNTIME
 		const int k_max_retries = 30;  // 30 retries * 100ms = 3 seconds max wait
 		const int k_retry_delay_ms = 100;
 		int retry_count = 0;
 
-		// First try HTTP, then HTTPS if HTTP fails
-		for (int ssl_attempt = 0; ssl_attempt <= 1 && !mcp_reachable; ssl_attempt++) {
-			bool try_ssl = (ssl_attempt == 1);
-			mcp->set_use_ssl(try_ssl);
-
-			if (try_ssl) {
-				diag("HTTP failed, trying HTTPS...");
-			}
-
-			retry_count = 0;
-			while (!mcp_reachable && retry_count < k_max_retries) {
-				usleep(k_retry_delay_ms * 1000);
-				mcp_reachable = mcp->check_server();
-				retry_count++;
-			}
-
-			if (mcp_reachable) {
-				using_ssl = try_ssl;
-				diag("MCP server reachable via %s after %d retries (%dms)",
-					try_ssl ? "HTTPS" : "HTTP", retry_count, retry_count * k_retry_delay_ms);
-			}
+		while (!mcp_reachable && retry_count < k_max_retries) {
+			usleep(k_retry_delay_ms * 1000);
+			mcp_reachable = mcp->check_server();
+			retry_count++;
 		}
 
-		ok(mcp_reachable, "MCP server reachable at %s (%s)", mcp->get_connection_info().c_str(),
-			using_ssl ? "HTTPS" : "HTTP");
+		diag("MCP HTTP server readiness after %d retries (%dms)",
+			retry_count, retry_count * k_retry_delay_ms);
+		ok(mcp_reachable, "MCP HTTP server reachable at %s", mcp->get_connection_info().c_str());
 		if (!mcp_reachable) {
 			skip(7, "Cannot continue without MCP connectivity");
 			can_continue = false;
@@ -359,9 +354,7 @@ int main(int argc, char** argv) {
 	}
 
 	if (admin) {
-		run_q(admin, "SET mcp-stats_endpoint_auth=''");
-		run_q(admin, "SET mcp-enabled=false");
-		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
 		mysql_close(admin);
 	}
 

--- a/test/tap/tests/nl2sql_model_selection-t.cpp
+++ b/test/tap/tests/nl2sql_model_selection-t.cpp
@@ -57,7 +57,7 @@ enum ModelProvider {
 string get_nl2sql_variable(const char* name) {
 	char query[256];
 	snprintf(query, sizeof(query),
-			 "SELECT variable_value FROM runtime_global_variables WHERE variable_name='genai-llm_%s'",
+			 "SELECT variable_value FROM global_variables WHERE variable_name='genai-llm_%s'",
 			 name);
 
 	diag("Admin: %s", query);
@@ -95,10 +95,8 @@ bool set_nl2sql_variable(const char* name, const char* value) {
 	const char* load_query = "LOAD GENAI VARIABLES TO RUNTIME";
 	diag("Admin: %s", load_query);
 	if (mysql_query(g_admin, load_query)) {
-		// Fallback to generic LOAD if specific one fails
-		load_query = "LOAD MYSQL VARIABLES TO RUNTIME";
-		diag("Admin: %s", load_query);
-		mysql_query(g_admin, load_query);
+		diag("Failed to load GenAI variables: %s", mysql_error(g_admin));
+		return false;
 	}
 
 	return true;
@@ -304,40 +302,59 @@ void test_config_variable_integration() {
 
 	// Save original values
 	string orig_provider = get_nl2sql_variable("provider");
+	string orig_model = get_nl2sql_variable("provider_model");
+	string orig_timeout = get_nl2sql_variable("timeout_ms");
 
 	// Test 1: Set provider to OpenAI
 	ok(set_nl2sql_variable("provider", "openai"),
 	   "Set model_provider to openai");
 	string current = get_nl2sql_variable("provider");
-	ok(current == "openai" || current.empty(),
+	ok(current == "openai",
 	   "Variable genai-llm_provider reflects new value 'openai'");
 
 	// Test 2: Set provider to Anthropic
 	ok(set_nl2sql_variable("provider", "anthropic"),
 	   "Set model_provider to anthropic");
 	current = get_nl2sql_variable("provider");
-	ok(current == "anthropic" || current.empty(),
+	ok(current == "anthropic",
 	   "Variable genai-llm_provider reflects new value 'anthropic'");
 
 	// Test 3: Set provider to Ollama
 	ok(set_nl2sql_variable("provider", "ollama"),
 	   "Set model_provider to ollama");
 	current = get_nl2sql_variable("provider");
-	ok(current == "ollama" || current.empty(),
+	ok(current == "ollama",
 	   "Variable genai-llm_provider reflects new value 'ollama'");
 
 	// Test 4: Set Ollama model variant
 	ok(set_nl2sql_variable("provider_model", "llama3.3"),
 	   "Set ollama_model to llama3.3");
+	ok(get_nl2sql_variable("provider_model") == "llama3.3",
+	   "Variable genai-llm_provider_model reflects new value 'llama3.3'");
 
 	// Test 5: Set timeout
 	ok(set_nl2sql_variable("timeout_ms", "60000"),
 	   "Set timeout_ms to 60000");
+	ok(get_nl2sql_variable("timeout_ms") == "60000",
+	   "Variable genai-llm_timeout_ms reflects new value '60000'");
 
-	// Restore original
-	if (!orig_provider.empty()) {
+	// Restore every variable changed by this test so later shard members see
+	// the same configuration this test inherited.
+	// Keep these as independent statements: cleanup must still attempt model
+	// and timeout if an earlier provider restore fails.
+	const bool provider_restored = !orig_provider.empty() &&
 		set_nl2sql_variable("provider", orig_provider.c_str());
-	}
+	const bool model_restored = !orig_model.empty() &&
+		set_nl2sql_variable("provider_model", orig_model.c_str());
+	const bool timeout_restored = !orig_timeout.empty() &&
+		set_nl2sql_variable("timeout_ms", orig_timeout.c_str());
+	const bool restored = provider_restored && model_restored && timeout_restored;
+	ok(restored,
+	   "Restore original provider, model, and timeout after integration checks");
+	ok(get_nl2sql_variable("provider") == orig_provider &&
+	   get_nl2sql_variable("provider_model") == orig_model &&
+	   get_nl2sql_variable("timeout_ms") == orig_timeout,
+	   "Restored NL2SQL variables match the inherited values");
 }
 
 // ============================================================================
@@ -372,8 +389,8 @@ int main(int argc, char** argv) {
 		return exit_status();
 	}
 
-	// Plan tests: 4 categories with 5 tests each + 1 category with 8 tests = 28 tests
-	plan(28);
+	// Plan tests: 4 categories with 5 tests each + 1 category with 12 tests = 32 tests
+	plan(32);
 
 	// Run test categories
 	test_latency_based_selection();

--- a/test/tap/tests/nl2sql_unit_base-t.cpp
+++ b/test/tap/tests/nl2sql_unit_base-t.cpp
@@ -1,331 +1,162 @@
 /**
  * @file nl2sql_unit_base-t.cpp
- * @brief TAP unit tests for NL2SQL converter basic functionality
- *
- * Test Categories:
- * 1. Initialization and Configuration
- * 2. Basic NL2SQL Conversion (mocked)
- * 3. Error Handling
- * 4. Variable Persistence
- *
- * Prerequisites:
- * - ProxySQL with AI features enabled
- * - Admin interface on localhost:6032
- * - Mock LLM responses (no live LLM required)
- *
- * Usage:
- *   make nl2sql_unit_base
- *   ./nl2sql_unit_base
- *
- * @date 2025-01-16
+ * @brief Verify NL2SQL configuration through canonical GenAI variables.
  */
 
-#include <algorithm>
+#include <cstdlib>
 #include <string>
-#include <string.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <vector>
 
 #include "mysql.h"
-#include "mysqld_error.h"
 
-#include "tap.h"
 #include "command_line.h"
-#include "utils.h"
+#include "tap.h"
 
 using std::string;
-using std::vector;
 
-// Global admin connection
-MYSQL* g_admin = NULL;
+namespace {
 
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * @brief Get NL2SQL variable value via Admin interface
- * @param name Variable name (without genai-llm_ prefix)
- * @return Variable value or empty string on error
- */
-string get_nl2sql_variable(const char* name) {
-	char query[256];
-	snprintf(query, sizeof(query),
-			 "SELECT variable_value FROM runtime_global_variables WHERE variable_name='genai-llm_%s'",
-			 name);
-
-	diag("Admin: %s", query);
-	if (mysql_query(g_admin, query)) {
-		diag("Failed to query variable: %s", mysql_error(g_admin));
-		return "";
-	}
-
-	MYSQL_RES* result = mysql_store_result(g_admin);
-	if (!result) {
-		return "";
-	}
-
-	MYSQL_ROW row = mysql_fetch_row(result);
-	string value = row ? (row[0] ? row[0] : "") : "";
-	diag("Read value: '%s'", value.c_str());
-
-	mysql_free_result(result);
-	return value;
-}
-
-/**
- * @brief Set NL2SQL variable and verify
- * @param name Variable name (without genai-llm_ prefix)
- * @param value New value
- * @return true if set successful, false otherwise
- */
-bool set_nl2sql_variable(const char* name, const char* value) {
-	char query[256];
-	snprintf(query, sizeof(query),
-			 "UPDATE global_variables SET variable_value='%s' WHERE variable_name='genai-llm_%s'",
-			 value, name);
-
-	diag("Admin: %s", query);
-	if (mysql_query(g_admin, query)) {
-		diag("Failed to set variable: %s", mysql_error(g_admin));
+bool execute_admin(MYSQL* admin, const string& sql) {
+	if (mysql_query(admin, sql.c_str()) != 0) {
+		diag("Admin command failed: %s: %s", sql.c_str(), mysql_error(admin));
 		return false;
 	}
-
-	// Load to runtime
-	const char* load_query = "LOAD GENAI VARIABLES TO RUNTIME";
-	diag("Admin: %s", load_query);
-	if (mysql_query(g_admin, load_query)) {
-		load_query = "LOAD MYSQL VARIABLES TO RUNTIME";
-		diag("Admin: %s", load_query);
-		if (mysql_query(g_admin, load_query)) {
-			diag("Failed to load variables: %s", mysql_error(g_admin));
-			return false;
-		}
-	}
-
+	MYSQL_RES* result = mysql_store_result(admin);
+	if (result != nullptr) mysql_free_result(result);
 	return true;
 }
 
-/**
- * @brief Execute NL2SQL query via a test connection
- * @param nl2sql_query Natural language query with NL2SQL: prefix
- * @return First row's first column value or empty string
- */
-string execute_nl2sql_query(const char* nl2sql_query) {
-	// For now, return a mock response
-	// In Phase 2, this will use a real MySQL connection
-	// that goes through MySQL_Session's NL2SQL handler
-	return "";
+string quote_value(MYSQL* admin, const string& value) {
+	string escaped(value.size() * 2 + 1, '\0');
+	const unsigned long length = mysql_real_escape_string(
+		admin, escaped.data(), value.c_str(), static_cast<unsigned long>(value.size()));
+	escaped.resize(length);
+	return "'" + escaped + "'";
 }
 
-// ============================================================================
-// Test: Initialization
-// ============================================================================
-
-/**
- * @test NL2SQL module initialization
- * @description Verify that NL2SQL module initializes correctly
- * @expected AI module should be accessible, variables should have defaults
- */
-void test_nl2sql_initialization() {
-	diag("=== NL2SQL Initialization Tests ===");
-
-	// Test 1: Check AI module exists
-	ok(true, "AI_Features_Manager global instance exists (placeholder)");
-
-	// Test 2: Check NL2SQL is enabled by default
-	string enabled = get_nl2sql_variable("enabled");
-	ok(enabled == "true" || enabled == "1" || enabled == "false" || enabled == "0" || enabled.empty(),
-	   "genai-llm_enabled has a valid boolean value: '%s'", enabled.c_str());
-
-	// Test 3: Check default model provider
-	string provider = get_nl2sql_variable("provider");
-	ok(provider == "ollama" || provider == "openai" || provider.empty(),
-	   "genai-llm_provider has a valid default: '%s'", provider.c_str());
-
-	// Test 4: Check default cache similarity threshold
-	string threshold = get_nl2sql_variable("cache_similarity_threshold");
-	ok(!threshold.empty(),
-	   "genai-llm_cache_similarity_threshold is configured: '%s'", threshold.c_str());
-
-	// Test 5: Check timeout
-	string timeout = get_nl2sql_variable("timeout_ms");
-	ok(!timeout.empty(),
-	   "genai-llm_timeout_ms is configured: '%s'", timeout.c_str());
-}
-
-// ============================================================================
-// Test: Configuration
-// ============================================================================
-
-/**
- * @test NL2SQL configuration management
- * @description Test setting and retrieving NL2SQL configuration variables
- * @expected Variables should be settable and persist across runtime changes
- */
-void test_nl2sql_configuration() {
-	diag("=== NL2SQL Configuration Tests ===");
-
-	// Save original values
-	string orig_model = get_nl2sql_variable("provider_model");
-	string orig_provider = get_nl2sql_variable("provider");
-
-	// Test 1: Set Ollama model
-	ok(set_nl2sql_variable("provider_model", "test-llama-model"),
-	   "Set genai-llm_provider_model to 'test-llama-model'");
-
-	// Test 2: Verify change
-	string current = get_nl2sql_variable("provider_model");
-	ok(current == "test-llama-model",
-	   "Variable genai-llm_provider_model reflects new value '%s'", current.c_str());
-
-	// Test 3: Set model provider to openai
-	ok(set_nl2sql_variable("provider", "openai"),
-	   "Set genai-llm_provider to 'openai'");
-
-	// Test 4: Verify provider change
-	current = get_nl2sql_variable("provider");
-	ok(current == "openai",
-	   "Provider changed to '%s'", current.c_str());
-
-	// Test 5: Restore original values
-	if (!orig_model.empty()) {
-		set_nl2sql_variable("provider_model", orig_model.c_str());
+bool read_variable(MYSQL* admin, const string& canonical_name, string& value) {
+	value.clear();
+	const string sql =
+		"SELECT variable_value FROM global_variables WHERE variable_name=" +
+		quote_value(admin, canonical_name);
+	if (mysql_query(admin, sql.c_str()) != 0) {
+		diag("Failed to read %s: %s", canonical_name.c_str(), mysql_error(admin));
+		return false;
 	}
-	if (!orig_provider.empty()) {
-		set_nl2sql_variable("provider", orig_provider.c_str());
-	}
-	ok(true, "Restored original configuration values");
+	MYSQL_RES* result = mysql_store_result(admin);
+	if (result == nullptr) return false;
+	MYSQL_ROW row = mysql_fetch_row(result);
+	const bool found = row != nullptr && row[0] != nullptr;
+	if (found) value = row[0];
+	mysql_free_result(result);
+	return found;
 }
 
-// ============================================================================
-// Test: Variable Persistence
-// ============================================================================
-
-/**
- * @test NL2SQL variable persistence
- * @description Verify LOAD/SAVE commands for NL2SQL variables
- * @expected Variables should persist across admin interfaces
- */
-void test_variable_persistence() {
-	diag("=== NL2SQL Variable Persistence Tests ===");
-
-	// Save original value
-	string orig_timeout = get_nl2sql_variable("timeout_ms");
-
-	// Test 1: Set variable
-	ok(set_nl2sql_variable("timeout_ms", "60000"),
-	   "Set genai-llm_timeout_ms to 60000");
-
-	// Test 2: Verify change in memory
-	string current = get_nl2sql_variable("timeout_ms");
-	ok(current == "60000",
-	   "Variable changed in runtime: '%s'", current.c_str());
-
-	// Test 3: LOAD from disk
-	diag("Admin: LOAD GENAI VARIABLES FROM DISK");
-	int rc = mysql_query(g_admin, "LOAD GENAI VARIABLES FROM DISK");
-	if (rc != 0) {
-		diag("Admin: LOAD MYSQL VARIABLES FROM DISK (fallback)");
-		rc = mysql_query(g_admin, "LOAD MYSQL VARIABLES FROM DISK");
-	}
-	ok(rc == 0, "LOAD GENAI VARIABLES FROM DISK succeeds");
-
-	// Restore original
-	if (!orig_timeout.empty()) {
-		set_nl2sql_variable("timeout_ms", orig_timeout.c_str());
-	}
+bool set_variable(MYSQL* admin, const string& canonical_name, const string& value) {
+	return execute_admin(
+		admin, "SET " + canonical_name + "=" + quote_value(admin, value));
 }
 
-// ============================================================================
-// Test: Error Handling
-// ============================================================================
-
-/**
- * @test NL2SQL error handling
- * @description Verify proper error handling for invalid inputs
- * @expected Should return appropriate error messages
- */
-void test_error_handling() {
-	diag("=== NL2SQL Error Handling Tests ===");
-
-	// Test 1: Empty variable name handling
-	diag("Testing empty variable name");
-	string result = get_nl2sql_variable("");
-	ok(result.empty(), "Empty variable name returns empty string");
-
-	// Test 2: Non-existent variable
-	diag("Testing non-existent variable: nonexistent_variable_xyz");
-	result = get_nl2sql_variable("nonexistent_variable_xyz");
-	ok(result.empty(), "Non-existent variable returns empty string");
-
-	// Test 3: Set variable with empty value
-	diag("Testing setting variable 'provider' to empty value");
-	ok(set_nl2sql_variable("provider", ""),
-	   "Setting variable to empty value succeeds");
-
-	// Test 4: Set variable with special characters
-	diag("Testing setting variable 'provider_model' with special characters");
-	ok(set_nl2sql_variable("provider_model", "test-value-with-dashes"),
-	   "Setting variable with special characters succeeds");
-
-	// Test 5: Set variable with very long value
-	diag("Testing long variable value handling (500 chars)");
-	string long_value(500, 'a');
-	char query[1024];
-	snprintf(query, sizeof(query),
-			 "UPDATE global_variables SET variable_value='%s' WHERE variable_name='genai-llm_provider_model'",
-			 long_value.c_str());
-	diag("Admin: %s", query);
-	int rc = mysql_query(g_admin, query);
-	ok(rc == 0, "Long variable value accepted in global_variables");
+void expect_variable(MYSQL* admin, const string& canonical_name, const string& expected) {
+	string value;
+	const bool found = read_variable(admin, canonical_name, value);
+	ok(found && value == expected,
+	   "%s is '%s' (got '%s')",
+	   canonical_name.c_str(), expected.c_str(), value.c_str());
 }
 
-// ============================================================================
-// Main
-// ============================================================================
+bool restore_variables(
+	MYSQL* admin,
+	const string& provider,
+	const string& model,
+	const string& timeout
+) {
+	return set_variable(admin, "genai-llm_provider", provider) &&
+		set_variable(admin, "genai-llm_provider_model", model) &&
+		set_variable(admin, "genai-llm_timeout_ms", timeout) &&
+		execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME") &&
+		execute_admin(admin, "SAVE GENAI VARIABLES TO DISK");
+}
 
-int main(int argc, char** argv) {
-	// Parse command line
+} // namespace
+
+int main() {
 	CommandLine cl;
 	if (cl.getEnv()) {
-		diag("Error getting environment variables");
-		return exit_status();
+		diag("Failed to read TAP environment");
+		return EXIT_FAILURE;
 	}
 
-	diag("Starting nl2sql_unit_base-t");
-	diag("This test verifies the basic configuration and lifecycle of the NL2SQL module.");
-	diag("It checks:");
-	diag("  - Module initialization and default variable values.");
-	diag("  - Configuration management (setting and getting variables via Admin).");
-	diag("  - Variable persistence across runtime and disk (LOAD/SAVE).");
-	diag("  - Error handling for invalid variable operations.");
-	diag("Note: This test interacts with global_variables prefixed with 'genai-llm_'.");
-
-	// Connect to admin interface
-	g_admin = mysql_init(NULL);
-	if (!g_admin) {
-		diag("Failed to initialize MySQL connection");
-		return exit_status();
+	MYSQL* admin = mysql_init(nullptr);
+	if (admin == nullptr ||
+	    mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+	                       nullptr, cl.admin_port, nullptr, 0) == nullptr) {
+		diag("Failed to connect to ProxySQL admin: %s", admin ? mysql_error(admin) : "mysql_init failed");
+		if (admin != nullptr) mysql_close(admin);
+		return EXIT_FAILURE;
 	}
 
-	if (!mysql_real_connect(g_admin, cl.host, cl.admin_username, cl.admin_password,
-							NULL, cl.admin_port, NULL, 0)) {
-		diag("Failed to connect to admin interface: %s", mysql_error(g_admin));
-		mysql_close(g_admin);
-		return exit_status();
+	plan(23);
+
+	string original_provider;
+	string original_model;
+	string original_timeout;
+	const bool originals_found =
+		read_variable(admin, "genai-llm_provider", original_provider) &&
+		read_variable(admin, "genai-llm_provider_model", original_model) &&
+		read_variable(admin, "genai-llm_timeout_ms", original_timeout);
+	if (!originals_found) {
+		diag("Canonical NL2SQL variables are missing");
+		original_provider = "openai";
+		original_model = "llama3.2";
+		original_timeout = "30000";
 	}
 
-	// Plan tests: 4 categories with total 18 tests
-	plan(18);
+	expect_variable(admin, "genai-llm_enabled", "false");
+	expect_variable(admin, "genai-llm_provider", "openai");
+	expect_variable(admin, "genai-llm_provider_model", "llama3.2");
+	expect_variable(admin, "genai-llm_cache_similarity_threshold", "85");
+	expect_variable(admin, "genai-llm_timeout_ms", "30000");
 
-	// Run test categories
-	test_nl2sql_initialization();
-	test_nl2sql_configuration();
-	test_variable_persistence();
-	test_error_handling();
+	ok(set_variable(admin, "genai-llm_provider_model", "tap-nl2sql-model"),
+	   "set full canonical provider-model name");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME"),
+	   "load provider model to runtime");
+	ok(set_variable(admin, "genai-llm_provider_model", "memory-decoy"),
+	   "change provider model only in memory");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES FROM RUNTIME"),
+	   "save provider model from runtime");
+	expect_variable(admin, "genai-llm_provider_model", "tap-nl2sql-model");
 
-	mysql_close(g_admin);
+	ok(set_variable(admin, "genai-llm_provider", "anthropic"),
+	   "set full canonical provider name");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME"),
+	   "load provider to runtime");
+	ok(set_variable(admin, "genai-llm_provider", "memory-decoy"),
+	   "change provider only in memory");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES FROM RUNTIME"),
+	   "save provider from runtime");
+	expect_variable(admin, "genai-llm_provider", "anthropic");
+
+	ok(set_variable(admin, "genai-llm_timeout_ms", "60000"),
+	   "set full canonical timeout name");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME"),
+	   "load timeout to runtime");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES TO DISK"),
+	   "save NL2SQL values to disk");
+	ok(set_variable(admin, "genai-llm_timeout_ms", "31000"),
+	   "change timeout after disk save");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES FROM DISK"),
+	   "load NL2SQL values from disk");
+	expect_variable(admin, "genai-llm_timeout_ms", "60000");
+
+	string missing_value;
+	ok(!read_variable(admin, "genai-nonexistent_variable_xyz", missing_value),
+	   "nonexistent canonical GenAI variable is absent");
+
+	ok(restore_variables(
+		admin, original_provider, original_model, original_timeout),
+	   "restore original NL2SQL variables in memory, runtime, and disk");
+
+	mysql_close(admin);
 	return exit_status();
 }

--- a/test/tap/tests/rag_stats_testing/prepare_test_db.sh
+++ b/test/tap/tests/rag_stats_testing/prepare_test_db.sh
@@ -1,45 +1,126 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Seed the RAG database opened by the ProxySQL process using Python stdlib.
 
-sqlite3 $(dirname $(realpath $0))/rag.db ".load $WORKSPACE/deps/sqlite3/sqlite3/vec0" \
-	< $(dirname $(realpath $0))/schema.sql
+set -euo pipefail
 
-sqlite3 $(dirname $(realpath $0))/rag.db ".load $WORKSPACE/deps/sqlite3/sqlite3/vec0" <<EOF
-DELETE FROM rag_sources;
-DELETE FROM rag_documents;
-DELETE FROM rag_chunks;
-DELETE FROM rag_fts_chunks;
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+RAG_DB_PATH="${RAG_DB_PATH:-/var/lib/proxysql/ai_features.db}"
+MODE="${1:-seed}"
 
--- First, insert a test source (required by foreign keys)
-INSERT INTO rag_sources (
-	source_id, name, enabled,
-	backend_type, backend_host, backend_port, backend_user, backend_pass, backend_db,
-	table_name, pk_column,
-	doc_map_json, chunking_json
-) VALUES (
-	1, 'test_source', 1,
-	'mysql', '127.0.0.1', 3306, 'root', 'root', 'test_db',
-	'test_table', 'id',
-	'{"doc_id":{"format":"test:{id}"}}',
-	'{"enabled":false,"unit":"chars","chunk_size":4000,"overlap":400,"min_chunk_size":800}'
-);
+if [[ "${MODE}" != "seed" && "${MODE}" != "cleanup" ]]; then
+    echo "usage: $0 [seed|cleanup]" >&2
+    exit 2
+fi
 
--- Insert a test document (requires source_id, source_name, pk_json)
-INSERT INTO rag_documents (doc_id, source_id, source_name, pk_json, title, metadata_json)
-VALUES ('test:doc1', 1, 'test_source', '{"id":1}', 'Test Document About MySQL', '{"Tags": "<mysql><test>"}');
+python3 - "${RAG_DB_PATH}" "${SCRIPT_DIR}/schema.sql" "${MODE}" <<'PY'
+import re
+import sqlite3
+import sys
+from pathlib import Path
 
--- Insert a test chunk (requires source_id)
-INSERT INTO rag_chunks (chunk_id, doc_id, source_id, chunk_index, body, title)
-VALUES ('test:doc1#0', 'test:doc1', 1, 0, 'This is a test chunk about MySQL databases and full-text search capabilities.', 'Test Document About MySQL');
 
--- Insert FTS entry
-INSERT INTO rag_fts_chunks (chunk_id, title, body)
-VALUES ('test:doc1#0', 'Test Document About MySQL', 'This is a test chunk about MySQL databases and full-text search capabilities.');
+db_path = Path(sys.argv[1])
+schema_path = Path(sys.argv[2])
+mode = sys.argv[3]
+db_path.parent.mkdir(parents=True, exist_ok=True)
 
--- Verify the data
-SELECT 'Documents:' AS table_name, COUNT(*) AS count FROM rag_documents
-UNION ALL
-SELECT 'Chunks:', COUNT(*) FROM rag_chunks
-UNION ALL
-SELECT 'FTS entries:', COUNT(*) FROM rag_fts_chunks;
-EOF
+# Python's stdlib SQLite has FTS5 but does not load ProxySQL's statically linked
+# sqlite-vec module.  ProxySQL creates rag_vec_chunks itself; this fixture only
+# needs the relational and FTS portions of the schema.
+schema = schema_path.read_text(encoding="utf-8")
+schema = re.sub(
+    r"CREATE VIRTUAL TABLE IF NOT EXISTS rag_vec_chunks\s+USING vec0\(.*?\);",
+    "",
+    schema,
+    flags=re.DOTALL,
+)
 
+source_id = 909901
+doc_id = "tap:rag:doc1"
+chunk_id = "tap:rag:doc1#0"
+
+with sqlite3.connect(db_path, timeout=30) as connection:
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.executescript(schema)
+    connection.execute("DELETE FROM rag_fts_chunks WHERE chunk_id = ?", (chunk_id,))
+    connection.execute("DELETE FROM rag_chunks WHERE chunk_id = ?", (chunk_id,))
+    connection.execute("DELETE FROM rag_documents WHERE doc_id = ?", (doc_id,))
+    connection.execute("DELETE FROM rag_sources WHERE source_id = ?", (source_id,))
+
+    if mode == "seed":
+        connection.execute(
+            """
+            INSERT INTO rag_sources (
+                source_id, name, enabled,
+                backend_type, backend_host, backend_port, backend_user,
+                backend_pass, backend_db, table_name, pk_column,
+                doc_map_json, chunking_json
+            ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                source_id,
+                "tap_rag_source",
+                "mysql",
+                "mysql",
+                3306,
+                "root",
+                "",
+                "test",
+                "tap_rag_documents",
+                "id",
+                '{"doc_id":{"format":"tap:rag:{id}"}}',
+                '{"enabled":false,"unit":"chars","chunk_size":4000,"overlap":400,"min_chunk_size":800}',
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO rag_documents
+                (doc_id, source_id, source_name, pk_json, title, metadata_json)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                doc_id,
+                source_id,
+                "tap_rag_source",
+                '{"id":1}',
+                "TAP Document About MySQL",
+                '{"tags":["mysql","tap"]}',
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO rag_chunks
+                (chunk_id, doc_id, source_id, chunk_index, body, title)
+            VALUES (?, ?, ?, 0, ?, ?)
+            """,
+            (
+                chunk_id,
+                doc_id,
+                source_id,
+                "A deterministic TAP chunk about MySQL databases and full-text search.",
+                "TAP Document About MySQL",
+            ),
+        )
+        connection.execute(
+            "INSERT INTO rag_fts_chunks (chunk_id, title, body) VALUES (?, ?, ?)",
+            (
+                chunk_id,
+                "TAP Document About MySQL",
+                "A deterministic TAP chunk about MySQL databases and full-text search.",
+            ),
+        )
+
+    counts = connection.execute(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM rag_documents WHERE doc_id = ?),
+          (SELECT COUNT(*) FROM rag_chunks WHERE chunk_id = ?),
+          (SELECT COUNT(*) FROM rag_fts_chunks WHERE chunk_id = ?)
+        """,
+        (doc_id, chunk_id, chunk_id),
+    ).fetchone()
+
+print(f"Documents: {counts[0]}")
+print(f"Chunks: {counts[1]}")
+print(f"FTS entries: {counts[2]}")
+PY

--- a/test/tap/tests/rag_stats_testing/test_rag_search_log.sh
+++ b/test/tap/tests/rag_stats_testing/test_rag_search_log.sh
@@ -1,312 +1,115 @@
-#!/bin/bash
-#
-# test_rag_search_log.sh - Test RAG Search Logging
-#
-# Tests that rag.search_fts operations are properly logged to rag_search_log table
-#
+#!/usr/bin/env bash
+# Verify RAG search logging with run-unique rows and no global table reset.
 
-set -eo pipefail
+set -uo pipefail
 
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../mcp_rules_testing/mcp_test_helpers.sh"
 
-# Source the helper functions
-if [ -f "${SCRIPT_DIR}/../mcp_rules_testing/mcp_test_helpers.sh" ]; then
-    source "${SCRIPT_DIR}/../mcp_rules_testing/mcp_test_helpers.sh"
-else
-    echo "ERROR: mcp_test_helpers.sh not found at ${SCRIPT_DIR}"
+TOTAL=0
+FAILED=0
+MARKER="tap_rag_${INFRA_ID:-local}_$$_$(date +%s)"
+RAG_CATALOG_PATH="${RAG_CATALOG_PATH:-/var/lib/proxysql/mcp_catalog.db}"
+
+assertion() {
+    TOTAL=$((TOTAL + 1))
+    if "$@"; then
+        echo "ok ${TOTAL} - ${DESCRIPTION}"
+    else
+        echo "not ok ${TOTAL} - ${DESCRIPTION}"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+call_search() {
+    local query="$1"
+    local k="$2"
+    local filters="$3"
+    local id="$4"
+    local request
+    request="$(jq -cn \
+        --arg query "${query}" --argjson k "${k}" --argjson filters "${filters}" --argjson id "${id}" \
+        '{jsonrpc:"2.0",id:$id,method:"tools/call",
+          params:{name:"rag.search_fts",arguments:{query:$query,k:$k,filters:$filters}}}')"
+    mcp_request rag "${request}"
+}
+
+response_succeeded() {
+    jq -e '((has("error") | not) and (.result.isError != true))' >/dev/null <<< "$1"
+}
+
+catalog_query() {
+    local sql="$1"
+    shift
+    python3 - "${RAG_CATALOG_PATH}" "${sql}" "$@" <<'PY'
+import sqlite3
+import sys
+
+path, sql, *parameters = sys.argv[1:]
+with sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5) as database:
+    for row in database.execute(sql, parameters):
+        print("\t".join("" if value is None else str(value) for value in row))
+PY
+}
+
+log_entry() {
+    catalog_query \
+        "SELECT log_id, query, k, COALESCE(NULLIF(filters, ''), '{}'), searched_at FROM rag_search_log WHERE query=? ORDER BY log_id DESC LIMIT 1" \
+        "$1"
+}
+
+log_count_like() {
+    catalog_query "SELECT COUNT(*) FROM rag_search_log WHERE query LIKE ?" "$1%"
+}
+
+if ! require_mcp_prerequisites || ! check_proxysql_admin || ! check_mcp_server; then
+    echo "RAG log prerequisites are unavailable" >&2
+    exit 1
+fi
+if [[ ! -r "${RAG_CATALOG_PATH}" ]]; then
+    echo "RAG catalog is unavailable at ${RAG_CATALOG_PATH}" >&2
     exit 1
 fi
 
-# Statistics
-TOTAL_TESTS=0
-PASSED_TESTS=0
-FAILED_TESTS=0
+basic_query="${MARKER}_basic"
+basic_response="$(call_search "${basic_query}" 5 '{}' 1)"
+DESCRIPTION="logged RAG search returns a successful MCP result"
+assertion response_succeeded "${basic_response}"
 
-# Run test function
-run_test() {
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    log_test "$1"
-    shift
-    if "$@"; then
-        log_info "✓ Test $TOTAL_TESTS passed"
-        PASSED_TESTS=$((PASSED_TESTS + 1))
-        return 0
-    else
-        log_error "✗ Test $TOTAL_TESTS failed"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
-        return 1
-    fi
-}
+basic_entry="$(log_entry "${basic_query}")"
+IFS=$'\t' read -r basic_id logged_query logged_k logged_filters logged_at <<< "${basic_entry}"
+DESCRIPTION="search log stores the run-unique query"
+assertion test "${logged_query:-}" = "${basic_query}"
 
-# Get search log entries for a specific query
-get_search_log() {
-    local query_pattern="$1"
-    local sql="SELECT log_id, query, k, filters, searched_at FROM rag_search_log WHERE query = '${query_pattern}' ORDER BY log_id DESC LIMIT 1;"
-    log_verbose "Admin query: ${sql}" >&2
-    local result=$(exec_admin_silent "${sql}")
-    if [ -n "$result" ]; then
-        # Convert tabs to pipes for consistent parsing
-        echo "$result" | tr '\t' '|'
-    fi
-}
+DESCRIPTION="search log stores the requested k value"
+assertion test "${logged_k:-}" = "5"
 
-# Count total search log entries
-count_search_log() {
-    local sql="SELECT COUNT(*) FROM rag_search_log;"
-    log_verbose "Admin query: ${sql}" >&2
-    exec_admin_silent "${sql}"
-}
+DESCRIPTION="search log stores a timestamp"
+assertion bash -c '[[ "$1" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2} ]]' bash "${logged_at:-}"
 
-main() {
-    echo "======================================"
-    echo "RAG Search Logging Tests"
-    echo "======================================"
-    echo ""
+filter_query="${MARKER}_filter"
+call_search "${filter_query}" 10 '{"source_ids":[909901]}' 2 >/dev/null
+filter_entry="$(log_entry "${filter_query}")"
+IFS=$'\t' read -r filter_id filter_text filter_k filter_json filter_at <<< "${filter_entry}"
+DESCRIPTION="search log stores structured filters"
+assertion grep -q 'source_ids' <<< "${filter_json:-}"
 
-    # Check ProxySQL admin connection
-    if ! check_proxysql_admin; then
-        log_error "Cannot connect to ProxySQL admin at ${PROXYSQL_ADMIN_HOST}:${PROXYSQL_ADMIN_PORT}"
-        exit 1
-    fi
-    log_info "Connected to ProxySQL admin"
+multi_before="$(log_count_like "${MARKER}_multi")"
+for suffix in 1 2 3; do
+    call_search "${MARKER}_multi${suffix}" 3 '{}' "$((suffix + 2))" >/dev/null
+done
+multi_after="$(log_count_like "${MARKER}_multi")"
+DESCRIPTION="three searches append three independent log rows"
+assertion test "$((multi_after - multi_before))" -eq 3
 
-    # Check MCP server connection
-    if ! check_mcp_server; then
-        log_error "MCP server not accessible at ${MCP_HOST}:${MCP_PORT}"
-        exit 1
-    fi
-    log_info "MCP server is accessible"
+call_search "${MARKER}_k20" 20 '{}' 6 >/dev/null
+call_search "${MARKER}_k50" 50 '{}' 7 >/dev/null
+k20_entry="$(log_entry "${MARKER}_k20")"
+k50_entry="$(log_entry "${MARKER}_k50")"
+IFS=$'\t' read -r _ _ k20 _ _ <<< "${k20_entry}"
+IFS=$'\t' read -r _ _ k50 _ _ <<< "${k50_entry}"
+DESCRIPTION="search log distinguishes different k values"
+assertion test "${k20:-}" = "20" -a "${k50:-}" = "50"
 
-    # Clear any existing search log entries
-    exec_admin_silent "DELETE FROM rag_search_log;" >/dev/null 2>&1
-    log_info "Cleared existing search log entries"
-
-    echo ""
-    echo "======================================"
-    echo "Test 1: Basic Search Logging"
-    echo "======================================"
-    echo ""
-
-    # Get initial count
-    log_info "Getting initial search log count..."
-    INITIAL_COUNT=$(count_search_log)
-    log_verbose "Initial count: ${INITIAL_COUNT}"
-
-    # Execute a simple FTS search
-    log_info "Executing rag.search_fts with query 'mysql'..."
-    payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.search_fts","arguments":{"query":"mysql","k":5}},"id":1}'
-    log_verbose "MCP request: ${payload}" >&2
-    response=$(mcp_request "rag" "${payload}")
-    log_verbose "Response: ${response}"
-
-    # Wait for logging
-    sleep 1
-
-    # Get final count
-    FINAL_COUNT=$(count_search_log)
-    log_verbose "Final count: ${FINAL_COUNT}"
-
-    # Verify a new entry was created
-    if [ "${FINAL_COUNT:-0}" -gt "${INITIAL_COUNT:-0}" ]; then
-        run_test "TR1.1: Search log entry created" true
-    else
-        run_test "TR1.1: Search log entry created" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 2: Query Text Logging"
-    echo "======================================"
-    echo ""
-
-    # Get the log entry for 'mysql' query
-    log_info "Retrieving search log entry for query 'mysql'..."
-    LOG_ENTRY=$(get_search_log "mysql")
-    log_verbose "Log entry: ${LOG_ENTRY}"
-
-    if [ -n "${LOG_ENTRY}" ]; then
-        # Parse the entry: log_id|query|k|filters|searched_at
-        LOGGED_QUERY=$(echo "${LOG_ENTRY}" | cut -d'|' -f2)
-        log_verbose "Logged query: ${LOGGED_QUERY}"
-
-        if [ "${LOGGED_QUERY}" = "mysql" ]; then
-            run_test "TR2.1: Query text is correctly logged" true
-        else
-            run_test "TR2.1: Query text is correctly logged (expected: mysql, got: ${LOGGED_QUERY})" false
-        fi
-    else
-        run_test "TR2.1: Query text is correctly logged" false
-        log_error "No log entry found for query 'mysql'"
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 3: K Parameter Logging"
-    echo "======================================"
-    echo ""
-
-    if [ -n "${LOG_ENTRY}" ]; then
-        LOGGED_K=$(echo "${LOG_ENTRY}" | cut -d'|' -f3)
-        log_verbose "Logged k: ${LOGGED_K}"
-
-        if [ "${LOGGED_K}" = "5" ]; then
-            run_test "TR3.1: K parameter is correctly logged" true
-        else
-            run_test "TR3.1: K parameter is correctly logged (expected: 5, got: ${LOGGED_K})" false
-        fi
-    else
-        run_test "TR3.1: K parameter is correctly logged" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 4: Filters Logging"
-    echo "======================================"
-    echo ""
-
-    # Execute a search with filters
-    log_info "Executing rag.search_fts with filters..."
-    filters_payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.search_fts","arguments":{"query":"database","k":10,"filters":{"source_ids":[1]}}},"id":2}'
-    log_verbose "MCP request: ${filters_payload}" >&2
-    filters_response=$(mcp_request "rag" "${filters_payload}")
-    log_verbose "Response: ${filters_response}"
-
-    # Wait for logging
-    sleep 1
-
-    # Get the log entry for 'database' query with filters
-    log_info "Retrieving search log entry for query 'database'..."
-    FILTERS_LOG_ENTRY=$(get_search_log "database")
-    log_verbose "Log entry: ${FILTERS_LOG_ENTRY}"
-
-    if [ -n "${FILTERS_LOG_ENTRY}" ]; then
-        LOGGED_FILTERS=$(echo "${FILTERS_LOG_ENTRY}" | cut -d'|' -f4)
-        log_verbose "Logged filters: ${LOGGED_FILTERS}"
-
-        # Check that filters JSON is present (should contain source_ids)
-        if echo "${LOGGED_FILTERS}" | grep -q "source_ids"; then
-            run_test "TR4.1: Filters are correctly logged" true
-        else
-            run_test "TR4.1: Filters are correctly logged (filters: ${LOGGED_FILTERS})" false
-        fi
-    else
-        run_test "TR4.1: Filters are correctly logged" false
-        log_error "No log entry found for query 'database'"
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 5: Timestamp Logging"
-    echo "======================================"
-    echo ""
-
-    if [ -n "${LOG_ENTRY}" ]; then
-        LOGGED_TIMESTAMP=$(echo "${LOG_ENTRY}" | cut -d'|' -f5)
-        log_verbose "Logged timestamp: ${LOGGED_TIMESTAMP}"
-
-        # Check that timestamp is not empty and looks like ISO format
-        if [ -n "${LOGGED_TIMESTAMP}" ] && echo "${LOGGED_TIMESTAMP}" | grep -qE "^[0-9]{4}-[0-9]{2}-[0-9]{2}"; then
-            run_test "TR5.1: Timestamp is correctly logged" true
-        else
-            run_test "TR5.1: Timestamp is correctly logged (timestamp: ${LOGGED_TIMESTAMP})" false
-        fi
-    else
-        run_test "TR5.1: Timestamp is correctly logged" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 6: Multiple Search Logging"
-    echo "======================================"
-    echo ""
-
-    # Get count before multiple searches
-    COUNT_BEFORE=$(count_search_log)
-    log_verbose "Count before: ${COUNT_BEFORE}"
-
-    # Execute multiple searches
-    log_info "Executing 3 different searches..."
-    for search_term in "proxy" "sql" "cache"; do
-        search_payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.search_fts","arguments":{"query":"'"${search_term}"'","k":3}},"id":3}'
-        log_verbose "MCP request: ${search_payload}" >&2
-        mcp_request "rag" "${search_payload}" >/dev/null
-        log_verbose "Search for '${search_term}' complete"
-    done
-    sleep 1
-
-    # Get count after
-    COUNT_AFTER=$(count_search_log)
-    log_verbose "Count after: ${COUNT_AFTER}"
-
-    # Verify 3 new entries were created
-    NEW_ENTRIES=$((COUNT_AFTER - COUNT_BEFORE))
-    if [ "${NEW_ENTRIES}" -eq 3 ]; then
-        run_test "TR6.1: Multiple searches are all logged (count: ${NEW_ENTRIES})" true
-    else
-        run_test "TR6.1: Multiple searches are all logged (expected: 3, got: ${NEW_ENTRIES})" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 7: K Parameter Variation"
-    echo "======================================"
-    echo ""
-
-    # Execute searches with different k values
-    log_info "Executing searches with different k values..."
-
-    # Search with k=20
-    k20_payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.search_fts","arguments":{"query":"performance","k":20}},"id":4}'
-    log_verbose "MCP request (k=20): ${k20_payload}" >&2
-    mcp_request "rag" "${k20_payload}" >/dev/null
-
-    # Search with k=50
-    k50_payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.search_fts","arguments":{"query":"optimization","k":50}},"id":5}'
-    log_verbose "MCP request (k=50): ${k50_payload}" >&2
-    mcp_request "rag" "${k50_payload}" >/dev/null
-
-    sleep 1
-
-    # Verify k values are logged correctly
-    K20_LOG=$(get_search_log "performance")
-    K50_LOG=$(get_search_log "optimization")
-
-    K20_VALUE=$(echo "${K20_LOG}" | cut -d'|' -f3)
-    K50_VALUE=$(echo "${K50_LOG}" | cut -d'|' -f3)
-
-    log_verbose "Logged k for 'performance': ${K20_VALUE}"
-    log_verbose "Logged k for 'optimization': ${K50_VALUE}"
-
-    if [ "${K20_VALUE}" = "20" ] && [ "${K50_VALUE}" = "50" ]; then
-        run_test "TR7.1: Different k values are correctly logged" true
-    else
-        run_test "TR7.1: Different k values are correctly logged (k20: ${K20_VALUE}, k50: ${K50_VALUE})" false
-    fi
-
-    # Display all search log entries
-    echo ""
-    echo "======================================"
-    echo "RAG Search Log Contents"
-    echo "======================================"
-    echo ""
-    exec_admin "SELECT log_id, query, k, filters, searched_at FROM rag_search_log ORDER BY log_id;"
-
-    # Summary
-    echo ""
-    echo "======================================"
-    echo "Test Summary"
-    echo "======================================"
-    echo "Total tests:   ${TOTAL_TESTS}"
-    echo -e "Passed:        ${GREEN}${PASSED_TESTS}${NC}"
-    echo -e "Failed:        ${RED}${FAILED_TESTS}${NC}"
-    echo ""
-
-    if [ ${FAILED_TESTS} -gt 0 ]; then
-        exit 1
-    else
-        exit 0
-    fi
-}
-
-main "$@"
+echo "${TOTAL} logging assertions, ${FAILED} failed"
+[[ ${FAILED} -eq 0 ]]

--- a/test/tap/tests/rag_stats_testing/test_rag_tool_counters.sh
+++ b/test/tap/tests/rag_stats_testing/test_rag_tool_counters.sh
@@ -1,297 +1,95 @@
-#!/bin/bash
-#
-# test_rag_tool_counters.sh - Test RAG Tool Invocation Counters
-#
-# Tests that tool usage tracking works for RAG endpoint tools
-#
+#!/usr/bin/env bash
+# Verify RAG tool counters by measuring deltas without clearing shared stats.
 
-set -eo pipefail
+set -uo pipefail
 
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../mcp_rules_testing/mcp_test_helpers.sh"
 
-# Source the helper functions
-if [ -f "${SCRIPT_DIR}/../mcp_rules_testing/mcp_test_helpers.sh" ]; then
-    source "${SCRIPT_DIR}/../mcp_rules_testing/mcp_test_helpers.sh"
-else
-    echo "ERROR: mcp_test_helpers.sh not found at ${SCRIPT_DIR}"
+TOTAL=0
+FAILED=0
+
+assertion() {
+    TOTAL=$((TOTAL + 1))
+    if "$@"; then
+        echo "ok ${TOTAL} - ${DESCRIPTION}"
+    else
+        echo "not ok ${TOTAL} - ${DESCRIPTION}"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+tool_count() {
+    exec_admin_silent \
+        "SELECT COALESCE((SELECT count FROM stats_mcp_query_tools_counters WHERE endpoint='RAG' AND tool='$1' AND schema='rag'), 0);"
+}
+
+tool_timing() {
+    exec_admin_silent \
+        "SELECT count, sum_time, min_time, max_time FROM stats_mcp_query_tools_counters WHERE endpoint='RAG' AND tool='$1' AND schema='rag';"
+}
+
+call_tool() {
+    local name="$1"
+    local arguments="$2"
+    local id="$3"
+    local request
+    request="$(jq -cn --arg name "${name}" --argjson arguments "${arguments}" --argjson id "${id}" \
+        '{jsonrpc:"2.0",id:$id,method:"tools/call",params:{name:$name,arguments:$arguments}}')"
+    mcp_request rag "${request}"
+}
+
+response_succeeded() {
+    jq -e '((has("error") | not) and (.result.isError != true))' >/dev/null <<< "$1"
+}
+
+if ! require_mcp_prerequisites || ! check_proxysql_admin || ! check_mcp_server; then
+    echo "RAG counter prerequisites are unavailable" >&2
     exit 1
 fi
 
-# Statistics
-TOTAL_TESTS=0
-PASSED_TESTS=0
-FAILED_TESTS=0
+fts_before="$(tool_count rag.search_fts)"
+fts_response="$(call_tool rag.search_fts '{"query":"mysql","k":5}' 1)"
+DESCRIPTION="rag.search_fts returns a successful MCP result"
+assertion response_succeeded "${fts_response}"
 
-# Run test function
-run_test() {
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    log_test "$1"
-    shift
-    if "$@"; then
-        log_info "✓ Test $TOTAL_TESTS passed"
-        PASSED_TESTS=$((PASSED_TESTS + 1))
-        return 0
-    else
-        log_error "✗ Test $TOTAL_TESTS failed"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
-        return 1
-    fi
-}
+fts_after="$(tool_count rag.search_fts)"
+DESCRIPTION="rag.search_fts increments its counter once"
+assertion test "$((fts_after - fts_before))" -eq 1
 
-# Get tool usage stats for a specific tool
-get_tool_stats() {
-    local endpoint="$1"
-    local tool_name="$2"
-    local schema="$3"
-    local query="SELECT count, sum_time, min_time, max_time FROM stats_mcp_query_tools_counters WHERE endpoint = '${endpoint}' AND tool = '${tool_name}' AND schema = '${schema}';"
-    log_verbose "Admin query: ${query}" >&2
-    local result=$(exec_admin_silent "${query}")
-    if [ -n "$result" ]; then
-        # Convert tabs to pipes for consistent parsing
-        echo "$result" | tr '\t' '|'
-    fi
-}
+admin_before="$(tool_count rag.admin.stats)"
+admin_response="$(call_tool rag.admin.stats '{}' 2)"
+DESCRIPTION="rag.admin.stats returns a successful MCP result"
+assertion response_succeeded "${admin_response}"
 
-main() {
-    echo "======================================"
-    echo "RAG Tool Invocation Counters Tests"
-    echo "======================================"
-    echo ""
+admin_after="$(tool_count rag.admin.stats)"
+DESCRIPTION="rag.admin.stats increments its counter once"
+assertion test "$((admin_after - admin_before))" -eq 1
 
-    # Check ProxySQL admin connection
-    if ! check_proxysql_admin; then
-        log_error "Cannot connect to ProxySQL admin at ${PROXYSQL_ADMIN_HOST}:${PROXYSQL_ADMIN_PORT}"
-        exit 1
-    fi
-    log_info "Connected to ProxySQL admin"
+multi_before="$(tool_count rag.search_fts)"
+for id in 3 4 5; do
+    call_tool rag.search_fts '{"query":"mysql","k":3}' "${id}" >/dev/null
+done
+multi_after="$(tool_count rag.search_fts)"
+DESCRIPTION="three additional searches increment the counter three times"
+assertion test "$((multi_after - multi_before))" -eq 3
 
-    # Check MCP server connection
-    if ! check_mcp_server; then
-        log_error "MCP server not accessible at ${MCP_HOST}:${MCP_PORT}"
-        exit 1
-    fi
-    log_info "MCP server is accessible"
+timing="$(tool_timing rag.search_fts)"
+IFS=$'\t' read -r count sum_time min_time max_time <<< "${timing}"
+DESCRIPTION="RAG timing counters preserve count and ordering"
+assertion test "${count:-0}" -ge 4 -a "${sum_time:-0}" -ge "${max_time:-0}" -a "${max_time:-0}" -ge "${min_time:-0}" -a "${min_time:-0}" -ge 0
 
-    # Clear any existing RAG stats
-    exec_admin_silent "DELETE FROM stats_mcp_query_tools_counters WHERE endpoint = 'RAG' AND schema = 'rag';" >/dev/null 2>&1
+identity="$(exec_admin_silent \
+    "SELECT endpoint || ':' || schema FROM stats_mcp_query_tools_counters WHERE tool='rag.search_fts' AND endpoint='RAG' AND schema='rag' LIMIT 1;")"
+DESCRIPTION="RAG counter rows retain endpoint and schema identity"
+assertion test "${identity}" = "RAG:rag"
 
-    echo ""
-    echo "======================================"
-    echo "Test 1: FTS Search Counter"
-    echo "======================================"
-    echo ""
+unknown_before="$(tool_count rag.unknown_tool)"
+unknown_response="$(call_tool rag.unknown_tool '{}' 99)"
+unknown_after="$(tool_count rag.unknown_tool)"
+DESCRIPTION="unknown RAG tools return an error and are still counted"
+assertion bash -c 'jq -e ".result.isError == true" >/dev/null <<< "$1" && [[ "$2" -eq 1 ]]' \
+    bash "${unknown_response}" "$((unknown_after - unknown_before))"
 
-    # Get initial stats
-    log_info "Getting initial stats for rag.search_fts..."
-    INITIAL_STATS=$(get_tool_stats "RAG" "rag.search_fts" "rag")
-    log_verbose "Initial stats: ${INITIAL_STATS}"
-
-    # Execute rag.search_fts
-    log_info "Executing rag.search_fts tool..."
-    payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.search_fts","arguments":{"query":"mysql","k":5}},"id":1}'
-    log_verbose "MCP request: ${payload}" >&2
-    response=$(mcp_request "rag" "${payload}")
-    log_verbose "Response: ${response}"
-
-    # Check if response was successful (counter tracking works even with empty results)
-    if echo "${response}" | grep -q '"isError":true'; then
-        log_error "FTS search returned error - counter tracking may not work if tool handler crashes"
-        response_error=1
-    else
-        log_info "FTS search executed (results may be empty if RAG DB is not populated)"
-        response_error=0
-    fi
-
-    # Get stats after execution
-    sleep 1
-    FINAL_STATS=$(get_tool_stats "RAG" "rag.search_fts" "rag")
-    log_verbose "Final stats: ${FINAL_STATS}"
-
-    # Verify counter incremented
-    if [ -z "${INITIAL_STATS}" ] && [ -n "${FINAL_STATS}" ]; then
-        run_test "TR1.1: Counter created for rag.search_fts" true
-    elif [ -n "${FINAL_STATS}" ]; then
-        run_test "TR1.1: Counter exists for rag.search_fts" true
-    else
-        run_test "TR1.1: Counter exists for rag.search_fts" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 2: Admin Stats Counter"
-    echo "======================================"
-    echo ""
-
-    # Get initial stats for admin tool
-    log_info "Getting initial stats for rag.admin.stats..."
-    INITIAL_ADMIN_STATS=$(get_tool_stats "RAG" "rag.admin.stats" "rag")
-    log_verbose "Initial stats: ${INITIAL_ADMIN_STATS}"
-
-    # Execute rag.admin.stats
-    log_info "Executing rag.admin.stats tool..."
-    admin_payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.admin.stats","arguments":{}},"id":2}'
-    log_verbose "MCP request: ${admin_payload}" >&2
-    admin_response=$(mcp_request "rag" "${admin_payload}")
-    log_verbose "Response: ${admin_response}"
-
-    # Get stats after execution
-    sleep 1
-    FINAL_ADMIN_STATS=$(get_tool_stats "RAG" "rag.admin.stats" "rag")
-    log_verbose "Final stats: ${FINAL_ADMIN_STATS}"
-
-    # Verify counter incremented
-    if [ -z "${INITIAL_ADMIN_STATS}" ] && [ -n "${FINAL_ADMIN_STATS}" ]; then
-        run_test "TR2.1: Counter created for rag.admin.stats" true
-    elif [ -n "${FINAL_ADMIN_STATS}" ]; then
-        run_test "TR2.1: Counter exists for rag.admin.stats" true
-    else
-        run_test "TR2.1: Counter exists for rag.admin.stats" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 3: Multiple Invocations"
-    echo "======================================"
-    echo ""
-
-    # Execute same tool multiple times
-    log_info "Executing rag.search_fts 3 more times..."
-    for i in 1 2 3; do
-        log_verbose "MCP request (${i}/3): ${payload}" >&2
-        mcp_request "rag" "${payload}" >/dev/null
-        log_verbose "Execution ${i}/3 complete"
-    done
-    sleep 1
-
-    # Get final stats
-    FINAL_STATS_MULTI=$(get_tool_stats "RAG" "rag.search_fts" "rag")
-    log_verbose "Final stats after multiple executions: ${FINAL_STATS_MULTI}"
-
-    # Parse count from stats (format: "count|sum_time|min_time|max_time")
-    FINAL_COUNT=$(echo "${FINAL_STATS_MULTI}" | cut -d'|' -f1)
-    log_verbose "Final count: ${FINAL_COUNT}"
-
-    # Verify count is at least 4 (1 initial + 3 more)
-    if [ "${FINAL_COUNT:-0}" -ge 4 ]; then
-        run_test "TR3.1: Counter increments correctly with multiple invocations (count=${FINAL_COUNT})" true
-    else
-        run_test "TR3.1: Counter increments correctly with multiple invocations (count=${FINAL_COUNT})" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 4: Timing Statistics"
-    echo "======================================"
-    echo ""
-
-    # Parse timing stats
-    SUM_TIME=$(echo "${FINAL_STATS_MULTI}" | cut -d'|' -f2)
-    MIN_TIME=$(echo "${FINAL_STATS_MULTI}" | cut -d'|' -f3)
-    MAX_TIME=$(echo "${FINAL_STATS_MULTI}" | cut -d'|' -f4)
-
-    log_verbose "Sum time: ${SUM_TIME} us"
-    log_verbose "Min time: ${MIN_TIME} us"
-    log_verbose "Max time: ${MAX_TIME} us"
-
-    # Verify timing stats are reasonable
-    # All should be positive integers
-    if [ "${SUM_TIME:-0}" -gt 0 ] && [ "${MIN_TIME:-0}" -gt 0 ] && [ "${MAX_TIME:-0}" -gt 0 ]; then
-        run_test "TR4.1: Timing statistics are positive values" true
-    else
-        run_test "TR4.1: Timing statistics are positive values" false
-    fi
-
-    # Max time should be >= min time
-    if [ "${MAX_TIME:-0}" -ge "${MIN_TIME:-0}" ]; then
-        run_test "TR4.2: Max time >= Min time" true
-    else
-        run_test "TR4.2: Max time >= Min time" false
-    fi
-
-    # Sum time should be >= max time
-    if [ "${SUM_TIME:-0}" -ge "${MAX_TIME:-0}" ]; then
-        run_test "TR4.3: Sum time >= Max time" true
-    else
-        run_test "TR4.3: Sum time >= Max time" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 5: Schema Column Value"
-    echo "======================================"
-    echo ""
-
-    # Verify that schema column is set to "rag" for RAG tools
-    log_verbose "Admin query: SELECT schema FROM stats_mcp_query_tools_counters WHERE endpoint = 'RAG' AND tool = 'rag.search_fts' LIMIT 1;"
-    SCHEMA_CHECK=$(exec_admin_silent "SELECT schema FROM stats_mcp_query_tools_counters WHERE endpoint = 'RAG' AND tool = 'rag.search_fts' LIMIT 1;")
-    if [ "${SCHEMA_CHECK}" = "rag" ]; then
-        run_test "TR5.1: Schema column is set to 'rag' for RAG tools" true
-    else
-        run_test "TR5.1: Schema column is set to 'rag' for RAG tools (got: ${SCHEMA_CHECK})" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 6: Endpoint Column Value"
-    echo "======================================"
-    echo ""
-
-    # Verify that endpoint column is set to "RAG"
-    log_verbose "Admin query: SELECT endpoint FROM stats_mcp_query_tools_counters WHERE tool = 'rag.search_fts' AND schema = 'rag' LIMIT 1;"
-    ENDPOINT_CHECK=$(exec_admin_silent "SELECT endpoint FROM stats_mcp_query_tools_counters WHERE tool = 'rag.search_fts' AND schema = 'rag' LIMIT 1;")
-    if [ "${ENDPOINT_CHECK}" = "RAG" ]; then
-        run_test "TR6.1: Endpoint column is set to 'RAG'" true
-    else
-        run_test "TR6.1: Endpoint column is set to 'RAG' (got: ${ENDPOINT_CHECK})" false
-    fi
-
-    echo ""
-    echo "======================================"
-    echo "Test 7: Unknown Tool Tracking"
-    echo "======================================"
-    echo ""
-
-    # Try to call an unknown tool - should still be tracked
-    log_info "Attempting to call unknown tool..."
-    unknown_payload='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.unknown_tool","arguments":{}},"id":99}'
-    log_verbose "MCP request: ${unknown_payload}" >&2
-    unknown_response=$(mcp_request "rag" "${unknown_payload}")
-    log_verbose "Response: ${unknown_response}"
-
-    sleep 1
-
-    # Verify that unknown tool was also tracked
-    UNKNOWN_STATS=$(get_tool_stats "RAG" "rag.unknown_tool" "rag")
-    if [ -n "${UNKNOWN_STATS}" ]; then
-        run_test "TR7.1: Unknown tool invocations are tracked" true
-    else
-        run_test "TR7.1: Unknown tool invocations are tracked" false
-    fi
-
-    # Display all RAG tool stats
-    echo ""
-    echo "======================================"
-    echo "RAG Tool Usage Statistics"
-    echo "======================================"
-    echo ""
-    exec_admin "SELECT endpoint, tool, schema, count, sum_time, min_time, max_time FROM stats_mcp_query_tools_counters WHERE endpoint = 'RAG' AND schema = 'rag' ORDER BY tool;"
-
-    # Summary
-    echo ""
-    echo "======================================"
-    echo "Test Summary"
-    echo "======================================"
-    echo "Total tests:   ${TOTAL_TESTS}"
-    echo -e "Passed:        ${GREEN}${PASSED_TESTS}${NC}"
-    echo -e "Failed:        ${RED}${FAILED_TESTS}${NC}"
-    echo ""
-
-    if [ ${FAILED_TESTS} -gt 0 ]; then
-        exit 1
-    else
-        exit 0
-    fi
-}
-
-main "$@"
+echo "${TOTAL} counter assertions, ${FAILED} failed"
+[[ ${FAILED} -eq 0 ]]

--- a/test/tap/tests/test_mcp_claude_headless_flow-t.sh
+++ b/test/tap/tests/test_mcp_claude_headless_flow-t.sh
@@ -1,146 +1,123 @@
 #!/usr/bin/env bash
-#
-# test_mcp_claude_headless_flow-t.sh
-#
-# TAP smoke test for ClaudeCode_Headless integration artifacts:
-# - static_harvest.sh wrapper
-# - two_phase_discovery.py orchestration script (dry-run always)
-# - optional real Claude execution (opt-in)
-#
+# TAP smoke test for the self-contained MCP headless discovery fixtures.
 
 set -euo pipefail
 
-PLAN=6
+PLAN=7
 DONE=0
 FAIL=0
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-HEADLESS_DIR="${REPO_ROOT}/scripts/mcp/DiscoveryAgent/ClaudeCode_Headless"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/mcp_rules_testing/mcp_test_helpers.sh"
+
+HEADLESS_DIR="${SCRIPT_DIR}/mcp_headless_testing"
 STATIC_HARVEST="${HEADLESS_DIR}/static_harvest.sh"
 TWO_PHASE="${HEADLESS_DIR}/two_phase_discovery.py"
-
-# Use actual target_id from local setup
-TARGET_ID="${MCP_TARGET_ID:-mysql-127.0.0.1-13306}"
-SCHEMA_NAME="${TEST_DB_NAME:-testdb}"
 MCP_CONFIG_PATH="${TAP_CLAUDE_MCP_CONFIG:-${HEADLESS_DIR}/mcp_config.example.json}"
+TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
+SCHEMA_NAME="${MYSQL_DATABASE:-test}"
 RUN_REAL_CLAUDE="${TAP_RUN_REAL_CLAUDE:-0}"
 CLAUDE_TIMEOUT_SEC="${TAP_CLAUDE_TIMEOUT:-900}"
-
+ENDPOINT="$(get_endpoint_url query)"
+export PROXYSQL_MCP_ENDPOINT="${ENDPOINT}"
 RUN_ID=""
 
-tap_ok() {
-    DONE=$((DONE + 1))
-    echo "msg: ok ${DONE} - $1"
-}
-
-tap_not_ok() {
-    DONE=$((DONE + 1))
-    FAIL=$((FAIL + 1))
-    echo "msg: not ok ${DONE} - $1"
-    if [[ $# -gt 1 ]]; then
-        echo "msg: # $2"
-    fi
-}
-
-tap_skip() {
-    DONE=$((DONE + 1))
-    echo "msg: ok ${DONE} - $1 # SKIP $2"
-}
-
-echo "msg: 1..${PLAN}"
-echo "msg: #"
+tap_plan "${PLAN}"
 echo "msg: # === MCP Claude Headless Flow Smoke Test ==="
-echo "msg: # This test validates the ClaudeCode_Headless integration artifacts:"
-echo "msg: # - static_harvest.sh wrapper for schema introspection"
-echo "msg: # - two_phase_discovery.py orchestration script (dry-run mode)"
-echo "msg: # - optional real Claude execution (opt-in via TAP_RUN_REAL_CLAUDE=1)"
-echo "msg: # The test ensures the headless discovery pipeline scripts exist and"
-echo "msg: # can be invoked with proper MCP target configuration."
-echo "msg: # ==============================================="
-echo "msg: #"
 
-# Enable MCP via Admin
-echo "msg: # Enabling MCP and registering targets via Admin interface..."
-mysql -u admin -padmin -h 127.0.0.1 -P 6032 <<EOF
-UPDATE global_variables SET variable_value='true' WHERE variable_name='mcp-enabled';
-UPDATE global_variables SET variable_value='false' WHERE variable_name='mcp-use_ssl';
-INSERT OR REPLACE INTO mcp_auth_profiles (auth_profile_id, db_username, db_password) VALUES ('default_mysql', 'root', 'root');
-INSERT OR REPLACE INTO mcp_target_profiles (target_id, protocol, hostgroup_id, auth_profile_id) VALUES ('mysql-127.0.0.1-13306', 'mysql', 0, 'default_mysql');
-EOF
-mysql -u admin -padmin -h 127.0.0.1 -P 6032 -e "LOAD MCP VARIABLES TO RUNTIME"
-mysql -u admin -padmin -h 127.0.0.1 -P 6032 -e "LOAD MCP PROFILES TO RUNTIME"
-
-# Use HTTP instead of HTTPS since we disabled SSL
-ENDPOINT="http://127.0.0.1:6071/mcp/query"
-
-if [[ -x "${STATIC_HARVEST}" && -f "${TWO_PHASE}" ]]; then
-    tap_ok "Claude headless scripts exist"
+if require_mcp_prerequisites && require_command python3; then
+    tap_ok "headless prerequisites are available"
 else
-    tap_not_ok "Claude headless scripts exist" "Missing ${STATIC_HARVEST} or ${TWO_PHASE}"
+    tap_not_ok "headless prerequisites are available"
 fi
 
-if command -v jq >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
-    tap_ok "jq and python3 available"
+if check_proxysql_admin; then
+    tap_ok "ProxySQL admin reachable at ${PROXYSQL_ADMIN_HOST}:${PROXYSQL_ADMIN_PORT}"
 else
-    tap_not_ok "jq and python3 available" "jq/python3 required"
+    tap_not_ok "ProxySQL admin reachable at ${PROXYSQL_ADMIN_HOST}:${PROXYSQL_ADMIN_PORT}"
 fi
 
-echo "msg: # Executing: ${STATIC_HARVEST} --endpoint ${ENDPOINT} --target-id ${TARGET_ID} --schema ${SCHEMA_NAME}"
-static_out="$("${STATIC_HARVEST}" --endpoint "${ENDPOINT}" --target-id "${TARGET_ID}" --schema "${SCHEMA_NAME}" --notes "tap_claude_headless_flow" 2>&1 || true)"
-RUN_ID="$(echo "${static_out}" | sed -n 's/^Run ID:[[:space:]]*\([0-9][0-9]*\)$/\1/p' | head -n1)"
+if check_mcp_server; then
+    tap_ok "authenticated MCP server reachable at ${MCP_HOST}:${MCP_PORT}"
+else
+    tap_not_ok "authenticated MCP server reachable at ${MCP_HOST}:${MCP_PORT}"
+fi
+
+if [[ -x "${STATIC_HARVEST}" && -f "${TWO_PHASE}" && -f "${MCP_CONFIG_PATH}" ]]; then
+    tap_ok "headless fixtures are staged below test/tap/tests"
+else
+    tap_not_ok "headless fixtures are staged below test/tap/tests" \
+        "Missing ${STATIC_HARVEST}, ${TWO_PHASE}, or ${MCP_CONFIG_PATH}"
+fi
+
+set +e
+static_out="$("${STATIC_HARVEST}" \
+    --endpoint "${ENDPOINT}" \
+    --target-id "${TARGET_ID}" \
+    --schema "${SCHEMA_NAME}" \
+    --notes "tap_claude_headless_flow" 2>&1)"
+static_status=$?
+set -e
+if [[ ${static_status} -eq 0 ]]; then
+    RUN_ID="$(sed -n 's/^Run ID:[[:space:]]*\([0-9][0-9]*\)$/\1/p' <<< "${static_out}" | head -n1)"
+fi
 if [[ -n "${RUN_ID}" ]]; then
-    tap_ok "static_harvest.sh returns run id: ${RUN_ID}"
+    tap_ok "static harvest returns run id ${RUN_ID}"
 else
-    tap_not_ok "static_harvest.sh returns run id" "${static_out}"
+    tap_not_ok "static harvest returns a run id" "${static_out}"
 fi
 
-echo "msg: # Executing dry-run: python3 ${TWO_PHASE} --mcp-config ${MCP_CONFIG_PATH} --target-id ${TARGET_ID} --run-id ${RUN_ID} --dry-run"
-dry_out="$(python3 "${TWO_PHASE}" --mcp-config "${MCP_CONFIG_PATH}" --target-id "${TARGET_ID}" --schema "${SCHEMA_NAME}" --run-id "${RUN_ID}" --dry-run 2>&1 || true)"
-if echo "${dry_out}" | grep -q "\[DRY RUN\]" && echo "${dry_out}" | grep -q "Target ID: ${TARGET_ID}"; then
-    tap_ok "two_phase_discovery.py dry-run includes target_id and succeeds"
+if [[ -n "${RUN_ID}" ]]; then
+    set +e
+    dry_out="$(python3 "${TWO_PHASE}" \
+        --mcp-config "${MCP_CONFIG_PATH}" \
+        --target-id "${TARGET_ID}" \
+        --schema "${SCHEMA_NAME}" \
+        --run-id "${RUN_ID}" \
+        --dry-run 2>&1)"
+    dry_status=$?
+    set -e
+    if [[ ${dry_status} -eq 0 ]] && grep -q "\[DRY RUN\]" <<< "${dry_out}" && \
+       grep -q "Target ID: ${TARGET_ID}" <<< "${dry_out}"; then
+        tap_ok "two-phase dry-run consumes the harvested target and run"
+    else
+        tap_not_ok "two-phase dry-run consumes the harvested target and run" "${dry_out}"
+    fi
 else
-    tap_not_ok "two_phase_discovery.py dry-run includes target_id and succeeds" "${dry_out}"
+    tap_skip "two-phase dry-run consumes the harvested target and run" "static harvest failed"
 fi
 
 if [[ "${RUN_REAL_CLAUDE}" != "1" ]]; then
     tap_skip "real Claude execution" "set TAP_RUN_REAL_CLAUDE=1 to enable"
+elif ! command -v claude >/dev/null 2>&1; then
+    tap_not_ok "real Claude execution" "TAP_RUN_REAL_CLAUDE=1 but claude is unavailable"
+elif [[ -z "${RUN_ID}" ]]; then
+    tap_not_ok "real Claude execution" "static harvest did not produce a run id"
 else
-    if ! command -v claude >/dev/null 2>&1; then
-        tap_skip "real Claude execution" "claude CLI not found"
+    set +e
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "${CLAUDE_TIMEOUT_SEC}" python3 "${TWO_PHASE}" \
+            --mcp-config "${MCP_CONFIG_PATH}" \
+            --target-id "${TARGET_ID}" \
+            --schema "${SCHEMA_NAME}" \
+            --run-id "${RUN_ID}" \
+            --dangerously-skip-permissions
+        real_status=$?
     else
-        set +e
-        if command -v timeout >/dev/null 2>&1; then
-            timeout "${CLAUDE_TIMEOUT_SEC}" python3 "${TWO_PHASE}" \
-                --mcp-config "${MCP_CONFIG_PATH}" \
-                --target-id "${TARGET_ID}" \
-                --schema "${SCHEMA_NAME}" \
-                --run-id "${RUN_ID}"
-            rc=$?
-        else
-            python3 "${TWO_PHASE}" \
-                --mcp-config "${MCP_CONFIG_PATH}" \
-                --target-id "${TARGET_ID}" \
-                --schema "${SCHEMA_NAME}" \
-                --run-id "${RUN_ID}"
-            rc=$?
-        fi
-        set -e
-        if [[ ${rc} -eq 0 ]]; then
-            tap_ok "real Claude execution completed"
-        else
-            tap_not_ok "real Claude execution completed" "exit_code=${rc}"
-        fi
+        python3 "${TWO_PHASE}" \
+            --mcp-config "${MCP_CONFIG_PATH}" \
+            --target-id "${TARGET_ID}" \
+            --schema "${SCHEMA_NAME}" \
+            --run-id "${RUN_ID}" \
+            --dangerously-skip-permissions
+        real_status=$?
+    fi
+    set -e
+    if [[ ${real_status} -eq 0 ]]; then
+        tap_ok "real Claude execution"
+    else
+        tap_not_ok "real Claude execution" "exit_status=${real_status}"
     fi
 fi
 
-if [[ -f "${MCP_CONFIG_PATH}" ]]; then
-    tap_ok "MCP config path exists (${MCP_CONFIG_PATH})"
-else
-    tap_skip "MCP config path exists" "${MCP_CONFIG_PATH} not present (dry-run still valid)"
-fi
-
-if [[ "${FAIL}" -ne 0 ]]; then
-    echo "msg: # FAILURES=${FAIL}/${PLAN}"
-    exit 1
-fi
-exit 0
+tap_finish

--- a/test/tap/tests/test_mcp_llm_discovery_phaseb-t.sh
+++ b/test/tap/tests/test_mcp_llm_discovery_phaseb-t.sh
@@ -23,13 +23,13 @@ if [[ ! -f "${HELPERS}" ]]; then
 fi
 source "${HELPERS}"
 
-TARGET_ID="${MCP_TARGET_ID:-mysql-127.0.0.1-13306}"
-MYSQL_SCHEMA="${MYSQL_DATABASE:-ffto_db}"
+TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
+MYSQL_SCHEMA="${MYSQL_DATABASE:-test}"
 
 RUN_ID=""
 AGENT_RUN_ID=""
 OBJECT_ID=""
-UNIQ_KEY="tap_phaseb_$(date +%s)"
+UNIQ_KEY="tap_phaseb_$(date +%s)_$$"
 
 tap_ok() {
     DONE=$((DONE + 1))
@@ -91,16 +91,13 @@ echo "msg: # No external LLM credentials required - CI-safe validation."
 echo "msg: # ========================================================"
 echo "msg: #"
 
-# Enable MCP via Admin
-echo "msg: # Enabling MCP and registering targets via Admin interface..." >&2
-exec_admin_silent "UPDATE global_variables SET variable_value='true' WHERE variable_name='mcp-enabled'; UPDATE global_variables SET variable_value='false' WHERE variable_name='mcp-use_ssl'; INSERT OR REPLACE INTO mcp_auth_profiles (auth_profile_id, db_username, db_password) VALUES ('default_mysql', 'root', 'root'); INSERT OR REPLACE INTO mcp_target_profiles (target_id, protocol, hostgroup_id, auth_profile_id) VALUES ('${TARGET_ID}', 'mysql', 0, 'default_mysql');"
-exec_admin_silent "LOAD MCP VARIABLES TO RUNTIME; LOAD MCP PROFILES TO RUNTIME;"
-
-# Override get_endpoint_url to use http since we disabled SSL
-get_endpoint_url() {
-    local endpoint="$1"
-    echo "http://${MCP_HOST}:${MCP_PORT}/mcp/${endpoint}"
-}
+if ! require_mcp_prerequisites; then
+    for _ in $(seq 1 "${PLAN}"); do
+        tap_not_ok "MCP shell prerequisites are available"
+    done
+    tap_finish
+    exit $?
+fi
 
 if check_proxysql_admin; then
     tap_ok "ProxySQL admin reachable"
@@ -260,13 +257,9 @@ if [[ -n "${RUN_ID}" && -n "${AGENT_RUN_ID}" && -n "${OBJECT_ID}" ]]; then
         tap_not_ok "agent.run_finish succeeds" "${finish_resp}"
     fi
 else
-    for i in {7..12}; do
+    for i in {7..14}; do
         tap_skip "skipping remaining tests" "previous setup failure"
     done
 fi
 
-if [[ "${FAIL}" -ne 0 ]]; then
-    echo "msg: # FAILURES=${FAIL}/${PLAN}"
-    exit 1
-fi
-exit 0
+tap_finish

--- a/test/tap/tests/test_mcp_rag_metrics-t.sh
+++ b/test/tap/tests/test_mcp_rag_metrics-t.sh
@@ -1,304 +1,76 @@
 #!/usr/bin/env bash
-#
-# test_mcp_rag_metrics-t - TAP Test for MCP RAG Metrics
-#
-# This script runs all RAG metrics and logging tests and outputs results in TAP format.
-#
+# TAP integration test for authenticated RAG requests, metrics, and logging.
 
-# change plan here, 0 means auto plan
-PLAN=0
+set -uo pipefail
+
+PLAN=6
 DONE=0
 FAIL=0
 
-trap fn_exit EXIT
-trap fn_exit SIGINT
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RAG_TESTS_DIR="${SCRIPT_DIR}/rag_stats_testing"
+source "${SCRIPT_DIR}/mcp_rules_testing/mcp_test_helpers.sh"
 
-# Get the test directory
-TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RAG_TESTS_DIR="${TEST_DIR}/rag_stats_testing"
+cleanup_rag_fixture() {
+    RAG_DB_PATH="${RAG_DB_PATH:-/var/lib/proxysql/ai_features.db}" \
+        bash "${RAG_TESTS_DIR}/prepare_test_db.sh" cleanup >/dev/null 2>&1 || true
+}
+trap cleanup_rag_fixture EXIT INT TERM
 
-# Colors (optional, for readability)
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
-fn_getenv () {
-	source .env 2>/dev/null
-	source $(basename $(dirname $0)).env 2>/dev/null
-	source $(basename $0 | sed 's/.sh//').env 2>/dev/null
+run_nested_test() {
+    local name="$1"
+    local program="$2"
+    local output
+    local status
+    output="$(bash "${program}" 2>&1)"
+    status=$?
+    while IFS= read -r line; do
+        [[ -n "${line}" ]] && echo "msg: # ${line}"
+    done <<< "${output}"
+    if [[ ${status} -eq 0 ]]; then
+        tap_ok "${name}"
+    else
+        tap_not_ok "${name}" "nested test exited ${status}"
+    fi
 }
 
-fn_plan () {
-	PLAN=${1:-$PLAN}
-	echo "msg: 1..${PLAN/#0/}"
-}
-
-fn_exit () {
-	trap - EXIT
-	trap - SIGINT
-	if [[ $DONE -eq $PLAN ]] && [[ $FAIL -eq 0 ]]; then
-		echo "msg: Test took $SECONDS sec"
-		exit 0
-	else
-		echo "msg: plan was $PLAN - done $DONE"
-		echo "msg: from $DONE done - $FAIL failed"
-		echo "msg: Test took $SECONDS sec"
-		exit 1
-	fi
-}
-
-# Execute test script and capture result
-fn_run_test () {
-	local test_name="$1"
-	local test_script="$2"
-
-	DONE=$(( $DONE + 1 ))
-	PLAN=$([[ $PLAN -lt $DONE ]] && echo $DONE || echo $PLAN)
-
-	# Run the test script
-	if bash "${test_script}"; then
-		echo "msg: ok $DONE - $test_name"
-	else
-		echo "msg: not ok $DONE - $test_name"
-		FAIL=$(( $FAIL + 1 ))
-	fi
-}
-
-# Helper function to run mysql command with proper password handling
-fn_mysql_exec () {
-	local host="$1"
-	local port="$2"
-	local user="$3"
-	local pass="$4"
-	local query="$5"
-
-	# Handle "none" as a special value meaning no password
-	if [ -z "${pass}" ] || [ "${pass}" = "none" ]; then
-		mysql -h "${host}" -P "${port}" -u "${user}" -e "${query}" 2>&1
-	else
-		mysql -h "${host}" -P "${port}" -u "${user}" -p"${pass}" -e "${query}" 2>&1
-	fi
-}
-
-# Check configuration variables
-fn_check_config () {
-	DONE=$(( $DONE + 1 ))
-	PLAN=$([[ $PLAN -lt $DONE ]] && echo $DONE || echo $PLAN)
-
-	local errors=0
-	local missing_vars=""
-	local config_details=""
-
-	# Check ProxySQL admin configuration
-	local admin_user="${TAP_ADMINUSERNAME:-radmin}"
-	local admin_pass="${TAP_ADMINPASSWORD:-radmin}"
-	local admin_host="${TAP_ADMINHOST:-127.0.0.1}"
-	local admin_port="${TAP_ADMINPORT:-6032}"
-
-	if [ -z "${admin_user}" ]; then
-		missing_vars="${missing_vars} TAP_ADMINUSERNAME"
-		errors=$((errors + 1))
-	fi
-
-	if [ -z "${admin_pass}" ]; then
-		missing_vars="${missing_vars} TAP_ADMINPASSWORD"
-		errors=$((errors + 1))
-	fi
-
-	# Check MCP server configuration
-	local mcp_host="${TAP_ADMINHOST:-127.0.0.1}"
-	local mcp_port="${TAP_MCPPORT:-6071}"
-
-	# Build configuration details for logging
-	config_details="ProxySQL Admin: ${admin_user}@${admin_host}:${admin_port} | MCP Server: ${mcp_host}:${mcp_port}"
-
-	if [ $errors -gt 0 ]; then
-		echo "msg: not ok $DONE - Configuration Check - Missing required variables:${missing_vars}"
-		echo "msg: #   Config: ${config_details}"
-		FAIL=$(( $FAIL + 1 ))
-		return 1
-	fi
-
-	echo "msg: ok $DONE - Configuration Check - All required variables are set"
-	echo "msg: #   Config: ${config_details}"
-	return 0
-}
-
-# Check if ProxySQL admin is accessible
-fn_check_proxysql_admin () {
-	DONE=$(( $DONE + 1 ))
-	PLAN=$([[ $PLAN -lt $DONE ]] && echo $DONE || echo $PLAN)
-
-	local admin_host="${TAP_ADMINHOST:-127.0.0.1}"
-	local admin_port="${TAP_ADMINPORT:-6032}"
-	local admin_user="${TAP_ADMINUSERNAME:-radmin}"
-	local admin_pass="${TAP_ADMINPASSWORD:-radmin}"
-
-	echo "msg: #   Connecting to ProxySQL Admin: ${admin_user}@${admin_host}:${admin_port}"
-
-	local output
-	output=$(fn_mysql_exec "${admin_host}" "${admin_port}" "${admin_user}" "${admin_pass}" "SELECT 1" 2>&1)
-	local result=$?
-
-	if [ $result -eq 0 ]; then
-		echo "msg: ok $DONE - ProxySQL Admin Connection - Connected successfully to ${admin_host}:${admin_port}"
-		return 0
-	else
-		echo "msg: not ok $DONE - ProxySQL Admin Connection - Failed to connect to ${admin_user}@${admin_host}:${admin_port}"
-		echo "msg: #   Error: ${output}"
-		FAIL=$(( $FAIL + 1 ))
-		return 1
-	fi
-}
-
-# Check if MCP server is accessible and RAG is enabled
-fn_check_mcp_rag () {
-	DONE=$(( $DONE + 1 ))
-	PLAN=$([[ $PLAN -lt $DONE ]] && echo $DONE || echo $PLAN)
-
-	local mcp_host="${TAP_ADMINHOST:-127.0.0.1}"
-	local mcp_port="${TAP_MCPPORT:-6071}"
-	local rag_url="https://${mcp_host}:${mcp_port}/mcp/rag"
-
-	echo "msg: #   Checking MCP RAG endpoint at ${rag_url}"
-
-	# Check if genai-rag_enabled is true
-	local admin_host="${TAP_ADMINHOST:-127.0.0.1}"
-	local admin_port="${TAP_ADMINPORT:-6032}"
-	local admin_user="${TAP_ADMINUSERNAME:-radmin}"
-	local admin_pass="${TAP_ADMINPASSWORD:-radmin}"
-
-	echo "msg: #   TODO: Checking on 'genai-rag_enabled' disabled, variable is no-op right now..."
-	# local rag_enabled
-	# rag_enabled=$(fn_mysql_exec "${admin_host}" "${admin_port}" "${admin_user}" "${admin_pass}" \
-	# 	"SELECT variable_value FROM global_variables WHERE variable_name='genai-rag_enabled';" \
-	# 	2>/dev/null | tail -n 1)
-
-	# if [ "${rag_enabled}" != "true" ]; then
-	# 	echo "msg: not ok $DONE - MCP RAG Check - RAG not enabled (genai-rag_enabled=${rag_enabled})"
-	# 	echo "msg: #   Enable RAG with: SET genai-rag_enabled=true"
-	# 	FAIL=$(( $FAIL + 1 ))
-	# 	return 1
-	# fi
-
-	echo "msg: #   RAG is enabled, checking endpoint..."
-
-	local response
-	local curl_error
-	response=$(curl -k -s -X POST "${rag_url}" \
-		-H "Content-Type: application/json" \
-		-d '{"jsonrpc":"2.0","method":"tools/list","id":1}' 2>&1)
-	curl_result=$?
-
-	if [ $curl_result -ne 0 ]; then
-		echo "msg: not ok $DONE - MCP RAG Endpoint - Failed to connect to ${rag_url}"
-		echo "msg: #   curl error: ${response}"
-		FAIL=$(( $FAIL + 1 ))
-		return 1
-	fi
-
-	if echo "${response}" | grep -q "tools"; then
-		echo "msg: ok $DONE - MCP RAG Endpoint - RAG endpoint responding at ${mcp_host}:${mcp_port}"
-		return 0
-	else
-		echo "msg: not ok $DONE - MCP RAG Endpoint - Endpoint did not respond correctly"
-		echo "msg: #   Response: ${response}"
-		FAIL=$(( $FAIL + 1 ))
-		return 1
-	fi
-}
-
-# Prepare RAG test database
-fn_prepare_rag_db () {
-	DONE=$(( $DONE + 1 ))
-	PLAN=$([[ $PLAN -lt $DONE ]] && echo $DONE || echo $PLAN)
-
-	local prepare_script="${RAG_TESTS_DIR}/prepare_test_db.sh"
-
-	echo "msg: #   Preparing RAG test database..."
-
-	# Check if prepare script exists
-	if [ ! -f "${prepare_script}" ]; then
-		echo "msg: not ok $DONE - RAG Database Preparation - prepare_test_db.sh not found at ${prepare_script}"
-		FAIL=$(( $FAIL + 1 ))
-		return 1
-	fi
-
-	# Make sure it's executable
-	chmod +x "${prepare_script}"
-
-	# Run the prepare script
-	local prep_output
-	prep_output=$(bash "${prepare_script}" 2>&1)
-	local prep_result=$?
-
-	if [ $prep_result -eq 0 ]; then
-		echo "msg: ok $DONE - RAG Database Preparation - Database ready"
-		echo "msg: #   Data inserted:"
-		echo "${prep_output}" | while IFS= read -r line; do
-			if [ -n "$line" ]; then
-				echo "msg: #     $line"
-			fi
-		done
-		return 0
-	else
-		echo "msg: not ok $DONE - RAG Database Preparation - Failed to prepare database"
-		echo "msg: #   Error: ${prep_output}"
-		FAIL=$(( $FAIL + 1 ))
-		return 1
-	fi
-}
-
-# Ensure test scripts are executable
-fn_make_executable () {
-	find "${RAG_TESTS_DIR}" -name "test_*.sh" -exec chmod +x {} \;
-}
-
-# test init
-fn_getenv
-fn_plan
-
-echo "msg: #"
+tap_plan "${PLAN}"
 echo "msg: # === MCP RAG Metrics Test Suite ==="
-echo "msg: # This test validates the MCP RAG (Retrieval-Augmented Generation) endpoint:"
-echo "msg: # - Pre-flight checks: ProxySQL admin, MCP server, RAG endpoint"
-echo "msg: # - RAG Tool Counters: validates tool invocation counters increment"
-echo "msg: # - RAG Search Logging: validates search queries are logged correctly"
-echo "msg: # The RAG endpoint provides FTS (full-text search) and vector search"
-echo "msg: # capabilities for semantic discovery of database schemas."
-echo "msg: # ==================================="
-echo "msg: #"
 
-# Ensure test scripts are executable
-fn_make_executable
+if require_mcp_prerequisites && require_command python3; then
+    tap_ok "RAG shell prerequisites are available"
+else
+    tap_not_ok "RAG shell prerequisites are available"
+fi
 
-# Pre-flight checks
-echo "msg: # Pre-flight checks..."
-echo "msg: #"
-fn_check_config
-fn_check_proxysql_admin
-fn_check_mcp_rag
+if check_proxysql_admin; then
+    tap_ok "ProxySQL admin reachable at ${PROXYSQL_ADMIN_HOST}:${PROXYSQL_ADMIN_PORT}"
+else
+    tap_not_ok "ProxySQL admin reachable at ${PROXYSQL_ADMIN_HOST}:${PROXYSQL_ADMIN_PORT}"
+fi
 
-# Prepare RAG test database
-echo "msg: #"
-echo "msg: # Preparing RAG test database..."
-echo "msg: #"
-fn_prepare_rag_db
+rag_tools="$(mcp_request rag '{"jsonrpc":"2.0","method":"tools/list","id":1}' 2>/dev/null)"
+if jq -e \
+    '[.result.tools[].name] | ((index("rag.search_fts") != null) and (index("rag.admin.stats") != null))' \
+    >/dev/null 2>&1 <<< "${rag_tools}"; then
+    tap_ok "authenticated RAG endpoint publishes its tools"
+else
+    tap_not_ok "authenticated RAG endpoint publishes its tools" "${rag_tools}"
+fi
 
-echo "msg: #"
-echo "msg: # Running RAG Metrics Tests..."
-echo "msg: #"
+prepare_output="$(RAG_DB_PATH="${RAG_DB_PATH:-/var/lib/proxysql/ai_features.db}" \
+    bash "${RAG_TESTS_DIR}/prepare_test_db.sh" seed 2>&1)"
+prepare_status=$?
+if [[ ${prepare_status} -eq 0 ]] && grep -q "Documents: 1" <<< "${prepare_output}" && \
+   grep -q "FTS entries: 1" <<< "${prepare_output}"; then
+    tap_ok "RAG database fixture is seeded through Python stdlib"
+else
+    tap_not_ok "RAG database fixture is seeded through Python stdlib" "${prepare_output}"
+fi
 
-# Test 1: RAG Tool Counters
-echo "msg: # Starting Test 1: RAG Tool Invocation Counters"
-fn_run_test "RAG Tool Counters" "${RAG_TESTS_DIR}/test_rag_tool_counters.sh"
+run_nested_test "RAG tool counters increase deterministically" \
+    "${RAG_TESTS_DIR}/test_rag_tool_counters.sh"
+run_nested_test "RAG searches are logged without clearing shared state" \
+    "${RAG_TESTS_DIR}/test_rag_search_log.sh"
 
-# Test 2: RAG Search Logging
-echo "msg: # Starting Test 2: RAG Search Logging"
-fn_run_test "RAG Search Logging" "${RAG_TESTS_DIR}/test_rag_search_log.sh"
-
-echo "msg: #"
-echo "msg: # Test suite completed"
-
-# test done
+tap_finish

--- a/test/tap/tests/test_mcp_static_harvest-t.sh
+++ b/test/tap/tests/test_mcp_static_harvest-t.sh
@@ -23,6 +23,13 @@ if [[ ! -f "${HELPERS}" ]]; then
 fi
 source "${HELPERS}"
 
+if ! require_mcp_prerequisites; then
+    tap_plan 1
+    tap_not_ok "MCP shell prerequisites are available"
+    tap_finish
+    exit $?
+fi
+
 MCP_MYSQL_TARGET_ID="${MCP_TARGET_ID:-tap_mysql_default}"
 MCP_PGSQL_TARGET_ID="${MCP_PGSQL_TARGET_ID:-tap_pgsql_default}"
 
@@ -133,8 +140,4 @@ else
     tap_not_ok "catalog run_id cannot be resolved across target_id boundaries" "${cross_target_resp}"
 fi
 
-if [[ "${FAIL}" -ne 0 ]]; then
-    echo "msg: # FAILURES=${FAIL}/${PLAN}"
-    exit 1
-fi
-exit 0
+tap_finish

--- a/test/tap/tests/test_stats_mcp_tables-t.cpp
+++ b/test/tap/tests/test_stats_mcp_tables-t.cpp
@@ -124,6 +124,10 @@ int main() {
 	create_test_data(mysql);
 
 	ok(configure_mcp(admin, cl), "MCP configured for stats test");
+	if (count_rows(admin, "stats_mcp_query_digest_reset") < 0 ||
+	    count_rows(admin, "stats_mcp_query_tools_counters_reset") < 0) {
+		BAIL_OUT("Failed to reset MCP statistics before generating test traffic");
+	}
 
 	MCPClient mcp(cl.admin_host, cl.mcp_port);
 	if (strlen(cl.mcp_auth_token) > 0) {

--- a/test/tap/tests/test_stats_mcp_tables-t.cpp
+++ b/test/tap/tests/test_stats_mcp_tables-t.cpp
@@ -95,7 +95,7 @@ int count_rows(MYSQL* admin, const char* table) {
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(11);
+	plan(12);
 
 	CommandLine cl;
 	if (cl.getEnv()) {
@@ -182,12 +182,20 @@ int main() {
 	int counters_after_reset = count_rows(admin, "stats_mcp_query_tools_counters");
 	ok(counters_after_reset == 0, "stats_mcp_query_tools_counters is empty after _reset (got %d)", counters_after_reset);
 
-	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-	run_q(admin, ("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str());
-	run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
-	run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());
-	run_q(admin, "LOAD MCP PROFILES TO RUNTIME");
-	run_q(admin, "LOAD MYSQL SERVERS TO RUNTIME");
+	bool cleanup_ok = true;
+	cleanup_ok = (run_q(admin, "LOAD MCP VARIABLES FROM DISK") == 0) && cleanup_ok;
+	cleanup_ok = (run_q(admin,
+		("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str()) == 0)
+		&& cleanup_ok;
+	cleanup_ok = (run_q(admin,
+		("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str()) == 0)
+		&& cleanup_ok;
+	cleanup_ok = (run_q(admin,
+		("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str()) == 0)
+		&& cleanup_ok;
+	cleanup_ok = (run_q(admin, "LOAD MCP PROFILES TO RUNTIME") == 0) && cleanup_ok;
+	cleanup_ok = (run_q(admin, "LOAD MYSQL SERVERS TO RUNTIME") == 0) && cleanup_ok;
+	ok(cleanup_ok, "MCP stats fixture cleanup and runtime restoration succeed");
 	mysql_close(mysql);
 	mysql_close(admin);
 	return exit_status();

--- a/test/tap/tests/test_stats_mcp_tables-t.cpp
+++ b/test/tap/tests/test_stats_mcp_tables-t.cpp
@@ -8,6 +8,7 @@
  * Also verifies _reset semantics (selecting _reset clears counters).
  */
 
+#include <cstring>
 #include <string>
 
 #include "mysql.h"
@@ -40,11 +41,14 @@ bool configure_mcp(MYSQL* admin, const CommandLine& cl) {
 	const std::string mysql_user = escape_sql_literal(cl.mysql_username);
 	const std::string mysql_password = escape_sql_literal(cl.mysql_password);
 	const std::string default_schema = escape_sql_literal(k_test_schema);
+	const std::string auth_token = escape_sql_literal(cl.mcp_auth_token);
 
 	const std::string queries[] = {
 		"SET mcp-port=" + std::to_string(cl.mcp_port),
 		"SET mcp-use_ssl=false",
 		"SET mcp-enabled=true",
+		"SET mcp-config_endpoint_auth='" + auth_token + "'",
+		"SET mcp-query_endpoint_auth='" + auth_token + "'",
 		"DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'",
 		"DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'",
 		"INSERT INTO mcp_auth_profiles (auth_profile_id, db_username, db_password, default_schema, use_ssl, ssl_mode, comment) VALUES "
@@ -121,7 +125,10 @@ int main() {
 
 	ok(configure_mcp(admin, cl), "MCP configured for stats test");
 
-	MCPClient mcp(cl.host, cl.mcp_port);
+	MCPClient mcp(cl.admin_host, cl.mcp_port);
+	if (strlen(cl.mcp_auth_token) > 0) {
+		mcp.set_auth_token(cl.mcp_auth_token);
+	}
 
 	{
 		json args = {
@@ -171,6 +178,12 @@ int main() {
 	int counters_after_reset = count_rows(admin, "stats_mcp_query_tools_counters");
 	ok(counters_after_reset == 0, "stats_mcp_query_tools_counters is empty after _reset (got %d)", counters_after_reset);
 
+	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+	run_q(admin, ("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str());
+	run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
+	run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());
+	run_q(admin, "LOAD MCP PROFILES TO RUNTIME");
+	run_q(admin, "LOAD MYSQL SERVERS TO RUNTIME");
 	mysql_close(mysql);
 	mysql_close(admin);
 	return exit_status();

--- a/test/tap/tests/test_tsdb_variables-t.cpp
+++ b/test/tap/tests/test_tsdb_variables-t.cpp
@@ -195,35 +195,36 @@ int main() {
 
 	// 12. Test Downsampling command
 	// NOTE: Downsampling only processes COMPLETED hours (data with timestamps before current_hour).
-	// Since we only have a few seconds of data, we need to insert test data with timestamps
-	// from at least 1 hour ago for the downsample to produce results.
+	// Since we only have a few seconds of data, insert test data in the most recently
+	// completed hour. Downsampling deliberately refreshes this boundary bucket so
+	// metrics committed just after an earlier pass are not lost.
 	diag("Testing TSDB downsampling via command...");
 
-	// Get current timestamp and calculate timestamp from 2 hours ago
+	// Get current timestamp and calculate the start of the previous hour.
 	time_t now = time(NULL);
-	time_t two_hours_ago = ((now - 7200) / 3600) * 3600; // Start of the hour, 2 hours ago
-	diag("Current time: %ld, Two hours ago (hour boundary): %ld", now, two_hours_ago);
+	time_t completed_hour = ((now - 3600) / 3600) * 3600;
+	diag("Current time: %ld, Previous hour boundary: %ld", now, completed_hour);
 
-	// Insert test data with timestamps from 2 hours ago (completed hour)
+	// Insert test data with timestamps from the completed hour.
 	diag("Inserting test metrics data with timestamps from completed hour...");
 	char insert_query[512];
 	snprintf(insert_query, sizeof(insert_query),
 		"INSERT OR REPLACE INTO stats_history.tsdb_metrics (timestamp, metric_name, labels, value) "
 		"VALUES (%ld, 'test_downsample_metric', '{\"test\":\"true\"}', 42.0)",
-		two_hours_ago);
+		completed_hour);
 	rc = mysql_query(admin, insert_query);
 	if (rc != 0) {
 		diag("Failed to insert test data: %s", mysql_error(admin));
 	}
 	drain_results(admin);
-	diag("Inserted test metric at timestamp %ld", two_hours_ago);
+	diag("Inserted test metric at timestamp %ld", completed_hour);
 
 	// Also insert a few more data points in the same hour for realistic test
 	for (int i = 1; i <= 3; i++) {
 		snprintf(insert_query, sizeof(insert_query),
 			"INSERT OR REPLACE INTO stats_history.tsdb_metrics (timestamp, metric_name, labels, value) "
 			"VALUES (%ld, 'test_downsample_metric', '{\"test\":\"true\"}', %f)",
-			two_hours_ago + i * 60, 42.0 + i); // Add data points every minute
+			completed_hour + i * 60, 42.0 + i); // Add data points every minute
 		mysql_query(admin, insert_query);
 		drain_results(admin);
 	}

--- a/test/tap/tests/test_tsdb_variables-t.cpp
+++ b/test/tap/tests/test_tsdb_variables-t.cpp
@@ -235,6 +235,29 @@ int main() {
 	fetch_single_string(admin, "SELECT COUNT(*) FROM stats_history.tsdb_metrics WHERE metric_name='test_downsample_metric'", before_count);
 	diag("Test metrics in tsdb_metrics before downsample: %s", before_count.c_str());
 
+	// Re-evaluate the boundary immediately before the command. A test that
+	// starts in the final milliseconds of an hour must not leave its fixture in
+	// what has just become the second-most-recent completed bucket.
+	const time_t command_now = time(NULL);
+	const time_t command_completed_hour = ((command_now - 3600) / 3600) * 3600;
+	if (command_completed_hour != completed_hour) {
+		diag("Hour rolled over during fixture setup; moving data from %ld to %ld",
+			completed_hour, command_completed_hour);
+		mysql_query(admin,
+			"DELETE FROM stats_history.tsdb_metrics WHERE metric_name='test_downsample_metric'");
+		drain_results(admin);
+		completed_hour = command_completed_hour;
+		for (int i = 0; i <= 3; ++i) {
+			snprintf(insert_query, sizeof(insert_query),
+				"INSERT OR REPLACE INTO stats_history.tsdb_metrics "
+				"(timestamp, metric_name, labels, value) "
+				"VALUES (%ld, 'test_downsample_metric', '{\"test\":\"true\"}', %f)",
+				completed_hour + i * 60, 42.0 + i);
+			mysql_query(admin, insert_query);
+			drain_results(admin);
+		}
+	}
+
 	// Run the downsample command
 	rc = mysql_query(admin, "PROXYSQL TSDB DOWNSAMPLE");
 	ok(rc == 0, "PROXYSQL TSDB DOWNSAMPLE command is supported");

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -451,7 +451,8 @@ UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 	pgsql_response_framer_unit-t \
 	pgsql_response_framer_traffic_unit-t \
 	ffto_state_machine_unit-t \
-	restapi_server_unit-t
+	restapi_server_unit-t \
+	mcp_client_unit-t
 
 ifeq ($(PROXYSQL31),1)
 UNIT_TESTS += caching_sha2_rsa_unit-t
@@ -557,6 +558,10 @@ ezoption_parser_unit-t: ezoption_parser_unit-t.cpp $(ODIR)/tap.o $(ODIR)/tap_noi
 	$(CXX) $< $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o \
 		-I$(TAP_IDIR) -I$(PROXYSQL_PATH)/include \
 		$(STDCPP) -O0 -ggdb $(WGCOV) $(LWGCOV) $(WASAN) -lpthread -o $@
+
+mcp_client_unit-t: mcp_client_unit-t.cpp $(TAP_PATH)/mcp_client.cpp $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o
+	$(CXX) $< $(TAP_PATH)/mcp_client.cpp $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o \
+		$(IDIRS) $(LDIRS) $(OPT) -Wl,-Bdynamic -lcurl -lpthread -o $@
 
 plugin_manager_unit-t: plugin_manager_unit-t.cpp $(FAKE_PLUGIN_SO) $(FAKE_PLUGIN2_SO) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o $(LIBPROXYSQLAR)
 	$(CXX) $< $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o \

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -462,6 +462,21 @@ ifeq ($(PROXYSQLED25519),1)
 UNIT_TESTS += ed25519_unit-t
 endif
 
+# GenAI units declared in the ai-g1/ai-g2 TAP shards. Keep this focused list
+# separate from the three plugin-lifecycle units, which are not group members.
+AI_GENAI_UNIT_TESTS := \
+	genai_config_query_unit-t \
+	genai_discovery_schema_unit-t \
+	genai_fts_string_unit-t \
+	genai_llm_clients_unit-t \
+	genai_mcp_endpoint_unit-t \
+	genai_mcp_thread_unit-t \
+	genai_mysql_catalog_unit-t \
+	genai_query_handler_unit-t \
+	genai_rag_fetch_from_source_unit-t \
+	genai_stats_parsing_unit-t \
+	genai_thread_unit-t
+
 # Plugin-chassis + mysqlx-plugin unit tests — built only when
 # libproxysql.a was compiled with -DPROXYSQL40 (autodetected higher up
 # in this Makefile).  v3.0/v3.1 builds have no plugin loader and the
@@ -513,21 +528,10 @@ UNIT_TESTS += \
 # variant so the full unit-test suite still compiles when
 # CI-unittests is re-enabled.
 ifneq ($(SKIP_GENAI_UNIT_TESTS),1)
-UNIT_TESTS += \
-	genai_fts_string_unit-t \
-	genai_llm_clients_unit-t \
+UNIT_TESTS += $(AI_GENAI_UNIT_TESTS) \
 	genai_plugin_load_unit-t \
 	genai_plugin_anomaly_unit-t \
-	genai_plugin_backend_client_unit-t \
-	genai_stats_parsing_unit-t \
-	genai_query_handler_unit-t \
-	genai_config_query_unit-t \
-	genai_rag_fetch_from_source_unit-t \
-	genai_mcp_endpoint_unit-t \
-	genai_mcp_thread_unit-t \
-	genai_thread_unit-t \
-	genai_discovery_schema_unit-t \
-	genai_mysql_catalog_unit-t
+	genai_plugin_backend_client_unit-t
 endif
 endif
 
@@ -539,6 +543,10 @@ all: $(UNIT_TESTS)
 # does the same thing.
 .PHONY: unit_tests
 unit_tests: all
+
+.PHONY: ai_genai_unit_tests
+.NOTPARALLEL: ai_genai_unit_tests
+ai_genai_unit_tests: $(AI_GENAI_UNIT_TESTS)
 
 .PHONY: debug
 debug: OPT += -DDEBUG
@@ -817,78 +825,27 @@ genai_plugin_load_unit-t: genai_plugin_load_unit-t.cpp $(GENAI_PLUGIN_SO) $(ODIR
 		$(IDIRS) $(LDIRS) $(OPT) $(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) \
 		$(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
 
-# genai_fts_string_unit-t includes MySQL_FTS.h (lives in plugins/genai/
-# include/) and instantiates MySQL_FTS, so the source file gets
-# compiled directly into the test — same compile-twice trick as
-# genai_plugin_anomaly_unit-t.  Without the explicit include path on
-# this rule the default %-t rule would search only the core include
-# directory, miss the plugin header, and fail with the same error CI
-# saw on ubuntu24-tap-genai-gcov.
-GENAI_FTS_SRCS := $(PROXYSQL_PATH)/plugins/genai/src/MySQL_FTS.cpp
-genai_fts_string_unit-t: genai_fts_string_unit-t.cpp $(GENAI_FTS_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_FTS_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o \
-		$(GENAI_PLUGIN_DEFINES) $(GENAI_PLUGIN_INCLUDE) $(IDIRS) $(LDIRS) $(OPT) $(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) \
-		$(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
+# Compile the plugin source set once for the eleven shard-declared tests. The
+# object path preserves each source's plugins/genai/src/... location, avoiding
+# basename collisions between the main and tool_handlers directories. OPT
+# carries the active debug, coverage, and sanitizer flags into every object.
+GENAI_SOURCE_ROOT := $(PROXYSQL_PATH)/plugins/genai/src
+GENAI_ALL_SRCS := $(sort $(wildcard $(GENAI_SOURCE_ROOT)/*.cpp $(GENAI_SOURCE_ROOT)/tool_handlers/*.cpp))
+GENAI_OBJECT_ROOT := $(ODIR)/genai
+GENAI_ALL_OBJS := $(patsubst $(PROXYSQL_PATH)/%.cpp,$(GENAI_OBJECT_ROOT)/%.o,$(GENAI_ALL_SRCS))
+GENAI_TEST_ARCHIVE := $(GENAI_OBJECT_ROOT)/libgenai_test.a
 
-GENAI_LLM_SRCS := $(PROXYSQL_PATH)/plugins/genai/src/LLM_Clients.cpp
-genai_llm_clients_unit-t: genai_llm_clients_unit-t.cpp $(GENAI_LLM_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_LLM_SRCS) $(ODIR)/tap.o $(ODIR)/test_globals.o $(ODIR)/test_init.o \
-		$(GENAI_PLUGIN_DEFINES) $(GENAI_PLUGIN_INCLUDE) $(IDIRS) $(LDIRS) $(OPT) $(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) \
-		$(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
+$(GENAI_OBJECT_ROOT)/%.o: $(PROXYSQL_PATH)/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) -c $< -o $@ $(GENAI_PLUGIN_DEFINES) $(GENAI_PLUGIN_INCLUDE) $(IDIRS) $(OPT)
 
-# Genai tests that include plugin headers from plugins/genai/include/
-# and instantiate genai types.  These tests call genai functions directly
-# (not through dlopen), so the genai symbols must be compiled into the
-# test binary.  The genai sources have deep transitive dependencies
-# (Stats_Tool_Handler → MCP_Tool_Handler → MCP_Thread → …), so the
-# simplest reliable approach is to compile all genai .cpp files into
-# each test that needs them.  plugin_main.cpp is excluded because it
-# contains the dlopen/dlsym entry point that would conflict.
-GENAI_ALL_SRCS := $(wildcard $(PROXYSQL_PATH)/plugins/genai/src/*.cpp $(PROXYSQL_PATH)/plugins/genai/src/tool_handlers/*.cpp)
+$(GENAI_TEST_ARCHIVE): $(GENAI_ALL_OBJS)
+	$(RM) $@
+	$(AR) rcs $@ $^
 
-genai_stats_parsing_unit-t: genai_stats_parsing_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_query_handler_unit-t: genai_query_handler_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_config_query_unit-t: genai_config_query_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_rag_fetch_from_source_unit-t: genai_rag_fetch_from_source_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_mcp_endpoint_unit-t: genai_mcp_endpoint_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_mcp_thread_unit-t: genai_mcp_thread_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_thread_unit-t: genai_thread_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_discovery_schema_unit-t: genai_discovery_schema_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
-		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
-
-genai_mysql_catalog_unit-t: genai_mysql_catalog_unit-t.cpp $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
-	$(CXX) $< $(GENAI_ALL_SRCS) $(TEST_HELPERS_OBJ) \
-		$(GENAI_PLUGIN_DEFINES) $(IDIRS) $(LDIRS) $(OPT) \
+$(AI_GENAI_UNIT_TESTS): %: %.cpp $(GENAI_TEST_ARCHIVE) $(TEST_HELPERS_OBJ) $(LIBPROXYSQLAR)
+	$(CXX) $< $(TEST_HELPERS_OBJ) $(GENAI_TEST_ARCHIVE) \
+		$(GENAI_PLUGIN_DEFINES) $(GENAI_PLUGIN_INCLUDE) $(IDIRS) $(LDIRS) $(OPT) \
 		$(WHOLE_LIBPROXYSQL) $(STATIC_LIBS) $(MYLIBS) -ldl $(ALLOW_MULTI_DEF) -o $@
 
 ifeq ($(UNAME_S),Linux)

--- a/test/tap/tests/unit/genai_discovery_schema_unit-t.cpp
+++ b/test/tap/tests/unit/genai_discovery_schema_unit-t.cpp
@@ -518,7 +518,6 @@ static void test_log_llm_search() {
 
 static void test_log_rag_search_fts() {
 	Discovery_Schema* ds = create_test_schema();
-	ds->init();  // Already called in create_test_schema
 
 	Discovery_Schema* ds2 = create_test_schema();
 	int rc = ds2->log_rag_search_fts("billing tables", 5, "{\"type\":\"table\"}");

--- a/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+++ b/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
@@ -20,9 +20,9 @@
 namespace {
 
 // Real in-memory SQLite databases.  Pre-populated with the table
-// shapes genai_start() reads.  No data — that's enough to make the
-// plugin's admin-DB queries succeed and return empty result sets,
-// which is the "fresh-install" scenario.
+// shapes genai_start() reads and a partial set of persisted variables,
+// modeling an existing installation that startup must complete without
+// overwriting operator values.
 SQLite3DB* g_admindb  = nullptr;
 SQLite3DB* g_configdb = nullptr;
 SQLite3DB* g_statsdb  = nullptr;
@@ -73,7 +73,7 @@ SQLite3DB* proxysql_plugin_get_configdb() { return g_configdb; }
 SQLite3DB* proxysql_plugin_get_statsdb()  { return g_statsdb; }
 
 int main() {
-	plan(57);
+	plan(60);
 
 	g_admindb  = new SQLite3DB();
 	g_configdb = new SQLite3DB();
@@ -90,6 +90,11 @@ int main() {
 			" ('mcp-port','7123'),('genai-threads','7')")) {
 			BAIL_OUT("failed to seed persisted GenAI plugin variables");
 		}
+	}
+	if (!g_admindb->execute(
+		"INSERT INTO global_variables(variable_name, variable_value)"
+		" VALUES('genai-llm_cache_enabled','false')")) {
+		BAIL_OUT("failed to seed persisted genai-llm_cache_enabled=false");
 	}
 
 	ProxySQL_PluginManager mgr;
@@ -117,6 +122,23 @@ int main() {
 
 	ok(mgr.start_all(err), "start_all succeeds");
 	if (!err.empty()) diag("start error: %s", err.c_str());
+
+	ok(g_configdb->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='genai-llm_cache_enabled' AND variable_value='true'") == 1,
+	   "configdb seeds compiled genai-llm_cache_enabled=true default");
+
+	ProxySQL_PluginCommandContext variable_cmd_ctx { g_admindb, g_configdb, g_statsdb };
+	ProxySQL_PluginCommandResult variable_save_result;
+	const bool variable_save_dispatched = mgr.dispatch_admin_command(
+		variable_cmd_ctx, "SAVE GENAI VARIABLES TO MEMORY", variable_save_result);
+	ok(variable_save_dispatched && variable_save_result.error_code == 0,
+	   "SAVE GENAI VARIABLES TO MEMORY dispatches via plugin (rc=%d, msg=%s)",
+	   variable_save_result.error_code, variable_save_result.message.c_str());
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='genai-llm_cache_enabled' AND variable_value='false'") == 1,
+	   "admindb preserves loaded genai-llm_cache_enabled=false");
 
 	struct VariableDatabase {
 		SQLite3DB* db;

--- a/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+++ b/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
@@ -39,6 +39,8 @@ void setup_admindb_schema(SQLite3DB* db) {
 	// include/ProxySQL_Admin_Tables_Definitions.h so the plugin's
 	// SELECTs (which name every column by name) succeed.
 	setup_global_variables_schema(db);
+	db->execute("CREATE TABLE IF NOT EXISTS runtime_global_variables ("
+	            " variable_name TEXT PRIMARY KEY, variable_value TEXT)");
 	db->execute("CREATE TABLE IF NOT EXISTS mcp_auth_profiles ("
 	            " auth_profile_id TEXT PRIMARY KEY, db_username TEXT,"
 	            " db_password TEXT, default_schema TEXT DEFAULT '',"
@@ -73,7 +75,7 @@ SQLite3DB* proxysql_plugin_get_configdb() { return g_configdb; }
 SQLite3DB* proxysql_plugin_get_statsdb()  { return g_statsdb; }
 
 int main() {
-	plan(60);
+	plan(83);
 
 	g_admindb  = new SQLite3DB();
 	g_configdb = new SQLite3DB();
@@ -83,6 +85,11 @@ int main() {
 	g_statsdb->open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 	setup_admindb_schema(g_admindb);
 	setup_global_variables_schema(g_configdb);
+	if (!g_admindb->execute(
+		"INSERT INTO runtime_global_variables(variable_name, variable_value)"
+		" VALUES('mysql-threads','4')")) {
+		BAIL_OUT("failed to seed unrelated runtime variable");
+	}
 
 	for (SQLite3DB* db : {g_configdb, g_admindb}) {
 		if (!db->execute(
@@ -140,6 +147,118 @@ int main() {
 		" WHERE variable_name='genai-llm_cache_enabled' AND variable_value='false'") == 1,
 	   "admindb preserves loaded genai-llm_cache_enabled=false");
 
+	// LOAD MCP VARIABLES must publish one coherent snapshot to both the
+	// handler and runtime_global_variables.  A second load replaces the
+	// snapshot rather than duplicating it, and a SQL failure must leave both
+	// destinations at the last committed value.
+	ok(g_admindb->execute(
+		"UPDATE global_variables SET variable_value='45000'"
+		" WHERE variable_name='mcp-timeout_ms'"),
+	   "set first MCP timeout value in main");
+	ProxySQL_PluginCommandResult first_runtime_result;
+	const bool first_runtime_dispatched = mgr.dispatch_admin_command(
+		variable_cmd_ctx, "LOAD MCP VARIABLES TO RUNTIME", first_runtime_result);
+	ok(first_runtime_dispatched && first_runtime_result.error_code == 0,
+	   "first LOAD MCP VARIABLES TO RUNTIME succeeds (rc=%d, msg=%s)",
+	   first_runtime_result.error_code, first_runtime_result.message.c_str());
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name LIKE 'mcp-%'") == 14,
+	   "first load publishes exactly 14 MCP runtime variables");
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name='mcp-timeout_ms' AND variable_value='45000'") == 1,
+	   "first load publishes mcp-timeout_ms=45000");
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name='mysql-threads' AND variable_value='4'") == 1,
+	   "first load preserves unrelated runtime variables");
+
+	ok(g_admindb->execute(
+		"UPDATE global_variables SET variable_value='46000'"
+		" WHERE variable_name='mcp-timeout_ms'"),
+	   "set replacement MCP timeout value in main");
+	ProxySQL_PluginCommandResult second_runtime_result;
+	const bool second_runtime_dispatched = mgr.dispatch_admin_command(
+		variable_cmd_ctx, "LOAD MCP VARIABLES TO RUNTIME", second_runtime_result);
+	ok(second_runtime_dispatched && second_runtime_result.error_code == 0,
+	   "second LOAD MCP VARIABLES TO RUNTIME succeeds (rc=%d, msg=%s)",
+	   second_runtime_result.error_code, second_runtime_result.message.c_str());
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name LIKE 'mcp-%'") == 14,
+	   "second load still publishes exactly 14 MCP runtime variables");
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name='mcp-timeout_ms' AND variable_value='46000'") == 1,
+	   "second load replaces mcp-timeout_ms with 46000");
+
+	ok(g_admindb->execute(
+		"CREATE TRIGGER reject_runtime_mcp_timeout BEFORE INSERT"
+		" ON runtime_global_variables"
+		" WHEN NEW.variable_name='mcp-timeout_ms'"
+		" BEGIN SELECT RAISE(ABORT, 'injected runtime publication failure'); END"),
+	   "install runtime publication failure trigger");
+	ok(g_admindb->execute(
+		"UPDATE global_variables SET variable_value='47000'"
+		" WHERE variable_name='mcp-timeout_ms'"),
+	   "set uncommittable MCP timeout value in main");
+	ProxySQL_PluginCommandResult failed_runtime_result;
+	const bool failed_runtime_dispatched = mgr.dispatch_admin_command(
+		variable_cmd_ctx, "LOAD MCP VARIABLES TO RUNTIME", failed_runtime_result);
+	ok(failed_runtime_dispatched && failed_runtime_result.error_code != 0,
+	   "failed runtime publication reports command error (rc=%d, msg=%s)",
+	   failed_runtime_result.error_code, failed_runtime_result.message.c_str());
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name='mcp-timeout_ms' AND variable_value='46000'") == 1,
+	   "failed publication preserves prior runtime timeout");
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name LIKE 'mcp-%'") == 14,
+	   "failed publication preserves complete prior MCP snapshot");
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name='mysql-threads' AND variable_value='4'") == 1,
+	   "failed publication preserves unrelated runtime variables");
+	ok(g_admindb->execute("DROP TRIGGER reject_runtime_mcp_timeout"),
+	   "remove runtime publication failure trigger");
+	ProxySQL_PluginCommandResult post_failure_save_result;
+	const bool post_failure_save_dispatched = mgr.dispatch_admin_command(
+		variable_cmd_ctx, "SAVE MCP VARIABLES TO MEMORY", post_failure_save_result);
+	ok(post_failure_save_dispatched && post_failure_save_result.error_code == 0,
+	   "SAVE after failed LOAD succeeds (rc=%d, msg=%s)",
+	   post_failure_save_result.error_code, post_failure_save_result.message.c_str());
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='mcp-timeout_ms' AND variable_value='46000'") == 1,
+	   "failed publication restores active handler timeout to 46000");
+
+	ok(g_admindb->execute(
+		"UPDATE global_variables SET variable_value='-1'"
+		" WHERE variable_name='mcp-timeout_ms'"),
+	   "set invalid MCP timeout value in main");
+	ProxySQL_PluginCommandResult invalid_runtime_result;
+	const bool invalid_runtime_dispatched = mgr.dispatch_admin_command(
+		variable_cmd_ctx, "LOAD MCP VARIABLES TO RUNTIME", invalid_runtime_result);
+	ok(invalid_runtime_dispatched && invalid_runtime_result.error_code != 0,
+	   "invalid MCP value reports command error (rc=%d, msg=%s)",
+	   invalid_runtime_result.error_code, invalid_runtime_result.message.c_str());
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM runtime_global_variables"
+		" WHERE variable_name='mcp-timeout_ms' AND variable_value='46000'") == 1,
+	   "invalid MCP value preserves prior runtime snapshot");
+	ProxySQL_PluginCommandResult invalid_save_result;
+	const bool invalid_save_dispatched = mgr.dispatch_admin_command(
+		variable_cmd_ctx, "SAVE MCP VARIABLES TO MEMORY", invalid_save_result);
+	ok(invalid_save_dispatched && invalid_save_result.error_code == 0,
+	   "SAVE after invalid LOAD succeeds (rc=%d, msg=%s)",
+	   invalid_save_result.error_code, invalid_save_result.message.c_str());
+	ok(g_admindb->return_one_int(
+		"SELECT COUNT(*) FROM global_variables"
+		" WHERE variable_name='mcp-timeout_ms' AND variable_value='46000'") == 1,
+	   "invalid MCP value restores active handler timeout to 46000");
+
 	struct VariableDatabase {
 		SQLite3DB* db;
 		const char* name;
@@ -166,10 +285,13 @@ int main() {
 			"SELECT COUNT(*) FROM global_variables"
 			" WHERE variable_name='genai-threads' AND variable_value='7'") == 1,
 		   "%s preserves persisted genai-threads", target.name);
-		ok(target.db->return_one_int(
-			"SELECT COUNT(*) FROM global_variables"
-			" WHERE variable_name='mcp-timeout_ms' AND variable_value='30000'") == 1,
-		   "%s persists missing mcp-timeout_ms default", target.name);
+		const char* timeout_query = target.db == g_admindb
+			? "SELECT COUNT(*) FROM global_variables"
+			  " WHERE variable_name='mcp-timeout_ms' AND variable_value='46000'"
+			: "SELECT COUNT(*) FROM global_variables"
+			  " WHERE variable_name='mcp-timeout_ms' AND variable_value='30000'";
+		ok(target.db->return_one_int(timeout_query) == 1,
+		   "%s contains its expected persisted mcp-timeout_ms", target.name);
 		ok(target.db->return_one_int(
 			"SELECT COUNT(*) FROM global_variables"
 			" WHERE variable_name='genai-rag_timeout_ms' AND variable_value='2000'") == 1,

--- a/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+++ b/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
@@ -1,17 +1,15 @@
-// Step 1 acceptance test for the genai plugin scaffold.
+// Lifecycle and persisted-variable regression coverage for the GenAI plugin.
 //
 // Drives the actual genai .so through load → init → start → stop → unload,
-// the same way proxysql will at startup.  Step 4.F extended the plugin
-// to actually read mcp-* admin variables and the mcp_auth/target profile
-// tables during start(), so this test now spins up real in-memory
-// SQLite3DBs (instead of the previous fake `char*` stubs) and creates
-// the tables genai_start expects.
+// the same way proxysql will at startup. The fixture uses real in-memory
+// SQLite3DBs and creates the tables genai_start expects.
 
 #include "ProxySQL_PluginManager.h"
 #include "sqlite3db.h"
 #include "tap.h"
 
 #include <string>
+#include <vector>
 
 #ifndef PROXYSQL_GENAI_PLUGIN_PATH
 #error "PROXYSQL_GENAI_PLUGIN_PATH must be defined"
@@ -26,6 +24,24 @@ namespace {
 SQLite3DB* g_admindb  = nullptr;
 SQLite3DB* g_configdb = nullptr;
 SQLite3DB* g_statsdb  = nullptr;
+
+struct AdminMutexHandoffProbe {
+	int release_count { 0 };
+	int acquire_count { 0 };
+	std::vector<char> events;
+};
+
+void record_admin_mutex_release(void* opaque) {
+	auto* probe = static_cast<AdminMutexHandoffProbe*>(opaque);
+	probe->events.push_back('R');
+	++probe->release_count;
+}
+
+void record_admin_mutex_acquire(void* opaque) {
+	auto* probe = static_cast<AdminMutexHandoffProbe*>(opaque);
+	probe->events.push_back('A');
+	++probe->acquire_count;
+}
 
 void setup_global_variables_schema(SQLite3DB* db) {
 	db->execute("CREATE TABLE IF NOT EXISTS global_variables ("
@@ -75,7 +91,7 @@ SQLite3DB* proxysql_plugin_get_configdb() { return g_configdb; }
 SQLite3DB* proxysql_plugin_get_statsdb()  { return g_statsdb; }
 
 int main() {
-	plan(83);
+	plan(86);
 
 	g_admindb  = new SQLite3DB();
 	g_configdb = new SQLite3DB();
@@ -146,6 +162,28 @@ int main() {
 		"SELECT COUNT(*) FROM global_variables"
 		" WHERE variable_name='genai-llm_cache_enabled' AND variable_value='false'") == 1,
 	   "admindb preserves loaded genai-llm_cache_enabled=false");
+
+	// A runtime reload can wait for active MCP work, including a request that
+	// is itself waiting for Admin. Verify the command yields the production
+	// Admin mutex around that blocking phase and reacquires it before return.
+	AdminMutexHandoffProbe handoff_probe;
+	ProxySQL_PluginCommandContext handoff_cmd_ctx {
+		g_admindb,
+		g_configdb,
+		g_statsdb,
+		&handoff_probe,
+		&record_admin_mutex_release,
+		&record_admin_mutex_acquire
+	};
+	ProxySQL_PluginCommandResult handoff_result;
+	const bool handoff_dispatched = mgr.dispatch_admin_command(
+		handoff_cmd_ctx, "LOAD GENAI VARIABLES TO RUNTIME", handoff_result);
+	ok(handoff_dispatched && handoff_result.error_code == 0,
+	   "LOAD GENAI VARIABLES TO RUNTIME succeeds with Admin mutex handoff");
+	ok(handoff_probe.release_count == 2 && handoff_probe.acquire_count == 2,
+	   "GenAI reload performs serialized-entry and runtime Admin handoffs");
+	ok(handoff_probe.events == std::vector<char>({'R', 'A', 'R', 'A'}),
+	   "GenAI reload preserves release/acquire ordering across both handoffs");
 
 	// LOAD MCP VARIABLES must publish one coherent snapshot to both the
 	// handler and runtime_global_variables.  A second load replaces the

--- a/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+++ b/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
@@ -9,6 +9,7 @@
 #include "tap.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifndef PROXYSQL_GENAI_PLUGIN_PATH
@@ -91,7 +92,7 @@ SQLite3DB* proxysql_plugin_get_configdb() { return g_configdb; }
 SQLite3DB* proxysql_plugin_get_statsdb()  { return g_statsdb; }
 
 int main() {
-	plan(86);
+	plan(95);
 
 	g_admindb  = new SQLite3DB();
 	g_configdb = new SQLite3DB();
@@ -101,6 +102,60 @@ int main() {
 	g_statsdb->open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 	setup_admindb_schema(g_admindb);
 	setup_global_variables_schema(g_configdb);
+
+	// Exercise a genuinely fresh installation before setting up the partial
+	// installation used by the rest of this regression. Both stores begin with
+	// empty global_variables tables and must receive the complete default set.
+	{
+		ProxySQL_PluginManager fresh_mgr;
+		std::string fresh_err {};
+		const bool fresh_loaded = fresh_mgr.load(PROXYSQL_GENAI_PLUGIN_PATH, fresh_err);
+		ok(fresh_loaded, "fresh-install plugin load succeeds");
+		if (!fresh_loaded) {
+			diag("fresh-install load error: %s", fresh_err.c_str());
+			BAIL_OUT("fresh-install plugin must load before lifecycle assertions");
+		}
+
+		const bool fresh_schemas = fresh_mgr.invoke_register_schemas_phase(fresh_err);
+		ok(fresh_schemas, "fresh-install register_schemas succeeds");
+		if (!fresh_schemas) {
+			BAIL_OUT("fresh-install schema registration must succeed");
+		}
+
+		const bool fresh_initialized = fresh_mgr.init_all(fresh_err);
+		ok(fresh_initialized, "fresh-install init_all succeeds");
+		if (!fresh_initialized) {
+			BAIL_OUT("fresh-install initialization must succeed");
+		}
+
+		const bool fresh_started = fresh_mgr.start_all(fresh_err);
+		ok(fresh_started, "fresh-install start_all succeeds");
+		if (!fresh_started) {
+			BAIL_OUT("fresh-install startup must succeed");
+		}
+
+		for (const auto& target : {
+			std::pair<SQLite3DB*, const char*>{g_configdb, "configdb"},
+			std::pair<SQLite3DB*, const char*>{g_admindb, "admindb"}
+		}) {
+			ok(target.first->return_one_int(
+				"SELECT COUNT(*) FROM global_variables WHERE variable_name LIKE 'mcp-%'") == 14,
+			   "fresh %s contains all 14 MCP defaults", target.second);
+			ok(target.first->return_one_int(
+				"SELECT COUNT(*) FROM global_variables WHERE variable_name LIKE 'genai-%'") == 32,
+			   "fresh %s contains all 32 GenAI defaults", target.second);
+		}
+
+		ok(fresh_mgr.stop_all(), "fresh-install stop_all succeeds");
+	}
+
+	// Reset only the variable stores; the existing schemas are reused for the
+	// partial-install preservation and command-dispatch checks below.
+	for (SQLite3DB* db : {g_configdb, g_admindb}) {
+		if (!db->execute("DELETE FROM global_variables")) {
+			BAIL_OUT("failed to reset fresh-install variable fixture");
+		}
+	}
 	if (!g_admindb->execute(
 		"INSERT INTO runtime_global_variables(variable_name, variable_value)"
 		" VALUES('mysql-threads','4')")) {
@@ -131,11 +186,8 @@ int main() {
 	}
 	ok(mgr.size() == 1, "exactly one plugin handle after load");
 
-	// Phase B (chassis): every plugin's register_schemas callback runs
-	// here, BEFORE init_all.  As of Step 4.G the genai plugin uses this
-	// callback to publish its admin/config/stats table set, so it MUST
-	// fire before the size assertions below or we'll see 0 tables in
-	// every kind.
+	// Phase B (chassis): every plugin's register_schemas callback runs here,
+	// before init_all, to publish its admin/config/stats table set.
 	ok(mgr.invoke_register_schemas_phase(err),
 	   "invoke_register_schemas_phase succeeds");
 	if (!err.empty()) diag("register_schemas error: %s", err.c_str());
@@ -408,7 +460,7 @@ int main() {
 	// Verify the plugin handles are still live (pre-destructor).
 	ok(mgr.size() == 1, "plugin handle still present after stop_all");
 
-	// Step 4.G: the plugin now owns the MCP admin / config table set.
+	// The plugin owns the MCP admin / config table set.
 	// Counts match plugins/genai/src/plugin_tables.cpp.
 	//   admin:  6 (mcp_query_rules, mcp_auth_profiles, mcp_target_profiles
 	//              + their runtime_* siblings)
@@ -420,7 +472,7 @@ int main() {
 	   "genai plugin registers 3 config-db tables (got %zu)",
 	   mgr.tables(ProxySQL_PluginDBKind::config_db).size());
 
-	// Step 4.F: the plugin registers MCP admin SQL verbs.  Verify
+	// The plugin registers MCP admin SQL verbs. Verify
 	// each registered alias resolves back to the canonical command
 	// via the plugin manager's alias resolver (which is the same
 	// path admin SQL dispatch uses).

--- a/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+++ b/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
@@ -27,14 +27,18 @@ SQLite3DB* g_admindb  = nullptr;
 SQLite3DB* g_configdb = nullptr;
 SQLite3DB* g_statsdb  = nullptr;
 
+void setup_global_variables_schema(SQLite3DB* db) {
+	db->execute("CREATE TABLE IF NOT EXISTS global_variables ("
+	            " variable_name TEXT PRIMARY KEY, variable_value TEXT)");
+}
+
 void setup_admindb_schema(SQLite3DB* db) {
 	// Minimal schema to satisfy mcp_load_variables_from_admindb /
 	// mcp_load_target_auth_map_from_admindb in the plugin.  Column
 	// shapes mirror the canonical DDLs in
 	// include/ProxySQL_Admin_Tables_Definitions.h so the plugin's
 	// SELECTs (which name every column by name) succeed.
-	db->execute("CREATE TABLE IF NOT EXISTS global_variables ("
-	            " variable_name TEXT PRIMARY KEY, variable_value TEXT)");
+	setup_global_variables_schema(db);
 	db->execute("CREATE TABLE IF NOT EXISTS mcp_auth_profiles ("
 	            " auth_profile_id TEXT PRIMARY KEY, db_username TEXT,"
 	            " db_password TEXT, default_schema TEXT DEFAULT '',"
@@ -69,7 +73,7 @@ SQLite3DB* proxysql_plugin_get_configdb() { return g_configdb; }
 SQLite3DB* proxysql_plugin_get_statsdb()  { return g_statsdb; }
 
 int main() {
-	plan(45);
+	plan(57);
 
 	g_admindb  = new SQLite3DB();
 	g_configdb = new SQLite3DB();
@@ -78,6 +82,15 @@ int main() {
 	g_configdb->open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 	g_statsdb->open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 	setup_admindb_schema(g_admindb);
+	setup_global_variables_schema(g_configdb);
+
+	for (SQLite3DB* db : {g_configdb, g_admindb}) {
+		if (!db->execute(
+			"INSERT INTO global_variables(variable_name, variable_value) VALUES"
+			" ('mcp-port','7123'),('genai-threads','7')")) {
+			BAIL_OUT("failed to seed persisted GenAI plugin variables");
+		}
+	}
 
 	ProxySQL_PluginManager mgr;
 	std::string err {};
@@ -104,6 +117,42 @@ int main() {
 
 	ok(mgr.start_all(err), "start_all succeeds");
 	if (!err.empty()) diag("start error: %s", err.c_str());
+
+	struct VariableDatabase {
+		SQLite3DB* db;
+		const char* name;
+	};
+
+	for (const VariableDatabase& target : {
+		VariableDatabase{g_configdb, "configdb"},
+		VariableDatabase{g_admindb, "admindb"}
+	}) {
+		const int mcp_count = target.db->return_one_int(
+			"SELECT COUNT(*) FROM global_variables WHERE variable_name LIKE 'mcp-%'");
+		const int genai_count = target.db->return_one_int(
+			"SELECT COUNT(*) FROM global_variables WHERE variable_name LIKE 'genai-%'");
+
+		ok(mcp_count == 14, "%s contains all 14 MCP variables (got %d)",
+		   target.name, mcp_count);
+		ok(genai_count == 32, "%s contains all 32 GenAI variables (got %d)",
+		   target.name, genai_count);
+		ok(target.db->return_one_int(
+			"SELECT COUNT(*) FROM global_variables"
+			" WHERE variable_name='mcp-port' AND variable_value='7123'") == 1,
+		   "%s preserves persisted mcp-port", target.name);
+		ok(target.db->return_one_int(
+			"SELECT COUNT(*) FROM global_variables"
+			" WHERE variable_name='genai-threads' AND variable_value='7'") == 1,
+		   "%s preserves persisted genai-threads", target.name);
+		ok(target.db->return_one_int(
+			"SELECT COUNT(*) FROM global_variables"
+			" WHERE variable_name='mcp-timeout_ms' AND variable_value='30000'") == 1,
+		   "%s persists missing mcp-timeout_ms default", target.name);
+		ok(target.db->return_one_int(
+			"SELECT COUNT(*) FROM global_variables"
+			" WHERE variable_name='genai-rag_timeout_ms' AND variable_value='2000'") == 1,
+		   "%s persists missing genai-rag_timeout_ms default", target.name);
+	}
 
 	// Runtime-view dispatch: SELECT against runtime_mcp_<X> should
 	// trigger the chassis dispatcher to invoke the plugin's

--- a/test/tap/tests/unit/mcp_client_unit-t.cpp
+++ b/test/tap/tests/unit/mcp_client_unit-t.cpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <stdexcept>
 #include <string>
@@ -16,8 +17,9 @@ namespace {
 
 class OneShotHttpServer {
 public:
-	OneShotHttpServer(int status, std::string body)
-		: listen_fd_(socket(AF_INET, SOCK_STREAM, 0)), status_(status), body_(std::move(body)) {
+	OneShotHttpServer(int status, std::string body, int timeout_ms = 2000)
+		: listen_fd_(socket(AF_INET, SOCK_STREAM, 0)), status_(status),
+		  body_(std::move(body)), timeout_ms_(timeout_ms) {
 		if (listen_fd_ < 0) throw std::runtime_error(std::strerror(errno));
 
 		int reuse = 1;
@@ -28,6 +30,15 @@ public:
 		address.sin_port = 0;
 		if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0 ||
 			listen(listen_fd_, 1) != 0) {
+			const std::string error = std::strerror(errno);
+			close(listen_fd_);
+			throw std::runtime_error(error);
+		}
+		const timeval timeout {
+			timeout_ms_ / 1000,
+			(timeout_ms_ % 1000) * 1000
+		};
+		if (setsockopt(listen_fd_, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
 			const std::string error = std::strerror(errno);
 			close(listen_fd_);
 			throw std::runtime_error(error);
@@ -59,6 +70,14 @@ private:
 	void serve() {
 		const int client = accept(listen_fd_, nullptr, nullptr);
 		if (client < 0) return;
+		const timeval timeout {
+			timeout_ms_ / 1000,
+			(timeout_ms_ % 1000) * 1000
+		};
+		if (setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+			close(client);
+			return;
+		}
 
 		char buffer[2048];
 		while (request_.find("\r\n\r\n") == std::string::npos) {
@@ -89,12 +108,23 @@ private:
 	std::string body_;
 	std::string request_;
 	std::thread worker_;
+	int timeout_ms_;
 };
 
 } // namespace
 
 int main() {
-	plan(9);
+	plan(10);
+
+	const auto idle_server_started = std::chrono::steady_clock::now();
+	{
+		OneShotHttpServer idle_server(200, R"({})", 100);
+	}
+	const auto idle_server_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::steady_clock::now() - idle_server_started);
+	ok(idle_server_elapsed.count() < 1000,
+	   "idle one-shot server teardown is bounded (took %lld ms)",
+	   static_cast<long long>(idle_server_elapsed.count()));
 
 	OneShotHttpServer authenticated_server(
 		200, R"({"jsonrpc":"2.0","result":{},"id":1})");

--- a/test/tap/tests/unit/mcp_client_unit-t.cpp
+++ b/test/tap/tests/unit/mcp_client_unit-t.cpp
@@ -1,0 +1,144 @@
+#include "mcp_client.h"
+#include "tap.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace {
+
+class OneShotHttpServer {
+public:
+	OneShotHttpServer(int status, std::string body)
+		: listen_fd_(socket(AF_INET, SOCK_STREAM, 0)), status_(status), body_(std::move(body)) {
+		if (listen_fd_ < 0) throw std::runtime_error(std::strerror(errno));
+
+		int reuse = 1;
+		setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+		sockaddr_in address {};
+		address.sin_family = AF_INET;
+		address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+		address.sin_port = 0;
+		if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0 ||
+			listen(listen_fd_, 1) != 0) {
+			const std::string error = std::strerror(errno);
+			close(listen_fd_);
+			throw std::runtime_error(error);
+		}
+
+		socklen_t address_size = sizeof(address);
+		if (getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&address), &address_size) != 0) {
+			const std::string error = std::strerror(errno);
+			close(listen_fd_);
+			throw std::runtime_error(error);
+		}
+		port_ = ntohs(address.sin_port);
+		worker_ = std::thread(&OneShotHttpServer::serve, this);
+	}
+
+	~OneShotHttpServer() {
+		if (worker_.joinable()) worker_.join();
+		if (listen_fd_ >= 0) close(listen_fd_);
+	}
+
+	int port() const { return port_; }
+
+	const std::string& request() {
+		if (worker_.joinable()) worker_.join();
+		return request_;
+	}
+
+private:
+	void serve() {
+		const int client = accept(listen_fd_, nullptr, nullptr);
+		if (client < 0) return;
+
+		char buffer[2048];
+		while (request_.find("\r\n\r\n") == std::string::npos) {
+			const ssize_t bytes = recv(client, buffer, sizeof(buffer), 0);
+			if (bytes <= 0) break;
+			request_.append(buffer, static_cast<size_t>(bytes));
+		}
+
+		const char* reason = status_ == 200 ? "OK" : "Unauthorized";
+		const std::string response =
+			"HTTP/1.1 " + std::to_string(status_) + " " + reason + "\r\n"
+			"Content-Type: application/json\r\n"
+			"Content-Length: " + std::to_string(body_.size()) + "\r\n"
+			"Connection: close\r\n\r\n" + body_;
+		size_t sent = 0;
+		while (sent < response.size()) {
+			const ssize_t bytes = send(
+				client, response.data() + sent, response.size() - sent, MSG_NOSIGNAL);
+			if (bytes <= 0) break;
+			sent += static_cast<size_t>(bytes);
+		}
+		close(client);
+	}
+
+	int listen_fd_ {-1};
+	int port_ {0};
+	int status_;
+	std::string body_;
+	std::string request_;
+	std::thread worker_;
+};
+
+} // namespace
+
+int main() {
+	plan(9);
+
+	OneShotHttpServer authenticated_server(
+		200, R"({"jsonrpc":"2.0","result":{},"id":1})");
+	MCPClient authenticated_client("127.0.0.1", authenticated_server.port(), 2000);
+	authenticated_client.set_auth_token("tap-token");
+	ok(authenticated_client.check_server(),
+	   "authenticated HTTP 200 JSON-RPC ping is ready");
+	const std::string authenticated_request = authenticated_server.request();
+	ok(authenticated_request.find("Authorization: Bearer tap-token\r\n") != std::string::npos,
+	   "readiness request sends configured bearer token");
+	ok(authenticated_request.find("POST /mcp/config HTTP/") != std::string::npos,
+	   "readiness request targets the config endpoint");
+
+	OneShotHttpServer unauthorized_server(
+		401, R"({"jsonrpc":"2.0","result":{},"id":1})");
+	MCPClient unauthorized_client("127.0.0.1", unauthorized_server.port(), 2000);
+	unauthorized_client.set_auth_token("wrong-token");
+	ok(!unauthorized_client.check_server(),
+	   "HTTP 401 is not accepted even when its body contains a result");
+	ok(unauthorized_client.get_last_error().find("401") != std::string::npos,
+	   "HTTP readiness failure preserves the response status");
+	unauthorized_server.request();
+
+	OneShotHttpServer malformed_server(200, R"(not JSON, but contains "result")");
+	MCPClient malformed_client("127.0.0.1", malformed_server.port(), 2000);
+	ok(!malformed_client.check_server(),
+	   "HTTP 200 body containing result text is rejected when it is not JSON");
+	malformed_server.request();
+
+	OneShotHttpServer wrong_id_server(
+		200, R"({"jsonrpc":"2.0","result":{},"id":99})");
+	MCPClient wrong_id_client("127.0.0.1", wrong_id_server.port(), 2000);
+	ok(!wrong_id_client.check_server(),
+	   "JSON-RPC response with a mismatched id is rejected");
+	wrong_id_server.request();
+
+	OneShotHttpServer anonymous_server(
+		200, R"({"jsonrpc":"2.0","result":{},"id":1})");
+	MCPClient anonymous_client("127.0.0.1", anonymous_server.port(), 2000);
+	ok(anonymous_client.check_server(),
+	   "readiness still supports an endpoint configured without authentication");
+	const std::string anonymous_request = anonymous_server.request();
+	ok(anonymous_request.find("Authorization:") == std::string::npos,
+	   "readiness omits Authorization when no token is configured");
+
+	return exit_status();
+}

--- a/test/tap/tests/unit/pgsql_txn_state_unit-t.cpp
+++ b/test/tap/tests/unit/pgsql_txn_state_unit-t.cpp
@@ -664,8 +664,37 @@ static void test_statemgr_abort_as_rollback() {
 	destroy_test_session(sess);
 }
 
+// ============================================================
+// Processlist query truncation
+// ============================================================
+
+static void test_current_query_short_truncation_limits() {
+	PgSQL_Session* sess = create_test_session();
+	std::string query = "SELECT 123456789";
+	sess->CurrentQuery.QueryPointer =
+		reinterpret_cast<unsigned char*>(query.data());
+	sess->CurrentQuery.QueryLength = query.size();
+
+	for (int max_length = 1; max_length <= 4; ++max_length) {
+		char* current_query = sess->get_current_query(max_length);
+		const std::string expected = max_length < 4
+			? query.substr(0, max_length)
+			: "S...";
+		ok(current_query != nullptr && expected == current_query,
+			"current query: max length %d is truncated safely", max_length);
+		free(current_query);
+	}
+
+	char* current_query = sess->get_current_query();
+	ok(current_query != nullptr && query == current_query,
+		"current query: unlimited length preserves the complete query");
+	free(current_query);
+
+	destroy_test_session(sess);
+}
+
 int main() {
-	plan(112);
+	plan(117);
 	test_init_minimal();
 
 	// --- Parser tests (54 tests) ---
@@ -702,7 +731,10 @@ int main() {
 	test_statemgr_end_as_commit();                  // 3
 	test_statemgr_abort_as_rollback();              // 3
 	// State manager subtotal: 58
-	// Grand total: 54 + 58 = 112
+
+	// --- Processlist query truncation (5 tests) ---
+	test_current_query_short_truncation_limits();   // 5
+	// Grand total: 54 + 58 + 5 = 117
 
 	test_cleanup_minimal();
 	return exit_status();

--- a/test/tap/tests/unit/statistics_unit-t.cpp
+++ b/test/tap/tests/unit/statistics_unit-t.cpp
@@ -616,6 +616,31 @@ static void test_insert_and_query_tsdb_metric() {
 	}
 }
 
+static void test_list_tsdb_metric_names() {
+	std::map<std::string, std::string> labels;
+	const time_t now = time(nullptr) + 50;
+	stats->insert_tsdb_metric("listed_metric_b", labels, 1.0, now);
+	stats->insert_tsdb_metric("listed_metric_a", labels, 2.0, now);
+	stats->insert_tsdb_metric("listed_metric_b", labels, 3.0, now + 1);
+
+	SQLite3_result* result = stats->list_tsdb_metric_names();
+	ok(result != nullptr, "list_tsdb_metric_names: returns a result");
+	if (result) {
+		bool found_a = false;
+		bool found_b = false;
+		for (int index = 0; index < result->rows_count; ++index) {
+			const char* name = result->rows[index]->fields[0];
+			found_a = found_a || (name != nullptr && strcmp(name, "listed_metric_a") == 0);
+			found_b = found_b || (name != nullptr && strcmp(name, "listed_metric_b") == 0);
+		}
+		ok(found_a && found_b,
+		   "list_tsdb_metric_names: returns both distinct inserted names");
+		delete result;
+	} else {
+		ok(false, "list_tsdb_metric_names: returns both distinct inserted names");
+	}
+}
+
 static void test_query_tsdb_metric_with_label_filter() {
 	time_t now = time(nullptr) + 100;  // offset to not collide with previous test
 
@@ -873,8 +898,8 @@ int main() {
 	num_tests += 42;
 	// TSDB timers: 9
 	num_tests += 9;
-	// TSDB metric insert/query: 9
-	num_tests += 9;
+	// TSDB metric insert/query: 11
+	num_tests += 11;
 	// TSDB backend health: 4
 	num_tests += 4;
 	// TSDB monitor concurrency: 1
@@ -944,6 +969,7 @@ int main() {
 
 	// TSDB metric insert/query
 	test_insert_and_query_tsdb_metric();
+	test_list_tsdb_metric_names();
 	test_query_tsdb_metric_with_label_filter();
 	test_query_tsdb_metric_with_single_quote_in_name();
 	test_query_tsdb_metric_swapped_time_range();

--- a/test/tap/tests/unit/statistics_unit-t.cpp
+++ b/test/tap/tests/unit/statistics_unit-t.cpp
@@ -33,9 +33,11 @@
 #include <cstring>
 #include <cstdlib>
 #include <array>
+#include <chrono>
 #include <string>
 #include <map>
 #include <memory>
+#include <thread>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -718,6 +720,47 @@ static void test_insert_and_query_backend_health() {
 	}
 }
 
+static void test_tsdb_query_does_not_wait_for_backend_probe() {
+	// TEST-NET-1 is deliberately non-routable on the public Internet. The
+	// monitor's nonblocking connect therefore remains in poll() until its
+	// one-second timeout, giving us a deterministic in-flight probe window.
+	srv_info_t info;
+	info.addr = "192.0.2.1";
+	info.port = 65000;
+	info.kind = "tsdb-unit-test";
+	srv_opts_t opts;
+	opts.weigth = 1;
+	opts.max_conns = 1;
+	opts.use_ssl = 0;
+
+	MyHGM->wrlock();
+	const int add_rc = MyHGM->create_new_server_in_hg(65000, info, opts);
+	MyHGM->wrunlock();
+	if (add_rc != 0) {
+		ok(false, "TSDB monitor probe fixture is created");
+		return;
+	}
+
+	stats->set_variable("enabled", "1");
+	stats->set_variable("monitor_enabled", "1");
+	std::thread monitor([]() { stats->tsdb_monitor_loop(); });
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+	const auto started = std::chrono::steady_clock::now();
+	(void)stats->get_tsdb_status();
+	const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::steady_clock::now() - started).count();
+
+	monitor.join();
+	MyHGM->wrlock();
+	MyHGM->remove_server_in_hg(65000, info.addr, info.port);
+	MyHGM->wrunlock();
+
+	ok(elapsed < 500,
+	   "TSDB status query does not wait for backend probe completion (elapsed=%lldms)",
+	   static_cast<long long>(elapsed));
+}
+
 // ============================================================
 // TSDB status
 // ============================================================
@@ -834,6 +877,8 @@ int main() {
 	num_tests += 9;
 	// TSDB backend health: 4
 	num_tests += 4;
+	// TSDB monitor concurrency: 1
+	num_tests += 1;
 	// TSDB status: 3
 	num_tests += 3;
 	// TSDB downsampling/retention: 5
@@ -906,6 +951,7 @@ int main() {
 
 	// TSDB backend health
 	test_insert_and_query_backend_health();
+	test_tsdb_query_does_not_wait_for_backend_probe();
 
 	// TSDB status
 	test_get_tsdb_status();

--- a/test/tap/tests/vector_db_performance-t.cpp
+++ b/test/tap/tests/vector_db_performance-t.cpp
@@ -18,7 +18,7 @@ using std::vector;
 
 namespace {
 
-constexpr size_t kEmbeddingDimensions = 1536;
+constexpr size_t EMBEDDING_DIMENSIONS = 1536;
 
 uint64_t fnv1a(const string& text) {
 	uint64_t hash = UINT64_C(14695981039346656037);
@@ -40,9 +40,9 @@ uint64_t splitmix64(uint64_t& state) {
 vector<float> mock_generate_embedding(const string& text) {
 	uint64_t state = fnv1a(text);
 	vector<float> embedding;
-	embedding.reserve(kEmbeddingDimensions);
+	embedding.reserve(EMBEDDING_DIMENSIONS);
 
-	for (size_t index = 0; index < kEmbeddingDimensions; ++index) {
+	for (size_t index = 0; index < EMBEDDING_DIMENSIONS; ++index) {
 		const uint32_t sample = static_cast<uint32_t>(splitmix64(state) >> 40);
 		const float normalized = static_cast<float>(sample) / 8388607.5f - 1.0f;
 		embedding.push_back(normalized);
@@ -123,8 +123,8 @@ void test_embedding_contract() {
 	const vector<float> repeated = mock_generate_embedding("distinct query 0");
 	const vector<float> distinct = mock_generate_embedding("distinct query 1");
 
-	ok(first.size() == kEmbeddingDimensions,
-	   "Mock embedding has the full %zu-dimensional shape", kEmbeddingDimensions);
+	ok(first.size() == EMBEDDING_DIMENSIONS,
+	   "Mock embedding has the full %zu-dimensional shape", EMBEDDING_DIMENSIONS);
 	ok(first == repeated, "Identical text produces an identical deterministic embedding");
 	ok(first != distinct, "Distinct text changes the deterministic embedding");
 
@@ -167,7 +167,7 @@ void test_workload(const char* label, size_t entry_count, size_t target) {
 	   "%s workload stores all %zu entries", label, entry_count);
 	ok(result.sql == expected_sql,
 	   "%s workload returns the exact query result", label);
-	ok(result.embedding_dimensions == kEmbeddingDimensions,
+	ok(result.embedding_dimensions == EMBEDDING_DIMENSIONS,
 	   "%s lookup uses the full vector shape", label);
 	ok(result.similarity > 0.999999 && result.similarity <= 1.000001,
 	   "%s exact lookup reports unit similarity (got %.8f)", label, result.similarity);

--- a/test/tap/tests/vector_db_performance-t.cpp
+++ b/test/tap/tests/vector_db_performance-t.cpp
@@ -1,409 +1,194 @@
 /**
  * @file vector_db_performance-t.cpp
- * @brief TAP unit tests for vector database performance
- *
- * Test Categories:
- * 1. Embedding generation timing for various text lengths
- * 2. KNN similarity search performance with different dataset sizes
- * 3. Cache hit vs miss performance comparison
- * 4. Concurrent access performance and thread safety
- * 5. Memory usage monitoring during vector operations
- * 6. Large dataset handling (1K+, 10K+ entries)
- *
- * @date 2026-01-16
+ * @brief Deterministic vector-cache correctness and completion checks.
  */
 
-#include "tap.h"
-#include <string>
-#include <string.h>
-#include <cstdio>
-#include <cstdlib>
-#include <cmath>
-#include <vector>
 #include <chrono>
-#include <thread>
-#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <vector>
 
-// ============================================================================
-// Mock structures and functions to simulate vector database operations
-// ============================================================================
+#include "tap.h"
 
-// Mock embedding generation (simulates GenAI embedding)
-static std::vector<float> mock_generate_embedding(const std::string& text) {
-	// Simulate time taken for embedding generation based on text length
-	// In real implementation, this would call GloGATH->embed_documents()
+using std::string;
+using std::vector;
 
-	// Simple mock: create a fixed-size embedding with values based on text
-	std::vector<float> embedding(1536, 0.0f); // Standard embedding size
+namespace {
 
-	// Fill with pseudo-random values based on text content
-	unsigned int hash = 0;
-	for (char c : text) {
-		hash = hash * 31 + static_cast<unsigned char>(c);
+constexpr size_t kEmbeddingDimensions = 1536;
+
+uint64_t fnv1a(const string& text) {
+	uint64_t hash = UINT64_C(14695981039346656037);
+	for (unsigned char character : text) {
+		hash ^= character;
+		hash *= UINT64_C(1099511628211);
 	}
+	return hash;
+}
 
-	// Use hash to generate deterministic but varied embedding values
-	for (size_t i = 0; i < embedding.size() && i < sizeof(hash); i++) {
-		embedding[i] = static_cast<float>((hash >> (i * 8)) & 0xFF) / 255.0f;
+uint64_t splitmix64(uint64_t& state) {
+	state += UINT64_C(0x9e3779b97f4a7c15);
+	uint64_t value = state;
+	value = (value ^ (value >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+	value = (value ^ (value >> 27)) * UINT64_C(0x94d049bb133111eb);
+	return value ^ (value >> 31);
+}
+
+vector<float> mock_generate_embedding(const string& text) {
+	uint64_t state = fnv1a(text);
+	vector<float> embedding;
+	embedding.reserve(kEmbeddingDimensions);
+
+	for (size_t index = 0; index < kEmbeddingDimensions; ++index) {
+		const uint32_t sample = static_cast<uint32_t>(splitmix64(state) >> 40);
+		const float normalized = static_cast<float>(sample) / 8388607.5f - 1.0f;
+		embedding.push_back(normalized);
 	}
-
 	return embedding;
 }
 
-// Mock cache entry structure
+double cosine_similarity(const vector<float>& left, const vector<float>& right) {
+	if (left.empty() || left.size() != right.size()) return 0.0;
+
+	double dot_product = 0.0;
+	double left_norm = 0.0;
+	double right_norm = 0.0;
+	for (size_t index = 0; index < left.size(); ++index) {
+		dot_product += static_cast<double>(left[index]) * right[index];
+		left_norm += static_cast<double>(left[index]) * left[index];
+		right_norm += static_cast<double>(right[index]) * right[index];
+	}
+	if (left_norm == 0.0 || right_norm == 0.0) return 0.0;
+	return dot_product / (std::sqrt(left_norm) * std::sqrt(right_norm));
+}
+
 struct MockCacheEntry {
-	std::string natural_language;
-	std::string generated_sql;
-	std::vector<float> embedding;
-	long long timestamp;
+	string natural_language;
+	string generated_sql;
+	vector<float> embedding;
 };
 
-// Mock vector database
+struct LookupResult {
+	long long elapsed_microseconds;
+	string sql;
+	double similarity;
+	size_t embedding_dimensions;
+};
+
 class MockVectorDB {
-private:
-	std::vector<MockCacheEntry> entries;
-	size_t max_entries;
-
 public:
-	MockVectorDB(size_t max_size = 10000) : max_entries(max_size) {}
-
-	// Simulate cache storage with timing
-	long long store_entry(const std::string& query, const std::string& sql) {
-		auto start = std::chrono::high_resolution_clock::now();
-
-		// Generate embedding
-		std::vector<float> embedding = mock_generate_embedding(query);
-
-		// Check if we need to evict old entries
-		if (entries.size() >= max_entries) {
-			// Remove oldest entry (simple FIFO)
-			entries.erase(entries.begin());
-		}
-
-		// Add new entry
-		MockCacheEntry entry;
-		entry.natural_language = query;
-		entry.generated_sql = sql;
-		entry.embedding = embedding;
-		entry.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
-			std::chrono::system_clock::now().time_since_epoch()).count();
-
-		entries.push_back(entry);
-
-		auto end = std::chrono::high_resolution_clock::now();
-		auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-		return duration.count();
+	explicit MockVectorDB(size_t maximum_entries = 10000)
+		: max_entries(maximum_entries) {
+		entries.reserve(maximum_entries);
 	}
 
-	// Simulate cache lookup with timing
-	std::pair<long long, std::string> lookup_entry(const std::string& query, float similarity_threshold = 0.85f) {
-		auto start = std::chrono::high_resolution_clock::now();
+	void store_entry(const string& query, const string& sql) {
+		if (entries.size() >= max_entries) entries.erase(entries.begin());
+		entries.push_back({query, sql, mock_generate_embedding(query)});
+	}
 
-		// Generate embedding for query
-		std::vector<float> query_embedding = mock_generate_embedding(query);
+	LookupResult lookup_entry(const string& query, double threshold = 0.85) const {
+		const auto start = std::chrono::steady_clock::now();
+		const vector<float> query_embedding = mock_generate_embedding(query);
+		double best_similarity = -1.0;
+		string best_sql;
 
-		// Find best match using cosine similarity
-		float best_similarity = -1.0f;
-		std::string best_sql = "";
-
-		for (const auto& entry : entries) {
-			float similarity = cosine_similarity(query_embedding, entry.embedding);
-			if (similarity > best_similarity && similarity >= similarity_threshold) {
+		for (const MockCacheEntry& entry : entries) {
+			const double similarity = cosine_similarity(query_embedding, entry.embedding);
+			if (similarity >= threshold && similarity > best_similarity) {
 				best_similarity = similarity;
 				best_sql = entry.generated_sql;
 			}
 		}
 
-		auto end = std::chrono::high_resolution_clock::now();
-		auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-		return std::make_pair(duration.count(), best_sql);
-	}
-
-	// Calculate cosine similarity between two vectors
-	float cosine_similarity(const std::vector<float>& a, const std::vector<float>& b) {
-		if (a.size() != b.size() || a.empty()) return 0.0f;
-
-		float dot_product = 0.0f;
-		float norm_a = 0.0f;
-		float norm_b = 0.0f;
-
-		for (size_t i = 0; i < a.size(); i++) {
-			dot_product += a[i] * b[i];
-			norm_a += a[i] * a[i];
-			norm_b += b[i] * b[i];
-		}
-
-		if (norm_a == 0.0f || norm_b == 0.0f) return 0.0f;
-
-		return dot_product / (sqrt(norm_a) * sqrt(norm_b));
+		const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::steady_clock::now() - start);
+		return {
+			elapsed.count(), best_sql, best_similarity, query_embedding.size()
+		};
 	}
 
 	size_t size() const { return entries.size(); }
-	void clear() { entries.clear(); }
+
+private:
+	vector<MockCacheEntry> entries;
+	size_t max_entries;
 };
 
-// ============================================================================
-// Test: Embedding Generation Timing
-// ============================================================================
+void test_embedding_contract() {
+	const vector<float> first = mock_generate_embedding("distinct query 0");
+	const vector<float> repeated = mock_generate_embedding("distinct query 0");
+	const vector<float> distinct = mock_generate_embedding("distinct query 1");
 
-void test_embedding_timing() {
-	diag("=== Embedding Generation Timing ===");
+	ok(first.size() == kEmbeddingDimensions,
+	   "Mock embedding has the full %zu-dimensional shape", kEmbeddingDimensions);
+	ok(first == repeated, "Identical text produces an identical deterministic embedding");
+	ok(first != distinct, "Distinct text changes the deterministic embedding");
 
-	// Test with different text lengths
-	std::vector<std::string> test_texts = {
-		"Short query",
-		"A medium length query with more words to process",
-		"A very long query that contains many words and should take more time to process because it has significantly more text content that needs to be analyzed and converted into embeddings for vector database operations",
-		std::string(1000, 'A') // Very long text
-	};
-
-	std::vector<long long> timings;
-
-	for (const auto& text : test_texts) {
-		auto start = std::chrono::high_resolution_clock::now();
-		auto embedding = mock_generate_embedding(text);
-		auto end = std::chrono::high_resolution_clock::now();
-
-		auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-		timings.push_back(duration.count());
-
-		ok(embedding.size() == 1536, "Embedding has correct size for text length %zu", text.length());
-	}
-
-	// Verify that longer texts take more time (roughly)
-	ok(timings[0] <= timings[1], "Medium text takes longer than short text");
-	ok(timings[1] <= timings[2], "Long text takes longer than medium text");
-
-	diag("Embedding times (microseconds): Short=%lld, Medium=%lld, Long=%lld, VeryLong=%lld",
-	     timings[0], timings[1], timings[2], timings[3]);
+	const double self_similarity = cosine_similarity(first, repeated);
+	const double distinct_similarity = cosine_similarity(first, distinct);
+	ok(self_similarity > 0.999999 && self_similarity <= 1.000001,
+	   "Identical embeddings have unit similarity (got %.8f)", self_similarity);
+	ok(distinct_similarity < 0.99,
+	   "Distinct embeddings stay below the 0.99 match threshold (got %.8f)",
+	   distinct_similarity);
 }
 
-// ============================================================================
-// Test: KNN Search Performance
-// ============================================================================
+void test_distinct_query_regression() {
+	MockVectorDB database;
+	database.store_entry("distinct query 0", "SELECT 0");
+	ok(database.size() == 1, "Regression fixture stores one vector entry");
 
-void test_knn_search_performance() {
-	diag("=== KNN Search Performance ===");
-
-	MockVectorDB db;
-
-	// Populate database with test entries
-	const size_t small_dataset = 100;
-	const size_t medium_dataset = 1000;
-	const size_t large_dataset = 10000;
-
-	// Test with small dataset
-	for (size_t i = 0; i < small_dataset; i++) {
-		std::string query = "Test query " + std::to_string(i);
-		std::string sql = "SELECT * FROM table WHERE id = " + std::to_string(i);
-		db.store_entry(query, sql);
-	}
-
-	// Test search performance
-	auto result = db.lookup_entry("Test query 50");
-	ok(result.second == "SELECT * FROM table WHERE id = 50" || result.second.empty(),
-	   "Search finds correct entry or no match in small dataset");
-
-	diag("Small dataset (%zu entries) search time: %lld microseconds", small_dataset, result.first);
-
-	// Clear and test with medium dataset
-	db.clear();
-	for (size_t i = 0; i < medium_dataset; i++) {
-		std::string query = "Test query " + std::to_string(i);
-		std::string sql = "SELECT * FROM table WHERE id = " + std::to_string(i);
-		db.store_entry(query, sql);
-	}
-
-	result = db.lookup_entry("Test query 500");
-	ok(result.second == "SELECT * FROM table WHERE id = 500" || result.second.empty(),
-	   "Search finds correct entry or no match in medium dataset");
-
-	diag("Medium dataset (%zu entries) search time: %lld microseconds", medium_dataset, result.first);
-
-	// Test with query that won't match exactly (tests full search)
-	result = db.lookup_entry("Completely different query");
-	ok(result.second.empty(), "No match found for completely different query");
-
-	diag("Non-matching query search time: %lld microseconds", result.first);
+	const LookupResult result = database.lookup_entry("distinct query 1", 0.99);
+	ok(result.sql.empty(),
+	   "Distinct query does not reuse an unrelated result at 0.99 similarity");
 }
 
-// ============================================================================
-// Test: Cache Hit vs Miss Performance
-// ============================================================================
+void test_workload(const char* label, size_t entry_count, size_t target) {
+	MockVectorDB database(entry_count);
+	const auto insert_start = std::chrono::steady_clock::now();
+	for (size_t index = 0; index < entry_count; ++index) {
+		database.store_entry(
+			"Workload query " + std::to_string(index),
+			"SELECT * FROM workload WHERE id=" + std::to_string(index));
+	}
+	const auto insert_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::steady_clock::now() - insert_start);
 
-void test_cache_hit_miss_performance() {
-	diag("=== Cache Hit vs Miss Performance ===");
+	const LookupResult result = database.lookup_entry(
+		"Workload query " + std::to_string(target), 0.99);
+	const string expected_sql =
+		"SELECT * FROM workload WHERE id=" + std::to_string(target);
 
-	MockVectorDB db;
-
-	// Add some entries
-	db.store_entry("Show me all users", "SELECT * FROM users;");
-	db.store_entry("Count the orders", "SELECT COUNT(*) FROM orders;");
-
-	// Test cache hit
-	auto hit_result = db.lookup_entry("Show me all users");
-	ok(!hit_result.second.empty(), "Cache hit returns result");
-
-	// Test cache miss
-	auto miss_result = db.lookup_entry("List all products");
-	ok(miss_result.second.empty(), "Cache miss returns empty result");
-
-	// Verify hit is faster than miss (should be roughly similar in mock, but let's check)
-	diag("Cache hit time: %lld microseconds, Cache miss time: %lld microseconds",
-	     hit_result.first, miss_result.first);
-
-	// Both should be reasonable times
-	ok(hit_result.first < 100000, "Cache hit time is reasonable (< 100ms)");
-	ok(miss_result.first < 100000, "Cache miss time is reasonable (< 100ms)");
+	ok(database.size() == entry_count,
+	   "%s workload stores all %zu entries", label, entry_count);
+	ok(result.sql == expected_sql,
+	   "%s workload returns the exact query result", label);
+	ok(result.embedding_dimensions == kEmbeddingDimensions,
+	   "%s lookup uses the full vector shape", label);
+	ok(result.similarity > 0.999999 && result.similarity <= 1.000001,
+	   "%s exact lookup reports unit similarity (got %.8f)", label, result.similarity);
+	ok(insert_elapsed.count() < 120000,
+	   "%s workload completes insertion within 120 seconds (took %lld ms)",
+	   label, static_cast<long long>(insert_elapsed.count()));
+	ok(result.elapsed_microseconds < 30000000,
+	   "%s workload completes lookup within 30 seconds (took %lld us)",
+	   label, result.elapsed_microseconds);
 }
 
-// ============================================================================
-// Test: Memory Usage Monitoring
-// ============================================================================
-
-void test_memory_usage() {
-	diag("=== Memory Usage Monitoring ===");
-
-	// This is a conceptual test - in real implementation, we would monitor actual memory usage
-	// For now, we'll test that the database doesn't grow unreasonably
-
-	MockVectorDB db(1000); // Limit to 1000 entries
-
-	// Add many entries
-	for (size_t i = 0; i < 500; i++) {
-		std::string query = "Query " + std::to_string(i);
-		std::string sql = "SELECT * FROM table WHERE id = " + std::to_string(i);
-		db.store_entry(query, sql);
-	}
-
-	ok(db.size() == 500, "Database has expected number of entries (500)");
-
-	// Add more entries to test size limit
-	for (size_t i = 500; i < 1200; i++) {
-		std::string query = "Query " + std::to_string(i);
-		std::string sql = "SELECT * FROM table WHERE id = " + std::to_string(i);
-		db.store_entry(query, sql);
-	}
-
-	// Should be capped at 1000 entries due to limit
-	ok(db.size() <= 1000, "Database size respects maximum limit");
-
-	diag("Database size after adding 1200 entries: %zu", db.size());
-}
-
-// ============================================================================
-// Test: Large Dataset Handling
-// ============================================================================
-
-void test_large_dataset_handling() {
-	diag("=== Large Dataset Handling ===");
-
-	MockVectorDB db;
-
-	// Test handling of large dataset (10K entries)
-	const size_t large_size = 10000;
-
-	auto start_insert = std::chrono::high_resolution_clock::now();
-
-	// Insert large number of entries
-	for (size_t i = 0; i < large_size; i++) {
-		std::string query = "Large dataset query " + std::to_string(i);
-		std::string sql = "SELECT * FROM large_table WHERE id = " + std::to_string(i);
-
-		// Every 1000 entries, report progress
-		if (i % 1000 == 0 && i > 0) {
-			diag("Inserted %zu entries...", i);
-		}
-
-		db.store_entry(query, sql);
-	}
-
-	auto end_insert = std::chrono::high_resolution_clock::now();
-	auto insert_duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_insert - start_insert);
-
-	ok(db.size() == large_size, "Large dataset (%zu entries) inserted successfully", large_size);
-	diag("Time to insert %zu entries: %ld ms", large_size, insert_duration.count());
-
-	// Test search performance in large dataset
-	auto search_result = db.lookup_entry("Large dataset query 5000");
-	ok(search_result.second == "SELECT * FROM large_table WHERE id = 5000" || search_result.second.empty(),
-	   "Search works in large dataset");
-
-	diag("Search time in %zu entry dataset: %lld microseconds", large_size, search_result.first);
-
-	// Performance should be reasonable even with large dataset
-	ok(search_result.first < 500000, "Search time reasonable in large dataset (< 500ms)");
-	ok(insert_duration.count() < 30000, "Insert time reasonable for large dataset (< 30s)");
-}
-
-// ============================================================================
-// Test: Concurrent Access Performance
-// ============================================================================
-
-void test_concurrent_access() {
-	diag("=== Concurrent Access Performance ===");
-
-	// This is a simplified test - in real implementation, we would test actual thread safety
-	MockVectorDB db;
-
-	// Populate with some data
-	for (size_t i = 0; i < 100; i++) {
-		std::string query = "Concurrent test " + std::to_string(i);
-		std::string sql = "SELECT * FROM concurrent_table WHERE id = " + std::to_string(i);
-		db.store_entry(query, sql);
-	}
-
-	// Simulate concurrent access by running multiple operations
-	const int num_operations = 10;
-	std::vector<long long> timings;
-
-	auto start = std::chrono::high_resolution_clock::now();
-
-	for (int i = 0; i < num_operations; i++) {
-		auto result = db.lookup_entry("Concurrent test " + std::to_string(i * 2));
-		timings.push_back(result.first);
-	}
-
-	auto end = std::chrono::high_resolution_clock::now();
-	auto total_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-
-	// All operations should complete successfully
-	ok(timings.size() == static_cast<size_t>(num_operations), "All concurrent operations completed");
-
-	// Calculate average time
-	long long total_time = 0;
-	for (long long time : timings) {
-		total_time += time;
-	}
-	long long avg_time = total_time / num_operations;
-
-	diag("Average time per concurrent operation: %lld microseconds", avg_time);
-	diag("Total time for %d operations: %ld microseconds", num_operations, total_duration.count());
-
-	// Operations should be reasonably fast
-	ok(avg_time < 50000, "Average concurrent operation time reasonable (< 50ms)");
-}
-
-// ============================================================================
-// Main
-// ============================================================================
+} // namespace
 
 int main() {
-	// Plan: 25 tests total
-	// Embedding timing: 5 tests
-	// KNN search performance: 4 tests
-	// Cache hit vs miss: 3 tests
-	// Memory usage: 3 tests
-	// Large dataset handling: 5 tests
-	// Concurrent access: 5 tests
 	plan(25);
 
-	test_embedding_timing();
-	test_knn_search_performance();
-	test_cache_hit_miss_performance();
-	test_memory_usage();
-	test_large_dataset_handling();
-	test_concurrent_access();
+	test_embedding_contract();
+	test_distinct_query_regression();
+	test_workload("small", 100, 50);
+	test_workload("medium", 1000, 500);
+	test_workload("large", 10000, 5000);
 
 	return exit_status();
 }

--- a/test/tap/tests/vector_features-t.cpp
+++ b/test/tap/tests/vector_features-t.cpp
@@ -1,339 +1,159 @@
 /**
  * @file vector_features-t.cpp
- * @brief TAP unit tests for Vector Features (NL2SQL cache & Anomaly similarity)
- *
- * Test Categories:
- * 1. Virtual vec0 table creation
- * 2. NL2SQL vector cache operations
- * 3. Anomaly threat pattern management
- * 4. Embedding generation (requires GenAI/llama-server)
- *
- * Prerequisites:
- * - ProxySQL with AI features enabled
- * - Admin interface on localhost:6032
- * - GenAI module with llama-server (for embedding tests)
- *
- * Usage:
- *   make vector_features
- *   ./vector_features
- *
- * @date 2025-01-16
+ * @brief Verify vector, cache, anomaly, and GenAI status configuration.
  */
 
-#include <algorithm>
+#include <cstdlib>
 #include <string>
-#include <string.h>
-#include <stdio.h>
 #include <unistd.h>
-#include <vector>
 
 #include "mysql.h"
-#include "mysqld_error.h"
 
-#include "tap.h"
 #include "command_line.h"
-#include "utils.h"
+#include "tap.h"
 
 using std::string;
-using std::vector;
 
-// Global admin connection
-MYSQL* g_admin = nullptr;
+namespace {
 
-// Global ProxySQL connection for testing
-MYSQL* g_proxy = nullptr;
-
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * @brief Get AI variable value via Admin interface
- * AI variables are stored as columns in mysql_servers table with ai_ prefix
- */
-string get_ai_variable(const char* name) {
-	char query[256];
-	snprintf(query, sizeof(query),
-			 "SELECT ai_%s FROM mysql_servers LIMIT 1", name);
-
-	if (mysql_query(g_admin, query)) {
-		diag("Failed to query variable: %s", mysql_error(g_admin));
-		return "";
-	}
-
-	MYSQL_RES* result = mysql_store_result(g_admin);
-	if (!result) {
-		return "";
-	}
-
-	MYSQL_ROW row = mysql_fetch_row(result);
-	string value = row ? (row[0] ? row[0] : "") : "";
-
-	mysql_free_result(result);
-	return value;
-}
-
-/**
- * @brief Set AI variable
- */
-bool set_ai_variable(const char* name, const char* value) {
-	char query[256];
-	snprintf(query, sizeof(query),
-			 "UPDATE mysql_servers SET ai_%s='%s'",
-			 name, value);
-
-	if (mysql_query(g_admin, query)) {
-		diag("Failed to set variable: %s", mysql_error(g_admin));
+bool execute_admin(MYSQL* admin, const string& sql) {
+	if (mysql_query(admin, sql.c_str()) != 0) {
+		diag("Admin command failed: %s: %s", sql.c_str(), mysql_error(admin));
 		return false;
 	}
-
-	snprintf(query, sizeof(query), "LOAD MYSQL VARIABLES TO RUNTIME");
-	if (mysql_query(g_admin, query)) {
-		diag("Failed to load variables: %s", mysql_error(g_admin));
-		return false;
-	}
-
+	MYSQL_RES* result = mysql_store_result(admin);
+	if (result != nullptr) mysql_free_result(result);
 	return true;
 }
 
-/**
- * @brief Check if AI features are initialized
- */
-bool check_ai_initialized() {
-	// Check if GloAI exists by trying to access AI variables
-	string enabled = get_ai_variable("nl2sql_enabled");
-	return !enabled.empty() || (enabled.empty() && true); // May be empty but OK
+string quote_value(MYSQL* admin, const string& value) {
+	string escaped(value.size() * 2 + 1, '\0');
+	const unsigned long length = mysql_real_escape_string(
+		admin, escaped.data(), value.c_str(), static_cast<unsigned long>(value.size()));
+	escaped.resize(length);
+	return "'" + escaped + "'";
 }
 
-// ============================================================================
-// Test 1: Virtual vec0 Table Creation
-// ============================================================================
-
-/**
- * @test Virtual vec0 tables are created
- * @description Verify that sqlite-vec virtual tables were created during init
- * @expected nl2sql_cache_vec, anomaly_patterns_vec, query_history_vec should exist
- */
-void test_virtual_tables_created() {
-	diag("=== Virtual vec0 Table Creation Tests ===");
-
-	// Note: We can't directly query the vector DB from SQL client
-	// This test verifies the AI features are initialized
-	ok(check_ai_initialized(), "AI features initialized");
-
-	// Check that vector DB path is configured
-	string db_path = get_ai_variable("vector_db_path");
-	ok(!db_path.empty() || db_path.empty(), "Vector DB path configured (or default used)");
-
-	// Check vector dimension
-	string dim = get_ai_variable("vector_dimension");
-	ok(dim == "1536" || dim.empty(), "Vector dimension is 1536 or default");
-}
-
-// ============================================================================
-// Test 2: NL2SQL Vector Cache Configuration
-// ============================================================================
-
-/**
- * @test NL2SQL cache configuration
- * @description Verify NL2SQL cache variables are accessible
- */
-void test_nl2sql_cache_config() {
-	diag("=== NL2SQL Vector Cache Configuration Tests ===");
-
-	// Test 1: Check cache enabled by default
-	string enabled = get_ai_variable("nl2sql_enabled");
-	ok(enabled == "true" || enabled == "1" || enabled.empty(),
-	   "NL2SQL enabled by default");
-
-	// Test 2: Check cache similarity threshold
-	string threshold = get_ai_variable("nl2sql_cache_similarity_threshold");
-	ok(threshold == "85" || threshold.empty(),
-	   "Cache similarity threshold is 85 or default");
-
-	// Test 3: Set and verify cache threshold
-	if (set_ai_variable("nl2sql_cache_similarity_threshold", "90")) {
-		string new_threshold = get_ai_variable("nl2sql_cache_similarity_threshold");
-		ok(new_threshold == "90" || new_threshold.empty(), "Cache threshold changed to 90");
-
-		// Restore default
-		set_ai_variable("nl2sql_cache_similarity_threshold", "85");
-	} else {
-		skip(1, "Cannot set cache threshold variable");
+bool query_scalar(MYSQL* admin, const string& sql, string& value) {
+	value.clear();
+	if (mysql_query(admin, sql.c_str()) != 0) {
+		diag("Admin query failed: %s: %s", sql.c_str(), mysql_error(admin));
+		return false;
 	}
+	MYSQL_RES* result = mysql_store_result(admin);
+	if (result == nullptr) return false;
+	MYSQL_ROW row = mysql_fetch_row(result);
+	const bool found = row != nullptr && row[0] != nullptr;
+	if (found) value = row[0];
+	mysql_free_result(result);
+	return found;
 }
 
-// ============================================================================
-// Test 3: Anomaly Detection Embedding Configuration
-// ============================================================================
-
-/**
- * @test Anomaly embedding similarity configuration
- * @description Verify anomaly embedding similarity variables are accessible
- */
-void test_anomaly_embedding_config() {
-	diag("=== Anomaly Embedding Configuration Tests ===");
-
-	// Test 1: Check anomaly enabled
-	string enabled = get_ai_variable("anomaly_enabled");
-	ok(enabled == "true" || enabled == "1" || enabled.empty(),
-	   "Anomaly Detection enabled by default");
-
-	// Test 2: Check similarity threshold
-	string threshold = get_ai_variable("anomaly_similarity_threshold");
-	ok(threshold == "85" || threshold.empty(),
-	   "Similarity threshold is 85 or default");
-
-	// Test 3: Check risk threshold
-	string risk = get_ai_variable("anomaly_risk_threshold");
-	ok(risk == "70" || risk.empty(),
-	   "Risk threshold is 70 or default");
+bool read_variable(MYSQL* admin, const string& canonical_name, string& value) {
+	return query_scalar(
+		admin,
+		"SELECT variable_value FROM global_variables WHERE variable_name=" +
+			quote_value(admin, canonical_name),
+		value);
 }
 
-// ============================================================================
-// Test 4: Vector Database File
-// ============================================================================
+bool set_variable(MYSQL* admin, const string& canonical_name, const string& value) {
+	return execute_admin(
+		admin, "SET " + canonical_name + "=" + quote_value(admin, value));
+}
 
-/**
- * @test Vector database file exists
- * @description Verify that the vector database file is created
- */
-void test_vector_db_file() {
-	diag("=== Vector Database File Tests ===");
+void expect_variable(MYSQL* admin, const string& canonical_name, const string& expected) {
+	string value;
+	const bool found = read_variable(admin, canonical_name, value);
+	ok(found && value == expected,
+	   "%s is '%s' (got '%s')",
+	   canonical_name.c_str(), expected.c_str(), value.c_str());
+}
 
-	// Get the vector DB path
-	string db_path = get_ai_variable("vector_db_path");
-	if (db_path.empty()) {
-		db_path = "/var/lib/proxysql/ai_features.db";
+void expect_status(MYSQL* admin, const string& name) {
+	string value;
+	const bool found = query_scalar(
+		admin,
+		"SELECT Value FROM stats_genai_global WHERE Variable_name=" +
+			quote_value(admin, name),
+		value);
+	bool numeric = found && !value.empty();
+	for (char character : value) {
+		if ((character < '0' || character > '9') && character != '.') numeric = false;
 	}
-
-	// Check if file exists (we can't directly access from test, but verify path is set)
-	ok(!db_path.empty(), "Vector DB path is configured");
-
-	diag("Vector DB path: %s", db_path.c_str());
+	ok(numeric, "stats_genai_global publishes numeric %s (got '%s')", name.c_str(), value.c_str());
 }
 
-// ============================================================================
-// Test 5: Status Variables
-// ============================================================================
+} // namespace
 
-/**
- * @test AI status variables exist
- * @description Verify Prometheus metrics are available
- */
-void test_status_variables() {
-	diag("=== Status Variables Tests ===");
-
-	// Test 1: Check ai_detected_anomalies exists
-	char query[256];
-	snprintf(query, sizeof(query), "SHOW STATUS LIKE 'ai_detected_anomalies'");
-
-	if (mysql_query(g_admin, query) == 0) {
-		MYSQL_RES* result = mysql_store_result(g_admin);
-		if (result) {
-			unsigned long rows = mysql_num_rows(result);
-			ok(rows > 0, "ai_detected_anomalies status variable exists");
-			mysql_free_result(result);
-		} else {
-			ok(false, "ai_detected_anomalies status variable exists");
-		}
-	} else {
-		ok(false, "ai_detected_anomalies status variable query succeeded");
-	}
-
-	// Test 2: Check ai_blocked_queries exists
-	snprintf(query, sizeof(query), "SHOW STATUS LIKE 'ai_blocked_queries'");
-
-	if (mysql_query(g_admin, query) == 0) {
-		MYSQL_RES* result = mysql_store_result(g_admin);
-		if (result) {
-			unsigned long rows = mysql_num_rows(result);
-			ok(rows > 0, "ai_blocked_queries status variable exists");
-			mysql_free_result(result);
-		} else {
-			ok(false, "ai_blocked_queries status variable exists");
-		}
-	} else {
-		ok(false, "ai_blocked_queries status variable query succeeded");
-	}
-}
-
-// ============================================================================
-// Test 6: Cache Statistics
-// ============================================================================
-
-/**
- * @test Cache statistics interface
- * @description Verify cache statistics can be retrieved
- */
-void test_cache_statistics() {
-	diag("=== Cache Statistics Tests ===");
-
-	// Note: We can't directly call get_cache_stats from SQL
-	// But we can verify the configuration allows it
-
-	// Test 1: Verify cache is enabled
-	string enabled = get_ai_variable("nl2sql_enabled");
-	ok(enabled == "true" || enabled == "1" || enabled.empty(),
-	   "Cache is enabled for statistics");
-
-	diag("Cache statistics available via: SHOW STATUS LIKE 'ai_nl2sql_cache_%%'");
-}
-
-// ============================================================================
-// Test 7: GenAI Module Check
-// ============================================================================
-
-/**
- * @test GenAI module availability
- * @description Check if GenAI module is loaded for embedding generation
- */
-void test_genai_module() {
-	diag("=== GenAI Module Tests ===");
-
-	// GenAI module is loaded via GloGATH
-	// We can't directly check it from SQL, but we can verify configuration
-
-	string genai_enabled = get_ai_variable("genai_enabled");
-	ok(genai_enabled == "true" || genai_enabled == "1" || genai_enabled.empty(),
-	   "GenAI module enabled or default");
-
-	diag("GenAI endpoint: http://127.0.0.1:8013/embedding");
-	diag("Note: Embedding tests require llama-server to be running");
-}
-
-// ============================================================================
-// Main
-// ============================================================================
-
-int main(int argc, char** argv) {
-	// Parse command line
+int main() {
 	CommandLine cl;
 	if (cl.getEnv()) {
-		diag("Error getting environment variables");
-		return exit_status();
+		diag("Failed to read TAP environment");
+		return EXIT_FAILURE;
 	}
 
-	// Connect to admin interface
-	g_admin = mysql_init(nullptr);
-	if (!mysql_real_connect(g_admin, cl.host, cl.admin_username, cl.admin_password,
-						nullptr, cl.admin_port, nullptr, 0)) {
-		diag("Failed to connect to admin interface");
-		return exit_status();
+	MYSQL* admin = mysql_init(nullptr);
+	if (admin == nullptr ||
+	    mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password,
+	                       nullptr, cl.admin_port, nullptr, 0) == nullptr) {
+		diag("Failed to connect to ProxySQL admin: %s", admin ? mysql_error(admin) : "mysql_init failed");
+		if (admin != nullptr) mysql_close(admin);
+		return EXIT_FAILURE;
 	}
 
-	// Plan tests: 7 categories with ~3 tests each
-	plan(20);
+	plan(22);
 
-	// Run test categories
-	test_virtual_tables_created();
-	test_nl2sql_cache_config();
-	test_anomaly_embedding_config();
-	test_vector_db_file();
-	test_status_variables();
-	test_cache_statistics();
-	test_genai_module();
+	string vector_count;
+	const bool count_found = query_scalar(
+		admin,
+		"SELECT COUNT(*) FROM global_variables WHERE variable_name IN ("
+		"'genai-vector_db_path','genai-vector_dimension',"
+		"'genai-llm_cache_enabled','genai-llm_cache_similarity_threshold',"
+		"'genai-anomaly_enabled','genai-anomaly_similarity_threshold',"
+		"'genai-anomaly_risk_threshold')",
+		vector_count);
+	ok(count_found && vector_count == "7",
+	   "all seven canonical vector/cache/anomaly variables exist (got '%s')",
+	   vector_count.c_str());
 
-	mysql_close(g_admin);
+	string vector_path;
+	const bool path_found = read_variable(admin, "genai-vector_db_path", vector_path);
+	ok(path_found && vector_path == "/var/lib/proxysql/ai_features.db",
+	   "canonical vector database path is configured (got '%s')", vector_path.c_str());
+	expect_variable(admin, "genai-vector_dimension", "1536");
+	ok(path_found && access(vector_path.c_str(), F_OK) == 0,
+	   "configured vector database exists in the shared isolated datadir");
+	expect_variable(admin, "genai-llm_cache_enabled", "true");
+	expect_variable(admin, "genai-llm_cache_similarity_threshold", "85");
+	expect_variable(admin, "genai-anomaly_enabled", "false");
+	expect_variable(admin, "genai-anomaly_similarity_threshold", "80");
+	expect_variable(admin, "genai-anomaly_risk_threshold", "70");
+
+	expect_status(admin, "genai_threads_initialized");
+	expect_status(admin, "anomaly_blocked_queries");
+	expect_status(admin, "mcp_total_requests");
+
+	const string threshold_name = "genai-llm_cache_similarity_threshold";
+	string original_threshold;
+	if (!read_variable(admin, threshold_name, original_threshold)) original_threshold = "85";
+
+	ok(set_variable(admin, threshold_name, "90"), "set canonical cache threshold in memory");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME"), "load cache threshold to runtime");
+	ok(set_variable(admin, threshold_name, "75"), "change cache threshold only in memory");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES FROM RUNTIME"), "save cache threshold from runtime");
+	expect_variable(admin, threshold_name, "90");
+	ok(execute_admin(admin, "SAVE GENAI VARIABLES TO DISK"), "save cache threshold to disk");
+	ok(set_variable(admin, threshold_name, "70"), "change cache threshold after disk save");
+	ok(execute_admin(admin, "LOAD GENAI VARIABLES FROM DISK"), "load cache threshold from disk");
+	expect_variable(admin, threshold_name, "90");
+
+	const bool restored =
+		set_variable(admin, threshold_name, original_threshold) &&
+		execute_admin(admin, "LOAD GENAI VARIABLES TO RUNTIME") &&
+		execute_admin(admin, "SAVE GENAI VARIABLES TO DISK");
+	ok(restored, "restore original cache threshold in memory, runtime, and disk");
+
+	mysql_close(admin);
 	return exit_status();
 }


### PR DESCRIPTION
## Summary

This PR now consolidates the GenAI/MCP repairs exposed when PR #6083 ran the label-selected ASAN TAP fan-out:

- seed every missing `mcp-*` and `genai-*` default transactionally while preserving operator values
- publish loaded MCP variables atomically and keep processlist settings behind core accessors
- configure explicit MCP bearer authentication, authenticate readiness checks, and update TAP clients and shell tests to the current endpoint contracts
- make vector/GenAI assertions deterministic and restore portable discovery, RAG, and headless coverage
- build every declared GenAI unit binary and fail reconciliation when a shard member is missing, duplicated, skipped, or fails
- isolate mutable shard state so NL2SQL and MCP statistics tests do not depend on execution order
- make GenAI runtime reload and teardown safe for every shared runtime consumer, including MCP AI/RAG calls, query hooks, status collection, and Admin command concurrency
- serialize all access to the shared TSDB SQLite connection with pthread-backed locking, including REST metric discovery, and handle downsampling hour rollover
- harden the AI harness with SQL-safe authentication tokens, verified HTTPS by default, bounded MCP requests and test sockets, explicit reconciliation failures, and checked cleanup
- fix the GenAI discovery-schema leaks found by LeakSanitizer and bound the PgSQL processlist snapshot used by MCP

No AI test has been removed or hidden. `CI-unit-tests-asan-coverage` is unchanged.

## Root causes

The AI shards combined several independent gaps: incomplete plugin initialization, an unprojected runtime view, missing authentication, stale test helpers and interfaces, nondeterministic vector expectations, silently absent unit binaries, mutable cross-test state, unsafe runtime dependency replacement, and unsynchronized TSDB access. ASAN made the existing timing and lifecycle weaknesses easier to expose, but the fixes preserve normal non-ASAN behavior.

## Verification

Verification on this branch:

- full local ASAN baseline before the final review pass: `CI-ai-g1` 22/22 and `CI-ai-g2` 22/22 declared programs executed and passed
- focused ASAN suites rerun after the final runtime and harness changes: lifecycle 95/95, GenAI thread 193/193, MCP thread 203/203, MCP endpoint 36/36, MCP client 10/10, and statistics/TSDB 109/109
- AI shard contract tests: 6/6
- AI shell/rendering contract tests: 8/8
- fresh plugin and affected unit builds: successful
- fresh focused TAP logs: no ASAN, LeakSanitizer, UBSAN, fatal-signal, or `not ok` records
- `git diff --check`: clean

GitHub Actions on the new head remains the final validation.

## Scope

This PR addresses the GenAI `CI-ai-g1` / `CI-ai-g2` findings. MySQL 9.0/9.5 binlog failures are intentionally outside this PR.

Closes #6098
Closes #6099
Closes #6100
Closes #6101
Closes #6102
Closes #6103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic startup seeding for missing MCP and GenAI variables while preserving configured values.
  * Added support for reading and updating the GenAI LLM cache setting.
  * Improved MCP authentication and readiness validation.

* **Bug Fixes**
  * Startup initialization now rolls back safely when variable seeding fails.
  * Improved reliability during GenAI reloads and MCP operations.
  * Fixed short-query truncation and concurrent statistics access issues.

* **Tests**
  * Expanded coverage for persistence, defaults, authentication, runtime reloads, and AI test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->