### PR TITLE
fix(ci): stage libpq only when required

### DIFF
--- a/.github/scripts/tests/test-mysqlx-runtime-handoff.py
+++ b/.github/scripts/tests/test-mysqlx-runtime-handoff.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import subprocess
+import tempfile
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def workflow_steps(path: str, job: str) -> list[dict]:
+    with (ROOT / path).open(encoding="utf-8") as stream:
+        workflow = yaml.safe_load(stream)
+    return workflow["jobs"][job]["steps"]
+
+
+def named_step(steps: list[dict], name: str) -> dict:
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"workflow step not found: {name}")
+
+
+def compile_shared(output: Path, source: str, *link_args: str) -> None:
+    result = subprocess.run(
+        ["cc", "-shared", "-fPIC", "-x", "c", "-", "-o", str(output), *link_args],
+        input=source,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def run_script(step: dict, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", "set -euo pipefail\n" + step["run"]],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def create_workspace(root: Path, dynamic_libpq: bool) -> tuple[Path, Path]:
+    repo = root / "proxysql"
+    tap_dir = repo / "test/tap/tap"
+    plugin_dir = repo / "plugins/mysqlx"
+    libpq_dir = repo / "deps/postgresql/postgresql/src/interfaces/libpq"
+    tap_dir.mkdir(parents=True)
+    plugin_dir.mkdir(parents=True)
+    libpq_dir.mkdir(parents=True)
+    (plugin_dir / "ProxySQL_MySQLX_Plugin.so").write_bytes(b"mysqlx-plugin")
+
+    libtap = tap_dir / "libtap.so"
+    libpq = libpq_dir / "libpq.so.5"
+    if dynamic_libpq:
+        compile_shared(libpq, "void pq_fixture(void) {}", "-Wl,-soname,libpq.so.5")
+        compile_shared(
+            libtap,
+            "extern void pq_fixture(void); void tap_fixture(void) { pq_fixture(); }",
+            f"-L{libpq_dir}",
+            "-Wl,--no-as-needed",
+            "-l:libpq.so.5",
+        )
+    else:
+        compile_shared(libtap, "void tap_fixture(void) {}")
+    return repo, libpq
+
+
+stage = named_step(
+    workflow_steps(".github/workflows/ci-builds.yml", "builds"),
+    "Stage MySQLX runtime libraries in test handoff",
+)
+assert "inputs.trusted" in stage["if"]
+assert "contains(matrix.type,'-mysqlx')" in stage["if"]
+
+with tempfile.TemporaryDirectory() as directory:
+    cwd = Path(directory)
+    repo, _ = create_workspace(cwd, dynamic_libpq=False)
+    result = run_script(stage, cwd)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "libtap.so uses static libpq" in result.stdout
+    runtime_dir = repo / "test/tap/tap/_runtime_libs"
+    assert not (runtime_dir / "libpq.so.5").exists()
+    assert (runtime_dir / "ProxySQL_MySQLX_Plugin.so").read_bytes() == b"mysqlx-plugin"
+
+with tempfile.TemporaryDirectory() as directory:
+    cwd = Path(directory)
+    repo, libpq = create_workspace(cwd, dynamic_libpq=True)
+    expected_libpq = libpq.read_bytes()
+    result = run_script(stage, cwd)
+    assert result.returncode == 0, result.stdout + result.stderr
+    runtime_dir = repo / "test/tap/tap/_runtime_libs"
+    assert (runtime_dir / "libpq.so.5").read_bytes() == expected_libpq
+
+with tempfile.TemporaryDirectory() as directory:
+    cwd = Path(directory)
+    _, libpq = create_workspace(cwd, dynamic_libpq=True)
+    libpq.unlink()
+    result = run_script(stage, cwd)
+    assert result.returncode != 0
+    assert "cannot stage libpq.so.5" in result.stdout + result.stderr
+
+with tempfile.TemporaryDirectory() as directory:
+    cwd = Path(directory)
+    repo, _ = create_workspace(cwd, dynamic_libpq=False)
+    (repo / "test/tap/tap/libtap.so").write_bytes(b"not-an-elf")
+    result = run_script(stage, cwd)
+    assert result.returncode != 0
+    assert "cannot inspect test/tap/tap/libtap.so" in result.stdout + result.stderr
+
+print("MySQLX runtime handoff contract passed")

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -423,67 +423,6 @@ jobs:
           # to fail and the entire TAP pipeline to break.
           # ------------------------------------------------------------
 
-          # Stage the runtime .so needed by the e2e test binaries
-          # into a path that's both already part of the _test cache
-          # (test/tap/tap/ is in `tar -cf - test/`) AND has its parent
-          # git-tracked (so post-checkout `mkdir -p` works on restore
-          # at the consumer side). The e2e -t binaries DT_NEEDED
-          # libre2.so.10 when built as a shared library; static RE2
-          # builds do not need it. Its baked RUNPATH points at
-          # /opt/proxysql/deps/re2/.../obj/so, a tarball-unpacked path
-          # that does not exist post-checkout. CI-mysqlx exports
-          # LD_LIBRARY_PATH pointing at this directory when running the
-          # e2e binaries inside the build image, which overrides RUNPATH
-          # lookup. The normal TAP executables link libpq statically, but
-          # libtap.so is a shared object and has a DT_NEEDED entry for the
-          # project-built libpq.so.5.  The libpq static archive is not PIC,
-          # so it cannot be linked into libtap.so.  Carry that exact shared
-          # library with the handoff instead of relying on a runner package.
-          if [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
-            mkdir -p test/tap/tap/_runtime_libs
-            # Stage the versioned runtime .so by its SONAME, tolerating a lost
-            # symlink. Resolve the SONAME if present, else fall back to the
-            # newest matching real file. Only a genuine deps-build break (no
-            # file at all) fails loudly, with a directory listing.
-            stage_lib() {
-              local dir="$1" soname="$2" dest="$3" src=""
-              if [ -e "$dir/$soname" ]; then
-                src="$dir/$soname"
-              else
-                src=$(ls -1 "$dir/$soname."* 2>/dev/null | sort -V | tail -n1 || true)
-              fi
-              if [ -z "$src" ] || [ ! -e "$src" ]; then
-                echo "ERROR: cannot stage $soname -- no file matching $dir/$soname* (deps build incomplete or shared lib not produced)"
-                ls -la "$dir" || true
-                return 1
-              fi
-              cp -L "$src" "$dest/$soname"
-              echo "staged $soname <- $(readlink -f "$src")"
-            }
-            # Current v3.0 RE2 builds are static-only, so obj/so is not
-            # created. Keep staging for branches that intentionally build
-            # shared RE2, where a missing library remains a real failure.
-            if [ -d deps/re2/re2/obj/so ]; then
-              stage_lib deps/re2/re2/obj/so libre2.so.10 test/tap/tap/_runtime_libs
-            else
-              echo "RE2 is static-only; no libre2 runtime library to stage"
-            fi
-            stage_lib deps/postgresql/postgresql/src/interfaces/libpq libpq.so.5 test/tap/tap/_runtime_libs
-            # Stage the chassis plugin .so files into the same dir for
-            # the same reason: the _src cache path list is shared
-            # infrastructure that we MUST NOT extend (changing it
-            # invalidates every downstream workflow's cache restore).
-            # The _test cache covers anything under test/, so anything
-            # we stash here travels along with the test/ tree from
-            # CI-builds to CI-mysqlx. CI-mysqlx's restore step copies
-            # them back to plugins/mysqlx/ before the soak harness
-            # bind-mounts the .so into the ProxySQL container.
-            cp -L plugins/mysqlx/ProxySQL_MySQLX_Plugin.so test/tap/tap/_runtime_libs/
-            cp -L plugins/genai/ProxySQL_GenAI_Plugin.so test/tap/tap/_runtime_libs/ 2>/dev/null || true
-            ls -la test/tap/tap/_runtime_libs/
-          fi
-          # ------------------------------------------------------------
-
           # Compile-time safety checks. A normal TAP build produces the
           # integration binaries in tests/; it need not build tests/unit.
           # The -tap-mysqlx cache is the exception: CI-mysqlx runs its
@@ -628,6 +567,59 @@ jobs:
         for LOG in proxysql/ci_build_log/build*.log ; do
           grep 'exited with code 0' ${LOG} || exit 1
         done
+
+    - name: Stage MySQLX runtime libraries in test handoff
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-mysqlx') }}
+      run: |
+        set -euo pipefail
+        cd proxysql/
+        runtime_dir="test/tap/tap/_runtime_libs"
+        mkdir -p "${runtime_dir}"
+
+        # Stage a versioned runtime .so by its SONAME, tolerating a lost
+        # symlink. Resolve the SONAME if present, else fall back to the newest
+        # matching real file. A missing library is fatal only when a built
+        # consumer actually declares it in DT_NEEDED.
+        stage_lib() {
+          local dir="$1" soname="$2" dest="$3" src=""
+          if [ -e "$dir/$soname" ]; then
+            src="$dir/$soname"
+          else
+            src=$(ls -1 "$dir/$soname."* 2>/dev/null | sort -V | tail -n1 || true)
+          fi
+          if [ -z "$src" ] || [ ! -e "$src" ]; then
+            echo "ERROR: cannot stage $soname -- no file matching $dir/$soname* (deps build incomplete or shared lib not produced)"
+            ls -la "$dir" || true
+            return 1
+          fi
+          cp -L "$src" "$dest/$soname"
+          echo "staged $soname <- $(readlink -f "$src")"
+        }
+
+        # Shared RE2 is optional because some branches build it statically.
+        if [ -d deps/re2/re2/obj/so ]; then
+          stage_lib deps/re2/re2/obj/so libre2.so.10 "${runtime_dir}"
+        else
+          echo "RE2 is static-only; no libre2 runtime library to stage"
+        fi
+
+        # v3.0 links libpq into libtap.so dynamically. Issue #6115 links
+        # libpq.a into each TAP executable and deliberately omits libpq.so.
+        # Inspect the built consumer so both source layouts work with this
+        # reusable workflow, while still failing if a required .so is absent.
+        if ! libtap_dynamic=$(readelf -d test/tap/tap/libtap.so); then
+          echo "ERROR: cannot inspect test/tap/tap/libtap.so" >&2
+          exit 1
+        fi
+        if grep -Fq 'Shared library: [libpq.so.5]' <<< "${libtap_dynamic}"; then
+          stage_lib deps/postgresql/postgresql/src/interfaces/libpq libpq.so.5 "${runtime_dir}"
+        else
+          echo "libtap.so uses static libpq; no libpq runtime library to stage"
+        fi
+
+        cp -L plugins/mysqlx/ProxySQL_MySQLX_Plugin.so "${runtime_dir}/"
+        cp -L plugins/genai/ProxySQL_GenAI_Plugin.so "${runtime_dir}/" 2>/dev/null || true
+        ls -la "${runtime_dir}/"
 
     - name: Stage GenAI plugin in test handoff
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-genai') }}


### PR DESCRIPTION
## Summary

- move MySQLX runtime-library staging into a named, testable handoff step
- inspect the built `libtap.so` before deciding whether `libpq.so.5` is required
- preserve strict failure when a declared runtime dependency is missing
- support both current v3.0 dynamic-libpq builds and PR #6122's static-only libpq build

## Root cause

The reusable `GH-Actions` workflow unconditionally staged `libpq.so.5`. PR #6122 deliberately builds only `libpq.a`, so its otherwise-successful `ubuntu22 -tap-mysqlx` build failed during post-build handoff staging.

## Verification

- TDD RED reproduced the missing named behavior, then GREEN covered real ELF fixtures
- static libpq: succeeds without staging `libpq.so.5`
- dynamic libpq: stages `libpq.so.5`
- required-but-missing libpq: fails loudly
- invalid/missing `libtap.so`: fails explicitly
- existing GenAI handoff and TAP-mode resolver tests pass
- all 76 workflow YAML files parse
- focused independent code review: PASS

PR #6122's held source-branch lint fix will be pushed only after this infrastructure PR is reviewed and merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally stages libpq.so.5 in the MySQLX CI handoff based on whether the built `libtap.so` needs it. Static-only libpq builds (PR #6122) now pass, while dynamic builds still stage the library and a required-but-missing `libpq.so.5` still fails the build.

- Moves the staging logic into a named step so it can be tested in isolation.
- Adds `test-mysqlx-runtime-handoff.py` covering static, dynamic, missing, and invalid `libtap.so` cases.

<sup>Written for commit 97cd12325d495eef0eb1fda0a19264bfdf8fb50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQLX test handoff setup by staging runtime libraries only when required.
  * Added detection for dynamically linked `libpq.so.5` dependencies.
  * Added clear failures when required runtime libraries are missing or cannot be inspected.
  * Ensured MySQLX and GenAI plugin libraries are included in test handoffs.

* **Tests**
  * Added coverage for static and dynamic library scenarios, missing dependencies, invalid binaries, and workflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->