### PR TITLE
fix: support static RE2 in TAP CI handoff

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -389,15 +389,15 @@ jobs:
           # (test/tap/tap/ is in `tar -cf - test/`) AND has its parent
           # git-tracked (so post-checkout `mkdir -p` works on restore
           # at the consumer side). The e2e -t binaries DT_NEEDED
-          # libre2.so.10, and their baked RUNPATH points at
-          # /opt/proxysql/deps/re2/.../obj/so. That path involves a
-          # symlink to a tarball-unpacked directory that doesn't exist
-          # post-checkout, so caching the deps/ subtree directly doesn't
-          # survive tar restore. CI-mysqlx exports LD_LIBRARY_PATH
-          # pointing at this directory when running the e2e binaries
-          # inside the build image, which overrides RUNPATH lookup.
-          # libpq is deliberately absent: issue #6115 links libpq.a into
-          # every consumer and no longer builds or ships libpq.so.
+          # libre2.so.10 when built as a shared library; static RE2
+          # builds do not need it. Its baked RUNPATH points at
+          # /opt/proxysql/deps/re2/.../obj/so, a tarball-unpacked path
+          # that does not exist post-checkout. CI-mysqlx exports
+          # LD_LIBRARY_PATH pointing at this directory when running the
+          # e2e binaries inside the build image, which overrides RUNPATH
+          # lookup. libpq is deliberately absent: issue #6115 links
+          # libpq.a into every consumer and no longer builds or ships
+          # libpq.so.
           if [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
             mkdir -p test/tap/tap/_runtime_libs
             # Stage the versioned runtime .so by its SONAME, tolerating a lost
@@ -419,7 +419,14 @@ jobs:
               cp -L "$src" "$dest/$soname"
               echo "staged $soname <- $(readlink -f "$src")"
             }
-            stage_lib deps/re2/re2/obj/so libre2.so.10 test/tap/tap/_runtime_libs
+            # Current v3.0 RE2 builds are static-only, so obj/so is not
+            # created. Keep staging for branches that intentionally build
+            # shared RE2, where a missing library remains a real failure.
+            if [ -d deps/re2/re2/obj/so ]; then
+              stage_lib deps/re2/re2/obj/so libre2.so.10 test/tap/tap/_runtime_libs
+            else
+              echo "RE2 is static-only; no libre2 runtime library to stage"
+            fi
             # Stage the chassis plugin .so files into the same dir for
             # the same reason: the _src cache path list is shared
             # infrastructure that we MUST NOT extend (changing it
@@ -435,15 +442,22 @@ jobs:
           fi
           # ------------------------------------------------------------
 
-          # Compile-time safety check: make sure unit tests actually got
-          # built. If they didn't, the build step above silently ignored
-          # a compile error and the delete below would "succeed" on an
-          # empty set. Fail loudly instead.
+          # Compile-time safety checks. A normal TAP build produces the
+          # integration binaries in tests/; it need not build tests/unit.
+          # The -tap-mysqlx cache is the exception: CI-mysqlx runs its
+          # mysqlx_*_unit-t and plugin_*_unit-t binaries directly.
+          # Fail loudly when the expected binaries are absent rather than
+          # letting cache-pruning succeed on an empty set.
+          TAP_COUNT=$(find test/tap/tests test/tap/tests_with_deps -path test/tap/tests/unit -prune -o -type f -name '*-t' -executable -print 2>/dev/null | wc -l)
           UNIT_COUNT=$(find test/tap/tests/unit -type f -name '*-t' -executable 2>/dev/null | wc -l)
-          echo ">>> Compiled ${UNIT_COUNT} unit test binaries"
-          if [ "${UNIT_COUNT}" -lt 1 ]; then
-            echo "ERROR: no unit test binaries found at test/tap/tests/unit/*-t"
-            echo "       This typically means a unit test failed to compile."
+          echo ">>> Compiled ${TAP_COUNT} TAP test binaries, including ${UNIT_COUNT} unit test binaries"
+          if [ "${TAP_COUNT}" -lt 1 ]; then
+            echo "ERROR: no executable TAP test binaries found under test/tap/tests"
+            echo "       This typically means the TAP build did not run or failed."
+            exit 1
+          fi
+          if [[ "${{ matrix.type }}" =~ "-mysqlx" ]] && [ "${UNIT_COUNT}" -lt 1 ]; then
+            echo "ERROR: no unit test binaries found at test/tap/tests/unit/*-t for the mysqlx cache"
             exit 1
           fi
 

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -129,8 +129,8 @@ jobs:
 
       - name: Restore plugin .so files from _runtime_libs
         # CI-builds stages plugins/mysqlx + plugins/genai .so files
-        # into test/tap/tap/_runtime_libs/ alongside libre2.so.10.
-        # The _src cache path list is shared
+        # into test/tap/tap/_runtime_libs/. Shared RE2 builds also stage
+        # libre2.so.10. The _src cache path list is shared
         # infrastructure that CANNOT be extended without invalidating
         # every other CI workflow's cache restore, so the plugin .so
         # files ride along inside the _test cache instead. Copy them
@@ -325,8 +325,8 @@ jobs:
 
       - name: Restore plugin .so files from _runtime_libs
         # CI-builds stages plugins/mysqlx + plugins/genai .so files
-        # into test/tap/tap/_runtime_libs/ alongside libre2.so.10.
-        # The _src cache path list is shared
+        # into test/tap/tap/_runtime_libs/. Shared RE2 builds also stage
+        # libre2.so.10. The _src cache path list is shared
         # infrastructure that CANNOT be extended without invalidating
         # every other CI workflow's cache restore, so the plugin .so
         # files ride along inside the _test cache instead. Copy them
@@ -610,8 +610,8 @@ jobs:
 
       - name: Restore plugin .so files from _runtime_libs
         # CI-builds stages plugins/mysqlx + plugins/genai .so files
-        # into test/tap/tap/_runtime_libs/ alongside libre2.so.10.
-        # The _src cache path list is shared
+        # into test/tap/tap/_runtime_libs/. Shared RE2 builds also stage
+        # libre2.so.10. The _src cache path list is shared
         # infrastructure that CANNOT be extended without invalidating
         # every other CI workflow's cache restore, so the plugin .so
         # files ride along inside the _test cache instead. Copy them


### PR DESCRIPTION
Fixes CI-builds failures exposed by the RE2 2025 upgrade.\n\n- Stage libre2.so.10 only when a shared RE2 build produced obj/so; static RE2 builds skip it.\n- Preserve the base branch's static libpq policy and existing plugin handoff.\n- Validate integration TAP binaries for every TAP build, and unit binaries only for the mysqlx handoff that consumes them.\n\nVerified with YAML parsing, workflow guard cases, git diff --check, and independent review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support static-only RE2 builds in TAP CI handoff and tighten binary validation to prevent false-positive cache restores. Previously CI always staged libre2.so.10 and required unit binaries; now it stages the RE2 runtime only for shared builds and requires unit binaries only for the mysqlx cache, while validating integration TAP binaries for all builds.

- Stage `libre2.so.10` only when `deps/re2/re2/obj/so` exists; static RE2 logs a skip. Shared-RE2 branches still fail if the library is missing.
- Add safety checks: fail when no executable TAP binaries are produced; for `-mysqlx` builds also fail when no unit binaries exist.
- Preserve the existing static `libpq` policy and plugin handoff. `ci-mysqlx` changes are comment-only to reflect conditional RE2 staging.

<sup>Written for commit ad68b1927046b94ebe58a18a1e3f87d5325e5482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build validation to ensure required test artifacts are available for each build type.
  - Clarified handling of runtime components across static and shared builds, reducing ambiguity in build checks.
  - Updated continuous integration documentation to better describe how test plugins and runtime libraries are prepared.
  - Preserved existing cleanup behavior and shared cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->