### PR TITLE
Add per-hostgroup connection acquisition stats

### DIFF
--- a/doc/Stats_Tables.md
+++ b/doc/Stats_Tables.md
@@ -174,6 +174,30 @@ CREATE TABLE stats_mysql_connection_pool (
 
 **stats_mysql_connection_pool_reset** - Identical schema to `stats_mysql_connection_pool` but allows resetting stats.
 
+#### 1.5.1 stats_mysql_hostgroup_connection_pool (`PROXYSQL31`)
+
+Backend connection acquisition metrics per MySQL hostgroup. This table and its
+reset variant are available only in builds compiled with `PROXYSQL31=1`.
+
+```sql
+CREATE TABLE stats_mysql_hostgroup_connection_pool (
+    hostgroup INT PRIMARY KEY,
+    acquisitions_total INT NOT NULL,
+    waits_total INT NOT NULL,
+    wait_time_us_total INT NOT NULL,
+    waiters INT NOT NULL
+)
+```
+
+- `acquisitions_total` - Successful backend connection acquisitions, including thread-local cache hits
+- `waits_total` - Logical acquisition requests that encountered at least one unsuccessful attempt
+- `wait_time_us_total` - Cumulative duration of completed or abandoned wait episodes
+- `waiters` - Sessions currently waiting for an eligible backend connection
+
+`stats_mysql_hostgroup_connection_pool_reset` has the same schema. Reading the
+reset table starts a new counter window but does not reset the live `waiters`
+gauge or the lifetime counters exported to Prometheus.
+
 ### 1.6 stats_mysql_free_connections
 
 Details about idle connections available in the pool.
@@ -855,6 +879,23 @@ CREATE TABLE stats_pgsql_connection_pool (
     Latency_us INT
 )
 ```
+
+#### 2.6.1 stats_pgsql_hostgroup_connection_pool (`PROXYSQL31`)
+
+Backend connection acquisition metrics per PostgreSQL hostgroup. It has the
+same columns and reset semantics as `stats_mysql_hostgroup_connection_pool` and
+is available only in builds compiled with `PROXYSQL31=1`.
+
+The four Prometheus metric families shared by both protocols are:
+
+- `proxysql_connpool_acquisitions_total`
+- `proxysql_connpool_waits_total`
+- `proxysql_connpool_wait_time_seconds_total`
+- `proxysql_connpool_waiters`
+
+Each series is labeled with `protocol` (`mysql` or `pgsql`) and `hostgroup`.
+Unlike the Admin table, Prometheus reports cumulative wait time in seconds and
+its counters remain monotonic when a reset table is read.
 
 ### 2.7 stats_pgsql_free_connections
 

--- a/include/Base_HostGroups_Manager.h
+++ b/include/Base_HostGroups_Manager.h
@@ -19,6 +19,9 @@ class MetricsCollector;
 #include "proxysql.h"
 #include "cpp.h"
 #include "GTID_Server_Data.h"
+#ifdef PROXYSQL31
+#include "HostgroupPoolStats.h"
+#endif
 
 
 #include <atomic>
@@ -298,6 +301,9 @@ template <typename HGC>
 class BaseHGC {	// MySQL Host Group Container
 	public:
 	unsigned int hid;
+#ifdef PROXYSQL31
+	HostgroupPoolStats pool_stats;
+#endif
 	std::atomic<uint32_t> num_online_servers;
 	time_t last_log_time_num_online_servers;
 	unsigned long long current_time_now;
@@ -579,6 +585,10 @@ class Base_HostGroups_Manager {
 	HGC * MyHGC_find(unsigned int);
 	HGC * MyHGC_lookup(unsigned int);
 	SQLite3_result * execute_query(char *query, char **error);
+#ifdef PROXYSQL31
+	HostgroupPoolStats * get_hostgroup_pool_stats(unsigned int hid);
+	SQLite3_result * SQL3_Hostgroup_Connection_Pool(bool reset);
+#endif
 
 	void wrlock();
 	void wrunlock();

--- a/include/Base_Session.h
+++ b/include/Base_Session.h
@@ -4,6 +4,9 @@
 
 #include "proxysql.h"
 #include "cpp.h"
+#ifdef PROXYSQL31
+#include "HostgroupPoolStats.h"
+#endif
 
 #ifndef CLASS_BASE_SESSION_H
 #define CLASS_BASE_SESSION_H
@@ -40,6 +43,9 @@ class Base_Session {
 	unsigned long long transaction_started_at;
 
 	T * thread;
+#ifdef PROXYSQL31
+	HostgroupPoolWait hostgroup_pool_wait;
+#endif
 	B *mybe;
 	PtrArray *mybes;
 	DS * client_myds;

--- a/include/HostgroupPoolStats.h
+++ b/include/HostgroupPoolStats.h
@@ -101,7 +101,13 @@ public:
 		cancel();
 	}
 
-	void observe(HostgroupPoolStats* stats, uint64_t now_us, bool acquired) {
+	HostgroupPoolStats* active_stats(unsigned int hostgroup_id) const {
+		return stats_ && hostgroup_id_ == hostgroup_id ? stats_ : nullptr;
+	}
+
+	void observe(
+		HostgroupPoolStats* stats, uint64_t now_us, bool acquired, unsigned int hostgroup_id
+	) {
 		if (acquired) {
 			finish(now_us);
 			if (stats) {
@@ -110,12 +116,13 @@ public:
 			return;
 		}
 
-		if (!stats || stats_ == stats) {
+		if (!stats || (stats_ == stats && hostgroup_id_ == hostgroup_id)) {
 			return;
 		}
 
 		finish(now_us);
 		stats_ = stats;
+		hostgroup_id_ = hostgroup_id;
 		started_us_ = now_us;
 		stats_->begin_wait();
 	}
@@ -128,6 +135,7 @@ public:
 		const uint64_t duration_us = now_us >= started_us_ ? now_us - started_us_ : 0;
 		stats_->end_wait(duration_us);
 		stats_ = nullptr;
+		hostgroup_id_ = 0;
 		started_us_ = 0;
 	}
 
@@ -138,6 +146,7 @@ public:
 
 		stats_->cancel_wait();
 		stats_ = nullptr;
+		hostgroup_id_ = 0;
 		started_us_ = 0;
 	}
 
@@ -147,6 +156,7 @@ public:
 
 private:
 	HostgroupPoolStats* stats_ {nullptr};
+	unsigned int hostgroup_id_ {0};
 	uint64_t started_us_ {0};
 };
 

--- a/include/HostgroupPoolStats.h
+++ b/include/HostgroupPoolStats.h
@@ -1,0 +1,144 @@
+#ifndef HOSTGROUP_POOL_STATS_H
+#define HOSTGROUP_POOL_STATS_H
+
+#ifdef PROXYSQL31
+
+#include <atomic>
+#include <cstdint>
+
+struct HostgroupPoolStatsSnapshot {
+	uint64_t acquisitions_total {0};
+	uint64_t waits_total {0};
+	uint64_t wait_time_us_total {0};
+	uint64_t waiters {0};
+};
+
+class HostgroupPoolStats {
+public:
+	void record_acquisition() {
+		acquisitions_total_.fetch_add(1, std::memory_order_relaxed);
+	}
+
+	void begin_wait() {
+		waits_total_.fetch_add(1, std::memory_order_relaxed);
+		waiters_.fetch_add(1, std::memory_order_relaxed);
+	}
+
+	void end_wait(uint64_t duration_us) {
+		wait_time_us_total_.fetch_add(duration_us, std::memory_order_relaxed);
+		waiters_.fetch_sub(1, std::memory_order_relaxed);
+	}
+
+	void cancel_wait() {
+		waiters_.fetch_sub(1, std::memory_order_relaxed);
+	}
+
+	HostgroupPoolStatsSnapshot lifetime_snapshot() const {
+		return {
+			acquisitions_total_.load(std::memory_order_relaxed),
+			waits_total_.load(std::memory_order_relaxed),
+			wait_time_us_total_.load(std::memory_order_relaxed),
+			waiters_.load(std::memory_order_relaxed)
+		};
+	}
+
+	HostgroupPoolStatsSnapshot window_snapshot() const {
+		const auto lifetime = lifetime_snapshot();
+		return {
+			lifetime.acquisitions_total - acquisitions_baseline_.load(std::memory_order_relaxed),
+			lifetime.waits_total - waits_baseline_.load(std::memory_order_relaxed),
+			lifetime.wait_time_us_total - wait_time_us_baseline_.load(std::memory_order_relaxed),
+			lifetime.waiters
+		};
+	}
+
+	HostgroupPoolStatsSnapshot reset_window() {
+		const auto lifetime = lifetime_snapshot();
+		const uint64_t acquisitions_baseline = acquisitions_baseline_.exchange(
+			lifetime.acquisitions_total, std::memory_order_relaxed);
+		const uint64_t waits_baseline = waits_baseline_.exchange(
+			lifetime.waits_total, std::memory_order_relaxed);
+		const uint64_t wait_time_us_baseline = wait_time_us_baseline_.exchange(
+			lifetime.wait_time_us_total, std::memory_order_relaxed);
+
+		return {
+			lifetime.acquisitions_total - acquisitions_baseline,
+			lifetime.waits_total - waits_baseline,
+			lifetime.wait_time_us_total - wait_time_us_baseline,
+			lifetime.waiters
+		};
+	}
+
+private:
+	std::atomic<uint64_t> acquisitions_total_ {0};
+	std::atomic<uint64_t> waits_total_ {0};
+	std::atomic<uint64_t> wait_time_us_total_ {0};
+	std::atomic<uint64_t> waiters_ {0};
+
+	std::atomic<uint64_t> acquisitions_baseline_ {0};
+	std::atomic<uint64_t> waits_baseline_ {0};
+	std::atomic<uint64_t> wait_time_us_baseline_ {0};
+};
+
+class HostgroupPoolWait {
+public:
+	HostgroupPoolWait() = default;
+	HostgroupPoolWait(const HostgroupPoolWait&) = delete;
+	HostgroupPoolWait& operator=(const HostgroupPoolWait&) = delete;
+
+	~HostgroupPoolWait() {
+		cancel();
+	}
+
+	void observe(HostgroupPoolStats* stats, uint64_t now_us, bool acquired) {
+		if (acquired) {
+			finish(now_us);
+			if (stats) {
+				stats->record_acquisition();
+			}
+			return;
+		}
+
+		if (!stats || stats_ == stats) {
+			return;
+		}
+
+		finish(now_us);
+		stats_ = stats;
+		started_us_ = now_us;
+		stats_->begin_wait();
+	}
+
+	void finish(uint64_t now_us) {
+		if (!stats_) {
+			return;
+		}
+
+		const uint64_t duration_us = now_us >= started_us_ ? now_us - started_us_ : 0;
+		stats_->end_wait(duration_us);
+		stats_ = nullptr;
+		started_us_ = 0;
+	}
+
+	void cancel() {
+		if (!stats_) {
+			return;
+		}
+
+		stats_->cancel_wait();
+		stats_ = nullptr;
+		started_us_ = 0;
+	}
+
+	bool active() const {
+		return stats_ != nullptr;
+	}
+
+private:
+	HostgroupPoolStats* stats_ {nullptr};
+	uint64_t started_us_ {0};
+};
+
+#endif // PROXYSQL31
+
+#endif // HOSTGROUP_POOL_STATS_H

--- a/include/HostgroupPoolStats.h
+++ b/include/HostgroupPoolStats.h
@@ -1,5 +1,5 @@
-#ifndef HOSTGROUP_POOL_STATS_H
-#define HOSTGROUP_POOL_STATS_H
+#ifndef __CLASS_HOSTGROUP_POOL_STATS_H
+#define __CLASS_HOSTGROUP_POOL_STATS_H
 
 #ifdef PROXYSQL31
 
@@ -16,60 +16,71 @@ struct HostgroupPoolStatsSnapshot {
 class HostgroupPoolStats {
 public:
 	void record_acquisition() {
-		acquisitions_total_.fetch_add(1, std::memory_order_relaxed);
+		acquisitions_total_.fetch_add(1);
 	}
 
 	void begin_wait() {
-		waits_total_.fetch_add(1, std::memory_order_relaxed);
-		waiters_.fetch_add(1, std::memory_order_relaxed);
+		waits_total_.fetch_add(1);
+		waiters_.fetch_add(1);
 	}
 
 	void end_wait(uint64_t duration_us) {
-		wait_time_us_total_.fetch_add(duration_us, std::memory_order_relaxed);
-		waiters_.fetch_sub(1, std::memory_order_relaxed);
+		wait_time_us_total_.fetch_add(duration_us);
+		waiters_.fetch_sub(1);
 	}
 
 	void cancel_wait() {
-		waiters_.fetch_sub(1, std::memory_order_relaxed);
+		waiters_.fetch_sub(1);
 	}
 
 	HostgroupPoolStatsSnapshot lifetime_snapshot() const {
 		return {
-			acquisitions_total_.load(std::memory_order_relaxed),
-			waits_total_.load(std::memory_order_relaxed),
-			wait_time_us_total_.load(std::memory_order_relaxed),
-			waiters_.load(std::memory_order_relaxed)
+			acquisitions_total_.load(),
+			waits_total_.load(),
+			wait_time_us_total_.load(),
+			waiters_.load()
 		};
 	}
 
 	HostgroupPoolStatsSnapshot window_snapshot() const {
-		const auto lifetime = lifetime_snapshot();
 		return {
-			lifetime.acquisitions_total - acquisitions_baseline_.load(std::memory_order_relaxed),
-			lifetime.waits_total - waits_baseline_.load(std::memory_order_relaxed),
-			lifetime.wait_time_us_total - wait_time_us_baseline_.load(std::memory_order_relaxed),
-			lifetime.waiters
+			window_value(acquisitions_total_, acquisitions_baseline_),
+			window_value(waits_total_, waits_baseline_),
+			window_value(wait_time_us_total_, wait_time_us_baseline_),
+			waiters_.load()
 		};
 	}
 
 	HostgroupPoolStatsSnapshot reset_window() {
-		const auto lifetime = lifetime_snapshot();
-		const uint64_t acquisitions_baseline = acquisitions_baseline_.exchange(
-			lifetime.acquisitions_total, std::memory_order_relaxed);
-		const uint64_t waits_baseline = waits_baseline_.exchange(
-			lifetime.waits_total, std::memory_order_relaxed);
-		const uint64_t wait_time_us_baseline = wait_time_us_baseline_.exchange(
-			lifetime.wait_time_us_total, std::memory_order_relaxed);
-
 		return {
-			lifetime.acquisitions_total - acquisitions_baseline,
-			lifetime.waits_total - waits_baseline,
-			lifetime.wait_time_us_total - wait_time_us_baseline,
-			lifetime.waiters
+			reset_counter(acquisitions_total_, acquisitions_baseline_),
+			reset_counter(waits_total_, waits_baseline_),
+			reset_counter(wait_time_us_total_, wait_time_us_baseline_),
+			waiters_.load()
 		};
 	}
 
 private:
+	static uint64_t window_value(
+		const std::atomic<uint64_t>& total, const std::atomic<uint64_t>& baseline
+	) {
+		const uint64_t baseline_value = baseline.load();
+		return total.load() - baseline_value;
+	}
+
+	static uint64_t reset_counter(
+		const std::atomic<uint64_t>& total, std::atomic<uint64_t>& baseline
+	) {
+		const uint64_t current = total.load();
+		uint64_t previous = baseline.load();
+		while (previous < current) {
+			if (baseline.compare_exchange_weak(previous, current)) {
+				return current - previous;
+			}
+		}
+		return 0;
+	}
+
 	std::atomic<uint64_t> acquisitions_total_ {0};
 	std::atomic<uint64_t> waits_total_ {0};
 	std::atomic<uint64_t> wait_time_us_total_ {0};
@@ -141,4 +152,4 @@ private:
 
 #endif // PROXYSQL31
 
-#endif // HOSTGROUP_POOL_STATS_H
+#endif // __CLASS_HOSTGROUP_POOL_STATS_H

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -436,6 +436,11 @@ struct p_hg_dyn_counter {
 		gtid_executed,
 		proxysql_mysql_error,
 		mysql_error,
+#ifdef PROXYSQL31
+		hostgroup_pool_acquisitions,
+		hostgroup_pool_waits,
+		hostgroup_pool_wait_time,
+#endif
 		SIZE_
 	};
 };
@@ -451,6 +456,9 @@ struct p_hg_dyn_gauge {
 		connection_pool_conn_used,
 		connection_pool_latency_us,
 		connection_pool_status,
+#ifdef PROXYSQL31
+		hostgroup_pool_waiters,
+#endif
 		SIZE_
 	};
 };
@@ -849,6 +857,12 @@ class MySQL_HostGroups_Manager : public Base_HostGroups_Manager<MyHGC> {
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_latency_us_map {};
 		std::map<std::string, prometheus::Counter*> p_connection_pool_queries_map {};
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_status_map {};
+#ifdef PROXYSQL31
+		std::map<std::string, prometheus::Counter*> p_hostgroup_pool_acquisitions_map {};
+		std::map<std::string, prometheus::Counter*> p_hostgroup_pool_waits_map {};
+		std::map<std::string, prometheus::Counter*> p_hostgroup_pool_wait_time_map {};
+		std::map<std::string, prometheus::Gauge*> p_hostgroup_pool_waiters_map {};
+#endif
 
 		/// Prometheus gtid_executed metrics
 		std::map<std::string, prometheus::Counter*> p_gtid_executed_map {};

--- a/include/PgSQL_HostGroups_Manager.h
+++ b/include/PgSQL_HostGroups_Manager.h
@@ -309,6 +309,11 @@ struct PgSQL_p_hg_dyn_counter {
 		gtid_executed,
 		proxysql_pgsql_error,
 		pgsql_error,
+#ifdef PROXYSQL31
+		hostgroup_pool_acquisitions,
+		hostgroup_pool_waits,
+		hostgroup_pool_wait_time,
+#endif
 		SIZE_
 	};
 };
@@ -324,6 +329,9 @@ struct PgSQL_p_hg_dyn_gauge {
 		connection_pool_conn_used,
 		connection_pool_latency_us,
 		connection_pool_status,
+#ifdef PROXYSQL31
+		hostgroup_pool_waiters,
+#endif
 		SIZE_
 	};
 };
@@ -656,6 +664,12 @@ class PgSQL_HostGroups_Manager : public Base_HostGroups_Manager<PgSQL_HGC> {
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_latency_us_map {};
 		std::map<std::string, prometheus::Counter*> p_connection_pool_queries_map {};
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_status_map {};
+#ifdef PROXYSQL31
+		std::map<std::string, prometheus::Counter*> p_hostgroup_pool_acquisitions_map {};
+		std::map<std::string, prometheus::Counter*> p_hostgroup_pool_waits_map {};
+		std::map<std::string, prometheus::Counter*> p_hostgroup_pool_wait_time_map {};
+		std::map<std::string, prometheus::Gauge*> p_hostgroup_pool_waiters_map {};
+#endif
 
 		/// Prometheus gtid_executed metrics
 		std::map<std::string, prometheus::Counter*> p_gtid_executed_map {};

--- a/include/ProxySQL_Admin_Tables_Definitions.h
+++ b/include/ProxySQL_Admin_Tables_Definitions.h
@@ -167,6 +167,10 @@
 #define STATS_SQLITE_TABLE_MYSQL_CONNECTION_POOL "CREATE TABLE stats_mysql_connection_pool (hostgroup INT , srv_host VARCHAR , srv_port INT , status VARCHAR , ConnUsed INT , ConnFree INT , ConnOK INT , ConnERR INT , MaxConnUsed INT , Queries INT , Queries_GTID_sync INT , Bytes_data_sent INT , Bytes_data_recv INT , Latency_us INT)"
 
 #define STATS_SQLITE_TABLE_MYSQL_CONNECTION_POOL_RESET "CREATE TABLE stats_mysql_connection_pool_reset (hostgroup INT , srv_host VARCHAR , srv_port INT , status VARCHAR , ConnUsed INT , ConnFree INT , ConnOK INT , ConnERR INT , MaxConnUsed INT , Queries INT , Queries_GTID_sync INT , Bytes_data_sent INT , Bytes_data_recv INT , Latency_us INT)"
+#ifdef PROXYSQL31
+#define STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL "CREATE TABLE stats_mysql_hostgroup_connection_pool (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
+#define STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL_RESET "CREATE TABLE stats_mysql_hostgroup_connection_pool_reset (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
+#endif
 
 #define STATS_SQLITE_TABLE_MYSQL_FREE_CONNECTIONS "CREATE TABLE stats_mysql_free_connections (fd INT NOT NULL , hostgroup INT NOT NULL , srv_host VARCHAR NOT NULL , srv_port INT NOT NULL , user VARCHAR NOT NULL , schema VARCHAR , init_connect VARCHAR , time_zone VARCHAR , sql_mode VARCHAR , autocommit VARCHAR , idle_ms INT , statistics VARCHAR , mysql_info VARCHAR)"
 
@@ -350,6 +354,10 @@
 #define STATS_SQLITE_TABLE_PGSQL_GLOBAL "CREATE TABLE stats_pgsql_global (Variable_Name VARCHAR NOT NULL PRIMARY KEY , Variable_Value VARCHAR NOT NULL)"
 #define STATS_SQLITE_TABLE_PGSQL_CONNECTION_POOL "CREATE TABLE stats_pgsql_connection_pool (hostgroup INT , srv_host VARCHAR , srv_port INT , status VARCHAR , ConnUsed INT , ConnFree INT , ConnOK INT , ConnERR INT , MaxConnUsed INT , Queries INT , Bytes_data_sent INT , Bytes_data_recv INT , Latency_us INT)"
 #define STATS_SQLITE_TABLE_PGSQL_CONNECTION_POOL_RESET "CREATE TABLE stats_pgsql_connection_pool_reset (hostgroup INT , srv_host VARCHAR , srv_port INT , status VARCHAR , ConnUsed INT , ConnFree INT , ConnOK INT , ConnERR INT , MaxConnUsed INT , Queries INT , Bytes_data_sent INT , Bytes_data_recv INT , Latency_us INT)"
+#ifdef PROXYSQL31
+#define STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL "CREATE TABLE stats_pgsql_hostgroup_connection_pool (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
+#define STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL_RESET "CREATE TABLE stats_pgsql_hostgroup_connection_pool_reset (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
+#endif
 #define STATS_SQLITE_TABLE_PGSQL_FREE_CONNECTIONS "CREATE TABLE stats_pgsql_free_connections (fd INT NOT NULL , hostgroup INT NOT NULL , srv_host VARCHAR NOT NULL , srv_port INT NOT NULL , user VARCHAR NOT NULL , database VARCHAR , init_connect VARCHAR , time_zone VARCHAR , sql_mode VARCHAR , idle_ms INT , statistics VARCHAR , pgsql_info VARCHAR)"
 #define STATS_SQLITE_TABLE_PGSQL_USERS "CREATE TABLE stats_pgsql_users (username VARCHAR PRIMARY KEY , frontend_connections INT NOT NULL , frontend_max_connections INT NOT NULL)"
 #define STATS_SQLITE_TABLE_PGSQL_PROCESSLIST "CREATE TABLE stats_pgsql_processlist (ThreadID INT NOT NULL , SessionID INTEGER PRIMARY KEY , user VARCHAR , database VARCHAR , cli_host VARCHAR , cli_port INT , hostgroup INT , l_srv_host VARCHAR , l_srv_port INT , srv_host VARCHAR , srv_port INT , backend_pid INT , backend_state VARCHAR , command VARCHAR , time_ms INT NOT NULL , info VARCHAR , status_flags INT , extended_info VARCHAR)"

--- a/include/ProxySQL_Admin_Tables_Definitions.h
+++ b/include/ProxySQL_Admin_Tables_Definitions.h
@@ -168,8 +168,8 @@
 
 #define STATS_SQLITE_TABLE_MYSQL_CONNECTION_POOL_RESET "CREATE TABLE stats_mysql_connection_pool_reset (hostgroup INT , srv_host VARCHAR , srv_port INT , status VARCHAR , ConnUsed INT , ConnFree INT , ConnOK INT , ConnERR INT , MaxConnUsed INT , Queries INT , Queries_GTID_sync INT , Bytes_data_sent INT , Bytes_data_recv INT , Latency_us INT)"
 #ifdef PROXYSQL31
-#define STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL "CREATE TABLE stats_mysql_hostgroup_connection_pool (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
-#define STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL_RESET "CREATE TABLE stats_mysql_hostgroup_connection_pool_reset (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
+inline constexpr char STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL[] = "CREATE TABLE stats_mysql_hostgroup_connection_pool (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)";
+inline constexpr char STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL_RESET[] = "CREATE TABLE stats_mysql_hostgroup_connection_pool_reset (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)";
 #endif
 
 #define STATS_SQLITE_TABLE_MYSQL_FREE_CONNECTIONS "CREATE TABLE stats_mysql_free_connections (fd INT NOT NULL , hostgroup INT NOT NULL , srv_host VARCHAR NOT NULL , srv_port INT NOT NULL , user VARCHAR NOT NULL , schema VARCHAR , init_connect VARCHAR , time_zone VARCHAR , sql_mode VARCHAR , autocommit VARCHAR , idle_ms INT , statistics VARCHAR , mysql_info VARCHAR)"
@@ -355,8 +355,8 @@
 #define STATS_SQLITE_TABLE_PGSQL_CONNECTION_POOL "CREATE TABLE stats_pgsql_connection_pool (hostgroup INT , srv_host VARCHAR , srv_port INT , status VARCHAR , ConnUsed INT , ConnFree INT , ConnOK INT , ConnERR INT , MaxConnUsed INT , Queries INT , Bytes_data_sent INT , Bytes_data_recv INT , Latency_us INT)"
 #define STATS_SQLITE_TABLE_PGSQL_CONNECTION_POOL_RESET "CREATE TABLE stats_pgsql_connection_pool_reset (hostgroup INT , srv_host VARCHAR , srv_port INT , status VARCHAR , ConnUsed INT , ConnFree INT , ConnOK INT , ConnERR INT , MaxConnUsed INT , Queries INT , Bytes_data_sent INT , Bytes_data_recv INT , Latency_us INT)"
 #ifdef PROXYSQL31
-#define STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL "CREATE TABLE stats_pgsql_hostgroup_connection_pool (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
-#define STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL_RESET "CREATE TABLE stats_pgsql_hostgroup_connection_pool_reset (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)"
+inline constexpr char STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL[] = "CREATE TABLE stats_pgsql_hostgroup_connection_pool (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)";
+inline constexpr char STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL_RESET[] = "CREATE TABLE stats_pgsql_hostgroup_connection_pool_reset (hostgroup INT PRIMARY KEY , acquisitions_total INT NOT NULL , waits_total INT NOT NULL , wait_time_us_total INT NOT NULL , waiters INT NOT NULL)";
 #endif
 #define STATS_SQLITE_TABLE_PGSQL_FREE_CONNECTIONS "CREATE TABLE stats_pgsql_free_connections (fd INT NOT NULL , hostgroup INT NOT NULL , srv_host VARCHAR NOT NULL , srv_port INT NOT NULL , user VARCHAR NOT NULL , database VARCHAR , init_connect VARCHAR , time_zone VARCHAR , sql_mode VARCHAR , idle_ms INT , statistics VARCHAR , pgsql_info VARCHAR)"
 #define STATS_SQLITE_TABLE_PGSQL_USERS "CREATE TABLE stats_pgsql_users (username VARCHAR PRIMARY KEY , frontend_connections INT NOT NULL , frontend_max_connections INT NOT NULL)"

--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -789,6 +789,9 @@ class ProxySQL_Admin {
 	void stats___mysql_processlist();
 	void stats___mysql_free_connections();
 	void stats___mysql_connection_pool(bool _reset);
+#ifdef PROXYSQL31
+	void stats___mysql_hostgroup_connection_pool(bool reset);
+#endif
 	void stats___mysql_errors(bool reset);
 	void stats___memory_metrics();
 	void stats___mysql_global();
@@ -801,6 +804,9 @@ class ProxySQL_Admin {
 	void stats___pgsql_users();
 	void stats___pgsql_free_connections();
 	void stats___pgsql_connection_pool(bool _reset);
+#ifdef PROXYSQL31
+	void stats___pgsql_hostgroup_connection_pool(bool reset);
+#endif
 	void stats___pgsql_processlist();
 	void stats___pgsql_errors(bool reset);
 	void stats___pgsql_client_host_cache(bool reset);

--- a/lib/Admin_Bootstrap.cpp
+++ b/lib/Admin_Bootstrap.cpp
@@ -866,6 +866,10 @@ bool ProxySQL_Admin::init(const bootstrap_info_t& bootstrap_info) {
 	insert_into_tables_defs(tables_defs_stats,"stats_mysql_processlist", STATS_SQLITE_TABLE_MYSQL_PROCESSLIST);
 	insert_into_tables_defs(tables_defs_stats,"stats_mysql_connection_pool", STATS_SQLITE_TABLE_MYSQL_CONNECTION_POOL);
 	insert_into_tables_defs(tables_defs_stats,"stats_mysql_connection_pool_reset", STATS_SQLITE_TABLE_MYSQL_CONNECTION_POOL_RESET);
+#ifdef PROXYSQL31
+	insert_into_tables_defs(tables_defs_stats,"stats_mysql_hostgroup_connection_pool", STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL);
+	insert_into_tables_defs(tables_defs_stats,"stats_mysql_hostgroup_connection_pool_reset", STATS_SQLITE_TABLE_MYSQL_HOSTGROUP_CONNECTION_POOL_RESET);
+#endif
 	insert_into_tables_defs(tables_defs_stats,"stats_mysql_free_connections", STATS_SQLITE_TABLE_MYSQL_FREE_CONNECTIONS);
 	insert_into_tables_defs(tables_defs_stats,"stats_mysql_query_digest", STATS_SQLITE_TABLE_MYSQL_QUERY_DIGEST);
 	insert_into_tables_defs(tables_defs_stats,"stats_mysql_query_digest_reset", STATS_SQLITE_TABLE_MYSQL_QUERY_DIGEST_RESET);
@@ -888,6 +892,10 @@ bool ProxySQL_Admin::init(const bootstrap_info_t& bootstrap_info) {
 	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_global", STATS_SQLITE_TABLE_PGSQL_GLOBAL);
 	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_connection_pool", STATS_SQLITE_TABLE_PGSQL_CONNECTION_POOL);
 	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_connection_pool_reset", STATS_SQLITE_TABLE_PGSQL_CONNECTION_POOL_RESET);
+#ifdef PROXYSQL31
+	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_hostgroup_connection_pool", STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL);
+	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_hostgroup_connection_pool_reset", STATS_SQLITE_TABLE_PGSQL_HOSTGROUP_CONNECTION_POOL_RESET);
+#endif
 	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_free_connections", STATS_SQLITE_TABLE_PGSQL_FREE_CONNECTIONS);
 	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_users", STATS_SQLITE_TABLE_PGSQL_USERS);
 	insert_into_tables_defs(tables_defs_stats,"stats_pgsql_processlist", STATS_SQLITE_TABLE_PGSQL_PROCESSLIST);

--- a/lib/Base_HostGroups_Manager.cpp
+++ b/lib/Base_HostGroups_Manager.cpp
@@ -42,6 +42,10 @@ template Base_HostGroups_Manager<MyHGC>::Base_HostGroups_Manager();
 template MyHGC * Base_HostGroups_Manager<MyHGC>::MyHGC_find(unsigned int);
 template MyHGC * Base_HostGroups_Manager<MyHGC>::MyHGC_create(unsigned int);
 template MyHGC * Base_HostGroups_Manager<MyHGC>::MyHGC_lookup(unsigned int);
+#ifdef PROXYSQL31
+template HostgroupPoolStats * Base_HostGroups_Manager<MyHGC>::get_hostgroup_pool_stats(unsigned int);
+template SQLite3_result * Base_HostGroups_Manager<MyHGC>::SQL3_Hostgroup_Connection_Pool(bool);
+#endif
 template void Base_HostGroups_Manager<MyHGC>::wrlock();
 template void Base_HostGroups_Manager<MyHGC>::wrunlock();
 
@@ -49,6 +53,10 @@ template Base_HostGroups_Manager<PgSQL_HGC>::Base_HostGroups_Manager();
 template PgSQL_HGC * Base_HostGroups_Manager<PgSQL_HGC>::MyHGC_find(unsigned int);
 template PgSQL_HGC * Base_HostGroups_Manager<PgSQL_HGC>::MyHGC_create(unsigned int);
 template PgSQL_HGC * Base_HostGroups_Manager<PgSQL_HGC>::MyHGC_lookup(unsigned int);
+#ifdef PROXYSQL31
+template HostgroupPoolStats * Base_HostGroups_Manager<PgSQL_HGC>::get_hostgroup_pool_stats(unsigned int);
+template SQLite3_result * Base_HostGroups_Manager<PgSQL_HGC>::SQL3_Hostgroup_Connection_Pool(bool);
+#endif
 template void Base_HostGroups_Manager<PgSQL_HGC>::wrlock();
 template void Base_HostGroups_Manager<PgSQL_HGC>::wrunlock();
 
@@ -2068,6 +2076,49 @@ HGC * Base_HostGroups_Manager<HGC>::MyHGC_lookup(unsigned int _hid) {
 	MyHostGroups_map.emplace(_hid,myhgc);
 	return myhgc;
 }
+
+#ifdef PROXYSQL31
+template <typename HGC>
+HostgroupPoolStats * Base_HostGroups_Manager<HGC>::get_hostgroup_pool_stats(unsigned int hid) {
+	wrlock();
+	HGC *hgc = MyHGC_lookup(hid);
+	wrunlock();
+	return &hgc->pool_stats;
+}
+
+template <typename HGC>
+SQLite3_result * Base_HostGroups_Manager<HGC>::SQL3_Hostgroup_Connection_Pool(bool reset) {
+	SQLite3_result *result = new SQLite3_result(5);
+	result->add_column_definition(SQLITE_TEXT, "hostgroup");
+	result->add_column_definition(SQLITE_TEXT, "acquisitions_total");
+	result->add_column_definition(SQLITE_TEXT, "waits_total");
+	result->add_column_definition(SQLITE_TEXT, "wait_time_us_total");
+	result->add_column_definition(SQLITE_TEXT, "waiters");
+
+	wrlock();
+	for (unsigned int i = 0; i < MyHostGroups->len; ++i) {
+		HGC *hgc = static_cast<HGC *>(MyHostGroups->index(i));
+		const HostgroupPoolStatsSnapshot snapshot = reset
+			? hgc->pool_stats.reset_window()
+			: hgc->pool_stats.window_snapshot();
+		const std::string hostgroup = std::to_string(hgc->hid);
+		const std::string acquisitions = std::to_string(snapshot.acquisitions_total);
+		const std::string waits = std::to_string(snapshot.waits_total);
+		const std::string wait_time = std::to_string(snapshot.wait_time_us_total);
+		const std::string waiters = std::to_string(snapshot.waiters);
+		char *row[] = {
+			const_cast<char *>(hostgroup.c_str()),
+			const_cast<char *>(acquisitions.c_str()),
+			const_cast<char *>(waits.c_str()),
+			const_cast<char *>(wait_time.c_str()),
+			const_cast<char *>(waiters.c_str())
+		};
+		result->add_row(row);
+	}
+	wrunlock();
+	return result;
+}
+#endif
 
 #if 0
 void MySQL_HostGroups_Manager::increase_reset_counter() {

--- a/lib/Base_HostGroups_Manager.cpp
+++ b/lib/Base_HostGroups_Manager.cpp
@@ -2081,14 +2081,14 @@ HGC * Base_HostGroups_Manager<HGC>::MyHGC_lookup(unsigned int _hid) {
 template <typename HGC>
 HostgroupPoolStats * Base_HostGroups_Manager<HGC>::get_hostgroup_pool_stats(unsigned int hid) {
 	wrlock();
-	HGC *hgc = MyHGC_lookup(hid);
+	HGC *hgc = MyHGC_find(hid);
 	wrunlock();
-	return &hgc->pool_stats;
+	return hgc ? &hgc->pool_stats : nullptr;
 }
 
 template <typename HGC>
 SQLite3_result * Base_HostGroups_Manager<HGC>::SQL3_Hostgroup_Connection_Pool(bool reset) {
-	SQLite3_result *result = new SQLite3_result(5);
+	auto result = std::make_unique<SQLite3_result>(5);
 	result->add_column_definition(SQLITE_TEXT, "hostgroup");
 	result->add_column_definition(SQLITE_TEXT, "acquisitions_total");
 	result->add_column_definition(SQLITE_TEXT, "waits_total");
@@ -2106,17 +2106,17 @@ SQLite3_result * Base_HostGroups_Manager<HGC>::SQL3_Hostgroup_Connection_Pool(bo
 		const std::string waits = std::to_string(snapshot.waits_total);
 		const std::string wait_time = std::to_string(snapshot.wait_time_us_total);
 		const std::string waiters = std::to_string(snapshot.waiters);
-		char *row[] = {
-			const_cast<char *>(hostgroup.c_str()),
-			const_cast<char *>(acquisitions.c_str()),
-			const_cast<char *>(waits.c_str()),
-			const_cast<char *>(wait_time.c_str()),
-			const_cast<char *>(waiters.c_str())
+		const char *row[] = {
+			hostgroup.c_str(),
+			acquisitions.c_str(),
+			waits.c_str(),
+			wait_time.c_str(),
+			waiters.c_str()
 		};
 		result->add_row(row);
 	}
 	wrunlock();
-	return result;
+	return result.release();
 }
 #endif
 

--- a/lib/Base_Session.cpp
+++ b/lib/Base_Session.cpp
@@ -74,6 +74,9 @@ Base_Session<S,DS,B,T>::Base_Session() {
 
 template<typename S, typename DS, typename B, typename T>
 Base_Session<S,DS,B,T>::~Base_Session() {
+#ifdef PROXYSQL31
+	hostgroup_pool_wait.finish(monotonic_time());
+#endif
 };
 
 template<typename S, typename DS, typename B, typename T>

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -629,6 +629,27 @@ hg_metrics_map = std::make_tuple(
 			"Tracks the mysql errors encountered.",
 			metric_tags {}
 		)
+#ifdef PROXYSQL31
+		,
+		std::make_tuple (
+			p_hg_dyn_counter::hostgroup_pool_acquisitions,
+			"proxysql_connpool_acquisitions_total",
+			"Successful backend connection acquisitions by hostgroup.",
+			metric_tags {{ "protocol", "mysql" }}
+		),
+		std::make_tuple (
+			p_hg_dyn_counter::hostgroup_pool_waits,
+			"proxysql_connpool_waits_total",
+			"Backend connection acquisition wait episodes by hostgroup.",
+			metric_tags {{ "protocol", "mysql" }}
+		),
+		std::make_tuple (
+			p_hg_dyn_counter::hostgroup_pool_wait_time,
+			"proxysql_connpool_wait_time_seconds_total",
+			"Cumulative duration of completed backend connection acquisition waits.",
+			metric_tags {{ "protocol", "mysql" }}
+		)
+#endif
 	},
 	// prometheus dynamic gauges
 	hg_dyn_gauge_vector {
@@ -666,6 +687,15 @@ hg_metrics_map = std::make_tuple(
 				{ "protocol", "mysql" }
 			}
 		)
+#ifdef PROXYSQL31
+		,
+		std::make_tuple (
+			p_hg_dyn_gauge::hostgroup_pool_waiters,
+			"proxysql_connpool_waiters",
+			"Sessions currently waiting to acquire a backend connection.",
+			metric_tags {{ "protocol", "mysql" }}
+		)
+#endif
 	}
 );
 
@@ -3450,6 +3480,26 @@ void MySQL_HostGroups_Manager::p_update_connection_pool() {
 			p_update_connection_pool_update_gauge(endpoint_id, common_labels,
 				status.p_connection_pool_status_map, ((int)mysrvc->get_status()) + 1, p_hg_dyn_gauge::connection_pool_status);
 		}
+#ifdef PROXYSQL31
+		const std::string hostgroup_id = std::to_string(myhgc->hid);
+		const std::map<std::string, std::string> labels {
+			{"hostgroup", hostgroup_id},
+			{"protocol", "mysql"}
+		};
+		const HostgroupPoolStatsSnapshot snapshot = myhgc->pool_stats.lifetime_snapshot();
+		p_update_map_counter(status.p_hostgroup_pool_acquisitions_map,
+			status.p_dyn_counter_array[p_hg_dyn_counter::hostgroup_pool_acquisitions],
+			hostgroup_id, labels, snapshot.acquisitions_total);
+		p_update_map_counter(status.p_hostgroup_pool_waits_map,
+			status.p_dyn_counter_array[p_hg_dyn_counter::hostgroup_pool_waits],
+			hostgroup_id, labels, snapshot.waits_total);
+		p_update_map_counter(status.p_hostgroup_pool_wait_time_map,
+			status.p_dyn_counter_array[p_hg_dyn_counter::hostgroup_pool_wait_time],
+			hostgroup_id, labels, snapshot.wait_time_us_total / 1000000.0);
+		p_update_map_gauge(status.p_hostgroup_pool_waiters_map,
+			status.p_dyn_gauge_array[p_hg_dyn_gauge::hostgroup_pool_waiters],
+			hostgroup_id, labels, snapshot.waiters);
+#endif
 	}
 
 	// Remove the non-present servers for the gauge metrics

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -8908,10 +8908,14 @@ void MySQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 		}
 #endif // STRESSTEST_POOL
 #ifdef PROXYSQL31
+		const unsigned int pool_stats_hid = mc ? mc->parent->myhgc->hid : mybe->hostgroup_id;
 		HostgroupPoolStats *pool_stats = mc
 			? &mc->parent->myhgc->pool_stats
-			: MyHGM->get_hostgroup_pool_stats(mybe->hostgroup_id);
-		hostgroup_pool_wait.observe(pool_stats, thread->curtime, mc != nullptr);
+			: hostgroup_pool_wait.active_stats(pool_stats_hid);
+		if (!pool_stats) {
+			pool_stats = MyHGM->get_hostgroup_pool_stats(pool_stats_hid);
+		}
+		hostgroup_pool_wait.observe(pool_stats, thread->curtime, mc != nullptr, pool_stats_hid);
 #endif
 		if (mc) {
 			mybe->server_myds->attach_connection(mc);

--- a/lib/MySQL_Session.cpp
+++ b/lib/MySQL_Session.cpp
@@ -8907,6 +8907,12 @@ void MySQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 #endif // STRESSTESTPOOL_MEASURE
 		}
 #endif // STRESSTEST_POOL
+#ifdef PROXYSQL31
+		HostgroupPoolStats *pool_stats = mc
+			? &mc->parent->myhgc->pool_stats
+			: MyHGM->get_hostgroup_pool_stats(mybe->hostgroup_id);
+		hostgroup_pool_wait.observe(pool_stats, thread->curtime, mc != nullptr);
+#endif
 		if (mc) {
 			mybe->server_myds->attach_connection(mc);
 			thread->status_variables.stvar[st_var_ConnPool_get_conn_success]++;
@@ -9245,6 +9251,9 @@ void MySQL_Session::LogQuery(MySQL_Data_Stream *myds, const unsigned int myerrno
 }
 
 void MySQL_Session::RequestEnd(MySQL_Data_Stream *myds,const unsigned int myerrno, const char * errmsg) {
+#ifdef PROXYSQL31
+	hostgroup_pool_wait.finish(thread ? thread->curtime : monotonic_time());
+#endif
 	// check if multiplexing needs to be disabled
 	char *qdt = NULL;
 

--- a/lib/PgSQL_HostGroups_Manager.cpp
+++ b/lib/PgSQL_HostGroups_Manager.cpp
@@ -747,6 +747,27 @@ hg_metrics_map = std::make_tuple(
 			"Tracks the pgsql errors encountered.",
 			metric_tags {}
 		)
+#ifdef PROXYSQL31
+		,
+		std::make_tuple (
+			PgSQL_p_hg_dyn_counter::hostgroup_pool_acquisitions,
+			"proxysql_connpool_acquisitions_total",
+			"Successful backend connection acquisitions by hostgroup.",
+			metric_tags {{ "protocol", "pgsql" }}
+		),
+		std::make_tuple (
+			PgSQL_p_hg_dyn_counter::hostgroup_pool_waits,
+			"proxysql_connpool_waits_total",
+			"Backend connection acquisition wait episodes by hostgroup.",
+			metric_tags {{ "protocol", "pgsql" }}
+		),
+		std::make_tuple (
+			PgSQL_p_hg_dyn_counter::hostgroup_pool_wait_time,
+			"proxysql_connpool_wait_time_seconds_total",
+			"Cumulative duration of completed backend connection acquisition waits.",
+			metric_tags {{ "protocol", "pgsql" }}
+		)
+#endif
 	},
 	// prometheus dynamic gauges
 	hg_dyn_gauge_vector {
@@ -784,6 +805,15 @@ hg_metrics_map = std::make_tuple(
 				{ "protocol", "pgsql" }
 			}
 		)
+#ifdef PROXYSQL31
+		,
+		std::make_tuple (
+			PgSQL_p_hg_dyn_gauge::hostgroup_pool_waiters,
+			"proxysql_connpool_waiters",
+			"Sessions currently waiting to acquire a backend connection.",
+			metric_tags {{ "protocol", "pgsql" }}
+		)
+#endif
 	}
 );
 
@@ -3197,6 +3227,26 @@ void PgSQL_HostGroups_Manager::p_update_connection_pool() {
 			p_update_connection_pool_update_gauge(endpoint_id, common_labels,
 				status.p_connection_pool_status_map, mysrvc->status + 1, PgSQL_p_hg_dyn_gauge::connection_pool_status);
 		}
+#ifdef PROXYSQL31
+		const std::string hostgroup_id = std::to_string(myhgc->hid);
+		const std::map<std::string, std::string> labels {
+			{"hostgroup", hostgroup_id},
+			{"protocol", "pgsql"}
+		};
+		const HostgroupPoolStatsSnapshot snapshot = myhgc->pool_stats.lifetime_snapshot();
+		p_update_map_counter(status.p_hostgroup_pool_acquisitions_map,
+			status.p_dyn_counter_array[PgSQL_p_hg_dyn_counter::hostgroup_pool_acquisitions],
+			hostgroup_id, labels, snapshot.acquisitions_total);
+		p_update_map_counter(status.p_hostgroup_pool_waits_map,
+			status.p_dyn_counter_array[PgSQL_p_hg_dyn_counter::hostgroup_pool_waits],
+			hostgroup_id, labels, snapshot.waits_total);
+		p_update_map_counter(status.p_hostgroup_pool_wait_time_map,
+			status.p_dyn_counter_array[PgSQL_p_hg_dyn_counter::hostgroup_pool_wait_time],
+			hostgroup_id, labels, snapshot.wait_time_us_total / 1000000.0);
+		p_update_map_gauge(status.p_hostgroup_pool_waiters_map,
+			status.p_dyn_gauge_array[PgSQL_p_hg_dyn_gauge::hostgroup_pool_waiters],
+			hostgroup_id, labels, snapshot.waiters);
+#endif
 	}
 
 	// Remove the non-present servers for the gauge metrics

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5472,10 +5472,14 @@ void PgSQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 	}
 #endif // STRESSTEST_POOL
 #ifdef PROXYSQL31
+	const unsigned int pool_stats_hid = mc ? mc->parent->myhgc->hid : mybe->hostgroup_id;
 	HostgroupPoolStats *pool_stats = mc
 		? &mc->parent->myhgc->pool_stats
-		: PgHGM->get_hostgroup_pool_stats(mybe->hostgroup_id);
-	hostgroup_pool_wait.observe(pool_stats, thread->curtime, mc != nullptr);
+		: hostgroup_pool_wait.active_stats(pool_stats_hid);
+	if (!pool_stats) {
+		pool_stats = PgHGM->get_hostgroup_pool_stats(pool_stats_hid);
+	}
+	hostgroup_pool_wait.observe(pool_stats, thread->curtime, mc != nullptr, pool_stats_hid);
 #endif
 	if (mc) {
 		mybe->server_myds->attach_connection(mc);

--- a/lib/PgSQL_Session.cpp
+++ b/lib/PgSQL_Session.cpp
@@ -5471,6 +5471,12 @@ void PgSQL_Session::handler___client_DSS_QUERY_SENT___server_DSS_NOT_INITIALIZED
 #endif // STRESSTESTPOOL_MEASURE
 	}
 #endif // STRESSTEST_POOL
+#ifdef PROXYSQL31
+	HostgroupPoolStats *pool_stats = mc
+		? &mc->parent->myhgc->pool_stats
+		: PgHGM->get_hostgroup_pool_stats(mybe->hostgroup_id);
+	hostgroup_pool_wait.observe(pool_stats, thread->curtime, mc != nullptr);
+#endif
 	if (mc) {
 		mybe->server_myds->attach_connection(mc);
 		thread->status_variables.stvar[st_var_ConnPool_get_conn_success]++;
@@ -5797,6 +5803,9 @@ void PgSQL_Session::handle_transaction_state() {
 }
 
 void PgSQL_Session::RequestEnd(PgSQL_Data_Stream* myds, bool called_on_failure) {
+#ifdef PROXYSQL31
+	hostgroup_pool_wait.finish(thread ? thread->curtime : monotonic_time());
+#endif
 
 	// check if multiplexing needs to be disabled
 	const char* query_digest_text = NULL;

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -1230,6 +1230,9 @@ void ProxySQL_Admin::flush_mysql_stats() {
 	stats___mysql_errors(true);
 	// Reset MySQL connection pool statistics
 	stats___mysql_connection_pool(true);
+#ifdef PROXYSQL31
+	stats___mysql_hostgroup_connection_pool(true);
+#endif
 	// Reset MySQL client host cache
 	stats___mysql_client_host_cache(true);
 
@@ -1247,6 +1250,9 @@ void ProxySQL_Admin::flush_pgsql_stats() {
 	stats___pgsql_errors(true);
 	// Reset PostgreSQL connection pool statistics
 	stats___pgsql_connection_pool(true);
+#ifdef PROXYSQL31
+	stats___pgsql_hostgroup_connection_pool(true);
+#endif
 	// Reset PostgreSQL client host cache
 	stats___pgsql_client_host_cache(true);
 
@@ -1293,6 +1299,10 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 	bool stats_pgsql_free_connections=false;
 	bool stats_mysql_connection_pool=false;
 	bool stats_mysql_connection_pool_reset=false;
+#ifdef PROXYSQL31
+	bool stats_mysql_hostgroup_connection_pool=false;
+	bool stats_mysql_hostgroup_connection_pool_reset=false;
+#endif
 	bool stats_mysql_query_digest=false;
 	bool stats_pgsql_query_digest = false;
 	bool stats_mysql_query_digest_reset=false;
@@ -1339,6 +1349,10 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 	bool stats_pgsql_global = false;
 	bool stats_pgsql_connection_pool = false;
 	bool stats_pgsql_connection_pool_reset = false;
+#ifdef PROXYSQL31
+	bool stats_pgsql_hostgroup_connection_pool = false;
+	bool stats_pgsql_hostgroup_connection_pool_reset = false;
+#endif
 
 #ifdef PROXYSQLTSDB
 	bool stats_tsdb = false;
@@ -1461,6 +1475,13 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 		if (strstr(query_no_space,"stats_mysql_connection_pool"))
 			{ stats_mysql_connection_pool=true; refresh=true; }
 	}
+#ifdef PROXYSQL31
+	if (strstr(query_no_space,"stats_mysql_hostgroup_connection_pool_reset")) {
+		stats_mysql_hostgroup_connection_pool_reset=true; refresh=true;
+	} else if (strstr(query_no_space,"stats_mysql_hostgroup_connection_pool")) {
+		stats_mysql_hostgroup_connection_pool=true; refresh=true;
+	}
+#endif
 	if (strstr(query_no_space, "stats_pgsql_connection_pool_reset")) {
 		stats_pgsql_connection_pool_reset = true; refresh = true;
 	} else {
@@ -1468,6 +1489,13 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 			stats_pgsql_connection_pool = true; refresh = true;
 		}
 	}
+#ifdef PROXYSQL31
+	if (strstr(query_no_space,"stats_pgsql_hostgroup_connection_pool_reset")) {
+		stats_pgsql_hostgroup_connection_pool_reset=true; refresh=true;
+	} else if (strstr(query_no_space,"stats_pgsql_hostgroup_connection_pool")) {
+		stats_pgsql_hostgroup_connection_pool=true; refresh=true;
+	}
+#endif
 	if (strstr(query_no_space,"stats_mysql_free_connections"))
 		{ stats_mysql_free_connections=true; refresh=true; }
 	if (strstr(query_no_space, "stats_pgsql_free_connections")) 
@@ -1697,12 +1725,26 @@ bool ProxySQL_Admin::GenericRefreshStatistics(const char *query_no_space, unsign
 			if (stats_mysql_connection_pool)
 				stats___mysql_connection_pool(false);
 		}
+#ifdef PROXYSQL31
+		if (stats_mysql_hostgroup_connection_pool_reset) {
+			stats___mysql_hostgroup_connection_pool(true);
+		} else if (stats_mysql_hostgroup_connection_pool) {
+			stats___mysql_hostgroup_connection_pool(false);
+		}
+#endif
 		if (stats_pgsql_connection_pool_reset) {
 			stats___pgsql_connection_pool(true);
 		} else {
 			if (stats_pgsql_connection_pool)
 				stats___pgsql_connection_pool(false);
 		}
+#ifdef PROXYSQL31
+		if (stats_pgsql_hostgroup_connection_pool_reset) {
+			stats___pgsql_hostgroup_connection_pool(true);
+		} else if (stats_pgsql_hostgroup_connection_pool) {
+			stats___pgsql_hostgroup_connection_pool(false);
+		}
+#endif
 		if (stats_mysql_free_connections)
 			stats___mysql_free_connections();
 		if (stats_pgsql_free_connections)
@@ -2144,6 +2186,12 @@ void ProxySQL_Admin::vacuum_stats(bool is_admin) {
 		"stats_mysql_connection_pool_reset",
 		"stats_pgsql_connection_pool",
 		"stats_pgsql_connection_pool_reset",
+#ifdef PROXYSQL31
+		"stats_mysql_hostgroup_connection_pool",
+		"stats_mysql_hostgroup_connection_pool_reset",
+		"stats_pgsql_hostgroup_connection_pool",
+		"stats_pgsql_hostgroup_connection_pool_reset",
+#endif
 		"stats_mysql_prepared_statements_info",
 		"stats_pgsql_prepared_statements_info",
 		"stats_mysql_processlist",

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -1223,6 +1223,40 @@ void ProxySQL_Admin::stats___mysql_connection_pool(bool _reset) {
 	delete resultset;
 }
 
+#ifdef PROXYSQL31
+static void stats___hostgroup_connection_pool(
+	SQLite3DB *statsdb, SQLite3_result *resultset, const char *table,
+	const char *reset_table, bool reset
+) {
+	if (!resultset) return;
+	const std::string delete_live = std::string("DELETE FROM ") + table;
+	const std::string insert_prefix = std::string("INSERT INTO ") + table + " VALUES (";
+	statsdb->execute("BEGIN");
+	statsdb->execute(delete_live.c_str());
+	for (SQLite3_row *row : resultset->rows) {
+		const std::string query = insert_prefix + row->fields[0] + "," + row->fields[1] + "," +
+			row->fields[2] + "," + row->fields[3] + "," + row->fields[4] + ")";
+		statsdb->execute(query.c_str());
+	}
+	if (reset) {
+		const std::string delete_reset = std::string("DELETE FROM ") + reset_table;
+		const std::string copy_reset = std::string("INSERT INTO ") + reset_table + " SELECT * FROM " + table;
+		statsdb->execute(delete_reset.c_str());
+		statsdb->execute(copy_reset.c_str());
+	}
+	statsdb->execute("COMMIT");
+	delete resultset;
+}
+
+void ProxySQL_Admin::stats___mysql_hostgroup_connection_pool(bool reset) {
+	if (!MyHGM) return;
+	stats___hostgroup_connection_pool(
+		statsdb, MyHGM->SQL3_Hostgroup_Connection_Pool(reset),
+		"stats_mysql_hostgroup_connection_pool",
+		"stats_mysql_hostgroup_connection_pool_reset", reset);
+}
+#endif
+
 void ProxySQL_Admin::stats___pgsql_connection_pool(bool _reset) {
 	if (!PgHGM) return;
 	SQLite3_result* resultset = PgHGM->SQL3_Connection_Pool(_reset);
@@ -1248,6 +1282,16 @@ void ProxySQL_Admin::stats___pgsql_connection_pool(bool _reset) {
 	statsdb->execute("COMMIT");
 	delete resultset;
 }
+
+#ifdef PROXYSQL31
+void ProxySQL_Admin::stats___pgsql_hostgroup_connection_pool(bool reset) {
+	if (!PgHGM) return;
+	stats___hostgroup_connection_pool(
+		statsdb, PgHGM->SQL3_Hostgroup_Connection_Pool(reset),
+		"stats_pgsql_hostgroup_connection_pool",
+		"stats_pgsql_hostgroup_connection_pool_reset", reset);
+}
+#endif
 
 void ProxySQL_Admin::stats___mysql_free_connections() {
 	int rc;

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -1228,24 +1228,28 @@ static void stats___hostgroup_connection_pool(
 	SQLite3DB *statsdb, SQLite3_result *resultset, const char *table,
 	const char *reset_table, bool reset
 ) {
-	if (!resultset) return;
+	std::unique_ptr<SQLite3_result> owned_resultset { resultset };
+	if (!owned_resultset) return;
+
+	constexpr const char *savepoint = "proxysql_hostgroup_connection_pool_stats";
 	const std::string delete_live = std::string("DELETE FROM ") + table;
 	const std::string insert_prefix = std::string("INSERT INTO ") + table + " VALUES (";
-	statsdb->execute("BEGIN");
-	statsdb->execute(delete_live.c_str());
-	for (SQLite3_row *row : resultset->rows) {
-		const std::string query = insert_prefix + row->fields[0] + "," + row->fields[1] + "," +
-			row->fields[2] + "," + row->fields[3] + "," + row->fields[4] + ")";
-		statsdb->execute(query.c_str());
+	std::string query = std::string("SAVEPOINT ") + savepoint + ";" + delete_live + ";";
+	for (SQLite3_row *row : owned_resultset->rows) {
+		query += insert_prefix + row->fields[0] + "," + row->fields[1] + "," +
+			row->fields[2] + "," + row->fields[3] + "," + row->fields[4] + ");";
 	}
 	if (reset) {
 		const std::string delete_reset = std::string("DELETE FROM ") + reset_table;
 		const std::string copy_reset = std::string("INSERT INTO ") + reset_table + " SELECT * FROM " + table;
-		statsdb->execute(delete_reset.c_str());
-		statsdb->execute(copy_reset.c_str());
+		query += delete_reset + ";" + copy_reset + ";";
 	}
-	statsdb->execute("COMMIT");
-	delete resultset;
+	query += std::string("RELEASE SAVEPOINT ") + savepoint;
+	if (!statsdb->execute(query.c_str())) {
+		const std::string rollback = std::string("ROLLBACK TO SAVEPOINT ") + savepoint +
+			";RELEASE SAVEPOINT " + savepoint;
+		statsdb->execute(rollback.c_str());
+	}
 }
 
 void ProxySQL_Admin::stats___mysql_hostgroup_connection_pool(bool reset) {
@@ -2549,8 +2553,8 @@ void ProxySQL_Admin::stats___mysql_prepared_statements_info() {
 
 void ProxySQL_Admin::stats___pgsql_prepared_statements_info() {
 	if (!GloPgStmt) return;
-	SQLite3_result* resultset = NULL;
-	resultset = GloPgStmt->get_prepared_statements_global_infos();
+	std::unique_ptr<SQLite3_result> owned_resultset { GloPgStmt->get_prepared_statements_global_infos() };
+	SQLite3_result* resultset = owned_resultset.get();
 	if (resultset == NULL) return;
 	statsdb->execute("BEGIN");
 	int rc;
@@ -2607,7 +2611,6 @@ void ProxySQL_Admin::stats___pgsql_prepared_statements_info() {
 	}
 	// RAII auto-finalizes statement1 and statement32
 	statsdb->execute("COMMIT");
-	delete resultset;
 }
 
 

--- a/lib/ProxySQL_Admin_Stats.cpp
+++ b/lib/ProxySQL_Admin_Stats.cpp
@@ -1231,25 +1231,22 @@ static void stats___hostgroup_connection_pool(
 	std::unique_ptr<SQLite3_result> owned_resultset { resultset };
 	if (!owned_resultset) return;
 
-	constexpr const char *savepoint = "proxysql_hostgroup_connection_pool_stats";
 	const std::string delete_live = std::string("DELETE FROM ") + table;
 	const std::string insert_prefix = std::string("INSERT INTO ") + table + " VALUES (";
-	std::string query = std::string("SAVEPOINT ") + savepoint + ";" + delete_live + ";";
+	statsdb->execute("BEGIN");
+	statsdb->execute(delete_live.c_str());
 	for (SQLite3_row *row : owned_resultset->rows) {
-		query += insert_prefix + row->fields[0] + "," + row->fields[1] + "," +
-			row->fields[2] + "," + row->fields[3] + "," + row->fields[4] + ");";
+		const std::string query = insert_prefix + row->fields[0] + "," + row->fields[1] + "," +
+			row->fields[2] + "," + row->fields[3] + "," + row->fields[4] + ")";
+		statsdb->execute(query.c_str());
 	}
 	if (reset) {
 		const std::string delete_reset = std::string("DELETE FROM ") + reset_table;
 		const std::string copy_reset = std::string("INSERT INTO ") + reset_table + " SELECT * FROM " + table;
-		query += delete_reset + ";" + copy_reset + ";";
+		statsdb->execute(delete_reset.c_str());
+		statsdb->execute(copy_reset.c_str());
 	}
-	query += std::string("RELEASE SAVEPOINT ") + savepoint;
-	if (!statsdb->execute(query.c_str())) {
-		const std::string rollback = std::string("ROLLBACK TO SAVEPOINT ") + savepoint +
-			";RELEASE SAVEPOINT " + savepoint;
-		statsdb->execute(rollback.c_str());
-	}
+	statsdb->execute("COMMIT");
 }
 
 void ProxySQL_Admin::stats___mysql_hostgroup_connection_pool(bool reset) {

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -59,6 +59,7 @@
   "gtid_server_data_unit-t" : [ "unit-tests-g1" ],
   "gtid_set_unit-t" : [ "unit-tests-g1" ],
   "gtid_trxid_interval_unit-t" : [ "unit-tests-g1" ],
+  "hostgroup_pool_stats_unit-t" : [ "unit-tests-g1","@proxysql_min_version:3.1" ],
   "hostgroup_routing_unit-t" : [ "unit-tests-g1" ],
   "hostgroups_unit-t" : [ "unit-tests-g1" ],
   "http_server_unit-t" : [ "unit-tests-g1" ],

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -286,14 +286,17 @@ ifneq ($(shell nm $(LIBPROXYSQLAR) 2>/dev/null | grep -c proxysql_ed25519_verify
 	PSQLED25519 := -DPROXYSQLED25519
 endif
 
-# PROXYSQL31 is the parent tier flag for FFTO + TSDB; the codebase has no
-# #ifdef PROXYSQL31 blocks of its own, so autodetect it as "at least one
-# of FFTO or TSDB is enabled".  This matches the top-level Makefile's
-# cascade (PROXYSQL31=1 => PROXYSQLFFTO=1 && PROXYSQLTSDB=1).
+# PROXYSQL31 changes shared class layouts, so detect a symbol emitted only by
+# the PROXYSQL31-gated hostgroup statistics implementation. Do not infer it
+# from child feature flags: FFTO or TSDB can be enabled independently.
 PSQL31 :=
-ifneq ($(PROXYSQLFFTO)$(PROXYSQLTSDB),)
+ifeq ($(PROXYSQL31),1)
+	PSQL31 := -DPROXYSQL31
+else
+ifneq ($(shell nm $(LIBPROXYSQLAR) 2>/dev/null | grep -c SQL3_Hostgroup_Connection_Pool),0)
 	PROXYSQL31 := 1
 	PSQL31 := -DPROXYSQL31
+endif
 endif
 
 ifneq ($(PROXYSQL40),)
@@ -455,7 +458,7 @@ UNIT_TESTS := smoke_test-t query_cache_unit-t query_processor_unit-t \
 	mcp_client_unit-t
 
 ifeq ($(PROXYSQL31),1)
-UNIT_TESTS += caching_sha2_rsa_unit-t
+UNIT_TESTS += caching_sha2_rsa_unit-t hostgroup_pool_stats_unit-t
 endif
 
 ifeq ($(PROXYSQLED25519),1)
@@ -566,6 +569,11 @@ ezoption_parser_unit-t: ezoption_parser_unit-t.cpp $(ODIR)/tap.o $(ODIR)/tap_noi
 	$(CXX) $< $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o \
 		-I$(TAP_IDIR) -I$(PROXYSQL_PATH)/include \
 		$(STDCPP) -O0 -ggdb $(WGCOV) $(LWGCOV) $(WASAN) -lpthread -o $@
+
+hostgroup_pool_stats_unit-t: hostgroup_pool_stats_unit-t.cpp $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o
+	$(CXX) $< $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o \
+		-I$(TAP_IDIR) -I$(PROXYSQL_PATH)/include \
+		$(STDCPP) -O0 -ggdb -DPROXYSQL31 $(WGCOV) $(LWGCOV) $(WASAN) -lpthread -o $@
 
 mcp_client_unit-t: mcp_client_unit-t.cpp $(TAP_PATH)/mcp_client.cpp $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o
 	$(CXX) $< $(TAP_PATH)/mcp_client.cpp $(ODIR)/tap.o $(ODIR)/tap_noise_stubs.o \

--- a/test/tap/tests/unit/hostgroup_pool_stats_unit-t.cpp
+++ b/test/tap/tests/unit/hostgroup_pool_stats_unit-t.cpp
@@ -1,0 +1,144 @@
+#include "tap.h"
+
+#include "HostgroupPoolStats.h"
+
+#include <atomic>
+#include <thread>
+
+static void test_immediate_acquisition() {
+	HostgroupPoolStats stats;
+	HostgroupPoolWait wait;
+
+	wait.observe(&stats, 100, true);
+
+	const auto lifetime = stats.lifetime_snapshot();
+	ok(lifetime.acquisitions_total == 1, "immediate acquisition increments acquisitions once");
+	ok(lifetime.waits_total == 0, "immediate acquisition does not create a wait episode");
+	ok(lifetime.wait_time_us_total == 0, "immediate acquisition records no wait time");
+	ok(lifetime.waiters == 0, "immediate acquisition leaves no current waiter");
+}
+
+static void test_retry_is_one_wait_episode() {
+	HostgroupPoolStats stats;
+	HostgroupPoolWait wait;
+
+	wait.observe(&stats, 1'000, false);
+	wait.observe(&stats, 2'000, false);
+
+	auto lifetime = stats.lifetime_snapshot();
+	ok(lifetime.waits_total == 1, "repeated misses count as one logical wait episode");
+	ok(lifetime.waiters == 1, "repeated misses keep exactly one current waiter");
+
+	wait.observe(&stats, 6'000, true);
+	lifetime = stats.lifetime_snapshot();
+	ok(lifetime.acquisitions_total == 1, "acquisition after retries increments acquisitions once");
+	ok(lifetime.waits_total == 1, "successful completion does not recount the wait episode");
+	ok(lifetime.wait_time_us_total == 5'000, "successful completion records full wait duration");
+	ok(lifetime.waiters == 0, "successful completion removes the current waiter");
+}
+
+static void test_abandoned_wait() {
+	HostgroupPoolStats stats;
+	HostgroupPoolWait wait;
+
+	wait.observe(&stats, 10'000, false);
+	wait.finish(13'500);
+	wait.finish(20'000);
+
+	const auto lifetime = stats.lifetime_snapshot();
+	ok(lifetime.waits_total == 1, "abandoned acquisition remains one wait episode");
+	ok(lifetime.wait_time_us_total == 3'500, "abandoned acquisition contributes wait duration once");
+	ok(lifetime.waiters == 0, "abandoned acquisition removes the current waiter exactly once");
+}
+
+static void test_reroute_moves_wait_between_hostgroups() {
+	HostgroupPoolStats first;
+	HostgroupPoolStats second;
+	HostgroupPoolWait wait;
+
+	wait.observe(&first, 100, false);
+	wait.observe(&second, 400, false);
+
+	const auto first_lifetime = first.lifetime_snapshot();
+	const auto second_lifetime = second.lifetime_snapshot();
+	ok(first_lifetime.waiters == 0 && first_lifetime.wait_time_us_total == 300,
+		"reroute closes the wait episode in the original hostgroup");
+	ok(second_lifetime.waiters == 1 && second_lifetime.waits_total == 1,
+		"reroute starts one wait episode in the new hostgroup");
+
+	wait.observe(&second, 900, true);
+	ok(second.lifetime_snapshot().wait_time_us_total == 500,
+		"rerouted acquisition records time only in its target hostgroup");
+}
+
+static void test_reset_preserves_lifetime_and_live_gauge() {
+	HostgroupPoolStats stats;
+	HostgroupPoolWait wait;
+
+	wait.observe(&stats, 1'000, true);
+	wait.observe(&stats, 2'000, false);
+
+	const auto before_reset = stats.reset_window();
+	ok(before_reset.acquisitions_total == 1 && before_reset.waits_total == 1,
+		"reset returns the completed Admin counter window");
+	ok(before_reset.waiters == 1, "reset reports the live waiter gauge");
+	ok(stats.lifetime_snapshot().acquisitions_total == 1 &&
+		stats.lifetime_snapshot().waits_total == 1,
+		"reset preserves monotonic lifetime counters");
+	ok(stats.window_snapshot().acquisitions_total == 0 &&
+		stats.window_snapshot().waits_total == 0,
+		"reset starts a fresh Admin counter window");
+	ok(stats.window_snapshot().waiters == 1,
+		"reset never clears the live waiter gauge");
+
+	wait.finish(5'000);
+	ok(stats.window_snapshot().wait_time_us_total == 3'000 &&
+		stats.window_snapshot().waiters == 0,
+		"wait completion after reset is retained without gauge underflow");
+}
+
+static void test_destructor_balances_waiter_gauge() {
+	HostgroupPoolStats stats;
+	{
+		HostgroupPoolWait wait;
+		wait.observe(&stats, 7'000, false);
+	}
+
+	ok(stats.lifetime_snapshot().waiters == 0,
+		"wait-state destruction cannot leak the current waiter gauge");
+}
+
+static void test_concurrent_resets_preserve_acquisitions() {
+	HostgroupPoolStats stats;
+	std::atomic<bool> done {false};
+	std::thread recorder([&]() {
+		for (uint64_t i = 0; i < 100'000; ++i) {
+			stats.record_acquisition();
+		}
+		done.store(true, std::memory_order_release);
+	});
+
+	uint64_t reset_total = 0;
+	while (!done.load(std::memory_order_acquire)) {
+		reset_total += stats.reset_window().acquisitions_total;
+	}
+	recorder.join();
+	reset_total += stats.reset_window().acquisitions_total;
+
+	ok(stats.lifetime_snapshot().acquisitions_total == 100'000,
+		"concurrent Admin resets preserve the monotonic lifetime counter");
+	ok(reset_total == 100'000,
+		"concurrent Admin reset windows neither lose nor duplicate acquisitions");
+}
+
+int main() {
+	plan(25);
+	test_immediate_acquisition();
+	test_retry_is_one_wait_episode();
+	test_abandoned_wait();
+	test_reroute_moves_wait_between_hostgroups();
+	test_reset_preserves_lifetime_and_live_gauge();
+	test_destructor_balances_waiter_gauge();
+	test_concurrent_resets_preserve_acquisitions();
+	return exit_status();
+}

--- a/test/tap/tests/unit/hostgroup_pool_stats_unit-t.cpp
+++ b/test/tap/tests/unit/hostgroup_pool_stats_unit-t.cpp
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <thread>
+#include <vector>
 
 static void test_immediate_acquisition() {
 	HostgroupPoolStats stats;
@@ -111,15 +112,15 @@ static void test_destructor_balances_waiter_gauge() {
 static void test_concurrent_resets_preserve_acquisitions() {
 	HostgroupPoolStats stats;
 	std::atomic<bool> done {false};
-	std::thread recorder([&]() {
+	std::thread recorder([&stats, &done]() {
 		for (uint64_t i = 0; i < 100'000; ++i) {
 			stats.record_acquisition();
 		}
-		done.store(true, std::memory_order_release);
+		done.store(true);
 	});
 
 	uint64_t reset_total = 0;
-	while (!done.load(std::memory_order_acquire)) {
+	while (!done.load()) {
 		reset_total += stats.reset_window().acquisitions_total;
 	}
 	recorder.join();
@@ -131,8 +132,51 @@ static void test_concurrent_resets_preserve_acquisitions() {
 		"concurrent Admin reset windows neither lose nor duplicate acquisitions");
 }
 
+static void test_concurrent_resetters_partition_acquisitions() {
+	HostgroupPoolStats stats;
+	std::atomic<bool> start {false};
+	std::atomic<bool> done {false};
+	std::atomic<uint64_t> reset_total {0};
+	std::vector<std::thread> resetters;
+
+	for (unsigned int i = 0; i < 32; ++i) {
+		resetters.emplace_back([&stats, &start, &done, &reset_total]() {
+			uint64_t local_total = 0;
+			while (!start.load()) {
+				std::this_thread::yield();
+			}
+			while (!done.load()) {
+				local_total += stats.reset_window().acquisitions_total;
+			}
+			reset_total.fetch_add(local_total);
+		});
+	}
+
+	std::thread recorder([&stats, &start, &done]() {
+		while (!start.load()) {
+			std::this_thread::yield();
+		}
+		for (uint64_t i = 0; i < 1'000'000; ++i) {
+			stats.record_acquisition();
+		}
+		done.store(true);
+	});
+
+	start.store(true);
+	recorder.join();
+	for (std::thread& resetter : resetters) {
+		resetter.join();
+	}
+	reset_total.fetch_add(stats.reset_window().acquisitions_total);
+
+	ok(stats.lifetime_snapshot().acquisitions_total == 1'000'000,
+		"multiple concurrent resetters preserve the lifetime acquisition count");
+	ok(reset_total.load() == 1'000'000,
+		"multiple concurrent resetters partition acquisitions without overlap or gaps");
+}
+
 int main() {
-	plan(25);
+	plan(27);
 	test_immediate_acquisition();
 	test_retry_is_one_wait_episode();
 	test_abandoned_wait();
@@ -140,5 +184,6 @@ int main() {
 	test_reset_preserves_lifetime_and_live_gauge();
 	test_destructor_balances_waiter_gauge();
 	test_concurrent_resets_preserve_acquisitions();
+	test_concurrent_resetters_partition_acquisitions();
 	return exit_status();
 }

--- a/test/tap/tests/unit/hostgroup_pool_stats_unit-t.cpp
+++ b/test/tap/tests/unit/hostgroup_pool_stats_unit-t.cpp
@@ -10,7 +10,7 @@ static void test_immediate_acquisition() {
 	HostgroupPoolStats stats;
 	HostgroupPoolWait wait;
 
-	wait.observe(&stats, 100, true);
+	wait.observe(&stats, 100, true, 10);
 
 	const auto lifetime = stats.lifetime_snapshot();
 	ok(lifetime.acquisitions_total == 1, "immediate acquisition increments acquisitions once");
@@ -23,14 +23,16 @@ static void test_retry_is_one_wait_episode() {
 	HostgroupPoolStats stats;
 	HostgroupPoolWait wait;
 
-	wait.observe(&stats, 1'000, false);
-	wait.observe(&stats, 2'000, false);
+	wait.observe(&stats, 1'000, false, 10);
+	ok(wait.active_stats(10) == &stats, "active wait exposes cached stats for the same hostgroup");
+	ok(wait.active_stats(20) == nullptr, "active wait does not reuse stats after a hostgroup change");
+	wait.observe(&stats, 2'000, false, 10);
 
 	auto lifetime = stats.lifetime_snapshot();
 	ok(lifetime.waits_total == 1, "repeated misses count as one logical wait episode");
 	ok(lifetime.waiters == 1, "repeated misses keep exactly one current waiter");
 
-	wait.observe(&stats, 6'000, true);
+	wait.observe(&stats, 6'000, true, 10);
 	lifetime = stats.lifetime_snapshot();
 	ok(lifetime.acquisitions_total == 1, "acquisition after retries increments acquisitions once");
 	ok(lifetime.waits_total == 1, "successful completion does not recount the wait episode");
@@ -42,7 +44,7 @@ static void test_abandoned_wait() {
 	HostgroupPoolStats stats;
 	HostgroupPoolWait wait;
 
-	wait.observe(&stats, 10'000, false);
+	wait.observe(&stats, 10'000, false, 10);
 	wait.finish(13'500);
 	wait.finish(20'000);
 
@@ -57,8 +59,8 @@ static void test_reroute_moves_wait_between_hostgroups() {
 	HostgroupPoolStats second;
 	HostgroupPoolWait wait;
 
-	wait.observe(&first, 100, false);
-	wait.observe(&second, 400, false);
+	wait.observe(&first, 100, false, 10);
+	wait.observe(&second, 400, false, 20);
 
 	const auto first_lifetime = first.lifetime_snapshot();
 	const auto second_lifetime = second.lifetime_snapshot();
@@ -67,7 +69,7 @@ static void test_reroute_moves_wait_between_hostgroups() {
 	ok(second_lifetime.waiters == 1 && second_lifetime.waits_total == 1,
 		"reroute starts one wait episode in the new hostgroup");
 
-	wait.observe(&second, 900, true);
+	wait.observe(&second, 900, true, 20);
 	ok(second.lifetime_snapshot().wait_time_us_total == 500,
 		"rerouted acquisition records time only in its target hostgroup");
 }
@@ -76,8 +78,8 @@ static void test_reset_preserves_lifetime_and_live_gauge() {
 	HostgroupPoolStats stats;
 	HostgroupPoolWait wait;
 
-	wait.observe(&stats, 1'000, true);
-	wait.observe(&stats, 2'000, false);
+	wait.observe(&stats, 1'000, true, 10);
+	wait.observe(&stats, 2'000, false, 10);
 
 	const auto before_reset = stats.reset_window();
 	ok(before_reset.acquisitions_total == 1 && before_reset.waits_total == 1,
@@ -102,7 +104,7 @@ static void test_destructor_balances_waiter_gauge() {
 	HostgroupPoolStats stats;
 	{
 		HostgroupPoolWait wait;
-		wait.observe(&stats, 7'000, false);
+		wait.observe(&stats, 7'000, false, 10);
 	}
 
 	ok(stats.lifetime_snapshot().waiters == 0,
@@ -176,7 +178,7 @@ static void test_concurrent_resetters_partition_acquisitions() {
 }
 
 int main() {
-	plan(27);
+	plan(29);
 	test_immediate_acquisition();
 	test_retry_is_one_wait_episode();
 	test_abandoned_wait();

--- a/test/tap/tests/unit/hostgroups_unit-t.cpp
+++ b/test/tap/tests/unit/hostgroups_unit-t.cpp
@@ -263,7 +263,7 @@ static void test_hostgroup_pool_stats(HGM *hgm, unsigned int hid, const char *pr
 	HostgroupPoolStats *stats = hgm->get_hostgroup_pool_stats(hid);
 	HostgroupPoolWait wait;
 	stats->record_acquisition();
-	wait.observe(stats, 100, false);
+	wait.observe(stats, 100, false, hid);
 
 	SQLite3_result *live = hgm->SQL3_Hostgroup_Connection_Pool(false);
 	SQLite3_row *live_row = find_hostgroup_row(live, hid);
@@ -283,7 +283,7 @@ static void test_hostgroup_pool_stats(HGM *hgm, unsigned int hid, const char *pr
 		"%s HGM: reset returns the completed window without clearing waiters", protocol);
 	delete reset;
 
-	wait.observe(stats, 350, true);
+	wait.observe(stats, 350, true, hid);
 	live = hgm->SQL3_Hostgroup_Connection_Pool(false);
 	live_row = find_hostgroup_row(live, hid);
 	ok(live_row && strcmp(live_row->fields[1], "1") == 0 &&

--- a/test/tap/tests/unit/hostgroups_unit-t.cpp
+++ b/test/tap/tests/unit/hostgroups_unit-t.cpp
@@ -237,12 +237,68 @@ static void test_pgsql_shun() {
 		"PgSQL HGM: shun_and_killall() returns true");
 }
 
+#ifdef PROXYSQL31
+static SQLite3_row *find_hostgroup_row(SQLite3_result *result, unsigned int hid) {
+	for (SQLite3_row *row : result->rows) {
+		if (static_cast<unsigned int>(strtoul(row->fields[0], nullptr, 10)) == hid) {
+			return row;
+		}
+	}
+	return nullptr;
+}
+
+template <typename HGM>
+static void test_hostgroup_pool_stats(HGM *hgm, unsigned int hid, const char *protocol) {
+	HostgroupPoolStats *stats = hgm->get_hostgroup_pool_stats(hid);
+	HostgroupPoolWait wait;
+	stats->record_acquisition();
+	wait.observe(stats, 100, false);
+
+	SQLite3_result *live = hgm->SQL3_Hostgroup_Connection_Pool(false);
+	SQLite3_row *live_row = find_hostgroup_row(live, hid);
+	ok(live_row != nullptr, "%s HGM: live hostgroup pool stats expose the hostgroup", protocol);
+	ok(live_row && strcmp(live_row->fields[1], "1") == 0 &&
+		strcmp(live_row->fields[2], "1") == 0 &&
+		strcmp(live_row->fields[3], "0") == 0 &&
+		strcmp(live_row->fields[4], "1") == 0,
+		"%s HGM: live stats report acquisitions, waits, duration, and waiters", protocol);
+	delete live;
+
+	SQLite3_result *reset = hgm->SQL3_Hostgroup_Connection_Pool(true);
+	SQLite3_row *reset_row = find_hostgroup_row(reset, hid);
+	ok(reset_row && strcmp(reset_row->fields[1], "1") == 0 &&
+		strcmp(reset_row->fields[2], "1") == 0 &&
+		strcmp(reset_row->fields[4], "1") == 0,
+		"%s HGM: reset returns the completed window without clearing waiters", protocol);
+	delete reset;
+
+	wait.observe(stats, 350, true);
+	live = hgm->SQL3_Hostgroup_Connection_Pool(false);
+	live_row = find_hostgroup_row(live, hid);
+	ok(live_row && strcmp(live_row->fields[1], "1") == 0 &&
+		strcmp(live_row->fields[2], "0") == 0 &&
+		strcmp(live_row->fields[3], "250") == 0 &&
+		strcmp(live_row->fields[4], "0") == 0,
+		"%s HGM: post-reset completions remain in the new window", protocol);
+	delete live;
+
+	const HostgroupPoolStatsSnapshot lifetime = stats->lifetime_snapshot();
+	ok(lifetime.acquisitions_total == 2 && lifetime.waits_total == 1 &&
+		lifetime.wait_time_us_total == 250 && lifetime.waiters == 0,
+		"%s HGM: Admin reset preserves lifetime metrics", protocol);
+}
+#endif
+
 // ============================================================================
 // Main
 // ============================================================================
 
 int main() {
+#ifdef PROXYSQL31
+	plan(27);
+#else
 	plan(17);
+#endif
 
 	int rc = test_init_minimal();
 	ok(rc == 0, "test_init_minimal() succeeds");
@@ -261,6 +317,10 @@ int main() {
 	// PgSQL tests
 	test_pgsql_create_and_remove();      // 3 tests
 	test_pgsql_shun();                   // 1 test
+#ifdef PROXYSQL31
+	test_hostgroup_pool_stats(MyHGM, 10, "MySQL"); // 5 tests
+	test_hostgroup_pool_stats(PgHGM, 100, "PgSQL"); // 5 tests
+#endif
 	// Total: 1+1+3+2+2+1+2+1+3+1 = 17... let me recount
 	// init: 2, create: 3, remove: 2, status: 2, latency: 1,
 	// independence: 2, duplicate: 1, pgsql_create: 3, pgsql_shun: 1

--- a/test/tap/tests/unit/hostgroups_unit-t.cpp
+++ b/test/tap/tests/unit/hostgroups_unit-t.cpp
@@ -248,6 +248,17 @@ static SQLite3_row *find_hostgroup_row(SQLite3_result *result, unsigned int hid)
 }
 
 template <typename HGM>
+static void test_unknown_hostgroup_stats_lookup(HGM *hgm, const char *protocol) {
+	std::unique_ptr<SQLite3_result> before { hgm->SQL3_Hostgroup_Connection_Pool(false) };
+	const int rows_before = before->rows_count;
+	HostgroupPoolStats *stats = hgm->get_hostgroup_pool_stats(999'999);
+	std::unique_ptr<SQLite3_result> after { hgm->SQL3_Hostgroup_Connection_Pool(false) };
+
+	ok(stats == nullptr && after->rows_count == rows_before,
+		"%s HGM: stats lookup does not create an unknown hostgroup", protocol);
+}
+
+template <typename HGM>
 static void test_hostgroup_pool_stats(HGM *hgm, unsigned int hid, const char *protocol) {
 	HostgroupPoolStats *stats = hgm->get_hostgroup_pool_stats(hid);
 	HostgroupPoolWait wait;
@@ -295,7 +306,7 @@ static void test_hostgroup_pool_stats(HGM *hgm, unsigned int hid, const char *pr
 
 int main() {
 #ifdef PROXYSQL31
-	plan(27);
+	plan(29);
 #else
 	plan(17);
 #endif
@@ -320,6 +331,8 @@ int main() {
 #ifdef PROXYSQL31
 	test_hostgroup_pool_stats(MyHGM, 10, "MySQL"); // 5 tests
 	test_hostgroup_pool_stats(PgHGM, 100, "PgSQL"); // 5 tests
+	test_unknown_hostgroup_stats_lookup(MyHGM, "MySQL"); // 1 test
+	test_unknown_hostgroup_stats_lookup(PgHGM, "PgSQL"); // 1 test
 #endif
 	// Total: 1+1+3+2+2+1+2+1+3+1 = 17... let me recount
 	// init: 2, create: 3, remove: 2, status: 2, latency: 1,

--- a/test/tap/tests/unit/hostgroups_unit-t.cpp
+++ b/test/tap/tests/unit/hostgroups_unit-t.cpp
@@ -265,34 +265,30 @@ static void test_hostgroup_pool_stats(HGM *hgm, unsigned int hid, const char *pr
 	stats->record_acquisition();
 	wait.observe(stats, 100, false, hid);
 
-	SQLite3_result *live = hgm->SQL3_Hostgroup_Connection_Pool(false);
-	SQLite3_row *live_row = find_hostgroup_row(live, hid);
+	std::unique_ptr<SQLite3_result> live { hgm->SQL3_Hostgroup_Connection_Pool(false) };
+	SQLite3_row *live_row = find_hostgroup_row(live.get(), hid);
 	ok(live_row != nullptr, "%s HGM: live hostgroup pool stats expose the hostgroup", protocol);
 	ok(live_row && strcmp(live_row->fields[1], "1") == 0 &&
 		strcmp(live_row->fields[2], "1") == 0 &&
 		strcmp(live_row->fields[3], "0") == 0 &&
 		strcmp(live_row->fields[4], "1") == 0,
 		"%s HGM: live stats report acquisitions, waits, duration, and waiters", protocol);
-	delete live;
 
-	SQLite3_result *reset = hgm->SQL3_Hostgroup_Connection_Pool(true);
-	SQLite3_row *reset_row = find_hostgroup_row(reset, hid);
+	std::unique_ptr<SQLite3_result> reset { hgm->SQL3_Hostgroup_Connection_Pool(true) };
+	SQLite3_row *reset_row = find_hostgroup_row(reset.get(), hid);
 	ok(reset_row && strcmp(reset_row->fields[1], "1") == 0 &&
 		strcmp(reset_row->fields[2], "1") == 0 &&
 		strcmp(reset_row->fields[4], "1") == 0,
 		"%s HGM: reset returns the completed window without clearing waiters", protocol);
-	delete reset;
 
 	wait.observe(stats, 350, true, hid);
-	live = hgm->SQL3_Hostgroup_Connection_Pool(false);
-	live_row = find_hostgroup_row(live, hid);
+	live.reset(hgm->SQL3_Hostgroup_Connection_Pool(false));
+	live_row = find_hostgroup_row(live.get(), hid);
 	ok(live_row && strcmp(live_row->fields[1], "1") == 0 &&
 		strcmp(live_row->fields[2], "0") == 0 &&
 		strcmp(live_row->fields[3], "250") == 0 &&
 		strcmp(live_row->fields[4], "0") == 0,
 		"%s HGM: post-reset completions remain in the new window", protocol);
-	delete live;
-
 	const HostgroupPoolStatsSnapshot lifetime = stats->lifetime_snapshot();
 	ok(lifetime.acquisitions_total == 2 && lifetime.waits_total == 1 &&
 		lifetime.wait_time_us_total == 250 && lifetime.waiters == 0,


### PR DESCRIPTION
## Summary

- add per-hostgroup backend connection acquisition statistics shared by MySQL and PostgreSQL
- expose live/reset Admin tables for both protocols
- export monotonic Prometheus counters and a live waiter gauge with `protocol` and `hostgroup` labels
- gate the complete feature behind `PROXYSQL31=1`

This is a v3.0-native replacement for the concepts in #3722. It uses the shared hostgroup/session architecture and fixes the lifecycle, reset, and Prometheus monotonicity issues that prevented the old MySQL-only implementation from being carried forward.

## Semantics

A wait episode begins when a backend acquisition request first fails. Retries in the same episode are not recounted. The episode ends on acquisition, reroute, request termination, or session destruction. Admin reset tables reset only their reporting window; Prometheus lifetime counters never decrease, and the current waiter gauge is never reset.

Admin tables:

- `stats_mysql_hostgroup_connection_pool` and `_reset`
- `stats_pgsql_hostgroup_connection_pool` and `_reset`

Prometheus metrics:

- `proxysql_connpool_acquisitions_total`
- `proxysql_connpool_waits_total`
- `proxysql_connpool_wait_time_seconds_total`
- `proxysql_connpool_waiters`

## Validation

- full build with `PROXYSQL31=1`
- full default build, including confirmation that gated table/metric names are absent
- 25 helper lifecycle/concurrency TAP assertions
- 27 gated hostgroup manager TAP assertions covering MySQL/PostgreSQL live and reset windows
- existing connection-pool, statistics, and hostgroup unit suites (71 assertions)
- isolated runtime smoke test of all four Admin tables and all four Prometheus families for both protocols

Closes #6148
Supersedes #3722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-hostgroup backend connection acquisition stats for both MySQL and PostgreSQL, gated behind `PROXYSQL31=1`. New Admin tables and Prometheus metrics with `protocol` and `hostgroup` labels expose acquisitions and wait episodes per hostgroup.

**New Features**

- Adds `stats_mysql_hostgroup_connection_pool`/`_reset` and `stats_pgsql_hostgroup_connection_pool`/`_reset`, plus Prometheus families `proxysql_connpool_acquisitions_total`, `proxysql_connpool_waits_total`, `proxysql_connpool_wait_time_seconds_total`, and `proxysql_connpool_waiters`.
- A wait episode starts when a backend acquisition request first fails; retries in the same episode count once.
- Episodes end on acquisition, reroute, request termination, or session destruction.
- Reading the `_reset` tables starts a new counter window; Prometheus counters remain monotonic and the waiter gauge is never reset.

**Bug Fixes**

- Test builds now detect `PROXYSQL31` by the presence of its gated symbol instead of inferring it from enabled child features.
- `stats___pgsql_prepared_statements_info` now releases its result set via RAII, avoiding a leak on early return.

<sup>Written for commit 5f7f9b95603c217dc4dba8fb0cc9514f28bb6381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MySQL and PostgreSQL hostgroup connection-pool statistics.
  * Added acquisition, wait count, wait time, and active waiter metrics.
  * Added live and resettable statistics tables for each protocol.
  * Statistics can be refreshed and reset through the administration interface.
* **Documentation**
  * Documented table schemas, reset behavior, and Prometheus metrics.
* **Tests**
  * Added coverage for wait tracking, resets, rerouting, concurrency, and both protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->