### PR TITLE
build: make MySQLX bridge dependencies deterministic

### DIFF
--- a/.github/workflows/CI-lint-groups-json.yml
+++ b/.github/workflows/CI-lint-groups-json.yml
@@ -25,6 +25,8 @@ jobs:
         run: python3 test/tap/groups/lint_groups_json.py
       - name: Check AI TAP shard split
         run: python3 test/tap/groups/test_ai_group_shards.py
+      - name: Check TAP Makefile dependency graph
+        run: python3 test/tap/groups/test_makefile_dependencies.py
       - name: Check every TAP source is registered in groups.json
         run: python3 test/tap/groups/check_groups.py --source
       - name: Check cluster simulator coverage contract

--- a/test/tap/groups/test_makefile_dependencies.py
+++ b/test/tap/groups/test_makefile_dependencies.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Regression contracts for TAP Makefile dependency boundaries."""
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+TAP_TESTS_DIR = ROOT / "test/tap/tests"
+MYSQLX_BRIDGE_TARGETS = (
+    "test_mysqlx_plugin_load-t",
+    "test_mysqlx_admin_tables-t",
+)
+
+
+class MakefileDependencyTest(unittest.TestCase):
+    def test_mysqlx_bridge_targets_share_one_unit_submake(self):
+        result = subprocess.run(
+            [
+                "make",
+                "--no-print-directory",
+                "-C",
+                str(TAP_TESTS_DIR),
+                "-n",
+                "-j2",
+                "MAKE=echo",
+                *MYSQLX_BRIDGE_TARGETS,
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+        unit_submakes = [
+            line.split()[2:]
+            for line in result.stdout.splitlines()
+            if line.startswith("-C unit ")
+        ]
+        self.assertEqual(
+            unit_submakes,
+            [list(MYSQLX_BRIDGE_TARGETS)],
+            result.stdout,
+        )
+
+        symlinks = [
+            line
+            for line in result.stdout.splitlines()
+            if line.startswith("ln -fs unit/")
+        ]
+        self.assertCountEqual(
+            symlinks,
+            [f"ln -fs unit/{target} {target}" for target in MYSQLX_BRIDGE_TARGETS],
+            result.stdout,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tap/tests/Makefile
+++ b/test/tap/tests/Makefile
@@ -293,15 +293,17 @@ test_tokenizer-t: test_tokenizer-t.cpp $(TAP_LDIR)/libtap$(SHLIB_EXT)
 test_mysql_query_digests_stages-t: test_mysql_query_digests_stages-t.cpp $(TAP_LDIR)/libtap$(SHLIB_EXT)
 	$(CXX) $< $(IDIRS) $(LDIRS) $(OPT) $(MYLIBS) -o $@
 
-.PHONY: test_mysqlx_plugin_load-t
-test_mysqlx_plugin_load-t:
-	$(MAKE) -C unit test_mysqlx_plugin_load-t
-	ln -fs unit/test_mysqlx_plugin_load-t $@
+MYSQLX_BRIDGE_TESTS := test_mysqlx_plugin_load-t test_mysqlx_admin_tables-t
 
-.PHONY: test_mysqlx_admin_tables-t
-test_mysqlx_admin_tables-t:
-	$(MAKE) -C unit test_mysqlx_admin_tables-t
-	ln -fs unit/test_mysqlx_admin_tables-t $@
+# Build both bridge tests in one unit submake. Separate recursive makes do not
+# share a dependency graph and can otherwise rebuild common objects such as
+# unit/obj/test_init.o concurrently.
+.PHONY: mysqlx-bridge-tests $(MYSQLX_BRIDGE_TESTS)
+mysqlx-bridge-tests:
+	$(MAKE) -C unit $(MYSQLX_BRIDGE_TESTS)
+
+$(MYSQLX_BRIDGE_TESTS): mysqlx-bridge-tests
+	ln -fs unit/$@ $@
 
 # test_mysqlx_listener_smoke-t was retired with the dormant MysqlxWorker
 # path in 98aee7db2. Listener-lifecycle coverage now lives in


### PR DESCRIPTION
## Summary

- model the two top-level MySQLX bridge tests as one shared build dependency
- delegate both binaries to a single `unit` submake while preserving each public symlink target
- add a CI regression contract for the TAP Makefile dependency graph

## Root cause

`test_mysqlx_plugin_load-t` and `test_mysqlx_admin_tables-t` each launched an independent recursive make in `test/tap/tests/unit`. The parent Makefile therefore had no dependency edge connecting their common helper objects and plugin build. During a parallel TAP build, both child makes could independently decide that `unit/obj/test_init.o` needed rebuilding and write the same output.

The shared parent target makes the dependency boundary explicit: one child make now owns both binaries and their common prerequisites. Parallelism remains enabled inside that child dependency graph.

## Validation

- Regression test first failed by observing two independent unit submakes.
- After the Makefile change it observes one unit submake containing both targets and both expected symlinks.
- Dependency contract passed 50/50 repeated runs.
- Full `CI-lint-groups-json` command set passed locally.
- `python3 -m py_compile` and `git diff --check` passed.

The PR's normal TSAN workflow provides the full Docker build verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes MySQLX bridge test builds deterministic by modeling both binaries as one shared dependency that runs a single `unit` submake. Previously each target invoked its own submake and could race rebuilding shared objects; now one parent target owns both while preserving per-target symlinks.

- Introduces `MYSQLX_BRIDGE_TESTS` and a phony `mysqlx-bridge-tests` in `test/tap/tests/Makefile`; `test_mysqlx_plugin_load-t` and `test_mysqlx_admin_tables-t` now depend on it.
- Keeps `ln -fs unit/$@ $@` symlinks so each target remains addressable by name.
- Adds `test/tap/groups/test_makefile_dependencies.py` and runs it in the `CI-lint-groups-json` workflow to assert one `unit` submake and both symlinks.
- No test runtime changes; only the TAP Makefile dependency graph changes. Parallelism remains inside the `unit` submake.

<sup>Written for commit 472fd5d3acfc495f7978e217a081c3ca3f60c2d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the MySQL X Bridge test build process so related targets are built consistently and efficiently.
  * Ensured both test targets produce the expected runnable binaries.

* **Tests**
  * Added automated regression coverage to verify shared build dependencies and generated test links.
  * Integrated the validation into continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->