### PR TITLE
test(pgsql): make monitor SSL transition resilient

### DIFF
--- a/test/tap/tests/pgsql-monitor_ssl_connections_test-t.cpp
+++ b/test/tap/tests/pgsql-monitor_ssl_connections_test-t.cpp
@@ -163,31 +163,61 @@ int main(int argc, char** argv) {
 
     ok(setUseSSL(admin, 0), "Set pgsql_server -> use_ssl = 0");
 
-    long initial_ssl2 = getMonitorValue(admin, "PgSQL_Monitor_ssl_connections_OK");
-    long initial_non2 = getMonitorValue(admin, "PgSQL_Monitor_non_ssl_connections_OK");
+    long transition_ssl = getMonitorValue(admin, "PgSQL_Monitor_ssl_connections_OK");
+    long transition_non = getMonitorValue(admin, "PgSQL_Monitor_non_ssl_connections_OK");
 
-    diag("Initial SSL OK (phase2): %ld", initial_ssl2);
-    diag("Initial NON-SSL OK (phase2): %ld", initial_non2);
+    diag("Initial SSL OK (phase2 transition): %ld", transition_ssl);
+    diag("Initial NON-SSL OK (phase2 transition): %ld", transition_non);
 
-    // Poll for the NON-SSL counter to increase, up to 3x the connect interval.
-    // After switching use_ssl from 1 to 0, the monitor needs to complete a
-    // full cycle with the new config before the NON-SSL counter increases.
+    // LOAD does not cancel a monitor operation already using the old config.
+    // First observe the new non-SSL mode and let any in-flight SSL operation
+    // drain. Two full intervals without another SSL increment establish the
+    // baseline for the strict phase-2 observation window below.
+    int stable_ssl_intervals = 0;
+    bool transition_settled = false;
+    for (int attempt = 0; attempt < 8; attempt++) {
+        usleep(connect_interval_ms * 1000);
+
+        long current_ssl = getMonitorValue(admin, "PgSQL_Monitor_ssl_connections_OK");
+        long current_non = getMonitorValue(admin, "PgSQL_Monitor_non_ssl_connections_OK");
+
+        if (current_ssl == transition_ssl) {
+            stable_ssl_intervals++;
+        } else {
+            stable_ssl_intervals = 0;
+        }
+
+        transition_ssl = current_ssl;
+        transition_non = current_non;
+        if (transition_non > after_non && stable_ssl_intervals >= 2) {
+            transition_settled = true;
+            break;
+        }
+    }
+
+    long initial_ssl2 = transition_ssl;
+    long initial_non2 = transition_non;
+
+    diag("Settled SSL OK (phase2): %ld", initial_ssl2);
+    diag("Settled NON-SSL OK (phase2): %ld", initial_non2);
+    diag("Phase2 transition settled: %s", transition_settled ? "yes" : "no");
+
     long after_ssl2 = initial_ssl2;
     long after_non2 = initial_non2;
     for (int attempt = 0; attempt < 6; attempt++) {
         usleep(connect_interval_ms * 1000);
+        after_ssl2 = getMonitorValue(admin, "PgSQL_Monitor_ssl_connections_OK");
         after_non2 = getMonitorValue(admin, "PgSQL_Monitor_non_ssl_connections_OK");
         if (after_non2 > initial_non2) break;
     }
-    after_ssl2 = getMonitorValue(admin, "PgSQL_Monitor_ssl_connections_OK");
 
     diag("After NON-SSL mode -> SSL OK: %ld", after_ssl2);
     diag("After NON-SSL mode -> NON-SSL OK: %ld", after_non2);
 
-    ok(after_non2 > initial_non2,
+    ok(transition_settled && after_non2 > initial_non2,
         "NON-SSL monitoring increased when use_ssl=0");
 
-    ok(after_ssl2 == initial_ssl2,
+    ok(transition_settled && after_ssl2 == initial_ssl2,
         "SSL monitoring unchanged when use_ssl=0");
 
     diag("SSL + NON-SSL monitoring test completed successfully");


### PR DESCRIPTION
## Summary

- wait for PostgreSQL monitoring to enter non-SSL mode before starting phase-two assertions
- allow an operation already using the pre-LOAD SSL configuration to drain
- retain a strict observation window that fails on any later SSL counter increase

## Root cause

LOAD PGSQL SERVERS TO RUNTIME updates the monitor configuration but does not cancel a connection operation already in flight. The test sampled its phase-two SSL baseline immediately after LOAD, so completion of one old SSL operation looked like continued SSL monitoring.

The transition now requires a non-SSL counter increase and two complete monitor intervals with a stable SSL counter. It then takes a new baseline, waits for another non-SSL cycle, and verifies that SSL remains unchanged.

Failing reproduction: https://github.com/sysown/proxysql/actions/runs/32150588332

## Validation

- syntax-only C++ compile: exit 0
- targeted binary link against the repository dependency build: exit 0
- live pgsql-monitor_ssl_connections_test-t: 7/7 TAP assertions passed, exit 0
- git diff --check: exit 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the pgsql monitor SSL transition test by waiting for non-SSL mode and allowing any in-flight SSL operation to drain before assertions. Previously the test took its phase-two SSL baseline immediately after LOAD and could misread a leftover SSL increment; now it requires a non-SSL increase and two stable intervals with unchanged SSL before taking the baseline and verifying.

**Review notes**
- Adds a settling loop (up to 8 connect intervals) that tracks stable SSL intervals and sets baselines from settled counters.
- Enforces a strict observation window: requires NON-SSL to increase and SSL to remain unchanged; fails if SSL increments.
- Test-only change; no production code affected. Runtime may increase by up to ~8 connect intervals during settlement.

<sup>Written for commit a24a6aabd7e4f6da77f526fafdcc5a9429167a0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL connection monitoring validation during transitions to non-SSL connections.
  * Added stronger checks to ensure monitoring results are verified only after connection counters stabilize.
  * Reduced the risk of false positives by requiring consistent counter behavior across consecutive monitoring intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->