### PR TITLE
fix(ci): skip LFS hydration when no files are tracked

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -293,15 +293,19 @@ jobs:
     # Each vendored dep may ship its own verify-source.bash (today only
     # deps/libssl/ has one); run whichever exist. The glob is guarded so a
     # branch with no verifier scripts (or no LFS files at all) still
-    # succeeds -- `for` over a non-matching glob iterates the literal,
-    # unexpanded pattern once, so the `[ -x ... ]` test is what actually
-    # skips it.
+    # succeeds. `git lfs pull` itself fails when the branch has no LFS
+    # attributes, so enumerate tracked paths first; `for` over a non-matching
+    # glob iterates the literal, unexpanded pattern once, so the `[ -x ... ]`
+    # test is what actually skips it.
     - name: Hydrate vendored source archives
-      if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && steps.cache-check.outputs.cache-hit != 'true' }}
       working-directory: proxysql
       run: |
         set -euo pipefail
-        git lfs pull
+        lfs_files="$(git lfs ls-files --name-only)"
+        if [ -n "${lfs_files}" ]; then
+          git lfs pull --include="" --exclude=""
+        fi
         for v in deps/*/verify-source.bash; do
           [ -x "$v" ] && "$v"
         done


### PR DESCRIPTION
## Problem

PR #6135 changed CI-builds to hydrate LFS archives generically. On branches with no `.gitattributes` LFS entries, including v3.0, `git lfs pull` exits with status 1. All CI-builds matrix legs consequently fail before the build begins.

The hydration step also executed its branch-provided verifier loop for untrusted fork calls, despite the reusable workflow contract stating that only checkout runs in that mode.

## Fix

- Use `git lfs ls-files --name-only` to detect whether the checked-out branch tracks LFS files, and call `git lfs pull` only when it does.
- Clear include/exclude filters for that pull so every tracked archive is hydrated.
- Gate the hydration and verifier step on `inputs.trusted`, consistent with the fork-CI security model.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-builds.yml")'`
- `actionlint .github/workflows/ci-builds.yml`

Local `git-lfs` is unavailable in this checkout; CI will exercise both the no-LFS v3.0 path and LFS-enabled branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI builds failing on branches with no LFS-tracked files. `git lfs pull` previously ran unconditionally and exited 1 on branches without `.gitattributes` LFS entries, breaking every build before it started.

- Git LFS hydration now enumerates tracked files and only pulls when any are present.
- Hydration and source verification now run only for trusted inputs, matching the fork-CI security model.

<sup>Written for commit 01b01c8302aaa6512eb3c9758223532a8af76723. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability for branches without Git LFS-tracked files.
  * Restricted vendored source archive hydration to trusted builds and skipped unnecessary LFS downloads.
  * Updated build guidance to reflect the revised archive handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->