### PR TITLE
fix(ci): satisfy static PostgreSQL prerequisites in lint probe

### DIFF
--- a/test/tap/groups/test_makefile_dependencies.py
+++ b/test/tap/groups/test_makefile_dependencies.py
@@ -16,6 +16,17 @@ MYSQLX_BRIDGE_TARGETS = (
 
 
 class MakefileDependencyTest(unittest.TestCase):
+    @staticmethod
+    def write_dependency_probe(probe_makefile, target, probe):
+        probe_makefile.write_text(
+            "$(POSTGRESQL_STATIC_LIBS):\n"
+            "\t@:\n"
+            f".PHONY: {probe}\n"
+            f"{target}: {probe}\n"
+            f"{probe}:\n"
+            f"\t@printf '%s\\n' 'TASK4_PROBE={probe} OPT=$(OPT)'\n"
+        )
+
     def required_output_line(self, lines, predicate, description, output):
         line = next((line for line in lines if predicate(line)), None)
         self.assertIsNotNone(
@@ -93,12 +104,7 @@ class MakefileDependencyTest(unittest.TestCase):
         ):
             with self.subTest(target=target), tempfile.TemporaryDirectory() as tmp:
                 probe_makefile = Path(tmp) / "probe.mk"
-                probe_makefile.write_text(
-                    f".PHONY: {probe}\n"
-                    f"{target}: {probe}\n"
-                    f"{probe}:\n"
-                    f"\t@printf '%s\\n' 'TASK4_PROBE={probe} OPT=$(OPT)'\n"
-                )
+                self.write_dependency_probe(probe_makefile, target, probe)
 
                 result = subprocess.run(
                     [
@@ -158,6 +164,54 @@ class MakefileDependencyTest(unittest.TestCase):
                         shared_compile_line,
                         result.stdout,
                     )
+
+    def test_probe_keeps_pattern_rule_with_static_postgresql_prerequisites(self):
+        """The OpenSSL probe must still inspect a pattern target's compile line."""
+        target = "test_static_postgresql_prerequisites-t"
+        probe = "task4_static_postgresql_prerequisite"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp) / "tests"
+            directory.mkdir()
+            pattern_makefile = Path(tmp) / "pattern.mk"
+            probe_makefile = Path(tmp) / "probe.mk"
+            pattern_makefile.write_text(
+                "POSTGRESQL_STATIC_LIBS := libpq.a libpgcommon.a libpgport.a\n"
+                f"{target}: private OPT += -DTEST_STATIC_POSTGRESQL\n"
+                "%-t: %-t.cpp $(POSTGRESQL_STATIC_LIBS)\n"
+                "\t@printf '%s\\n' 'COMPILE $< OPT=$(OPT)'\n"
+            )
+            (directory / f"{target}.cpp").touch()
+            self.write_dependency_probe(probe_makefile, target, probe)
+
+            result = subprocess.run(
+                [
+                    "make",
+                    "--no-print-directory",
+                    "-B",
+                    "-n",
+                    "-C",
+                    str(directory),
+                    "-f",
+                    str(pattern_makefile),
+                    "-f",
+                    str(probe_makefile),
+                    target,
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=30,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.required_output_line(
+                result.stdout.splitlines(),
+                lambda line: f"{target}.cpp" in line,
+                f"target compile line for {target}",
+                result.stdout,
+            )
 
     def test_mysqlx_bridge_targets_share_one_unit_submake(self):
         result = subprocess.run(

--- a/test/tap/groups/test_makefile_dependencies.py
+++ b/test/tap/groups/test_makefile_dependencies.py
@@ -166,7 +166,7 @@ class MakefileDependencyTest(unittest.TestCase):
                     )
 
     def test_probe_keeps_pattern_rule_with_static_postgresql_prerequisites(self):
-        """The OpenSSL probe must still inspect a pattern target's compile line."""
+        """The probe must inspect a pattern target with static PostgreSQL prerequisites."""
         target = "test_static_postgresql_prerequisites-t"
         probe = "task4_static_postgresql_prerequisite"
 
@@ -206,10 +206,18 @@ class MakefileDependencyTest(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-            self.required_output_line(
-                result.stdout.splitlines(),
+            lines = result.stdout.splitlines()
+            compile_line = self.required_output_line(
+                lines,
                 lambda line: f"{target}.cpp" in line,
                 f"target compile line for {target}",
+                result.stdout,
+            )
+            self.assertIn("-DTEST_STATIC_POSTGRESQL", compile_line, result.stdout)
+            self.required_output_line(
+                lines,
+                lambda line: f"TASK4_PROBE={probe}" in line,
+                f"probe line for {probe}",
                 result.stdout,
             )
 


### PR DESCRIPTION
## Summary
- make the Makefile dependency probe provide no-op rules for declared static PostgreSQL archives
- retain the production build dependencies while allowing GNU Make to select the generic TAP target during dry-run linting
- cover the clean-runner static-prerequisite case

## Verification
- `python3 test/tap/groups/test_makefile_dependencies.py` (Linux container): 5 tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lint probe failing on static PostgreSQL prerequisites by providing no-op rules for the declared static archives, so GNU Make can select the generic TAP target during dry-run linting. Adds a test that verifies the probe still inspects a pattern target's compile line when static PostgreSQL prerequisites are present.

<sup>Written for commit 1ae7391ed11354b8fdfc514fe24cc2b3470a43ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded regression coverage for Makefile dependency handling.
  - Added validation for pattern-rule targets that include static PostgreSQL libraries.
  - Confirmed that affected targets continue to expose their compile commands and required build options.
  - Improved reuse of dependency checks across related build tests, including OpenSSL dependency validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->