### PR TITLE
Fix bootstrap user import with caching_sha2_password

### DIFF
--- a/include/proxysql_admin.h
+++ b/include/proxysql_admin.h
@@ -149,6 +149,12 @@ struct bootstrap_info_t {
 	~bootstrap_info_t();
 };
 
+/**
+ * Atomically replaces mysql_users with users returned by the bootstrap query.
+ * MySQL field lengths are preserved when binding values to SQLite.
+ */
+bool import_bootstrap_users(SQLite3DB* db, MYSQL_RES* users, std::string& error);
+
 // ProxySQL_Admin shared variables
 extern int admin__web_verbosity;
 

--- a/lib/Admin_Bootstrap.cpp
+++ b/lib/Admin_Bootstrap.cpp
@@ -252,14 +252,6 @@ struct BOOT_SRV_INFO_T {
 	};
 };
 
-struct boot_user_info_t {
-	string user;
-	string ssl_type;
-	string auth_string;
-	string auth_plugin;
-	bool password_expired;
-};
-
 struct BOOT_USER_INFO_T {
 	enum {
 		USER,
@@ -329,47 +321,107 @@ string build_boot_servers_insert(const vector<boot_srv_cnf_t>& srvs_info_defs) {
 	return servers_insert;
 }
 
-string build_boot_users_insert(MYSQL_RES* users) {
-	vector<boot_user_info_t> users_info {};
+bool import_bootstrap_users(SQLite3DB* db, MYSQL_RES* users, string& error) {
+	error.clear();
+
+	if (db == nullptr || users == nullptr) {
+		error = "Invalid bootstrap user import arguments";
+		return false;
+	}
+
+	auto sqlite_error = [db](const char* operation) {
+		return cstr_format("%s: %s", operation, (*proxy_sqlite3_errmsg)(db->get_db())).str;
+	};
+	auto rollback = [db, &error]() {
+		if (!db->execute("ROLLBACK")) {
+			error += "; rollback failed";
+		}
+	};
+
+	if (!db->execute("BEGIN IMMEDIATE")) {
+		error = sqlite_error("Failed to begin mysql_users import");
+		return false;
+	}
+
+	auto [rc, stmt] = db->prepare_v2(
+		"INSERT INTO mysql_users (username,password,active,use_ssl) VALUES (?1,?2,1,?3)"
+	);
+	if (rc != SQLITE_OK) {
+		error = sqlite_error("Failed to prepare mysql_users import");
+		rollback();
+		return false;
+	}
+
+	if (!db->execute("DELETE FROM mysql_users")) {
+		error = sqlite_error("Failed to clear mysql_users");
+		rollback();
+		return false;
+	}
 
 	while (MYSQL_ROW row = mysql_fetch_row(users)) {
-		users_info.push_back({
-			string { row[BOOT_USER_INFO_T::USER] },
-			string { row[BOOT_USER_INFO_T::SSL_TYPE] },
-			string { row[BOOT_USER_INFO_T::AUTH_STRING] },
-			string { row[BOOT_USER_INFO_T::AUTH_PLUGIN] },
-			static_cast<bool>(atoi(row[BOOT_USER_INFO_T::PASSWORD_EXPIRED]))
-		});
-	}
-
-	// MySQL Users
-	const string t_users_insert {
-		"INSERT INTO mysql_users (username,password,active,use_ssl) VALUES "
-	};
-	string t_users_values {};
-
-	for (const boot_user_info_t& user : users_info) {
-		uint32_t use_ssl = user.ssl_type.empty() ? 0 : 1;
-		const char t_values[] { "(\"%s\", \"%s\", %d, %d)" };
-
-		string srv_values = cstr_format(
-			t_values,
-			user.user.c_str(),        // USERNAME
-			user.auth_string.c_str(), // HOSTNAME
-			1,                        // ACTIVE: Always ON
-			use_ssl                   // USE_SSL: Dependent on backend user
-		).str;
-
-		if (&user != &users_info.back()) {
-			srv_values += ",";
+		unsigned long* lengths = mysql_fetch_lengths(users);
+		if (lengths == nullptr || row[BOOT_USER_INFO_T::USER] == nullptr) {
+			error = "Bootstrap user row is missing its username or field lengths";
+			rollback();
+			return false;
 		}
 
-		t_users_values += srv_values;
+		const unsigned long username_len = lengths[BOOT_USER_INFO_T::USER];
+		const unsigned long password_len = lengths[BOOT_USER_INFO_T::AUTH_STRING];
+		if (username_len > static_cast<unsigned long>(std::numeric_limits<int>::max()) ||
+			password_len > static_cast<unsigned long>(std::numeric_limits<int>::max())) {
+			error = "Bootstrap username or password exceeds SQLite's binding limit";
+			rollback();
+			return false;
+		}
+
+		rc = (*proxy_sqlite3_bind_text)(
+			stmt.get(), 1, row[BOOT_USER_INFO_T::USER], static_cast<int>(username_len), SQLITE_TRANSIENT
+		);
+		if (rc == SQLITE_OK && row[BOOT_USER_INFO_T::AUTH_STRING] == nullptr) {
+			rc = (*proxy_sqlite3_bind_null)(stmt.get(), 2);
+		} else if (rc == SQLITE_OK) {
+			rc = (*proxy_sqlite3_bind_text)(
+				stmt.get(), 2, row[BOOT_USER_INFO_T::AUTH_STRING],
+				static_cast<int>(password_len), SQLITE_TRANSIENT
+			);
+		}
+		if (rc == SQLITE_OK) {
+			const int use_ssl = row[BOOT_USER_INFO_T::SSL_TYPE] != nullptr &&
+				lengths[BOOT_USER_INFO_T::SSL_TYPE] != 0;
+			rc = (*proxy_sqlite3_bind_int)(stmt.get(), 3, use_ssl);
+		}
+		if (rc != SQLITE_OK) {
+			error = sqlite_error("Failed to bind bootstrap user");
+			rollback();
+			return false;
+		}
+
+		SAFE_SQLITE3_STEP2(stmt.get());
+		if (rc != SQLITE_DONE) {
+			error = sqlite_error("Failed to insert bootstrap user");
+			rollback();
+			return false;
+		}
+
+		rc = (*proxy_sqlite3_reset)(stmt.get());
+		if (rc == SQLITE_OK) {
+			rc = (*proxy_sqlite3_clear_bindings)(stmt.get());
+		}
+		if (rc != SQLITE_OK) {
+			error = sqlite_error("Failed to reset mysql_users import statement");
+			rollback();
+			return false;
+		}
 	}
 
-	const string users_insert { t_users_insert + t_users_values };
+	if (!db->execute("COMMIT")) {
+		error = sqlite_error("Failed to commit mysql_users import");
+		rollback();
+		return false;
+	}
 
-	return users_insert;
+	return true;
 }
 
 map<uint64_t,srv_defs_t> get_cur_hg_attrs(SQLite3DB* admindb) {
@@ -1171,9 +1223,11 @@ bool ProxySQL_Admin::init(const bootstrap_info_t& bootstrap_info) {
 		admindb->execute("DELETE FROM mysql_servers");
 		admindb->execute(servers_insert.c_str());
 
-		const string users_insert { build_boot_users_insert(bootstrap_info.users) };
-		admindb->execute("DELETE FROM mysql_users");
-		admindb->execute(users_insert.c_str());
+		string users_import_error {};
+		if (!import_bootstrap_users(admindb, bootstrap_info.users, users_import_error)) {
+			proxy_error("Bootstrap failed while importing MySQL users: %s\n", users_import_error.c_str());
+			return false;
+		}
 
 		// Make the configuration persistent
 		flush_GENERIC__from_to("mysql_servers", "memory_to_disk");

--- a/lib/Admin_Bootstrap.cpp
+++ b/lib/Admin_Bootstrap.cpp
@@ -321,6 +321,74 @@ string build_boot_servers_insert(const vector<boot_srv_cnf_t>& srvs_info_defs) {
 	return servers_insert;
 }
 
+/** Formats the current SQLite error with bootstrap import context. */
+static string bootstrap_users_sqlite_error(SQLite3DB* db, const char* operation) {
+	return cstr_format("%s: %s", operation, (*proxy_sqlite3_errmsg)(db->get_db())).str;
+}
+
+/** Rolls back a bootstrap user import while preserving its original error. */
+static void rollback_bootstrap_users(SQLite3DB* db, string& error) {
+	if (!db->execute("ROLLBACK")) {
+		error += "; rollback failed";
+	}
+}
+
+/** Binds and inserts one bootstrap user without interpreting credential bytes. */
+static bool insert_bootstrap_user(
+	SQLite3DB* db, sqlite3_stmt* stmt, MYSQL_ROW row, unsigned long* lengths, string& error
+) {
+	if (lengths == nullptr || row[BOOT_USER_INFO_T::USER] == nullptr) {
+		error = "Bootstrap user row is missing its username or field lengths";
+		return false;
+	}
+
+	const unsigned long username_len = lengths[BOOT_USER_INFO_T::USER];
+	const unsigned long auth_string_len = lengths[BOOT_USER_INFO_T::AUTH_STRING];
+	if (username_len > static_cast<unsigned long>(std::numeric_limits<int>::max()) ||
+		auth_string_len > static_cast<unsigned long>(std::numeric_limits<int>::max())) {
+		error = "Bootstrap username or password exceeds SQLite's binding limit";
+		return false;
+	}
+
+	int rc = (*proxy_sqlite3_bind_text)(
+		stmt, 1, row[BOOT_USER_INFO_T::USER], static_cast<int>(username_len), SQLITE_TRANSIENT
+	);
+	if (rc == SQLITE_OK && row[BOOT_USER_INFO_T::AUTH_STRING] == nullptr) {
+		rc = (*proxy_sqlite3_bind_null)(stmt, 2);
+	} else if (rc == SQLITE_OK) {
+		rc = (*proxy_sqlite3_bind_text)(
+			stmt, 2, row[BOOT_USER_INFO_T::AUTH_STRING],
+			static_cast<int>(auth_string_len), SQLITE_TRANSIENT
+		);
+	}
+	if (rc == SQLITE_OK) {
+		const int use_ssl = row[BOOT_USER_INFO_T::SSL_TYPE] != nullptr &&
+			lengths[BOOT_USER_INFO_T::SSL_TYPE] != 0;
+		rc = (*proxy_sqlite3_bind_int)(stmt, 3, use_ssl);
+	}
+	if (rc != SQLITE_OK) {
+		error = bootstrap_users_sqlite_error(db, "Failed to bind bootstrap user");
+		return false;
+	}
+
+	SAFE_SQLITE3_STEP2(stmt);
+	if (rc != SQLITE_DONE) {
+		error = bootstrap_users_sqlite_error(db, "Failed to insert bootstrap user");
+		return false;
+	}
+
+	rc = (*proxy_sqlite3_reset)(stmt);
+	if (rc == SQLITE_OK) {
+		rc = (*proxy_sqlite3_clear_bindings)(stmt);
+	}
+	if (rc != SQLITE_OK) {
+		error = bootstrap_users_sqlite_error(db, "Failed to reset mysql_users import statement");
+		return false;
+	}
+
+	return true;
+}
+
 bool import_bootstrap_users(SQLite3DB* db, MYSQL_RES* users, string& error) {
 	error.clear();
 
@@ -329,17 +397,8 @@ bool import_bootstrap_users(SQLite3DB* db, MYSQL_RES* users, string& error) {
 		return false;
 	}
 
-	auto sqlite_error = [db](const char* operation) {
-		return cstr_format("%s: %s", operation, (*proxy_sqlite3_errmsg)(db->get_db())).str;
-	};
-	auto rollback = [db, &error]() {
-		if (!db->execute("ROLLBACK")) {
-			error += "; rollback failed";
-		}
-	};
-
 	if (!db->execute("BEGIN IMMEDIATE")) {
-		error = sqlite_error("Failed to begin mysql_users import");
+		error = bootstrap_users_sqlite_error(db, "Failed to begin mysql_users import");
 		return false;
 	}
 
@@ -347,77 +406,27 @@ bool import_bootstrap_users(SQLite3DB* db, MYSQL_RES* users, string& error) {
 		"INSERT INTO mysql_users (username,password,active,use_ssl) VALUES (?1,?2,1,?3)"
 	);
 	if (rc != SQLITE_OK) {
-		error = sqlite_error("Failed to prepare mysql_users import");
-		rollback();
+		error = bootstrap_users_sqlite_error(db, "Failed to prepare mysql_users import");
+		rollback_bootstrap_users(db, error);
 		return false;
 	}
 
 	if (!db->execute("DELETE FROM mysql_users")) {
-		error = sqlite_error("Failed to clear mysql_users");
-		rollback();
+		error = bootstrap_users_sqlite_error(db, "Failed to clear mysql_users");
+		rollback_bootstrap_users(db, error);
 		return false;
 	}
 
 	while (MYSQL_ROW row = mysql_fetch_row(users)) {
-		unsigned long* lengths = mysql_fetch_lengths(users);
-		if (lengths == nullptr || row[BOOT_USER_INFO_T::USER] == nullptr) {
-			error = "Bootstrap user row is missing its username or field lengths";
-			rollback();
-			return false;
-		}
-
-		const unsigned long username_len = lengths[BOOT_USER_INFO_T::USER];
-		const unsigned long password_len = lengths[BOOT_USER_INFO_T::AUTH_STRING];
-		if (username_len > static_cast<unsigned long>(std::numeric_limits<int>::max()) ||
-			password_len > static_cast<unsigned long>(std::numeric_limits<int>::max())) {
-			error = "Bootstrap username or password exceeds SQLite's binding limit";
-			rollback();
-			return false;
-		}
-
-		rc = (*proxy_sqlite3_bind_text)(
-			stmt.get(), 1, row[BOOT_USER_INFO_T::USER], static_cast<int>(username_len), SQLITE_TRANSIENT
-		);
-		if (rc == SQLITE_OK && row[BOOT_USER_INFO_T::AUTH_STRING] == nullptr) {
-			rc = (*proxy_sqlite3_bind_null)(stmt.get(), 2);
-		} else if (rc == SQLITE_OK) {
-			rc = (*proxy_sqlite3_bind_text)(
-				stmt.get(), 2, row[BOOT_USER_INFO_T::AUTH_STRING],
-				static_cast<int>(password_len), SQLITE_TRANSIENT
-			);
-		}
-		if (rc == SQLITE_OK) {
-			const int use_ssl = row[BOOT_USER_INFO_T::SSL_TYPE] != nullptr &&
-				lengths[BOOT_USER_INFO_T::SSL_TYPE] != 0;
-			rc = (*proxy_sqlite3_bind_int)(stmt.get(), 3, use_ssl);
-		}
-		if (rc != SQLITE_OK) {
-			error = sqlite_error("Failed to bind bootstrap user");
-			rollback();
-			return false;
-		}
-
-		SAFE_SQLITE3_STEP2(stmt.get());
-		if (rc != SQLITE_DONE) {
-			error = sqlite_error("Failed to insert bootstrap user");
-			rollback();
-			return false;
-		}
-
-		rc = (*proxy_sqlite3_reset)(stmt.get());
-		if (rc == SQLITE_OK) {
-			rc = (*proxy_sqlite3_clear_bindings)(stmt.get());
-		}
-		if (rc != SQLITE_OK) {
-			error = sqlite_error("Failed to reset mysql_users import statement");
-			rollback();
+		if (!insert_bootstrap_user(db, stmt.get(), row, mysql_fetch_lengths(users), error)) {
+			rollback_bootstrap_users(db, error);
 			return false;
 		}
 	}
 
 	if (!db->execute("COMMIT")) {
-		error = sqlite_error("Failed to commit mysql_users import");
-		rollback();
+		error = bootstrap_users_sqlite_error(db, "Failed to commit mysql_users import");
+		rollback_bootstrap_users(db, error);
 		return false;
 	}
 

--- a/lib/Admin_Bootstrap.cpp
+++ b/lib/Admin_Bootstrap.cpp
@@ -417,6 +417,7 @@ bool import_bootstrap_users(SQLite3DB* db, MYSQL_RES* users, string& error) {
 		return false;
 	}
 
+	mysql_data_seek(users, 0);
 	while (MYSQL_ROW row = mysql_fetch_row(users)) {
 		if (!insert_bootstrap_user(db, stmt.get(), row, mysql_fetch_lengths(users), error)) {
 			rollback_bootstrap_users(db, error);

--- a/test/tap/groups/groups.json
+++ b/test/tap/groups/groups.json
@@ -1,5 +1,6 @@
 {
   "admin-listen_on_unix-t" : [ "legacy-g1","mariadb10-galera-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],
+  "admin_bootstrap_users_unit-t" : [ "unit-tests-g1" ],
   "admin_disk_upgrade_unit-t" : [ "unit-tests-g1" ],
   "admin_set_credentials_logging-t" : [ "no-infra-g1" ],
   "admin_show_create_table-t" : [ "legacy-g1","mariadb10-galera-g1","mysql-auto_increment_delay_multiplex=0-g1","mysql-multiplexing=false-g1","mysql-query_digests=0-g1","mysql-query_digests_keep_comment=1-g1","mysql84-g1","mysql84-gr-g1","mysql90-g1","mysql90-gr-g1","mysql93-g1","mysql93-gr-g1","mysql95-g1","mysql95-gr-g1" ],

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -478,6 +478,7 @@ UNIT_TESTS := smoke_test-t vendored_openssl_version_unit-t \
 	gtid_trxid_interval_unit-t \
 	gtid_set_unit-t \
 	gtid_server_data_unit-t \
+	admin_bootstrap_users_unit-t \
 	admin_disk_upgrade_unit-t \
 	glovars_unit-t \
 	pgsql_servers_ssl_params_unit-t \

--- a/test/tap/tests/unit/admin_bootstrap_users_unit-t.cpp
+++ b/test/tap/tests/unit/admin_bootstrap_users_unit-t.cpp
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -23,9 +24,9 @@ namespace {
 constexpr size_t USER_FIELD_COUNT = 5;
 using user_row_t = std::array<std::string, USER_FIELD_COUNT>;
 
-class mysql_result_fixture_t {
+class MySQL_Result_Fixture {
 public:
-	explicit mysql_result_fixture_t(const std::vector<user_row_t>& values)
+	explicit MySQL_Result_Fixture(const std::vector<user_row_t>& values)
 		: buffers_(values.size()), row_ptrs_(values.size()), rows_(values.size()) {
 		for (size_t row_idx = 0; row_idx < values.size(); ++row_idx) {
 			size_t buffer_size = 0;
@@ -70,28 +71,19 @@ private:
 	std::vector<MYSQL_ROWS> rows_;
 };
 
-SQLite3_result* query(SQLite3DB& db, const char* sql) {
-	char* error = nullptr;
-	SQLite3_result* result = db.execute_statement(sql, &error);
-	if (error != nullptr) {
-		diag("Query failed: %s", error);
-		free(error);
-	}
-	return result;
-}
-
 void test_import_preserves_sql_metacharacters() {
 	SQLite3DB db;
-	db.open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
+	char db_path[] { ":memory:" };
+	db.open(db_path, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
 	db.execute(ADMIN_SQLITE_TABLE_MYSQL_USERS);
 	db.execute("INSERT INTO mysql_users (username,password) VALUES ('old_user','old_password')");
 
 	const std::string username { "quoted\"user" };
-	const std::string password {
+	const std::string auth_string {
 		"$A$005$[:V=2k#\t\"SP+AgqtYBw6HA0wp/3.73nwB/oSh5eAzZxtu2Vc1SJMTrUTn8WLB"
 	};
-	mysql_result_fixture_t users {{
-		{ username, "ANY", password, "caching_sha2_password", "N" },
+	MySQL_Result_Fixture users {{
+		{ username, "ANY", auth_string, "caching_sha2_password", "N" },
 		{ "plain_user", "", "plain_password", "mysql_native_password", "N" }
 	}};
 
@@ -101,15 +93,16 @@ void test_import_preserves_sql_metacharacters() {
 	ok(db.return_one_int("SELECT COUNT(*) FROM mysql_users") == 2,
 		"bootstrap import atomically replaces the previous users");
 
-	SQLite3_result* result = query(db,
-		"SELECT username,password,use_ssl FROM mysql_users WHERE username='quoted\"user'");
+	std::unique_ptr<SQLite3_result> result { db.execute_statement(
+		"SELECT username,password,use_ssl FROM mysql_users WHERE username='quoted\"user'"
+	) };
 	ok(result != nullptr && result->rows_count == 1,
 		"bootstrap import stores a username containing a double quote");
 	if (result != nullptr && result->rows_count == 1) {
 		SQLite3_row* row = result->rows[0];
 		ok(std::string(row->fields[0], row->sizes[0]) == username,
 			"bootstrap import preserves the exact username bytes");
-		ok(std::string(row->fields[1], row->sizes[1]) == password,
+		ok(std::string(row->fields[1], row->sizes[1]) == auth_string,
 			"bootstrap import preserves the exact caching_sha2_password bytes");
 		ok(strcmp(row->fields[2], "1") == 0,
 			"bootstrap import maps a non-empty ssl_type to use_ssl=1");
@@ -118,16 +111,16 @@ void test_import_preserves_sql_metacharacters() {
 		ok(false, "bootstrap import preserves the exact caching_sha2_password bytes");
 		ok(false, "bootstrap import maps a non-empty ssl_type to use_ssl=1");
 	}
-	delete result;
 }
 
 void test_failed_import_rolls_back() {
 	SQLite3DB db;
-	db.open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
+	char db_path[] { ":memory:" };
+	db.open(db_path, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
 	db.execute(ADMIN_SQLITE_TABLE_MYSQL_USERS);
 	db.execute("INSERT INTO mysql_users (username,password) VALUES ('old_user','old_password')");
 
-	mysql_result_fixture_t users {{
+	MySQL_Result_Fixture users {{
 		{ "duplicate", "", "first", "mysql_native_password", "N" },
 		{ "duplicate", "", "second", "mysql_native_password", "N" }
 	}};

--- a/test/tap/tests/unit/admin_bootstrap_users_unit-t.cpp
+++ b/test/tap/tests/unit/admin_bootstrap_users_unit-t.cpp
@@ -1,0 +1,156 @@
+/**
+ * @file admin_bootstrap_users_unit-t.cpp
+ * @brief Regression coverage for bootstrap user imports (issue #6159).
+ */
+
+#include "tap.h"
+#include "test_globals.h"
+#include "test_init.h"
+
+#include "ProxySQL_Admin_Tables_Definitions.h"
+#include "mysql.h"
+#include "sqlite3db.h"
+
+#include <array>
+#include <cstring>
+#include <string>
+#include <vector>
+
+bool import_bootstrap_users(SQLite3DB* db, MYSQL_RES* users, std::string& error);
+
+namespace {
+
+constexpr size_t USER_FIELD_COUNT = 5;
+using user_row_t = std::array<std::string, USER_FIELD_COUNT>;
+
+class mysql_result_fixture_t {
+public:
+	explicit mysql_result_fixture_t(const std::vector<user_row_t>& values)
+		: buffers_(values.size()), row_ptrs_(values.size()), rows_(values.size()) {
+		for (size_t row_idx = 0; row_idx < values.size(); ++row_idx) {
+			size_t buffer_size = 0;
+			for (const std::string& value : values[row_idx]) {
+				buffer_size += value.size() + 1;
+			}
+
+			buffers_[row_idx].resize(buffer_size);
+			size_t offset = 0;
+			for (size_t field_idx = 0; field_idx < USER_FIELD_COUNT; ++field_idx) {
+				const std::string& value = values[row_idx][field_idx];
+				row_ptrs_[row_idx][field_idx] = buffers_[row_idx].data() + offset;
+				memcpy(buffers_[row_idx].data() + offset, value.data(), value.size());
+				offset += value.size();
+				buffers_[row_idx][offset++] = '\0';
+			}
+			// MariaDB Connector/C derives buffered-result lengths from the next
+			// field pointer, including this sentinel after the final field.
+			row_ptrs_[row_idx][USER_FIELD_COUNT] = buffers_[row_idx].data() + offset;
+			rows_[row_idx].data = row_ptrs_[row_idx].data();
+			rows_[row_idx].next = row_idx + 1 < rows_.size() ? &rows_[row_idx + 1] : nullptr;
+		}
+
+		data_.data = rows_.empty() ? nullptr : rows_.data();
+		data_.rows = rows_.size();
+		data_.fields = USER_FIELD_COUNT;
+		result_.field_count = USER_FIELD_COUNT;
+		result_.row_count = rows_.size();
+		result_.data = &data_;
+		result_.data_cursor = data_.data;
+		result_.lengths = lengths_.data();
+	}
+
+	MYSQL_RES* get() { return &result_; }
+
+private:
+	MYSQL_RES result_ {};
+	MYSQL_DATA data_ {};
+	std::array<unsigned long, USER_FIELD_COUNT> lengths_ {};
+	std::vector<std::vector<char>> buffers_;
+	std::vector<std::array<char*, USER_FIELD_COUNT + 1>> row_ptrs_;
+	std::vector<MYSQL_ROWS> rows_;
+};
+
+SQLite3_result* query(SQLite3DB& db, const char* sql) {
+	char* error = nullptr;
+	SQLite3_result* result = db.execute_statement(sql, &error);
+	if (error != nullptr) {
+		diag("Query failed: %s", error);
+		free(error);
+	}
+	return result;
+}
+
+void test_import_preserves_sql_metacharacters() {
+	SQLite3DB db;
+	db.open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
+	db.execute(ADMIN_SQLITE_TABLE_MYSQL_USERS);
+	db.execute("INSERT INTO mysql_users (username,password) VALUES ('old_user','old_password')");
+
+	const std::string username { "quoted\"user" };
+	const std::string password {
+		"$A$005$[:V=2k#\t\"SP+AgqtYBw6HA0wp/3.73nwB/oSh5eAzZxtu2Vc1SJMTrUTn8WLB"
+	};
+	mysql_result_fixture_t users {{
+		{ username, "ANY", password, "caching_sha2_password", "N" },
+		{ "plain_user", "", "plain_password", "mysql_native_password", "N" }
+	}};
+
+	std::string error;
+	const bool imported = import_bootstrap_users(&db, users.get(), error);
+	ok(imported, "bootstrap import accepts quotes and control characters: %s", error.c_str());
+	ok(db.return_one_int("SELECT COUNT(*) FROM mysql_users") == 2,
+		"bootstrap import atomically replaces the previous users");
+
+	SQLite3_result* result = query(db,
+		"SELECT username,password,use_ssl FROM mysql_users WHERE username='quoted\"user'");
+	ok(result != nullptr && result->rows_count == 1,
+		"bootstrap import stores a username containing a double quote");
+	if (result != nullptr && result->rows_count == 1) {
+		SQLite3_row* row = result->rows[0];
+		ok(std::string(row->fields[0], row->sizes[0]) == username,
+			"bootstrap import preserves the exact username bytes");
+		ok(std::string(row->fields[1], row->sizes[1]) == password,
+			"bootstrap import preserves the exact caching_sha2_password bytes");
+		ok(strcmp(row->fields[2], "1") == 0,
+			"bootstrap import maps a non-empty ssl_type to use_ssl=1");
+	} else {
+		ok(false, "bootstrap import preserves the exact username bytes");
+		ok(false, "bootstrap import preserves the exact caching_sha2_password bytes");
+		ok(false, "bootstrap import maps a non-empty ssl_type to use_ssl=1");
+	}
+	delete result;
+}
+
+void test_failed_import_rolls_back() {
+	SQLite3DB db;
+	db.open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
+	db.execute(ADMIN_SQLITE_TABLE_MYSQL_USERS);
+	db.execute("INSERT INTO mysql_users (username,password) VALUES ('old_user','old_password')");
+
+	mysql_result_fixture_t users {{
+		{ "duplicate", "", "first", "mysql_native_password", "N" },
+		{ "duplicate", "", "second", "mysql_native_password", "N" }
+	}};
+
+	std::string error;
+	const bool imported = import_bootstrap_users(&db, users.get(), error);
+	ok(!imported, "bootstrap import reports a row insertion failure");
+	ok(!error.empty(), "bootstrap import supplies an error for a failed row");
+	ok(db.return_one_int("SELECT COUNT(*) FROM mysql_users") == 1,
+		"failed bootstrap import preserves the previous user set");
+	ok(db.return_one_int("SELECT COUNT(*) FROM mysql_users WHERE username='old_user'") == 1,
+		"failed bootstrap import rolls back the initial delete");
+}
+
+} // namespace
+
+int main() {
+	plan(10);
+	test_init_minimal();
+
+	test_import_preserves_sql_metacharacters();
+	test_failed_import_rolls_back();
+
+	test_cleanup_minimal();
+	return exit_status();
+}

--- a/test/tap/tests/unit/admin_bootstrap_users_unit-t.cpp
+++ b/test/tap/tests/unit/admin_bootstrap_users_unit-t.cpp
@@ -86,6 +86,8 @@ void test_import_preserves_sql_metacharacters() {
 		{ username, "ANY", auth_string, "caching_sha2_password", "N" },
 		{ "plain_user", "", "plain_password", "mysql_native_password", "N" }
 	}};
+	// Bootstrap import must not depend on whether another reader inspected the result.
+	mysql_fetch_row(users.get());
 
 	std::string error;
 	const bool imported = import_bootstrap_users(&db, users.get(), error);


### PR DESCRIPTION
## Summary

- replace SQL string interpolation during bootstrap user import with a prepared SQLite statement
- bind usernames and authentication strings using the exact lengths returned by MySQL
- replace users transactionally and abort bootstrap on import failure, preserving the previous user set
- add regression coverage for quotes and control characters in caching-SHA2 hashes and for rollback on insertion failure
- register the regression test in the unit-test CI shard

Fixes #6159

## Testing

- `make -C test/tap/tests/unit admin_bootstrap_users_unit-t SKIP_GENAI_UNIT_TESTS=1 -j4`
- `./test/tap/tests/unit/admin_bootstrap_users_unit-t` (10/10 passed)
- `test/infra/control/run-ci-lint.bash`
- `make -j4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bootstrap user imports now preserve special and control characters in usernames and passwords.
  * Imports replace existing users atomically, preventing partial updates if an error occurs.
  * SSL-enabled users are correctly recognized during import.
  * Import failures are reported while preserving the previous user configuration.

* **Tests**
  * Added regression coverage for successful imports, rollback behavior, SSL mapping, and special-character handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->