### PR TITLE
fix(ci): generic, branch-derived LFS hydration in ci-builds.yml

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -261,16 +261,50 @@ jobs:
         fetch-depth: 0
         path: 'proxysql'
 
-    - name: Hydrate vendored OpenSSL source
+    # Checkout above sets GIT_LFS_SKIP_SMUDGE (see the comment on that step),
+    # so every LFS-tracked file -- vendored source tarballs -- currently sits
+    # in the "proxysql" checkout as a pointer stub. Hydrate them here, driven
+    # entirely by what the checked-out branch's .gitattributes declares.
+    #
+    # This is deliberately generic rather than a per-archive step, because
+    # this file is shared by ALL branches (every CI-*.yml caller on every
+    # branch pins `ci-builds.yml@GH-Actions`): a hardcoded archive name/
+    # version can only ever be correct for one branch at a time, and a
+    # version bump would require an atomic-impossible cross-branch edit
+    # (workflow here, archive on the target branch). The concrete proof this
+    # already bit us: this step used to hardcode
+    # "deps/libssl/openssl-3.5.7.tar.gz", a path that does not exist on v3.0
+    # at all -- so it silently hydrated nothing on every v3.0 build, saved
+    # only by its own `-f` guard. PR #6133 then added a second vendored
+    # archive (deps/duckdb/duckdb-1.4.5.tar.gz) and hit the same wall: no
+    # amount of hardcoding one archive name generalizes to two, let alone to
+    # whatever the next branch vendors.
+    #
+    # `git lfs pull` with no --include fetches every LFS object the checked-
+    # out branch's .gitattributes tracks -- so a version bump, or a brand
+    # new vendored dep, needs no change here at all. The tradeoff: it also
+    # fetches LFS objects a given build tier won't use (e.g. DuckDB's 98MB
+    # on a build that never touches PROXYSQL40). That's accepted deliberately
+    # for correctness and zero per-dep maintenance; if LFS bandwidth becomes
+    # a real problem, this is the place to add filtering back -- but note
+    # any such filter reintroduces per-dep knowledge here and its own
+    # staleness risk (exactly the bug being fixed now).
+    #
+    # Each vendored dep may ship its own verify-source.bash (today only
+    # deps/libssl/ has one); run whichever exist. The glob is guarded so a
+    # branch with no verifier scripts (or no LFS files at all) still
+    # succeeds -- `for` over a non-matching glob iterates the literal,
+    # unexpanded pattern once, so the `[ -x ... ]` test is what actually
+    # skips it.
+    - name: Hydrate vendored source archives
       if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
       working-directory: proxysql
       run: |
         set -euo pipefail
-        archive="deps/libssl/openssl-3.5.7.tar.gz"
-        if [[ -f "${archive}" ]]; then
-          git lfs pull --include="${archive}" --exclude=""
-          deps/libssl/verify-source.bash
-        fi
+        git lfs pull
+        for v in deps/*/verify-source.bash; do
+          [ -x "$v" ] && "$v"
+        done
 
 #    - name: Patch TAP-tests
 #      if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci-package-build.yml
+++ b/.github/workflows/ci-package-build.yml
@@ -136,13 +136,21 @@ jobs:
 #        action_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
+    # This job builds a shippable package from source, so it needs real
+    # content for whatever the checked-out branch vendors via git-lfs, not
+    # pointer stubs. `lfs: true` has actions/checkout fetch everything that
+    # branch's .gitattributes declares -- generic like ci-builds.yml's
+    # hydration step, just via the action's built-in mechanism, since this
+    # GH-hosted runner has none of ci-builds.yml's self-hosted persistent-
+    # workspace reasons to defer/skip smudging at checkout time.
     - name: Checkout repository
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.SHA }}
         fetch-depth: 0
-       
+        lfs: true
+
     - name: Build package
       run: |
         #[[ $(git describe --long --abbrev=7) == ${{ needs.clean.outputs.gitdescribe }} ]] || exit 1

--- a/.github/workflows/ci-pg-compat.yml
+++ b/.github/workflows/ci-pg-compat.yml
@@ -35,8 +35,17 @@ jobs:
     timeout-minutes: 120
     permissions: write-all
     steps:
+      # This job builds from source (see below), so it needs real content for
+      # whatever the checked-out branch vendors via git-lfs, not pointer
+      # stubs. `lfs: true` has actions/checkout fetch everything that
+      # branch's .gitattributes declares -- generic like ci-builds.yml's
+      # hydration step, just via the action's built-in mechanism, since this
+      # GH-hosted runner has none of ci-builds.yml's self-hosted persistent-
+      # workspace reasons to defer/skip smudging at checkout time.
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          lfs: true
 
       # Inline build (CI-3p-* model, not the CI-trigger/CI-builds cache-chain
       # model used by the TAP families): no ccache pattern exists elsewhere


### PR DESCRIPTION
## Problem

`ci-builds.yml` checks out with `GIT_LFS_SKIP_SMUDGE: "1"` (persistent self-hosted workspace; see the comment on that step), then hydrated exactly **one** hardcoded archive:

```yaml
archive="deps/libssl/openssl-3.5.7.tar.gz"
if [[ -f "${archive}" ]]; then
  git lfs pull --include="${archive}" --exclude=""
  deps/libssl/verify-source.bash
fi
```

Two structural flaws, both already latent:

1. **Version coupling.** This file is shared by every branch — all 85 caller workflows (`CI-*.yml` on every branch) pin `ci-builds.yml@GH-Actions`. A hardcoded archive name/version can only ever be correct for one branch; bumping OpenSSL means editing a workflow on a *different* branch than the one shipping the new tarball, so the two changes can't land atomically.
2. **Cross-branch collision, confirmed.** `deps/libssl/openssl-3.5.7.tar.gz` does not exist on `v3.0` at all (verified: `git show origin/v3.0:.gitattributes` → no such file, no `.gitattributes`). It only exists on the unmerged `feature/issue-6115-vendored-openssl` branch. So this step has been silently hydrating nothing on every v3.0 build, saved only by its own `-f` guard.

**#6133** (DuckDB Server plugin) adds a second archive, `deps/duckdb/duckdb-1.4.5.tar.gz` (98 MB, confirmed present via that branch's `.gitattributes`), and is currently failing CI for exactly this reason — a second hardcoded `--include=` line can't serve two branches with two different archives.

## Fix

Replace the per-archive step with one driven entirely by what the **checked-out branch** declares:

```bash
set -euo pipefail
git lfs pull
for v in deps/*/verify-source.bash; do
  [ -x "$v" ] && "$v"
done
```

- `git lfs pull` (no `--include`) fetches every LFS object the branch's `.gitattributes` tracks — a version bump or a brand-new vendored dep needs **no workflow change**.
- The verify loop runs whichever `deps/*/verify-source.bash` scripts exist (today only `deps/libssl/`); the glob is guarded (`[ -x ... ]`) so a branch with none, or no LFS files at all, still succeeds. Tested locally: no-match glob, existing-dirs-without-verifier, one-real-verifier, and a failing-verifier case (correctly fails the step) — see PR description script logic mirrored in the step itself.
- **Trade-off, accepted deliberately:** a plain `git lfs pull` fetches every LFS object the branch tracks, including DuckDB's 98 MB, even for tiers that never build it. This favors correctness and zero per-dep maintenance. If LFS bandwidth becomes a problem, that's the place to add filtering back — but any such filter reintroduces per-dep knowledge and its own staleness risk (exactly today's bug).
- Comments in the step explain all of the above in place, aimed at the next person tempted to "simplify" this back to a hardcoded name during a merge conflict.

## Audit: other reusable workflows

Confirmed `ci-builds.yml` was the only reusable workflow containing this specific hydration step. Went further and checked every `ci-*.yml` for anything that builds ProxySQL from a fresh source checkout (as opposed to consuming `ci-builds.yml`'s handoff artifacts, which is how `ci-unittests.yml`, `ci-selftests.yml`, `ci-basictests.yml`, and `ci-shuntest.yml` all work):

- `ci-codeql.yml`, `ci-maketest.yml` — already build from source but set `lfs: true` on checkout, so actions/checkout hydrates everything generically already. No change needed.
- `ci-pg-compat.yml`, `ci-package-build.yml` — build from source (`PROXYSQL31=1 make debug`, and `make <dist><type>` respectively) but had **no LFS handling at all** (no `lfs: true`, no skip-smudge). Currently dormant (v3.0 has no `.gitattributes`/LFS files today), but they'd silently receive pointer stubs and fail confusingly the moment any tier they build vendors an LFS dep — the identical failure mode, just less obvious. Hardened both with `lfs: true` on checkout, matching the existing `ci-codeql.yml`/`ci-maketest.yml` pattern (no need for ci-builds.yml's more complex self-hosted-specific dance, since these run on ephemeral GitHub-hosted runners).
- No other `ci-*.yml` invokes `make` against a fresh checkout.

## Verification

- YAML parses (`yaml.safe_load` on all three changed files).
- Shell fragment tested standalone in a scratch dir under `bash -euo pipefail`: no-`deps/` case, `deps/*/` dirs with no verifier, one real verifier, and a failing verifier (correctly propagates failure) — all behave as intended.
- Step placement unchanged: still runs immediately after checkout, before Build.
- **Not verified: an actual CI run.** This needs to merge and then be exercised by a real caller (e.g. #6133's CI-builds run) to confirm end-to-end.

## Why this must merge first

#6133 cannot pass CI-builds until this lands, since its DuckDB archive hits the same hardcoded-hydration wall described above. Fixes/unblocks #6133.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `ci-builds.yml`'s hardcoded LFS hydration step with a generic, branch-driven `git lfs pull`, and adds `lfs: true` to the two other reusable workflows that build from source without any LFS handling.

- All branches pin this shared workflow, so the old hardcoded `deps/libssl/openssl-3.5.7.tar.gz` path could only ever be correct for one branch; it doesn't exist on `v3.0`, so those builds silently hydrated nothing.
- #6133's new DuckDB archive hits the same wall, making this PR a prerequisite for that work.
- `git lfs pull` without `--include` fetches every LFS object the checked-out branch's `.gitattributes` tracks, so version bumps and new vendored deps need no workflow change.
- A guarded loop runs whichever `deps/*/verify-source.bash` scripts exist; branches with none still pass.
- Plain pull fetches unused LFS objects (e.g., DuckDB's 98 MB) on tiers that don't build it — accepted for zero per-dep maintenance.
- `ci-pg-compat.yml` and `ci-package-build.yml` now set `lfs: true` on checkout, matching the `ci-codeql.yml` and `ci-maketest.yml` pattern.
- Not yet exercised on a real CI run; merge first, then a caller like #6133 confirms end-to-end.

<sup>Written for commit 05e651de20f78bfac0ce07a0891b2ece14f916dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source-based builds by reliably fetching Git LFS–managed vendored archives during checkout.
  - Automatically hydrates and verifies available vendored dependency sources across build workflows.
  - Prevented builds from failing on branches without LFS files or source-verification scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->