### PR TITLE
ci: skip package installation checks for sanitizer builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ build-%: PKG_FILE=$(if $(filter tarball,$(shell echo ${BLD_NAME} | grep -o 'tarb
 build-%:
 	@echo 'building $@'
 	@IMG_NAME=$(PKG_NAME) IMG_TYPE=$(subst -,_,$(PKG_TYPE)) IMG_COMP=$(subst -,_,$(PKG_COMP)) BLD_NAME=$(BLD_NAME) $(MAKE) $(PKG_FILE)
-	$(if $(and $(filter true,$(GITHUB_ACTIONS)),$(filter-out tar.gz,$(PKG_KIND))),@test/infra/control/verify-package-install.bash "$(PKG_FILE)",@:)
+	$(if $(filter 1,$(WITHASAN) $(WITHTSAN)),@:,$(if $(and $(filter true,$(GITHUB_ACTIONS)),$(filter-out tar.gz,$(PKG_KIND))),@test/infra/control/verify-package-install.bash "$(PKG_FILE)",@:))
 
 # Scope the compose project per build variant, not just per commit. On shared
 # self-hosted CI runners several matrix variants of the same commit build

--- a/test/infra/control/test-package-ci-verification.bash
+++ b/test/infra/control/test-package-ci-verification.bash
@@ -24,4 +24,16 @@ if grep -Fq "$VERIFY_COMMAND" <<<"$tarball_output"; then
     exit 1
 fi
 
+asan_output=$(GITHUB_ACTIONS=true WITHASAN=1 make -n -C "$ROOT_DIR" ubuntu24-tap)
+if grep -Fq "$VERIFY_COMMAND" <<<"$asan_output"; then
+    echo "ASAN test builds must not run the clean-install verification hook" >&2
+    exit 1
+fi
+
+tsan_output=$(GITHUB_ACTIONS=true WITHTSAN=1 make -n -C "$ROOT_DIR" ubuntu24-tap)
+if grep -Fq "$VERIFY_COMMAND" <<<"$tsan_output"; then
+    echo "TSAN test builds must not run the clean-install verification hook" >&2
+    exit 1
+fi
+
 echo 'package CI verification hook test: PASS'


### PR DESCRIPTION
## Problem

PR #6131 added the clean-install verifier to the generic `build-%` Make target whenever `GITHUB_ACTIONS=true`. The ASAN and TSAN test workflows invoke `make ubuntu24-tap`, which also produces a debug `.deb` as an incidental build output. That made the verifier install the sanitizer-instrumented package in a separate clean `ubuntu:24.04` container, where its required sanitizer runtime is intentionally absent:

```text
libasan.so.8: cannot open shared object file
libtsan.so.2: cannot open shared object file
```

The unit tests correctly run the binaries inside `ubuntu24_dbg_build`, the image that provides the matching sanitizer runtime. The clean-install check is not meaningful for these test-only artifacts.

## Fix

Skip the generic package-install verification when `WITHASAN=1` or `WITHTSAN=1`. Ordinary GitHub Actions DEB/RPM package builds, including regular debug packages, retain the existing verification. No new workflow-specific variable is added.

## Verification

- `test/infra/control/test-package-ci-verification.bash`
- Validated `make -n` output: regular CI packages retain the verifier; ASAN and TSAN `ubuntu24-tap` builds omit it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the package-install verification hook for ASAN and TSAN test builds so their CI no longer fails when the sanitizer runtime is missing from the verification container.

- ASAN/TSAN `ubuntu24-tap` builds skip the verifier; regular CI package builds, including debug packages, keep it.
- Adds regression tests asserting the verifier is omitted for sanitizer builds.

<sup>Written for commit a3a02b5e12e82a07aec9a3206b0706088fc90b39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitizer builds now skip package-install verification during CI, preventing unnecessary verification steps for ASAN and TSAN builds.

* **Tests**
  * Added coverage to confirm ASAN and TSAN Ubuntu 24 test builds do not run clean-install package verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->