### PR TITLE
ci: verify every release package installation

### DIFF
--- a/.github/workflows/CI-lint-groups-json.yml
+++ b/.github/workflows/CI-lint-groups-json.yml
@@ -33,6 +33,10 @@ jobs:
         run: test/infra/control/test-cluster-simulator-coverage.bash
       - name: Check coverage collector invariants
         run: test/infra/control/validate-coverage-gcov-toolchain.bash
+      - name: Check package CI verification hook
+        run: test/infra/control/test-package-ci-verification.bash
+      - name: Check package install verifier
+        run: test/infra/control/test-verify-package-install.bash
       - name: Check group infra/workflow coverage (warn-only)
         # Warns when a group references a missing infra (phantom), or when no
         # workflow on either branch can select the group at all -- meaning

--- a/.github/workflows/CI-lint-groups-json.yml
+++ b/.github/workflows/CI-lint-groups-json.yml
@@ -11,6 +11,8 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
       - name: Fetch GH-Actions branch
         # The reusable half of every workflow pair lives on GH-Actions, so the
         # coverage lint needs that ref to tell an unwired group from one wired

--- a/.github/workflows/CI-package-arm64-almalinux10-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux10.yml
+++ b/.github/workflows/CI-package-arm64-almalinux10.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux8-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux8.yml
+++ b/.github/workflows/CI-package-arm64-almalinux8.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux9-genai.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-almalinux9.yml
+++ b/.github/workflows/CI-package-arm64-almalinux9.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos10-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos10-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos10.yml
+++ b/.github/workflows/CI-package-arm64-centos10.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos9-genai.yml
+++ b/.github/workflows/CI-package-arm64-centos9-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-centos9.yml
+++ b/.github/workflows/CI-package-arm64-centos9.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian12-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian12-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian12.yml
+++ b/.github/workflows/CI-package-arm64-debian12.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian13-genai.yml
+++ b/.github/workflows/CI-package-arm64-debian13-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-debian13.yml
+++ b/.github/workflows/CI-package-arm64-debian13.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora42-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora42-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora42.yml
+++ b/.github/workflows/CI-package-arm64-fedora42.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora43-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora43-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora43.yml
+++ b/.github/workflows/CI-package-arm64-fedora43.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora44-genai.yml
+++ b/.github/workflows/CI-package-arm64-fedora44-genai.yml
@@ -113,16 +113,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-fedora44.yml
+++ b/.github/workflows/CI-package-arm64-fedora44.yml
@@ -113,16 +113,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse15-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse15.yml
+++ b/.github/workflows/CI-package-arm64-opensuse15.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse16-genai.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-opensuse16.yml
+++ b/.github/workflows/CI-package-arm64-opensuse16.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu22.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu22.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24-genai.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         PROXYSQL40=1 make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-package-arm64-ubuntu24.yml
+++ b/.github/workflows/CI-package-arm64-ubuntu24.yml
@@ -111,16 +111,6 @@ jobs:
       run: |
         make ${{ env.MAKE_TARGET }}
 
-    - name: Verify package installs on clean ${{ env.DISTRO }}
-      run: |
-        PKG=$(ls binaries/*.deb binaries/*.rpm 2>/dev/null | head -1)
-        if [[ -z "$PKG" ]]; then
-          echo "ERROR: no package file found in binaries/" >&2
-          ls -la binaries/
-          exit 1
-        fi
-        test/infra/control/verify-package-install.bash "$PKG"
-
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,7 @@ build-%: PKG_FILE=$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarb
 build-%:
 	@echo 'building $@'
 	@IMG_NAME=$(PKG_NAME) IMG_TYPE=$(subst -,_,$(PKG_TYPE)) IMG_COMP=$(subst -,_,$(PKG_COMP)) BLD_NAME=$(BLD_NAME) $(MAKE) $(PKG_FILE)
+	$(if $(and $(filter true,$(GITHUB_ACTIONS)),$(filter-out tar.gz,$(PKG_KIND))),@test/infra/control/verify-package-install.bash "$(PKG_FILE)",@:)
 
 # Scope the compose project per build variant, not just per commit. On shared
 # self-hosted CI runners several matrix variants of the same commit build

--- a/test/infra/control/test-package-ci-verification.bash
+++ b/test/infra/control/test-package-ci-verification.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+VERIFY_COMMAND='test/infra/control/verify-package-install.bash "binaries/'
+
+ci_output=$(GITHUB_ACTIONS=true make -n -C "$ROOT_DIR" almalinux8)
+ci_count=$(grep -Fc "$VERIFY_COMMAND" <<<"$ci_output" || true)
+if [[ "$ci_count" -ne 1 ]]; then
+    echo "expected one package verification in a CI package build; found $ci_count" >&2
+    exit 1
+fi
+
+local_output=$(env -u GITHUB_ACTIONS make -n -C "$ROOT_DIR" almalinux8)
+if grep -Fq "$VERIFY_COMMAND" <<<"$local_output"; then
+    echo "local package builds must not run the CI verification hook" >&2
+    exit 1
+fi
+
+tarball_output=$(GITHUB_ACTIONS=true make -n -C "$ROOT_DIR" tarball-almalinux9)
+if grep -Fq "$VERIFY_COMMAND" <<<"$tarball_output"; then
+    echo "tarballs must remain on their dedicated runtime test" >&2
+    exit 1
+fi
+
+echo 'package CI verification hook test: PASS'

--- a/test/infra/control/test-verify-package-install.bash
+++ b/test/infra/control/test-verify-package-install.bash
@@ -7,17 +7,25 @@ TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 FAKE_BIN="$TMP_DIR/bin"
+DOCKER_PULL_LOG="$TMP_DIR/docker-pulls"
 ZYPPER_ARGS_LOG="$TMP_DIR/zypper-args"
 mkdir -p "$FAKE_BIN"
-touch "$TMP_DIR/proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm"
 
 cat >"$FAKE_BIN/rpm" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
 
+cat >"$FAKE_BIN/dpkg" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
 cat >"$FAKE_BIN/docker" <<'EOF'
 #!/usr/bin/env bash
+if [[ "$1" == pull ]]; then
+  printf '%s\n' "$2" >>"$DOCKER_PULL_LOG"
+fi
 if [[ "${FAKE_DOCKER_FAIL_COMMAND:-}" == "$1" ]]; then
   exit 1
 fi
@@ -38,6 +46,11 @@ case "$1" in
 esac
 EOF
 
+cat >"$FAKE_BIN/apt-get" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
 cat >"$FAKE_BIN/zypper" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >"$ZYPPER_ARGS_LOG"
@@ -56,29 +69,52 @@ EOF
 
 chmod +x "$FAKE_BIN"/*
 
+export DOCKER_PULL_LOG
 export FAKE_CONTAINER_BIN="$FAKE_BIN"
 export ZYPPER_ARGS_LOG
 
-PATH="$FAKE_BIN:$PATH" \
-  "$ROOT_DIR/test/infra/control/verify-package-install.bash" \
-  "$TMP_DIR/proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm"
+cases=(
+  'proxysql_3.1.11-ubuntu24_arm64.deb|ubuntu:24.04'
+  'proxysql_3.1.11-dbg-debian12_amd64.deb|debian:bookworm-slim'
+  'proxysql_3.1.11-ubuntu22-clang_amd64.deb|ubuntu:22.04'
+  'proxysql-3.1.11-1-almalinux9.aarch64.rpm|almalinux:9'
+  'proxysql-3.1.11-1-dbg-centos9.x86_64.rpm|quay.io/centos/centos:stream9'
+  'proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm|opensuse/leap:15.6'
+)
 
-expected='--non-interactive --no-gpg-checks install -y /tmp/pkg.rpm'
-actual=$(<"$ZYPPER_ARGS_LOG")
-if [[ "$actual" != "$expected" ]]; then
-  echo "expected zypper arguments: $expected" >&2
-  echo "actual zypper arguments:   $actual" >&2
+for test_case in "${cases[@]}"; do
+  package=${test_case%%|*}
+  expected_image=${test_case#*|}
+  package_path="$TMP_DIR/$package"
+  touch "$package_path"
+
+  PATH="$FAKE_BIN:$PATH" \
+    "$ROOT_DIR/test/infra/control/verify-package-install.bash" "$package_path" \
+    >/dev/null
+
+  actual_image=$(tail -1 "$DOCKER_PULL_LOG")
+  if [[ "$actual_image" != "$expected_image" ]]; then
+    echo "$package: expected image $expected_image, got $actual_image" >&2
+    exit 1
+  fi
+done
+
+expected_zypper='--non-interactive --no-gpg-checks install -y /tmp/pkg.rpm'
+actual_zypper=$(<"$ZYPPER_ARGS_LOG")
+if [[ "$actual_zypper" != "$expected_zypper" ]]; then
+  echo "expected zypper arguments: $expected_zypper" >&2
+  echo "actual zypper arguments:   $actual_zypper" >&2
   exit 1
 fi
 
+failure_package="$TMP_DIR/proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm"
 for failed_command in pull run; do
   if PATH="$FAKE_BIN:$PATH" FAKE_DOCKER_FAIL_COMMAND="$failed_command" \
-    "$ROOT_DIR/test/infra/control/verify-package-install.bash" \
-    "$TMP_DIR/proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm" \
+    "$ROOT_DIR/test/infra/control/verify-package-install.bash" "$failure_package" \
     >/dev/null 2>&1; then
     echo "docker $failed_command failure must fail package verification" >&2
     exit 1
   fi
 done
 
-echo 'verify-package-install openSUSE unsigned-RPM test: PASS'
+echo 'package filename, unsigned RPM, and fail-closed tests: PASS'

--- a/test/infra/control/test-verify-package-install.bash
+++ b/test/infra/control/test-verify-package-install.bash
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+ZYPPER_ARGS_LOG="$TMP_DIR/zypper-args"
+mkdir -p "$FAKE_BIN"
+touch "$TMP_DIR/proxysql-3.1.11-1-opensuse15.x86_64.rpm"
+
+cat >"$FAKE_BIN/rpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  pull|run|cp|kill|rm)
+    exit 0
+    ;;
+  exec)
+    shift
+    [[ "${1:-}" == "-i" ]] && shift
+    shift
+    PATH="$FAKE_CONTAINER_BIN:/usr/bin:/bin" "$@"
+    ;;
+  *)
+    echo "unexpected docker command: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+cat >"$FAKE_BIN/zypper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$ZYPPER_ARGS_LOG"
+[[ " $* " == *" --no-gpg-checks "* ]]
+EOF
+
+cat >"$FAKE_BIN/proxysql" <<'EOF'
+#!/usr/bin/env bash
+echo 'ProxySQL version 3.1.11'
+EOF
+
+cat >"$FAKE_BIN/od" <<'EOF'
+#!/usr/bin/env bash
+echo ' 7f 45 4c 46'
+EOF
+
+chmod +x "$FAKE_BIN"/*
+
+export FAKE_CONTAINER_BIN="$FAKE_BIN"
+export ZYPPER_ARGS_LOG
+
+PATH="$FAKE_BIN:$PATH" \
+  "$ROOT_DIR/test/infra/control/verify-package-install.bash" \
+  "$TMP_DIR/proxysql-3.1.11-1-opensuse15.x86_64.rpm"
+
+expected='--non-interactive --no-gpg-checks install -y /tmp/pkg.rpm'
+actual=$(<"$ZYPPER_ARGS_LOG")
+if [[ "$actual" != "$expected" ]]; then
+  echo "expected zypper arguments: $expected" >&2
+  echo "actual zypper arguments:   $actual" >&2
+  exit 1
+fi
+
+echo 'verify-package-install openSUSE unsigned-RPM test: PASS'

--- a/test/infra/control/test-verify-package-install.bash
+++ b/test/infra/control/test-verify-package-install.bash
@@ -9,7 +9,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 FAKE_BIN="$TMP_DIR/bin"
 ZYPPER_ARGS_LOG="$TMP_DIR/zypper-args"
 mkdir -p "$FAKE_BIN"
-touch "$TMP_DIR/proxysql-3.1.11-1-opensuse15.x86_64.rpm"
+touch "$TMP_DIR/proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm"
 
 cat >"$FAKE_BIN/rpm" <<'EOF'
 #!/usr/bin/env bash
@@ -18,6 +18,9 @@ EOF
 
 cat >"$FAKE_BIN/docker" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${FAKE_DOCKER_FAIL_COMMAND:-}" == "$1" ]]; then
+  exit 1
+fi
 case "$1" in
   pull|run|cp|kill|rm)
     exit 0
@@ -58,7 +61,7 @@ export ZYPPER_ARGS_LOG
 
 PATH="$FAKE_BIN:$PATH" \
   "$ROOT_DIR/test/infra/control/verify-package-install.bash" \
-  "$TMP_DIR/proxysql-3.1.11-1-opensuse15.x86_64.rpm"
+  "$TMP_DIR/proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm"
 
 expected='--non-interactive --no-gpg-checks install -y /tmp/pkg.rpm'
 actual=$(<"$ZYPPER_ARGS_LOG")
@@ -67,5 +70,15 @@ if [[ "$actual" != "$expected" ]]; then
   echo "actual zypper arguments:   $actual" >&2
   exit 1
 fi
+
+for failed_command in pull run; do
+  if PATH="$FAKE_BIN:$PATH" FAKE_DOCKER_FAIL_COMMAND="$failed_command" \
+    "$ROOT_DIR/test/infra/control/verify-package-install.bash" \
+    "$TMP_DIR/proxysql-3.1.11-1-opensuse15-clang.x86_64.rpm" \
+    >/dev/null 2>&1; then
+    echo "docker $failed_command failure must fail package verification" >&2
+    exit 1
+  fi
+done
 
 echo 'verify-package-install openSUSE unsigned-RPM test: PASS'

--- a/test/infra/control/verify-package-install.bash
+++ b/test/infra/control/verify-package-install.bash
@@ -51,7 +51,7 @@ PKG_STEM="${PKG_STEM%-clang}"
 DISTRO="${PKG_STEM##*-}"
 if [[ -z "$DISTRO" ]]; then
     echo "ERROR: could not extract distro from filename: $PKG_FILE" >&2
-    echo "  Expected: proxysql_<vers>-<distro>_<arch>.deb or proxysql-<vers>-1-<distro>.<arch>.rpm" >&2
+    echo "  Expected: proxysql_<vers>-<distro>[-clang]_<arch>.deb or proxysql-<vers>-1-<distro>[-clang].<arch>.rpm" >&2
     exit 1
 fi
 

--- a/test/infra/control/verify-package-install.bash
+++ b/test/infra/control/verify-package-install.bash
@@ -119,7 +119,10 @@ case "$PKG_TYPE" in
         elif command -v yum &>/dev/null; then
             yum install -y -q /tmp/pkg.rpm 2>&1
         elif command -v zypper &>/dev/null; then
-            zypper --non-interactive install -y /tmp/pkg.rpm 2>&1
+            # Release-build RPMs are intentionally unsigned until the
+            # release-kraken signing step.  Keep dependency resolution and
+            # installation strict while deferring only the signature gate.
+            zypper --non-interactive --no-gpg-checks install -y /tmp/pkg.rpm 2>&1
         else
             echo "ERROR: no supported package manager (dnf/yum/zypper)" >&2
             exit 1

--- a/test/infra/control/verify-package-install.bash
+++ b/test/infra/control/verify-package-install.bash
@@ -37,10 +37,18 @@ else
     exit 1
 fi
 
-# Extract distro from filename.
-# DEB:   proxysql_<vers>-<distro>_<arch>.deb        => ubuntu24
-# RPM:   proxysql-<vers>-1-<distro>.<arch>.rpm       => centos9
-DISTRO="$(echo "$PKG_FILE" | sed -n 's/.*\-\([a-z0-9]\+\)[-_.].*\.\(deb\|rpm\)$/\1/p')"
+# Extract distro from filename after removing the extension, architecture,
+# and optional compiler suffix.
+# DEB: proxysql_<vers>-<distro>[-clang]_<arch>.deb  => ubuntu24
+# RPM: proxysql-<vers>-1-<distro>[-clang].<arch>.rpm => centos9
+PKG_STEM="${PKG_FILE%.deb}"
+PKG_STEM="${PKG_STEM%.rpm}"
+PKG_STEM="${PKG_STEM%_amd64}"
+PKG_STEM="${PKG_STEM%_arm64}"
+PKG_STEM="${PKG_STEM%.x86_64}"
+PKG_STEM="${PKG_STEM%.aarch64}"
+PKG_STEM="${PKG_STEM%-clang}"
+DISTRO="${PKG_STEM##*-}"
 if [[ -z "$DISTRO" ]]; then
     echo "ERROR: could not extract distro from filename: $PKG_FILE" >&2
     echo "  Expected: proxysql_<vers>-<distro>_<arch>.deb or proxysql-<vers>-1-<distro>.<arch>.rpm" >&2
@@ -91,8 +99,8 @@ echo ""
 # ---- Pull the clean distro image ----
 echo "==> Pulling $IMAGE ..."
 if ! docker pull "$IMAGE" >/dev/null 2>&1; then
-    echo "WARNING: could not pull $IMAGE — skipping verification" >&2
-    exit 0
+    echo "ERROR: could not pull $IMAGE" >&2
+    exit 1
 fi
 echo ""
 
@@ -185,8 +193,8 @@ trap cleanup EXIT
 
 echo "==> Starting clean container from $IMAGE ..."
 if ! docker run -d --name "$CID" "$IMAGE" sleep 120 >/dev/null 2>&1; then
-    echo "WARNING: could not start container from $IMAGE — skipping" >&2
-    exit 0
+    echo "ERROR: could not start container from $IMAGE" >&2
+    exit 1
 fi
 
 # Copy package into container


### PR DESCRIPTION
## Summary

- run the existing clean-install verifier from the shared package build target for every GitHub Actions `.deb` and `.rpm` build
- remove 28 duplicated ARM64 workflow-local verifier steps
- support standard, debug, and clang package filenames across DEB/RPM and amd64/arm64
- allow unsigned openSUSE RPMs only during the documented pre-signing verification stage
- fail verification when its Docker image cannot be pulled or started
- run the lightweight verifier regression tests in existing CI

## Release impact

All 168 Mechanism B package workflows now verify the exact newly built package before the upload step. Local package builds remain unchanged, and tarballs keep their existing dedicated runtime test.

No `GH-Actions` branch change is required: its package workflow checks out the source SHA and invokes the same Makefile target, with `GITHUB_ACTIONS=true` supplied by Actions.

## Verification

- `test/infra/control/test-package-ci-verification.bash`
- `test/infra/control/test-verify-package-install.bash`
- ShellCheck on the verifier and both tests
- actionlint on all 29 changed workflows
- audit that all 168 release package workflows invoke exactly one shared Makefile target

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
All 168 release package workflows now verify the exact package they just built before uploading: the check moved from the 28 ARM64 workflow steps into the shared Makefile build target. Previously the verifier skipped with a warning when its Docker image could not be pulled or started; it now fails closed.

**Details**
- Removed the duplicated ARM64 verifier steps; the script now handles debug and clang package filenames across DEB/RPM and amd64/arm64.
- Verification runs only with `GITHUB_ACTIONS=true`, so local builds are unchanged; tarballs keep their dedicated runtime test.
- openSUSE RPMs install with `--no-gpg-checks` during the documented pre-signing verification stage.
- New regression tests for the verifier and the Makefile hook run in `CI-lint-groups-json.yml`, which now fetches full git history so those tests can resolve tags.

<sup>Written for commit 354ea1754a84e36ba4380ecc7d2d716e4307f547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package-install verification across Debian-, RPM-, and openSUSE-based distributions.
  * Added support for updated package filename formats, including architecture and optional compiler suffixes.
  * Verification now reports container image download and startup failures correctly.
  * Improved RPM installation handling by allowing noninteractive installation without GPG checks.

* **CI**
  * Package builds now verify installation during CI before release assets are uploaded.
  * Added automated coverage for verification behavior and distribution mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->