### PR TITLE
test: isolate PostgreSQL RESET ALL startup state

### DIFF
--- a/test/tap/tests/pgsql-set_statement_test-t.cpp
+++ b/test/tap/tests/pgsql-set_statement_test-t.cpp
@@ -129,11 +129,14 @@ static AdminRows pgsql_admin_rows(MYSQL* admin, const char* query) {
     return rows;
 }
 
-static std::string pgsql_admin_quote(MYSQL* admin, const std::string& value) {
-    std::vector<char> escaped(value.size() * 2 + 1);
-    const unsigned long escaped_length = mysql_real_escape_string(
-        admin, escaped.data(), value.c_str(), value.size());
-    return "'" + std::string(escaped.data(), escaped_length) + "'";
+static std::string pgsql_admin_quote(const std::string& value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (const char character : value) {
+        if (character == '\'') escaped += "''";
+        else escaped += character;
+    }
+    return "'" + escaped + "'";
 }
 
 class PgsqlPoolRuntimeGuard {
@@ -189,9 +192,12 @@ public:
 
     bool restore() {
         if (!initialized_ || restored_) return true;
-        restored_ = true;
 
         bool restored = true;
+        if (!set_free_connections_pct("0") || !wait_for_free_connections("0")) {
+            diag("Failed to drain PostgreSQL free connections before restoring pool configuration");
+            restored = false;
+        }
         if (!replace_main_servers(original_runtime_servers_) ||
             !replace_main_variables(original_runtime_variables_) ||
             !load_pool_configuration()) {
@@ -203,6 +209,7 @@ public:
             diag("Failed to restore PostgreSQL main configuration after pool test");
             restored = false;
         }
+        restored_ = restored;
         return restored;
     }
 
@@ -231,7 +238,7 @@ private:
                                 "comment) VALUES (";
             for (size_t i = 0; i < server.size(); ++i) {
                 if (i) query += ", ";
-                query += pgsql_admin_quote(admin_, server[i]);
+                query += pgsql_admin_quote(server[i]);
             }
             query += ")";
             if (!pgsql_admin_exec(admin_, query.c_str())) return false;
@@ -247,8 +254,8 @@ private:
             }
             const std::string query = "INSERT OR REPLACE INTO global_variables "
                                       "(variable_name, variable_value) VALUES (" +
-                                      pgsql_admin_quote(admin_, variable[0]) + ", " +
-                                      pgsql_admin_quote(admin_, variable[1]) + ")";
+                                      pgsql_admin_quote(variable[0]) + ", " +
+                                      pgsql_admin_quote(variable[1]) + ")";
             if (!pgsql_admin_exec(admin_, query.c_str())) return false;
         }
         return true;

--- a/test/tap/tests/pgsql-set_statement_test-t.cpp
+++ b/test/tap/tests/pgsql-set_statement_test-t.cpp
@@ -16,6 +16,7 @@
 #include <ctime>
 #include <sys/select.h>
 #include "libpq-fe.h"
+#include <mysql.h>
 #include "command_line.h"
 #include "noise_utils.h"
 #include "tap.h"
@@ -75,6 +76,114 @@ struct TestCase {
 
 std::fstream f_proxysql_log{};
 PGConnPtr admin_conn{nullptr, &PQfinish};
+
+static bool pgsql_admin_exec(MYSQL* admin, const char* query) {
+    if (mysql_query(admin, query)) {
+        diag("Admin query failed: '%s': %s", query, mysql_error(admin));
+        return false;
+    }
+    MYSQL_RES* result = mysql_store_result(admin);
+    if (result) mysql_free_result(result);
+    return true;
+}
+
+static std::string pgsql_admin_scalar(MYSQL* admin, const char* query) {
+    if (mysql_query(admin, query)) {
+        diag("Admin query failed: '%s': %s", query, mysql_error(admin));
+        return "";
+    }
+
+    std::string value;
+    MYSQL_RES* result = mysql_store_result(admin);
+    if (result) {
+        MYSQL_ROW row = mysql_fetch_row(result);
+        if (row && row[0]) value = row[0];
+        mysql_free_result(result);
+    }
+    return value;
+}
+
+static std::vector<std::pair<std::string, std::string>> pgsql_admin_rows2(MYSQL* admin, const char* query) {
+    std::vector<std::pair<std::string, std::string>> rows;
+    if (mysql_query(admin, query)) {
+        diag("Admin query failed: '%s': %s", query, mysql_error(admin));
+        return rows;
+    }
+
+    MYSQL_RES* result = mysql_store_result(admin);
+    if (result) {
+        MYSQL_ROW row;
+        while ((row = mysql_fetch_row(result))) {
+            rows.emplace_back(row[0] ? row[0] : "", row[1] ? row[1] : "");
+        }
+        mysql_free_result(result);
+    }
+    return rows;
+}
+
+class PgsqlPoolRuntimeGuard {
+public:
+    bool initialize() {
+        admin_ = mysql_init(NULL);
+        if (!admin_ || !mysql_real_connect(admin_, cl.admin_host, cl.admin_username, cl.admin_password,
+                                           NULL, cl.admin_port, NULL, 0)) {
+            diag("Unable to connect to ProxySQL admin: %s", admin_ ? mysql_error(admin_) : "mysql_init failed");
+            return false;
+        }
+
+        original_max_connections_ = pgsql_admin_rows2(admin_,
+            "SELECT hostgroup_id, max_connections FROM pgsql_servers ORDER BY hostgroup_id");
+        original_free_connections_pct_ = pgsql_admin_scalar(admin_,
+            "SELECT variable_value FROM global_variables WHERE variable_name='pgsql-free_connections_pct'");
+        if (original_max_connections_.empty() || original_free_connections_pct_.empty()) {
+            diag("Unable to snapshot PostgreSQL pool runtime configuration");
+            return false;
+        }
+
+        initialized_ = true;
+        if (!pgsql_admin_exec(admin_, "UPDATE pgsql_servers SET max_connections=1") ||
+            !pgsql_admin_exec(admin_, "LOAD PGSQL SERVERS TO RUNTIME")) {
+            return false;
+        }
+        return true;
+    }
+
+    bool set_free_connections_pct(const char* value) {
+        const std::string query = std::string("SET pgsql-free_connections_pct=") + value;
+        return pgsql_admin_exec(admin_, query.c_str()) &&
+               pgsql_admin_exec(admin_, "LOAD PGSQL VARIABLES TO RUNTIME");
+    }
+
+    bool wait_for_free_connections(const char* expected) {
+        for (int i = 0; i < 150; ++i) {
+            const std::string free_connections = pgsql_admin_scalar(admin_,
+                "SELECT IFNULL(SUM(ConnFree),0) FROM stats_pgsql_connection_pool");
+            if (free_connections == expected) return true;
+            usleep(100 * 1000);
+        }
+        diag("Timed out waiting for %s free PostgreSQL backend connection(s)", expected);
+        return false;
+    }
+
+    ~PgsqlPoolRuntimeGuard() {
+        if (initialized_) {
+            for (const auto& row : original_max_connections_) {
+                const std::string query = "UPDATE pgsql_servers SET max_connections=" + row.second +
+                                          " WHERE hostgroup_id=" + row.first;
+                pgsql_admin_exec(admin_, query.c_str());
+            }
+            pgsql_admin_exec(admin_, "LOAD PGSQL SERVERS TO RUNTIME");
+            set_free_connections_pct(original_free_connections_pct_.c_str());
+        }
+        if (admin_) mysql_close(admin_);
+    }
+
+private:
+    MYSQL* admin_{nullptr};
+    bool initialized_{false};
+    std::vector<std::pair<std::string, std::string>> original_max_connections_;
+    std::string original_free_connections_pct_;
+};
 
 bool check_logs_for_command(const std::string& command_regex) {
     // Issue #5788: log-scrape race. PROXYSQL FLUSH LOGS over a persistent
@@ -2114,10 +2223,47 @@ bool test_pipeline_with_locked_hostgroup() {
 bool test_reset_all_locked_hostgroup_pipeline() {
     diag("=== Test: RESET ALL with locked hostgroup when startup values match ===");
 
-    // Note: In this test, we rely on the fact that a fresh connection has
-    // matching startup values between client and backend (both use defaults)
+    // A new frontend can reuse a backend that was created for another client's
+    // startup options. Build that stale-backend state explicitly: it is the
+    // pool state that made this test fail in CI.
+    PgsqlPoolRuntimeGuard pool_config;
+    if (!pool_config.initialize() ||
+        !pool_config.set_free_connections_pct("0") ||
+        !pool_config.wait_for_free_connections("0") ||
+        !pool_config.set_free_connections_pct("100")) {
+        return false;
+    }
+
+    {
+        const std::string startup_value = "SQL,\\\\ DMY";
+        PGConnPtr stale_conn = createNewConnection(BACKEND, "-c DateStyle=" + startup_value);
+        if (!stale_conn) return false;
+
+        const std::string stale_datestyle = get_variable_simple(stale_conn.get(), "DateStyle");
+        if (stale_datestyle.find("SQL") == std::string::npos) {
+            diag("Expected stale backend startup DateStyle SQL, got '%s'", stale_datestyle.c_str());
+            return false;
+        }
+    }
+
+    if (!pool_config.wait_for_free_connections("1")) return false;
+
+    // The test's success path requires matching startup values. Remove the
+    // deliberately stale backend before creating the default client, so that
+    // its physical backend is created with the same startup values.
+    if (!pool_config.set_free_connections_pct("0") ||
+        !pool_config.wait_for_free_connections("0")) {
+        return false;
+    }
+
     PGConnPtr conn = createNewConnection(BACKEND);
     if (!conn) return false;
+
+    const std::string current_datestyle = get_variable_simple(conn.get(), "DateStyle");
+    if (current_datestyle.find("ISO") == std::string::npos) {
+        diag("Expected default client DateStyle ISO, got '%s'", current_datestyle.c_str());
+        return false;
+    }
 
     // Step 1: Enter pipeline mode (fresh connection, startup values match)
     if (PQenterPipelineMode(conn.get()) != 1) {

--- a/test/tap/tests/pgsql-set_statement_test-t.cpp
+++ b/test/tap/tests/pgsql-set_statement_test-t.cpp
@@ -103,8 +103,10 @@ static std::string pgsql_admin_scalar(MYSQL* admin, const char* query) {
     return value;
 }
 
-static std::vector<std::pair<std::string, std::string>> pgsql_admin_rows2(MYSQL* admin, const char* query) {
-    std::vector<std::pair<std::string, std::string>> rows;
+using AdminRows = std::vector<std::vector<std::string>>;
+
+static AdminRows pgsql_admin_rows(MYSQL* admin, const char* query) {
+    AdminRows rows;
     if (mysql_query(admin, query)) {
         diag("Admin query failed: '%s': %s", query, mysql_error(admin));
         return rows;
@@ -113,12 +115,25 @@ static std::vector<std::pair<std::string, std::string>> pgsql_admin_rows2(MYSQL*
     MYSQL_RES* result = mysql_store_result(admin);
     if (result) {
         MYSQL_ROW row;
+        const unsigned int fields = mysql_num_fields(result);
         while ((row = mysql_fetch_row(result))) {
-            rows.emplace_back(row[0] ? row[0] : "", row[1] ? row[1] : "");
+            std::vector<std::string> values;
+            values.reserve(fields);
+            for (unsigned int i = 0; i < fields; ++i) {
+                values.emplace_back(row[i] ? row[i] : "");
+            }
+            rows.push_back(std::move(values));
         }
         mysql_free_result(result);
     }
     return rows;
+}
+
+static std::string pgsql_admin_quote(MYSQL* admin, const std::string& value) {
+    std::vector<char> escaped(value.size() * 2 + 1);
+    const unsigned long escaped_length = mysql_real_escape_string(
+        admin, escaped.data(), value.c_str(), value.size());
+    return "'" + std::string(escaped.data(), escaped_length) + "'";
 }
 
 class PgsqlPoolRuntimeGuard {
@@ -131,18 +146,25 @@ public:
             return false;
         }
 
-        original_max_connections_ = pgsql_admin_rows2(admin_,
-            "SELECT hostgroup_id, max_connections FROM pgsql_servers ORDER BY hostgroup_id");
-        original_free_connections_pct_ = pgsql_admin_scalar(admin_,
-            "SELECT variable_value FROM global_variables WHERE variable_name='pgsql-free_connections_pct'");
-        if (original_max_connections_.empty() || original_free_connections_pct_.empty()) {
-            diag("Unable to snapshot PostgreSQL pool runtime configuration");
+        original_main_servers_ = pgsql_admin_rows(admin_, pgsql_servers_select("pgsql_servers").c_str());
+        original_runtime_servers_ = pgsql_admin_rows(admin_, pgsql_servers_select("runtime_pgsql_servers").c_str());
+        original_main_variables_ = pgsql_admin_rows(admin_,
+            "SELECT variable_name, variable_value FROM global_variables "
+            "WHERE variable_name LIKE 'pgsql-%' ORDER BY variable_name");
+        original_runtime_variables_ = pgsql_admin_rows(admin_,
+            "SELECT variable_name, variable_value FROM runtime_global_variables "
+            "WHERE variable_name LIKE 'pgsql-%' ORDER BY variable_name");
+        if (original_main_servers_.empty() || original_runtime_servers_.empty() ||
+            original_main_variables_.empty() || original_runtime_variables_.empty()) {
+            diag("Unable to snapshot PostgreSQL main and runtime configuration");
             return false;
         }
 
         initialized_ = true;
-        if (!pgsql_admin_exec(admin_, "UPDATE pgsql_servers SET max_connections=1") ||
-            !pgsql_admin_exec(admin_, "LOAD PGSQL SERVERS TO RUNTIME")) {
+        if (!replace_main_servers(original_runtime_servers_) ||
+            !replace_main_variables(original_runtime_variables_) ||
+            !pgsql_admin_exec(admin_, "UPDATE pgsql_servers SET max_connections=1") ||
+            !load_pool_configuration()) {
             return false;
         }
         return true;
@@ -165,24 +187,85 @@ public:
         return false;
     }
 
-    ~PgsqlPoolRuntimeGuard() {
-        if (initialized_) {
-            for (const auto& row : original_max_connections_) {
-                const std::string query = "UPDATE pgsql_servers SET max_connections=" + row.second +
-                                          " WHERE hostgroup_id=" + row.first;
-                pgsql_admin_exec(admin_, query.c_str());
-            }
-            pgsql_admin_exec(admin_, "LOAD PGSQL SERVERS TO RUNTIME");
-            set_free_connections_pct(original_free_connections_pct_.c_str());
+    bool restore() {
+        if (!initialized_ || restored_) return true;
+        restored_ = true;
+
+        bool restored = true;
+        if (!replace_main_servers(original_runtime_servers_) ||
+            !replace_main_variables(original_runtime_variables_) ||
+            !load_pool_configuration()) {
+            diag("Failed to restore PostgreSQL pool runtime configuration");
+            restored = false;
         }
+        if (!replace_main_servers(original_main_servers_) ||
+            !replace_main_variables(original_main_variables_)) {
+            diag("Failed to restore PostgreSQL main configuration after pool test");
+            restored = false;
+        }
+        return restored;
+    }
+
+    ~PgsqlPoolRuntimeGuard() {
+        restore();
         if (admin_) mysql_close(admin_);
     }
 
 private:
+    static std::string pgsql_servers_select(const char* table) {
+        return std::string("SELECT hostgroup_id, hostname, port, status, weight, compression, ") +
+               "max_connections, max_replication_lag, use_ssl, max_latency_ms, comment FROM " +
+               table + " ORDER BY hostgroup_id, hostname, port";
+    }
+
+    bool replace_main_servers(const AdminRows& servers) {
+        if (!pgsql_admin_exec(admin_, "DELETE FROM pgsql_servers")) return false;
+
+        for (const auto& server : servers) {
+            if (server.size() != 11) {
+                diag("Unexpected pgsql_servers row width while restoring configuration");
+                return false;
+            }
+            std::string query = "INSERT INTO pgsql_servers (hostgroup_id, hostname, port, status, weight, "
+                                "compression, max_connections, max_replication_lag, use_ssl, max_latency_ms, "
+                                "comment) VALUES (";
+            for (size_t i = 0; i < server.size(); ++i) {
+                if (i) query += ", ";
+                query += pgsql_admin_quote(admin_, server[i]);
+            }
+            query += ")";
+            if (!pgsql_admin_exec(admin_, query.c_str())) return false;
+        }
+        return true;
+    }
+
+    bool replace_main_variables(const AdminRows& variables) {
+        for (const auto& variable : variables) {
+            if (variable.size() != 2) {
+                diag("Unexpected pgsql variable row width while restoring configuration");
+                return false;
+            }
+            const std::string query = "INSERT OR REPLACE INTO global_variables "
+                                      "(variable_name, variable_value) VALUES (" +
+                                      pgsql_admin_quote(admin_, variable[0]) + ", " +
+                                      pgsql_admin_quote(admin_, variable[1]) + ")";
+            if (!pgsql_admin_exec(admin_, query.c_str())) return false;
+        }
+        return true;
+    }
+
+    bool load_pool_configuration() {
+        return pgsql_admin_exec(admin_, "LOAD PGSQL SERVERS TO RUNTIME") &&
+               pgsql_admin_exec(admin_, "LOAD PGSQL VARIABLES TO RUNTIME");
+    }
+
     MYSQL* admin_{nullptr};
     bool initialized_{false};
-    std::vector<std::pair<std::string, std::string>> original_max_connections_;
-    std::string original_free_connections_pct_;
+    bool restored_{false};
+    AdminRows original_main_servers_;
+    AdminRows original_runtime_servers_;
+    AdminRows original_main_variables_;
+    AdminRows original_runtime_variables_;
 };
 
 bool check_logs_for_command(const std::string& command_regex) {
@@ -2240,8 +2323,8 @@ bool test_reset_all_locked_hostgroup_pipeline() {
         if (!stale_conn) return false;
 
         const std::string stale_datestyle = get_variable_simple(stale_conn.get(), "DateStyle");
-        if (stale_datestyle.find("SQL") == std::string::npos) {
-            diag("Expected stale backend startup DateStyle SQL, got '%s'", stale_datestyle.c_str());
+        if (stale_datestyle != "SQL, DMY") {
+            diag("Expected stale backend startup DateStyle 'SQL, DMY', got '%s'", stale_datestyle.c_str());
             return false;
         }
     }
@@ -2260,8 +2343,8 @@ bool test_reset_all_locked_hostgroup_pipeline() {
     if (!conn) return false;
 
     const std::string current_datestyle = get_variable_simple(conn.get(), "DateStyle");
-    if (current_datestyle.find("ISO") == std::string::npos) {
-        diag("Expected default client DateStyle ISO, got '%s'", current_datestyle.c_str());
+    if (current_datestyle != "ISO, MDY") {
+        diag("Expected default client DateStyle 'ISO, MDY', got '%s'", current_datestyle.c_str());
         return false;
     }
 
@@ -2336,7 +2419,9 @@ bool test_reset_all_locked_hostgroup_pipeline() {
     bool conn_ok = (PQresultStatus(res) == PGRES_TUPLES_OK);
     PQclear(res);
 
-    return lock_ok && reset_ok && conn_ok;
+    const bool test_ok = lock_ok && reset_ok && conn_ok;
+    conn.reset();
+    return pool_config.restore() && test_ok;
 }
 
 // Test: DISCARD ALL with locked hostgroup in pipeline mode


### PR DESCRIPTION
Fixes #6160.

## Problem

`pgsql-set_statement_test-t` assumed that a fresh frontend client always receives a physical PostgreSQL backend with the same startup values. That is not guaranteed by pooling.

The affected scenario is:

1. A physical backend is created for a client using `options=-c DateStyle=SQL, DMY`.
2. The client disconnects and the backend remains in the free pool.
3. A later default client uses `DateStyle=ISO, MDY` but is assigned that existing physical backend.
4. In pipeline mode, after the session becomes locked to a hostgroup, `RESET ALL` is correctly rejected. PostgreSQL would restore the physical backend's original startup value, so ProxySQL's safety guard prevents a state mismatch.

The product code is intentionally left unchanged: the guard in `PgSQL_Session.cpp` is correct and safety-preserving. The test had an implicit pooled-state dependency.

## Fix

Make the test construct both relevant states explicitly, using runtime-only administration:

- Snapshot each `pgsql_servers.max_connections` value and `pgsql-free_connections_pct`.
- Cap runtime capacity and drain the free pool.
- Create and retain one backend with `DateStyle=SQL, DMY`, proving the stale-backend state.
- Drain that deliberately stale backend before creating the default client used by the existing success-path assertion.
- Restore every changed runtime value with RAII, including on early failure.

There are no `SAVE ... TO DISK` or `LOAD ... FROM DISK` commands. TAP tests do not persist or alter disk configuration.

## Validation

Reproduced the pre-fix failure in the documented isolated test environment:

```
WORKSPACE=$(pwd) INFRA_ID=issue-6160-red TAP_GROUP=legacy-g4 SKIP_CLUSTER_START=1 \
  TEST_PY_TAP_INCL='^pgsql-set_statement_test-t$' \
  test/infra/control/run-tests-isolated.bash
```

The red run reached the target assertion and failed with:

```
ERROR: RESET ALL is not supported when hostgroup is locked and connection startup values differ.
Mismatched variables: DateStyle
not ok 70 - RESET ALL with locked hostgroup in pipeline mode
```

With the fix, the same documented isolated runner passed twice:

```
ok 70 - RESET ALL with locked hostgroup in pipeline mode
```

Also passed:

```
PROXYSQL31=1 make -j"$(nproc)" debug
PROXYSQL31=1 make build_tap_test_debug
test/infra/control/run-ci-lint.bash
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `pgsql-set_statement_test-t` TAP test so it no longer assumes a fresh frontend client always gets a physical backend with default startup values. The test now explicitly creates and drains a stale backend before verifying `RESET ALL` in locked hostgroup pipeline mode. Fixes #6160.

**Bug Fixes**
- The test uses runtime admin commands to cap `pgsql_servers.max_connections` and drain the free pool, restoring all values with RAII on early failure.
- No product code or persisted configuration is changed.

<sup>Written for commit ed75ddbf865bb89506e2f3fe1f4ef430c0bb1c27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL connection pool reliability during configuration resets and connection reuse.
  * Ensured server and session settings are fully restored after administrative operations.
  * Strengthened validation of date-format settings and result handling to prevent inconsistent behavior.
  * Improved recovery when configuration restoration encounters an error.
  * Improved handling of quoted values across SQL compatibility modes.
  * Preserved complete result sets when administrative queries return varying numbers of columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->