### PR TITLE
fix(ci): make missing LFS verifiers a no-op

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -294,9 +294,9 @@ jobs:
     # deps/libssl/ has one); run whichever exist. The glob is guarded so a
     # branch with no verifier scripts (or no LFS files at all) still
     # succeeds. `git lfs pull` itself fails when the branch has no LFS
-    # attributes, so enumerate tracked paths first; `for` over a non-matching
-    # glob iterates the literal, unexpanded pattern once, so the `[ -x ... ]`
-    # test is what actually skips it.
+    # attributes, so enumerate tracked paths first; enable nullglob so a
+    # missing verifier expands to no loop iterations rather than a literal
+    # non-executable pattern that would fail under `set -e`.
     - name: Hydrate vendored source archives
       if: ${{ inputs.trusted && steps.cache-check.outputs.cache-hit != 'true' }}
       working-directory: proxysql
@@ -306,8 +306,9 @@ jobs:
         if [ -n "${lfs_files}" ]; then
           git lfs pull --include="" --exclude=""
         fi
+        shopt -s nullglob
         for v in deps/*/verify-source.bash; do
-          [ -x "$v" ] && "$v"
+          "$v"
         done
 
 #    - name: Patch TAP-tests


### PR DESCRIPTION
## Problem

PR #6141 correctly skips `git lfs pull` when a checked-out branch has no LFS files. CI-builds still failed because Bash expands an unmatched `deps/*/verify-source.bash` glob to its literal pattern. The false `[ -x "$v" ]` final loop-body status then makes the `for` compound command return nonzero under `set -e`.

## Fix

Enable `nullglob` before iterating verifiers. A branch with no verifier scripts has zero loop iterations and succeeds; executable verifiers still run and failures still stop the job.

## Verification

- YAML parsed with Ruby `YAML.load_file`.
- `actionlint` was run before the worktree branch changed; it reported no workflow errors.
- Bash probes covered missing, successful, and failing verifier scripts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures on branches with no LFS verifier scripts by enabling `nullglob` before the verifier loop, so a missing `deps/*/verify-source.bash` match expands to zero iterations instead of a literal pattern that fails under `set -e`. Executable verifiers still run and failures still stop the job.

<sup>Written for commit 4bcfde3505764ff5f45d086067d4101bc1b09938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build validation reliability when verifier files are absent.
  * Build checks now correctly report verifier scripts that cannot be executed, helping identify configuration issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->