### PR TITLE
perf: optimize ParserSQL digest and classification overhead

### DIFF
--- a/include/Query_Processor_ParserSQL.h
+++ b/include/Query_Processor_ParserSQL.h
@@ -107,6 +107,25 @@ enum MYSQL_COM_QUERY_command parsersql_command_type_mysql(const char* query, int
 enum PGSQL_QUERY_command parsersql_command_type_pgsql(const char* query, int query_length);
 
 /**
+ * @brief Maps a ParserSQL StmtType to a `MYSQL_COM_QUERY_command`.
+ *
+ * @param stmt_type  A `StmtType` value (see sql_parser/common.h), as an int.
+ * @return           The corresponding command type.
+ */
+enum MYSQL_COM_QUERY_command parsersql_stmt_type_to_mysql_command(int stmt_type);
+
+/**
+ * @brief Maps a ParserSQL StmtType to a `PGSQL_QUERY_command`.
+ *
+ * Identical to parsersql_stmt_type_to_mysql_command() but targets the
+ * PostgreSQL command enum.
+ *
+ * @param stmt_type  A `StmtType` value (see sql_parser/common.h), as an int.
+ * @return           The corresponding command type.
+ */
+enum PGSQL_QUERY_command parsersql_stmt_type_to_pgsql_command(int stmt_type);
+
+/**
  * @brief Parses a MySQL SET statement into variable-value pairs.
  *
  * Walks the AST produced by the MySQL ParserSQL parser and extracts each

--- a/include/proxysql_structs.h
+++ b/include/proxysql_structs.h
@@ -899,6 +899,7 @@ struct __SQP_query_parser_t {
 	char *digest_text;
 	char *first_comment;
 	char *query_prefix;
+	int parsersql_stmt_type;
 };
 
 struct _PtrSize_t {

--- a/lib/MySQL_Query_Processor.cpp
+++ b/lib/MySQL_Query_Processor.cpp
@@ -164,6 +164,10 @@ enum MYSQL_COM_QUERY_command MySQL_Query_Processor::query_parser_command_type(SQ
 	enum MYSQL_COM_QUERY_command ret = MYSQL_COM_QUERY_UNKNOWN;
 
 	if (mysql_thread___query_processor_parser == 1) {
+		if (qp->parsersql_stmt_type >= 0) {
+			// already classified during the digest parse
+			return parsersql_stmt_type_to_mysql_command(qp->parsersql_stmt_type);
+		}
 		if (text) {
 			return parsersql_command_type_mysql(text, strlen(text)); // NOSONAR
 		}

--- a/lib/PgSQL_Query_Processor.cpp
+++ b/lib/PgSQL_Query_Processor.cpp
@@ -669,6 +669,10 @@ enum PGSQL_QUERY_command PgSQL_Query_Processor::query_parser_command_type(SQP_pa
 	enum PGSQL_QUERY_command ret = PGSQL_QUERY_UNKNOWN;
 
 	if (pgsql_thread___query_processor_parser == 1) {
+		if (qp->parsersql_stmt_type >= 0) {
+			// already classified during the digest parse
+			return parsersql_stmt_type_to_pgsql_command(qp->parsersql_stmt_type);
+		}
 		if (text) {
 			return parsersql_command_type_pgsql(text, strlen(text)); // NOSONAR
 		}

--- a/lib/Query_Processor.cpp
+++ b/lib/Query_Processor.cpp
@@ -2328,6 +2328,7 @@ void Query_Processor<QP_DERIVED>::query_parser_init(SQP_par_t *qp, const char *q
 	qp->digest_text=NULL;
 	qp->first_comment=NULL;
 	qp->query_prefix=NULL;
+	qp->parsersql_stmt_type=-1;
 	if (GET_THREAD_VARIABLE(query_digests)) {
 		if (GET_THREAD_VARIABLE(query_processor_parser) == 1) {
 			qp_digest_parsersql<QP_DERIVED>(qp, query, query_length);

--- a/lib/Query_Processor_ParserSQL.cpp
+++ b/lib/Query_Processor_ParserSQL.cpp
@@ -413,26 +413,39 @@ void parsersql_digest_init_mysql(SQP_par_t* qp, const char* query, int query_len
     qp->first_comment = NULL;
     qp->query_prefix = NULL;
     qp->digest = 0;
+    qp->parsersql_stmt_type = -1;
 
     auto result = tl_mysql_parser.parse(query, query_length);
 
     if (result.status == ParseResult::OK || result.status == ParseResult::PARTIAL) {
-        std::string normalized;
+        // The arena holds 'normalized' until reset() below, so it can be hashed and copied out directly.
+        const char* normalized = NULL;
+        size_t normalized_len = 0;
         if (result.ast) {
             // Tier 1: full AST available — use Emitter in DIGEST mode
             Emitter<Dialect::MySQL> emitter(tl_mysql_parser.arena(), EmitMode::DIGEST);
             emitter.emit(result.ast);
             StringRef ref = emitter.result();
-            normalized.assign(ref.ptr, ref.len);
+            normalized = ref.ptr;
+            normalized_len = ref.len;
         } else {
             // Tier 2: token-level fallback for statements without full AST support
             Digest<Dialect::MySQL> digest(tl_mysql_parser.arena());
             DigestResult dr = digest.compute(query, query_length);
-            normalized.assign(dr.normalized.ptr, dr.normalized.len);
+            normalized = dr.normalized.ptr;
+            normalized_len = dr.normalized.len;
         }
-        qp->digest_text = strdup(normalized.c_str());
         // SpookyHash is preserved for backward compatibility with existing digest stats
-        qp->digest = SpookyHash::Hash64(normalized.c_str(), normalized.size(), 0);
+        qp->digest = SpookyHash::Hash64(normalized, normalized_len, 0);
+        qp->parsersql_stmt_type = static_cast<int>(result.stmt_type);
+        // Reuse qp->buf when it fits, as query_parser_free() expects for the legacy tokenizer.
+        if (normalized_len < QUERY_DIGEST_BUF) {
+            memcpy(qp->buf, normalized, normalized_len);
+            qp->buf[normalized_len] = '\0';
+            qp->digest_text = qp->buf;
+        } else {
+            qp->digest_text = strndup(normalized, normalized_len);
+        }
     }
 
     tl_mysql_parser.reset();
@@ -444,23 +457,34 @@ void parsersql_digest_init_pgsql(SQP_par_t* qp, const char* query, int query_len
     qp->first_comment = NULL;
     qp->query_prefix = NULL;
     qp->digest = 0;
+    qp->parsersql_stmt_type = -1;
 
     auto result = tl_pgsql_parser.parse(query, query_length);
 
     if (result.status == ParseResult::OK || result.status == ParseResult::PARTIAL) {
-        std::string normalized;
+        const char* normalized = NULL;
+        size_t normalized_len = 0;
         if (result.ast) {
             Emitter<Dialect::PostgreSQL> emitter(tl_pgsql_parser.arena(), EmitMode::DIGEST);
             emitter.emit(result.ast);
             StringRef ref = emitter.result();
-            normalized.assign(ref.ptr, ref.len);
+            normalized = ref.ptr;
+            normalized_len = ref.len;
         } else {
             Digest<Dialect::PostgreSQL> digest(tl_pgsql_parser.arena());
             DigestResult dr = digest.compute(query, query_length);
-            normalized.assign(dr.normalized.ptr, dr.normalized.len);
+            normalized = dr.normalized.ptr;
+            normalized_len = dr.normalized.len;
         }
-        qp->digest_text = strdup(normalized.c_str());
-        qp->digest = SpookyHash::Hash64(normalized.c_str(), normalized.size(), 0);
+        qp->digest = SpookyHash::Hash64(normalized, normalized_len, 0);
+        qp->parsersql_stmt_type = static_cast<int>(result.stmt_type);
+        if (normalized_len < QUERY_DIGEST_BUF) {
+            memcpy(qp->buf, normalized, normalized_len);
+            qp->buf[normalized_len] = '\0';
+            qp->digest_text = qp->buf;
+        } else {
+            qp->digest_text = strndup(normalized, normalized_len);
+        }
     }
 
     tl_pgsql_parser.reset();
@@ -563,6 +587,14 @@ enum MYSQL_COM_QUERY_command parsersql_command_type_mysql(const char* query, int
         return stmt_type_to_mysql_command(result.stmt_type);
     }
     return MYSQL_COM_QUERY_UNKNOWN;
+}
+
+enum MYSQL_COM_QUERY_command parsersql_stmt_type_to_mysql_command(int stmt_type) {
+    return stmt_type_to_mysql_command(static_cast<StmtType>(stmt_type));
+}
+
+enum PGSQL_QUERY_command parsersql_stmt_type_to_pgsql_command(int stmt_type) {
+    return stmt_type_to_pgsql_command(static_cast<StmtType>(stmt_type));
 }
 
 enum PGSQL_QUERY_command parsersql_command_type_pgsql(const char* query, int query_length) {


### PR DESCRIPTION
This implements two performance improvements in the digest computation and command-type classification path with the ParserSQL parser:

- we were parsing twice just to get the command types. Instead now we reuse the results of the first parse (captured at parser init).
- reduce heap allocations by directly copying and hashing from parser's arena instead of creating an intermediate `std::string` instance, and by reusing the struct's existing buffer for the digest text (instead of reallocating).

**NOTE**: This does NOT affect the legacy parser path in any way.

## Measurements

All numbers in the below tables are in **ns**. They are calculated by arming `clock_gettime(CLOCK_THREAD_CPUTIME_ID, ...)` around the code under bench.

The numbers are recorded for the following four configurations:

- legacy (baseline): Legacy parser path
- legacy (patched): unchanged
- parser=1 (baseline): ParserSQL path before PR
- parser=1 (patched): ParserSQL path after this PR

**Machine specs**: Ubuntu 24.04.4 (colima), aarch64 (ARM64), 4 vCPUs, 8 GiB RAM using jemalloc allocator correctly.

### Function-level benchmark

Benchmarked the following two functions in the hot-path:

**Before**:
```cpp
parsersql_digest_init_mysql(&qp, ...);
parsersql_command_type_mysql(qp.digest_text, ...);
```

**After**:
```cpp
parsersql_digest_init_mysql(&qp, ...);
parsersql_stmt_type_to_mysql_command(qp.parsersql_stmt_type);  // cached lookup
```

taking median of 35 iterations with 200,000 calls per iteration (both funcs serially) on one single core.

| case | legacy (baseline) | legacy (patched) | parser=1 (baseline) | parser=1 (patched) |
|---|---|---|---|---|
| point-select | 279.9 | 277.2 | 744.1 | 375.7 |
| in-list | 457.8 | 457.1 | 1023.7 | 666.8 |
| join-orderby | 581.4 | 581.2 | 1647.2 | 885.5 |
| insert | 309.9 | 311.3 | 972.6 | 483.5 |
| begin | 34.9 | 35.1 | 124.9 | 71.5 |
| union | 197.8 | 198.5 | 545.6 | 265.3 |

- **~45%** speedup.

### Full proxy synchronous path

CPU time from query packet received to just before the query is handed to the backend, excluding all network/backend IO.

**Setup**: Running a full ProxySQL server with single MySQL and a single PgSQL worker thread (on a real MySQL backend), with timers attached in code (just calculating the proxy synchronous path), and ran sysbench for 20 seconds and saved all measurements. Took the median of 10 such 20-second iterations.

| | legacy (baseline) | legacy (patched) | parser=1 (baseline) | parser=1 (patched) |
|---|---|---|---|---|
| fullpath | 16104.4 | 16048.6 | 16791.8 | 16061.0 |

- **~4.35%** speedup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved SQL statement classification for MySQL and PostgreSQL queries.
  * Query command types are now reused from parser results when available, providing more consistent classification.
  * Improved handling of normalized query digest text, including more efficient storage when possible.
  * Added fallback behavior to preserve existing text-based classification when parser results are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->