### PR TITLE
ci: use MySQL binlog reader v2.4.0

### DIFF
--- a/.github/workflows/CI-lint-groups-json.yml
+++ b/.github/workflows/CI-lint-groups-json.yml
@@ -25,6 +25,8 @@ jobs:
         run: python3 test/tap/groups/lint_groups_json.py
       - name: Check AI TAP shard split
         run: python3 test/tap/groups/test_ai_group_shards.py
+      - name: Check binlog reader infrastructure contract
+        run: python3 test/tap/groups/test_binlog_reader_infra.py
       - name: Check every TAP source is registered in groups.json
         run: python3 test/tap/groups/check_groups.py --source
       - name: Check cluster simulator coverage contract

--- a/test/infra/infra-dbdeployer-mysql84-binlog/docker/Dockerfile
+++ b/test/infra/infra-dbdeployer-mysql84-binlog/docker/Dockerfile
@@ -1,9 +1,5 @@
-# NOTE: v2.3 is required for MySQL 8.4 (v2.1 uses SHOW MASTER STATUS which is removed in 8.4)
-# Build it from https://github.com/sysown/proxysql_mysqlbinlog (tag 2.3+):
-#   cd /tmp/proxysql_mysqlbinlog && make build-debian12
-#   cp binaries/proxysql-mysqlbinlog_*.deb test/infra/docker-mysql84-binlogreader/
-#   bash test/infra/docker-mysql84-binlogreader/build.sh
-FROM proxysql/ci-infra:proxysql-mysqlbinlog-v2.3 AS binlog-reader
+# v2.4.0 supports caching_sha2_password and TLS connections required by MySQL 8.4+.
+FROM ghcr.io/sysown/proxysql-mysqlbinlog:2.4.0-ubuntu22 AS binlog-reader
 
 FROM ubuntu:22.04
 
@@ -44,7 +40,7 @@ RUN mkdir -p /root/opt/mysql \
 RUN dbdeployer defaults update reserved-ports '0'
 
 # Copy proxysql_binlog_reader from the binlog reader image
-COPY --from=binlog-reader /usr/bin/proxysql_binlog_reader /usr/local/bin/proxysql_binlog_reader
+COPY --from=binlog-reader /bin/proxysql_binlog_reader /usr/local/bin/proxysql_binlog_reader
 
 # Make MySQL client available in PATH for docker exec health checks
 ENV PATH="/root/opt/mysql/8.4.8/bin:${PATH}"

--- a/test/infra/infra-dbdeployer-mysql84-binlog/docker/entrypoint.sh
+++ b/test/infra/infra-dbdeployer-mysql84-binlog/docker/entrypoint.sh
@@ -140,6 +140,8 @@ done
 
 # Start proxysql_binlog_reader processes (one per MySQL node)
 # Each reader connects to its MySQL node and listens on a GTID port
+# These isolated sandboxes use generated self-signed certificates, so keep TLS
+# required while intentionally disabling certificate verification for CI only.
 echo "Starting binlog readers..."
 mkdir -p /var/log/mysqlbinlog
 
@@ -155,6 +157,8 @@ for i in 0 1 2; do
         -p binlog \
         -P ${MYSQL_PORT} \
         -l ${READER_PORT} \
+        --ssl-mode=REQUIRED \
+        --ssl-verify-server-cert=0 \
         -f >> /var/log/mysqlbinlog/reader_${MYSQL_PORT}.log 2>&1 &
 done
 

--- a/test/infra/infra-dbdeployer-mysql90-binlog/docker/Dockerfile
+++ b/test/infra/infra-dbdeployer-mysql90-binlog/docker/Dockerfile
@@ -1,9 +1,5 @@
-# NOTE: v2.3 is required for MySQL 9.0 (v2.1 uses SHOW MASTER STATUS which was removed in 8.4+)
-# Build it from https://github.com/sysown/proxysql_mysqlbinlog (tag 2.3+):
-#   cd /tmp/proxysql_mysqlbinlog && make build-debian12
-#   cp binaries/proxysql-mysqlbinlog_*.deb test/infra/docker-mysql84-binlogreader/
-#   bash test/infra/docker-mysql84-binlogreader/build.sh
-FROM proxysql/ci-infra:proxysql-mysqlbinlog-v2.3 AS binlog-reader
+# v2.4.0 supports caching_sha2_password and TLS connections required by MySQL 8.4+.
+FROM ghcr.io/sysown/proxysql-mysqlbinlog:2.4.0-ubuntu22 AS binlog-reader
 
 FROM ubuntu:22.04
 
@@ -44,7 +40,7 @@ RUN mkdir -p /root/opt/mysql \
 RUN dbdeployer defaults update reserved-ports '0'
 
 # Copy proxysql_binlog_reader from the binlog reader image
-COPY --from=binlog-reader /usr/bin/proxysql_binlog_reader /usr/local/bin/proxysql_binlog_reader
+COPY --from=binlog-reader /bin/proxysql_binlog_reader /usr/local/bin/proxysql_binlog_reader
 
 # Make MySQL client available in PATH for docker exec health checks
 ENV PATH="/root/opt/mysql/9.0.1/bin:${PATH}"

--- a/test/infra/infra-dbdeployer-mysql90-binlog/docker/entrypoint.sh
+++ b/test/infra/infra-dbdeployer-mysql90-binlog/docker/entrypoint.sh
@@ -139,6 +139,8 @@ done
 
 # Start proxysql_binlog_reader processes (one per MySQL node)
 # Each reader connects to its MySQL node and listens on a GTID port
+# These isolated sandboxes use generated self-signed certificates, so keep TLS
+# required while intentionally disabling certificate verification for CI only.
 echo "Starting binlog readers..."
 mkdir -p /var/log/mysqlbinlog
 
@@ -154,6 +156,8 @@ for i in 0 1 2; do
         -p binlog \
         -P ${MYSQL_PORT} \
         -l ${READER_PORT} \
+        --ssl-mode=REQUIRED \
+        --ssl-verify-server-cert=0 \
         -f >> /var/log/mysqlbinlog/reader_${MYSQL_PORT}.log 2>&1 &
 done
 

--- a/test/infra/infra-dbdeployer-mysql95-binlog/docker/Dockerfile
+++ b/test/infra/infra-dbdeployer-mysql95-binlog/docker/Dockerfile
@@ -1,9 +1,5 @@
-# NOTE: v2.3 is required for MySQL 9.5 (v2.1 uses SHOW MASTER STATUS which was removed in 8.4+)
-# Build it from https://github.com/sysown/proxysql_mysqlbinlog (tag 2.3+):
-#   cd /tmp/proxysql_mysqlbinlog && make build-debian12
-#   cp binaries/proxysql-mysqlbinlog_*.deb test/infra/docker-mysql84-binlogreader/
-#   bash test/infra/docker-mysql84-binlogreader/build.sh
-FROM proxysql/ci-infra:proxysql-mysqlbinlog-v2.3 AS binlog-reader
+# v2.4.0 supports caching_sha2_password and TLS connections required by MySQL 8.4+.
+FROM ghcr.io/sysown/proxysql-mysqlbinlog:2.4.0-ubuntu22 AS binlog-reader
 
 FROM ubuntu:22.04
 
@@ -44,7 +40,7 @@ RUN mkdir -p /root/opt/mysql \
 RUN dbdeployer defaults update reserved-ports '0'
 
 # Copy proxysql_binlog_reader from the binlog reader image
-COPY --from=binlog-reader /usr/bin/proxysql_binlog_reader /usr/local/bin/proxysql_binlog_reader
+COPY --from=binlog-reader /bin/proxysql_binlog_reader /usr/local/bin/proxysql_binlog_reader
 
 # Make MySQL client available in PATH for docker exec health checks
 ENV PATH="/root/opt/mysql/9.5.0/bin:${PATH}"

--- a/test/infra/infra-dbdeployer-mysql95-binlog/docker/entrypoint.sh
+++ b/test/infra/infra-dbdeployer-mysql95-binlog/docker/entrypoint.sh
@@ -139,6 +139,8 @@ done
 
 # Start proxysql_binlog_reader processes (one per MySQL node)
 # Each reader connects to its MySQL node and listens on a GTID port
+# These isolated sandboxes use generated self-signed certificates, so keep TLS
+# required while intentionally disabling certificate verification for CI only.
 echo "Starting binlog readers..."
 mkdir -p /var/log/mysqlbinlog
 
@@ -154,6 +156,8 @@ for i in 0 1 2; do
         -p binlog \
         -P ${MYSQL_PORT} \
         -l ${READER_PORT} \
+        --ssl-mode=REQUIRED \
+        --ssl-verify-server-cert=0 \
         -f >> /var/log/mysqlbinlog/reader_${MYSQL_PORT}.log 2>&1 &
 done
 

--- a/test/tap/groups/test_binlog_reader_infra.py
+++ b/test/tap/groups/test_binlog_reader_infra.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import re
+import shlex
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INFRA_NAMES = (
+    "infra-dbdeployer-mysql84-binlog",
+    "infra-dbdeployer-mysql90-binlog",
+    "infra-dbdeployer-mysql95-binlog",
+)
+READER_IMAGE = "ghcr.io/sysown/proxysql-mysqlbinlog:2.4.0-ubuntu22"
+READER_BINARY = "/bin/proxysql_binlog_reader"
+
+
+def docker_stage_image(dockerfile: str, stage: str) -> str:
+    for line in dockerfile.splitlines():
+        fields = line.split()
+        if len(fields) == 4 and fields[0].upper() == "FROM" and fields[2].upper() == "AS":
+            if fields[3] == stage:
+                return fields[1]
+    raise AssertionError(f"Docker stage {stage!r} not found")
+
+
+def copied_reader_source(dockerfile: str) -> str:
+    pattern = re.compile(
+        r"^COPY\s+--from=binlog-reader\s+(\S*proxysql_binlog_reader)\s+"
+        r"/usr/local/bin/proxysql_binlog_reader\s*$",
+        re.MULTILINE,
+    )
+    match = pattern.search(dockerfile)
+    if match is None:
+        raise AssertionError("binlog reader COPY instruction not found")
+    return match.group(1)
+
+
+def reader_command_tokens(entrypoint: str) -> list[str]:
+    pattern = re.compile(
+        r"^\s*proxysql_binlog_reader\s+\\\n(?P<arguments>.*?)"
+        r"\s*>>\s*/var/log/mysqlbinlog/reader_\$\{MYSQL_PORT\}\.log",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(entrypoint)
+    if match is None:
+        raise AssertionError("binlog reader command not found")
+    command = "proxysql_binlog_reader " + match.group("arguments").replace("\\\n", " ")
+    return shlex.split(command)
+
+
+class BinlogReaderInfraContractTest(unittest.TestCase):
+    def test_all_modern_binlog_infras_use_v240_with_ci_tls_policy(self) -> None:
+        for infra_name in INFRA_NAMES:
+            with self.subTest(infra=infra_name):
+                docker_dir = REPO_ROOT / "test" / "infra" / infra_name / "docker"
+                dockerfile = (docker_dir / "Dockerfile").read_text(encoding="utf-8")
+                entrypoint = (docker_dir / "entrypoint.sh").read_text(encoding="utf-8")
+
+                self.assertEqual(
+                    docker_stage_image(dockerfile, "binlog-reader"),
+                    READER_IMAGE,
+                )
+                self.assertEqual(copied_reader_source(dockerfile), READER_BINARY)
+
+                tokens = reader_command_tokens(entrypoint)
+                self.assertIn("--ssl-mode=REQUIRED", tokens)
+                self.assertIn("--ssl-verify-server-cert=0", tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tap/tests/prepare_statement_err3024-t.cpp
+++ b/test/tap/tests/prepare_statement_err3024-t.cpp
@@ -145,17 +145,20 @@ static backend_kind_t detect_backend_via_admin(const CommandLine& cl) {
 // silently ignored). Its equivalent is the SET STATEMENT … FOR … wrapper,
 // which is a valid prepared-statement body and surfaces the timeout via the
 // MariaDB-specific error code 1969. See issue #5783.
+//
+// SUM forces SLEEP to be evaluated while producing the aggregate row, after
+// result metadata is available. The primary-key predicate keeps the workload
+// deterministic while preserving the execute-success/store-result-error path.
 static unsigned int select_timeout_dialect(backend_kind_t kind) {
 	if (kind == backend_kind_t::mariadb) {
 		select_query[0] =
 			"SET STATEMENT max_statement_time=0.01 FOR "
-			"SELECT COUNT(*) FROM test.sbtest1 a JOIN test.sbtest1 b "
-			"WHERE (a.id+b.id)%2";
+			"SELECT SUM(SLEEP(id)) FROM test.sbtest1 WHERE id=1";
 		return 1969; // MariaDB ER_STATEMENT_TIMEOUT
 	}
 	select_query[0] =
-		"SELECT /*+ MAX_EXECUTION_TIME(10) */ COUNT(*) "
-		"FROM test.sbtest1 a JOIN test.sbtest1 b WHERE (a.id+b.id)%2";
+		"SELECT /*+ MAX_EXECUTION_TIME(10) */ SUM(SLEEP(id)) "
+		"FROM test.sbtest1 WHERE id=1";
 	return 3024; // MySQL ER_QUERY_TIMEOUT
 }
 

--- a/test/tap/tests/prepare_statement_err3024-t.cpp
+++ b/test/tap/tests/prepare_statement_err3024-t.cpp
@@ -146,19 +146,21 @@ static backend_kind_t detect_backend_via_admin(const CommandLine& cl) {
 // which is a valid prepared-statement body and surfaces the timeout via the
 // MariaDB-specific error code 1969. See issue #5783.
 //
-// SUM forces SLEEP to be evaluated while producing the aggregate row, after
-// result metadata is available. The primary-key predicate keeps the workload
-// deterministic while preserving the execute-success/store-result-error path.
+// Keep SLEEP as the predicate of a table SELECT.  MySQL 5.7 turns an interrupt
+// into a normal value when SLEEP is combined with an equality predicate or
+// consumed by SUM(), so mysql_stmt_store_result() sees success instead of the
+// intended timeout.  COUNT(*) still provides stable result metadata, while
+// the non-empty fixture guarantees that the predicate is evaluated.
 static unsigned int select_timeout_dialect(backend_kind_t kind) {
 	if (kind == backend_kind_t::mariadb) {
 		select_query[0] =
 			"SET STATEMENT max_statement_time=0.01 FOR "
-			"SELECT SUM(SLEEP(id)) FROM test.sbtest1 WHERE id=1";
+			"SELECT COUNT(*) FROM test.sbtest1 WHERE SLEEP(1)";
 		return 1969; // MariaDB ER_STATEMENT_TIMEOUT
 	}
 	select_query[0] =
-		"SELECT /*+ MAX_EXECUTION_TIME(10) */ SUM(SLEEP(id)) "
-		"FROM test.sbtest1 WHERE id=1";
+		"SELECT /*+ MAX_EXECUTION_TIME(10) */ COUNT(*) "
+		"FROM test.sbtest1 WHERE SLEEP(1)";
 	return 3024; // MySQL ER_QUERY_TIMEOUT
 }
 

--- a/test/tap/tests/test_tsdb_variables-t.cpp
+++ b/test/tap/tests/test_tsdb_variables-t.cpp
@@ -45,6 +45,62 @@ static bool fetch_single_string(MYSQL* mysql, const string& query, string& out) 
 	return true;
 }
 
+static bool fetch_total_datapoints(MYSQL* admin, long long& total) {
+	if (mysql_query(admin, "SHOW TSDB STATUS")) {
+		diag("SHOW TSDB STATUS failed: %s", mysql_error(admin));
+		return false;
+	}
+	MYSQL_RES* res = mysql_store_result(admin);
+	if (res) mysql_free_result(res);
+	drain_results(admin);
+
+	string value;
+	if (!fetch_single_string(
+			admin,
+			"SELECT Variable_Value FROM stats_tsdb WHERE Variable_Name='Total_Datapoints'",
+			value)) {
+		return false;
+	}
+	total = atoll(value.c_str());
+	return true;
+}
+
+static bool fetch_admin_datapoints(MYSQL* admin, long long& total) {
+	string value;
+	if (!fetch_single_string(admin, "SELECT COUNT(*) FROM stats_history.tsdb_metrics", value)) {
+		return false;
+	}
+	total = atoll(value.c_str());
+	return true;
+}
+
+static bool wait_for_tsdb_connections_to_agree(MYSQL* admin, long long& total) {
+	long long admin_before = 0;
+	long long stats_total = 0;
+	long long admin_after = 0;
+
+	// SHOW TSDB STATUS reads through ProxySQL_Statistics::statsdb_disk, while
+	// stats_history is the Admin connection's attachment to the same file. A
+	// matching count bracketed by two Admin reads proves both connections see
+	// the same committed snapshot even if a final sampler pass lands between
+	// attempts.
+	for (int attempt = 0; attempt < 100; ++attempt) {
+		if (!fetch_admin_datapoints(admin, admin_before)
+				|| !fetch_total_datapoints(admin, stats_total)
+				|| !fetch_admin_datapoints(admin, admin_after)) {
+			return false;
+		}
+		if (admin_before == stats_total && stats_total == admin_after) {
+			total = stats_total;
+			return true;
+		}
+		usleep(100000);
+	}
+	diag("TSDB connections did not converge (admin before: %lld, stats: %lld, admin after: %lld)",
+		admin_before, stats_total, admin_after);
+	return false;
+}
+
 int main() {
 	CommandLine cl;
 	if (cl.getEnv()) {
@@ -52,7 +108,7 @@ int main() {
 		return EXIT_FAILURE;
 	}
 
-	plan(19);
+	plan(28);
 
 	MYSQL* admin = mysql_init(NULL);
 	if (!admin) {
@@ -193,12 +249,41 @@ int main() {
 	bool dp_ok = fetch_single_string(admin, "SELECT Variable_Value FROM stats_tsdb WHERE Variable_Name='Total_Datapoints'", count);
 	ok(dp_ok && atoi(count.c_str()) > 0, "SHOW TSDB STATUS reports datapoints > 0 (found %s)", count.c_str());
 
+	// Reduce background TSDB writes before crossing from the Admin connection
+	// (stats_history attachment) to the statistics module's own SQLite
+	// connection. A sampler pass that was already in flight is handled by the
+	// explicit cross-connection snapshot check below.
+	rc = mysql_query(admin, "SET tsdb-sample_interval='3600'");
+	ok(rc == 0, "SET tsdb-sample_interval=3600 works");
+	drain_results(admin);
+	rc = mysql_query(admin, "SET tsdb-monitor_enabled='0'");
+	ok(rc == 0, "SET tsdb-monitor_enabled=0 works");
+	drain_results(admin);
+	rc = mysql_query(admin, "LOAD TSDB VARIABLES TO RUNTIME");
+	ok(rc == 0, "Quiescent TSDB variables load to runtime");
+	drain_results(admin);
+
 	// 12. Test Downsampling command
 	// NOTE: Downsampling only processes COMPLETED hours (data with timestamps before current_hour).
 	// Since we only have a few seconds of data, insert test data in the most recently
 	// completed hour. Downsampling deliberately refreshes this boundary bucket so
 	// metrics committed just after an earlier pass are not lost.
 	diag("Testing TSDB downsampling via command...");
+
+	// A prior interrupted invocation must not affect the exact fixture counts
+	// or satisfy the hourly assertion with stale data.
+	mysql_query(admin,
+		"DELETE FROM stats_history.tsdb_metrics WHERE metric_name='test_downsample_metric'");
+	drain_results(admin);
+	mysql_query(admin,
+		"DELETE FROM stats_history.tsdb_metrics_hour WHERE metric_name='test_downsample_metric'");
+	drain_results(admin);
+
+	long long clean_baseline = 0;
+	const bool clean_connections_agree = wait_for_tsdb_connections_to_agree(admin, clean_baseline);
+	ok(clean_connections_agree,
+		"Admin and statistics connections agree after fixture cleanup (count: %lld)",
+		clean_baseline);
 
 	// Get current timestamp and calculate the start of the previous hour.
 	time_t now = time(NULL);
@@ -232,8 +317,12 @@ int main() {
 
 	// Check metrics count before downsampling
 	string before_count;
-	fetch_single_string(admin, "SELECT COUNT(*) FROM stats_history.tsdb_metrics WHERE metric_name='test_downsample_metric'", before_count);
+	const bool fixture_count_ok = fetch_single_string(
+		admin,
+		"SELECT COUNT(*) FROM stats_history.tsdb_metrics WHERE metric_name='test_downsample_metric'",
+		before_count);
 	diag("Test metrics in tsdb_metrics before downsample: %s", before_count.c_str());
+	ok(fixture_count_ok && before_count == "4", "Admin connection sees all four fixture rows");
 
 	// Re-evaluate the boundary immediately before the command. A test that
 	// starts in the final milliseconds of an hour must not leave its fixture in
@@ -257,6 +346,12 @@ int main() {
 			drain_results(admin);
 		}
 	}
+
+	long long visible_datapoints = 0;
+	const bool connections_agree = wait_for_tsdb_connections_to_agree(admin, visible_datapoints);
+	ok(connections_agree && visible_datapoints >= clean_baseline + 4,
+		"Statistics connection sees the four new fixture rows (before: %lld, after: %lld)",
+		clean_baseline, visible_datapoints);
 
 	// Run the downsample command
 	rc = mysql_query(admin, "PROXYSQL TSDB DOWNSAMPLE");
@@ -287,6 +382,18 @@ int main() {
 	mysql_query(admin, "DELETE FROM stats_history.tsdb_metrics WHERE metric_name='test_downsample_metric'");
 	drain_results(admin);
 	mysql_query(admin, "DELETE FROM stats_history.tsdb_metrics_hour WHERE metric_name='test_downsample_metric'");
+	drain_results(admin);
+
+	// Restore the runtime state established and persisted earlier in this test
+	// so later TAP tests do not inherit the temporary quiescent settings.
+	rc = mysql_query(admin, "SET tsdb-sample_interval='1'");
+	ok(rc == 0, "Restore tsdb-sample_interval=1");
+	drain_results(admin);
+	rc = mysql_query(admin, "SET tsdb-monitor_enabled='1'");
+	ok(rc == 0, "Restore tsdb-monitor_enabled=1");
+	drain_results(admin);
+	rc = mysql_query(admin, "LOAD TSDB VARIABLES TO RUNTIME");
+	ok(rc == 0, "Restored TSDB variables load to runtime");
 	drain_results(admin);
 
 	mysql_close(admin);


### PR DESCRIPTION
## Summary

- upgrade the MySQL 8.4, 9.0, and 9.5 binlog CI infrastructures from reader v2.3 to the official v2.4.0 Ubuntu 22 image
- copy the reader from its new `/bin/proxysql_binlog_reader` package path
- require TLS while intentionally disabling certificate verification for generated self-signed certificates inside the isolated CI sandboxes
- add a network-free lint contract that keeps all three infrastructures aligned

## Root cause

Reader v2.3 exits against MySQL 9.x with error 2061:

```
Authentication plugin 'caching_sha2_password' reported error: Authentication requires secure connection.
```

Reader v2.4.0 adds `caching_sha2_password` and TLS support.

## Validation

- contract test demonstrated RED with v2.3 and GREEN with v2.4.0
- complete CI lint command set passed after merging the latest `v3.0`
- all MySQL 8.4, 9.0, and 9.5 infrastructure images built with the exact v2.4.0 Ubuntu 22 artifact
- all nine readers reached `Reading binlogs` and listened on their configured ports
- MySQL 9.0 and 9.5 binlog sessions were confirmed to use TLS 1.3
- entrypoint Bash syntax, Python compilation, and `git diff --check` passed

## Follow-up CI hardening

- make `prepare_statement_err3024-t` deterministic across MySQL and MariaDB by using a table `SLEEP(1)` predicate while preserving the execute-success/store-result-timeout protocol path
- make `test_tsdb_variables-t` remove stale fixtures, synchronize the Admin and statistics SQLite views around fixture insertion, and restore its temporary runtime settings

## Follow-up validation

- MySQL 8.4 sync libmariadb, async libmariadb, and sync libmysql variants each passed 33/33 in repeated runs with error 3024 delivered at `mysql_stmt_store_result`
- MariaDB 10.11 passed 33/33 with error 1969 delivered at `mysql_stmt_store_result`
- the TSDB variables/downsampling test passed 28/28 in five consecutive ASAN runs
- independent final review found no remaining Critical or Important issues

## Residual validation

Anonymous access to the newly published GHCR tag is denied. The target workflows authenticate with `packages: read`; this draft PR's clean GitHub-hosted runners are the authoritative check that cross-repository package access is configured correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade CI MySQL 8.4/9.0/9.5 binlog infrastructures to the official binlog reader v2.4.0 and require TLS to fix v2.3 auth failures on MySQL 9.x (error 2061 with `caching_sha2_password`). Also makes statement-timeout and TSDB TAP tests deterministic across variants.

- Use `ghcr.io/sysown/proxysql-mysqlbinlog:2.4.0-ubuntu22`; copy `/bin/proxysql_binlog_reader` (new path).
- Start readers with `--ssl-mode=REQUIRED` and `--ssl-verify-server-cert=0` to work with CI self-signed certs.
- Add `test/tap/groups/test_binlog_reader_infra.py` and wire it into `CI-lint-groups-json.yml` to enforce image tag, binary path, and TLS flags across all three infrastructures.
- Make statement-timeout test portable: use `SELECT COUNT(*) FROM test.sbtest1 WHERE SLEEP(1)` to surface 3024 (MySQL) or 1969 (MariaDB) at `mysql_stmt_store_result`.
- Harden TSDB TAP: quiesce sampling, ensure Admin and statistics snapshots match, clean fixtures, and restore runtime variables.
- Workflows pulling the GHCR image must have `packages: read`. No app/runtime migrations.

<sup>Written for commit 9aaf4a2344a6191cb7a13400bf10e7b432194eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binlog reader compatibility for MySQL 8.4, 9.0, and 9.5.
  * Added TLS configuration for secure binlog reader connections.
  * Improved timeout handling across MySQL and MariaDB environments.

* **Tests**
  * Added automated validation for binlog reader images, binaries, and TLS settings.
  * Expanded time-series database and infrastructure test coverage.
  * Integrated binlog reader validation into continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

----
## Summary by Gitar

- **Test & CI Improvements:**
    - Added `test/tap/groups/test_binlog_reader_infra.py` and integrated it into `CI-lint-groups-json.yml` to enforce binlog reader infrastructure contracts.
    - Updated `test_tsdb_variables-t.cpp` with robust cross-connection snapshot synchronization checks and test cleanup fixes.
    - Refactored `prepare_statement_err3024-t.cpp` to use deterministic `SUM(SLEEP(id))` queries for timeout testing.

<sub>This will update automatically on new commits.</sub>