### PR TITLE
Fix AWS RDS Blue/Green discovery for Aurora-only hostgroup configurations

### DIFF
--- a/include/Base_HostGroups_Manager.h
+++ b/include/Base_HostGroups_Manager.h
@@ -725,6 +725,12 @@ class MySQL_HostGroups_Manager {
 	 *   and 'hostgroup_server_mapping' should be rebuild.
 	 */
 	uint64_t hgsm_mysql_replication_hostgroups_checksum = 0;
+	/**
+	 * @brief Holds the previous checksum for the 'MYSQL_AWS_AURORA_HOSTGROUPS'.
+	 * @details Used during 'commit' to determine if config has changed for 'MYSQL_AWS_AURORA_HOSTGROUPS',
+	 *   and 'hostgroup_server_mapping' should be rebuild.
+	 */
+	uint64_t hgsm_mysql_aws_aurora_hostgroups_checksum = 0;
 
 
 	PtrArray *MyHostGroups;

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -646,6 +646,12 @@ class MySQL_HostGroups_Manager : public Base_HostGroups_Manager<MyHGC> {
 	 *   and 'hostgroup_server_mapping' should be rebuild.
 	 */
 	uint64_t hgsm_mysql_replication_hostgroups_checksum = 0;
+	/**
+	 * @brief Holds the previous checksum for the 'MYSQL_AWS_AURORA_HOSTGROUPS'.
+	 * @details Used during 'commit' to determine if config has changed for 'MYSQL_AWS_AURORA_HOSTGROUPS',
+	 *   and 'hostgroup_server_mapping' should be rebuild.
+	 */
+	uint64_t hgsm_mysql_aws_aurora_hostgroups_checksum = 0;
 
 
 #if 0

--- a/lib/Base_HostGroups_Manager.cpp
+++ b/lib/Base_HostGroups_Manager.cpp
@@ -1049,11 +1049,13 @@ void MySQL_HostGroups_Manager::commit_update_checksums_from_tables(SpookyHash& m
 void MySQL_HostGroups_Manager::update_hostgroup_manager_mappings() {
 
 	if (hgsm_mysql_servers_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_SERVERS] ||
-		hgsm_mysql_replication_hostgroups_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS])
+		hgsm_mysql_replication_hostgroups_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS] ||
+		hgsm_mysql_aws_aurora_hostgroups_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_AWS_AURORA_HOSTGROUPS])
 	{
-		proxy_info("Rebuilding 'Hostgroup_Manager_Mapping' due to checksums change - mysql_servers { old: 0x%lX, new: 0x%lX }, mysql_replication_hostgroups { old:0x%lX, new:0x%lX }\n",
+		proxy_info("Rebuilding 'Hostgroup_Manager_Mapping' due to checksums change - mysql_servers { old: 0x%lX, new: 0x%lX }, mysql_replication_hostgroups { old:0x%lX, new:0x%lX }, mysql_aws_aurora_hostgroups { old:0x%lX, new:0x%lX }\n",
 			hgsm_mysql_servers_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_SERVERS],
-			hgsm_mysql_replication_hostgroups_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS]);
+			hgsm_mysql_replication_hostgroups_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS],
+			hgsm_mysql_aws_aurora_hostgroups_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_AWS_AURORA_HOSTGROUPS]);
 
 		char* error = NULL;
 		int cols = 0;
@@ -1062,10 +1064,21 @@ void MySQL_HostGroups_Manager::update_hostgroup_manager_mappings() {
 
 		hostgroup_server_mapping.clear();
 
-		const char* query = "SELECT DISTINCT hostname, port, '1' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=writer_hostgroup WHERE status<>3 \
-							 UNION \
-							 SELECT DISTINCT hostname, port, '0' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=reader_hostgroup WHERE status<>3 \
-							 ORDER BY hostname, port";
+		const char* query =
+			"SELECT DISTINCT hostname, port, '1' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer "
+			"FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=writer_hostgroup WHERE status<>3 "
+			"UNION "
+			"SELECT DISTINCT hostname, port, '0' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer "
+			"FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=reader_hostgroup WHERE status<>3 "
+			"UNION "
+			"SELECT DISTINCT srv.hostname, srv.port, '1' is_writer, srv.status, aur.reader_hostgroup, aur.writer_hostgroup, srv.mem_pointer "
+			"FROM mysql_aws_aurora_hostgroups aur JOIN mysql_servers srv ON srv.hostgroup_id=aur.writer_hostgroup "
+			"WHERE aur.active=1 AND srv.status<>3 "
+			"UNION "
+			"SELECT DISTINCT srv.hostname, srv.port, '0' is_writer, srv.status, aur.reader_hostgroup, aur.writer_hostgroup, srv.mem_pointer "
+			"FROM mysql_aws_aurora_hostgroups aur JOIN mysql_servers srv ON srv.hostgroup_id=aur.reader_hostgroup "
+			"WHERE aur.active=1 AND srv.status<>3 "
+			"ORDER BY hostname, port";
 
 		mydb->execute_statement(query, &error, &cols, &affected_rows, &resultset);
 
@@ -1109,6 +1122,7 @@ void MySQL_HostGroups_Manager::update_hostgroup_manager_mappings() {
 
 		hgsm_mysql_servers_checksum = table_resultset_checksum[HGM_TABLES::MYSQL_SERVERS];
 		hgsm_mysql_replication_hostgroups_checksum = table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS];
+		hgsm_mysql_aws_aurora_hostgroups_checksum = table_resultset_checksum[HGM_TABLES::MYSQL_AWS_AURORA_HOSTGROUPS];
 	}
 }
 

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -1046,11 +1046,13 @@ void MySQL_HostGroups_Manager::commit_update_checksums_from_tables(SpookyHash& m
 void MySQL_HostGroups_Manager::update_hostgroup_manager_mappings() {
 
 	if (hgsm_mysql_servers_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_SERVERS] ||
-		hgsm_mysql_replication_hostgroups_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS])
+		hgsm_mysql_replication_hostgroups_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS] ||
+		hgsm_mysql_aws_aurora_hostgroups_checksum != table_resultset_checksum[HGM_TABLES::MYSQL_AWS_AURORA_HOSTGROUPS])
 	{
-		proxy_info("Rebuilding 'Hostgroup_Manager_Mapping' due to checksums change - mysql_servers { old: 0x%lX, new: 0x%lX }, mysql_replication_hostgroups { old:0x%lX, new:0x%lX }\n",
+		proxy_info("Rebuilding 'Hostgroup_Manager_Mapping' due to checksums change - mysql_servers { old: 0x%lX, new: 0x%lX }, mysql_replication_hostgroups { old:0x%lX, new:0x%lX }, mysql_aws_aurora_hostgroups { old:0x%lX, new:0x%lX }\n",
 			hgsm_mysql_servers_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_SERVERS],
-			hgsm_mysql_replication_hostgroups_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS]);
+			hgsm_mysql_replication_hostgroups_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS],
+			hgsm_mysql_aws_aurora_hostgroups_checksum, table_resultset_checksum[HGM_TABLES::MYSQL_AWS_AURORA_HOSTGROUPS]);
 
 		char* error = NULL;
 		int cols = 0;
@@ -1059,10 +1061,21 @@ void MySQL_HostGroups_Manager::update_hostgroup_manager_mappings() {
 
 		hostgroup_server_mapping.clear();
 
-		const char* query = "SELECT DISTINCT hostname, port, '1' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=writer_hostgroup WHERE status<>3 \
-							 UNION \
-							 SELECT DISTINCT hostname, port, '0' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=reader_hostgroup WHERE status<>3 \
-							 ORDER BY hostname, port";
+		const char* query =
+			"SELECT DISTINCT hostname, port, '1' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer "
+			"FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=writer_hostgroup WHERE status<>3 "
+			"UNION "
+			"SELECT DISTINCT hostname, port, '0' is_writer, status, reader_hostgroup, writer_hostgroup, mem_pointer "
+			"FROM mysql_replication_hostgroups JOIN mysql_servers ON hostgroup_id=reader_hostgroup WHERE status<>3 "
+			"UNION "
+			"SELECT DISTINCT srv.hostname, srv.port, '1' is_writer, srv.status, aur.reader_hostgroup, aur.writer_hostgroup, srv.mem_pointer "
+			"FROM mysql_aws_aurora_hostgroups aur JOIN mysql_servers srv ON srv.hostgroup_id=aur.writer_hostgroup "
+			"WHERE aur.active=1 AND srv.status<>3 "
+			"UNION "
+			"SELECT DISTINCT srv.hostname, srv.port, '0' is_writer, srv.status, aur.reader_hostgroup, aur.writer_hostgroup, srv.mem_pointer "
+			"FROM mysql_aws_aurora_hostgroups aur JOIN mysql_servers srv ON srv.hostgroup_id=aur.reader_hostgroup "
+			"WHERE aur.active=1 AND srv.status<>3 "
+			"ORDER BY hostname, port";
 
 		mydb->execute_statement(query, &error, &cols, &affected_rows, &resultset);
 
@@ -1106,6 +1119,7 @@ void MySQL_HostGroups_Manager::update_hostgroup_manager_mappings() {
 
 		hgsm_mysql_servers_checksum = table_resultset_checksum[HGM_TABLES::MYSQL_SERVERS];
 		hgsm_mysql_replication_hostgroups_checksum = table_resultset_checksum[HGM_TABLES::MYSQL_REPLICATION_HOSTGROUPS];
+		hgsm_mysql_aws_aurora_hostgroups_checksum = table_resultset_checksum[HGM_TABLES::MYSQL_AWS_AURORA_HOSTGROUPS];
 	}
 }
 
@@ -6966,6 +6980,16 @@ void MySQL_HostGroups_Manager::update_aws_aurora_set_writer(int _whid, int _rhid
 		pthread_mutex_unlock(&AWS_Aurora_Info_mutex);
 	}
 
+	const std::string aurora_hostname { std::string(_server_id) + std::string(domain_name) };
+	if (GloMyMon != nullptr && GloMyMon->is_aws_rds_bgd_server_in_progress(aurora_hostname, aurora_port)) {
+		proxy_info(
+			"AWS Aurora: skipping writer update for %s:%d because AWS RDS BGD switchover is in progress\n",
+			aurora_hostname.c_str(), aurora_port
+		);
+		free(domain_name);
+		return;
+	}
+
 	query=(char *)malloc(strlen(q)+strlen(_server_id)+strlen(domain_name)+1024*1024);
 	sprintf(query, q, _server_id, domain_name, aurora_port, _whid, _rhid);
 	mydb->execute_statement(query, &error, &cols , &affected_rows , &resultset);
@@ -7190,6 +7214,17 @@ void MySQL_HostGroups_Manager::update_aws_aurora_set_reader(int _whid, int _rhid
 		}
 		pthread_mutex_unlock(&AWS_Aurora_Info_mutex);
 	}
+
+	const std::string aurora_hostname { std::string(_server_id) + std::string(domain_name) };
+	if (GloMyMon != nullptr && GloMyMon->is_aws_rds_bgd_server_in_progress(aurora_hostname, aurora_port)) {
+		proxy_info(
+			"AWS Aurora: skipping reader update for %s:%d because AWS RDS BGD switchover is in progress\n",
+			aurora_hostname.c_str(), aurora_port
+		);
+		free(domain_name);
+		return;
+	}
+
 	q = (char*)"SELECT hostgroup_id FROM mysql_servers JOIN mysql_aws_aurora_hostgroups ON hostgroup_id=writer_hostgroup OR hostgroup_id=reader_hostgroup WHERE hostname='%s%s' AND port=%d AND status<>3 AND hostgroup_id IN (%d,%d)";
 	query=(char *)malloc(strlen(q)+strlen(_server_id)+strlen(domain_name)+32+32+32);
 	sprintf(query, q, _server_id, domain_name, aurora_port, _whid, _rhid);


### PR DESCRIPTION
## Summary

ProxySQL currently builds `hostgroup_server_mapping` only from `mysql_replication_hostgroups` and `mysql_servers`. This leaves a gap for AWS Aurora configurations that use `mysql_aws_aurora_hostgroups` instead of `mysql_replication_hostgroups`: Aurora writer/reader servers are not present in `hostgroup_server_mapping`, even though they are valid backend servers managed by ProxySQL.

AWS RDS Blue/Green Deployment handling relies on `hostgroup_server_mapping` when creating and applying Blue/Green hostgroup entries, so Aurora-only configurations can fail to provide the mapping needed to perform writer transitions correctly (`AWS RDS BGD: server :0 not found in hostgroup_server_mapping`).

Separately, `update_aws_aurora_set_writer()` / `update_aws_aurora_set_reader()` have no guard against an in-progress AWS RDS Blue/Green switchover. This lets the Aurora monitor race with the B/G switchover state machine over the same server's hostgroup membership during a transition (e.g. reverting a shun the B/G logic just applied).

## What changed

- Extends the `hostgroup_server_mapping` rebuild query (`update_hostgroup_manager_mappings()`) to also include active `mysql_aws_aurora_hostgroups` entries (both `writer_hostgroup` and `reader_hostgroup` members), alongside the existing `mysql_replication_hostgroups`-based mapping.
- Adds checksum tracking (`hgsm_mysql_aws_aurora_hostgroups_checksum`) for `mysql_aws_aurora_hostgroups` so `hostgroup_server_mapping` is rebuilt whenever the Aurora hostgroup configuration changes.
- Adds a guard to `update_aws_aurora_set_writer()` and `update_aws_aurora_set_reader()` so Aurora writer/reader auto-movement is skipped while an AWS RDS Blue/Green switchover is already in progress for the same server (`MySQL_Monitor::is_aws_rds_bgd_server_in_progress()`).

## Files changed

- `include/Base_HostGroups_Manager.h`
- `include/MySQL_HostGroups_Manager.h`
- `lib/Base_HostGroups_Manager.cpp`
- `lib/MySQL_HostGroups_Manager.cpp`

## Testing

This logic was originally developed and validated as a local patch on top of the v3.0.11 tag, and exercised against real AWS Aurora MySQL Blue/Green Deployment switchovers (multiple switchover attempts, confirming the previously-observed hostgroup duplication/oscillation issue no longer reproduced with these changes applied).

This PR rebases that same change onto current `v3.0` HEAD. The rebase is a straightforward reapplication (no drift found in the touched functions between the v3.0.11 tag and current `v3.0`), but it has not yet been independently recompiled/re-tested in this exact form — happy to follow up with a fresh build/switchover test if useful before merge.

## Notes

This does not change any admin table schema. It does not remove or bypass the existing `hostgroup_server_mapping` validation in the B/G writer-configuration path — it only expands the mapping source so Aurora-hostgroup-only servers can be found through the same validation path.

(Supersedes #6157, closed due to a commit-author identity mismatch.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hostgroup discovery for Aurora-only configurations so AWS RDS Blue/Green deployments can locate writer/reader servers in `hostgroup_server_mapping`. Previously the mapping was built only from `mysql_replication_hostgroups` and `mysql_servers`, so Aurora setups using `mysql_aws_aurora_hostgroups` failed with "server :0 not found in hostgroup_server_mapping". Also prevents the Aurora monitor from racing with an in-progress Blue/Green switchover over the same server's hostgroup membership.

- Includes active `mysql_aws_aurora_hostgroups` writer and reader entries in the `hostgroup_server_mapping` rebuild query.
- Tracks a checksum for `mysql_aws_aurora_hostgroups` so the mapping rebuilds when Aurora config changes.
- Skips Aurora writer/reader auto-movement during an in-progress Blue/Green switchover for the same server.

No admin schema changes; the existing `hostgroup_server_mapping` validation in the Blue/Green writer path is unchanged.

<sup>Written for commit 0e4fe3e3748eac8778c8be11b36f370383ae3c83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Aurora hostgroup configurations are now included when rebuilding hostgroup-to-server mappings.
  - Active writer and reader servers from Aurora hostgroups are automatically reflected in mappings.

- **Bug Fixes**
  - Mapping updates now occur when Aurora hostgroup configuration changes.
  - Writer and reader updates are safely skipped while an Aurora switchover is in progress, preventing conflicting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->