### PR TITLE
fix(ci): hand off project libpq for MySQLX tests

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -395,9 +395,11 @@ jobs:
           # that does not exist post-checkout. CI-mysqlx exports
           # LD_LIBRARY_PATH pointing at this directory when running the
           # e2e binaries inside the build image, which overrides RUNPATH
-          # lookup. libpq is deliberately absent: issue #6115 links
-          # libpq.a into every consumer and no longer builds or ships
-          # libpq.so.
+          # lookup. The normal TAP executables link libpq statically, but
+          # libtap.so is a shared object and has a DT_NEEDED entry for the
+          # project-built libpq.so.5.  The libpq static archive is not PIC,
+          # so it cannot be linked into libtap.so.  Carry that exact shared
+          # library with the handoff instead of relying on a runner package.
           if [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
             mkdir -p test/tap/tap/_runtime_libs
             # Stage the versioned runtime .so by its SONAME, tolerating a lost
@@ -427,6 +429,7 @@ jobs:
             else
               echo "RE2 is static-only; no libre2 runtime library to stage"
             fi
+            stage_lib deps/postgresql/postgresql/src/interfaces/libpq libpq.so.5 test/tap/tap/_runtime_libs
             # Stage the chassis plugin .so files into the same dir for
             # the same reason: the _src cache path list is shared
             # infrastructure that we MUST NOT extend (changing it


### PR DESCRIPTION
Fixes the MySQLX TAP handoff without installing a runner package.

`libtap.so` has a dynamic `libpq.so.5` dependency. Normal TAP executables use static `libpq.a`, but that archive is non-PIC and cannot be embedded in `libtap.so`. CI-builds now stages the project-built `libpq.so.5` in `_runtime_libs`, which CI-mysqlx already exposes through `LD_LIBRARY_PATH`.

Verification:
- parsed the reusable workflow YAML;
- reproduced that the Ubuntu 22 build image cannot resolve `libtap.so` without libpq;
- verified it resolves with only the project-built `libpq.so.5` mounted, with no distro `libpq5` installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stages the project-built `libpq.so.5` with MySQLX TAP tests so `libtap.so` resolves at runtime without installing a runner package. Previously the Ubuntu 22 build image failed to load `libtap.so` unless a distro `libpq` was present; now CI hands off the exact shared library via `LD_LIBRARY_PATH`.

- Updates `.github/workflows/ci-builds.yml` for `-mysqlx` jobs to stage `libpq.so.5` into `test/tap/tap/_runtime_libs` using `stage_lib`.
- Uses the existing `LD_LIBRARY_PATH` export from CI-mysqlx; no RUNPATH or linker flag changes.
- Scope limited to MySQLX TAP; other TAP executables keep static `libpq.a`. No migration or runner package installs required.

<sup>Written for commit d6bd7f6916bb49c2456b1e4d84dc2907fe660ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by including the required shared PostgreSQL library with the cached MySQLX build artifacts.

* **Documentation**
  * Clarified the shared-library requirement and noted that the static PostgreSQL archive cannot satisfy it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->