### PR TITLE
Release temporary connection after terminating a backend

### DIFF
--- a/lib/PgSQL_Connection.cpp
+++ b/lib/PgSQL_Connection.cpp
@@ -3121,6 +3121,8 @@ void* PgSQL_backend_kill_thread(void* arg) {
 			proxy_error("Terminate failed: %s\n", PQerrorMessage(kill_conn));
 		}
 		PQclear(res);
+		// release the connection used to run the terminate
+		PQfinish(kill_conn);
 
 
 		//proxy_warning("Terminating connection on %s:%d with backend PID %d\n", ka->hostname, ka->port, ka->backend_pid);


### PR DESCRIPTION
(same as title)

Closes [#6129](https://github.com/sysown/proxysql/issues/6129)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection termination handling by ensuring temporary database connections are properly closed after termination requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->