### PR TITLE
ci: install MySQLX e2e runtime dependency

### DIFF
--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -467,6 +467,12 @@ jobs:
             proxysql/packaging:build-ubuntu22-v4.0.0 \
             bash -c '
               set -e
+              # The TAP binaries link libproxysql, which in turn needs libpq.
+              # The packaging build image deliberately omits this runtime
+              # library, unlike the normal TAP image. Install it before
+              # loading any mysqlx e2e binary.
+              apt-get update -qq
+              DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends libpq5
               DISCOVERED="${MYSQLX_E2E_PORT:?missing}"
               source /opt/proxysql/test/tap/groups/mysqlx-e2e/env.sh
               export MYSQLX_E2E_PORT="$DISCOVERED"


### PR DESCRIPTION
## Summary

- install `libpq5` in the packaging build image immediately before MySQLX e2e TAP binaries run
- fix the dynamic-loader failure: `test_mysqlx_e2e_handshake-t` requires `libpq.so.5` through `libproxysql`

## Validation

- parsed `.github/workflows/ci-mysqlx.yml` after rebasing onto current `GH-Actions`
- ran the exact `apt-get update && apt-get install libpq5` command in `proxysql/packaging:build-ubuntu22-v4.0.0` and verified `/usr/lib/x86_64-linux-gnu/libpq.so.5` exists
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs `libpq5` in the MySQLX e2e CI job so TAP binaries that link `libproxysql` can load `libpq.so.5`. Previously the packaging build image lacked this library and MySQLX e2e tests failed at startup; now they run under the same image.

**Review notes**
- Scope: `.github/workflows/ci-mysqlx.yml` only, in the job using `proxysql/packaging:build-ubuntu22-v4.0.0`.
- Adds `apt-get update` and `DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libpq5` right before launching the binaries.
- CI-only change; small time cost; no product or artifact changes.

<sup>Written for commit 283f63bdb9627ca3ba2bfbe6c2eab36d151feac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MySQL X end-to-end test environment setup by installing a required runtime package before tests run.
  * Improved reliability of automated test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->