### PR TITLE
fix(v4.0/MCP): LOAD MCP <X> FROM DISK must not install to runtime

### DIFF
--- a/doc/MCP/VARIABLES.md
+++ b/doc/MCP/VARIABLES.md
@@ -267,6 +267,18 @@ At startup Admin copies the on-disk copies back into `main.` before the genai
 plugin's start phase runs, and the plugin installs them into the runtime from
 there. No post-restart `LOAD MCP PROFILES FROM DISK` is required.
 
+`LOAD MCP <X> FROM DISK` (and its `TO MEMORY` alias) moves disk → memory and
+nothing else, so you can stage an on-disk configuration and review or edit it
+in `main.` before committing to it. `LOAD MCP <X> TO RUNTIME` is the only verb
+that applies configuration, and the only one that may start or restart the MCP
+listener:
+
+```sql
+LOAD MCP PROFILES FROM DISK;                 -- stage: disk -> main, runtime untouched
+SELECT * FROM mcp_target_profiles;           -- review / edit
+LOAD MCP PROFILES TO RUNTIME;                -- apply
+```
+
 > **Note:** in releases before this behaviour was added, only `mcp-*` variables
 > came back after a restart (they live in `global_variables`); profiles and
 > query rules came back empty, so the MCP listener started with no targets. On

--- a/doc/MCP/VARIABLES.md
+++ b/doc/MCP/VARIABLES.md
@@ -269,9 +269,10 @@ there. No post-restart `LOAD MCP PROFILES FROM DISK` is required.
 
 `LOAD MCP <X> FROM DISK` (and its `TO MEMORY` alias) moves disk → memory and
 nothing else, so you can stage an on-disk configuration and review or edit it
-in `main.` before committing to it. `LOAD MCP <X> TO RUNTIME` is the only verb
-that applies configuration, and the only one that may start or restart the MCP
-listener:
+in `main.` before committing to it. Within this disk/memory/runtime workflow,
+`LOAD MCP <X> TO RUNTIME` is the step that applies configuration and may start
+or restart the MCP listener (`LOAD MCP VARIABLES FROM CONFIG` is a separate
+config-file workflow that also applies variables and reevaluates the listener):
 
 ```sql
 LOAD MCP PROFILES FROM DISK;                 -- stage: disk -> main, runtime untouched

--- a/plugins/genai/README.md
+++ b/plugins/genai/README.md
@@ -92,10 +92,10 @@ dispatcher routes by canonical name + alias.
 | Command | Effect |
 |---|---|
 | `LOAD MCP VARIABLES TO RUNTIME` | push `mcp-*` from `main.global_variables` into `MCP_Threads_Handler` |
-| `LOAD MCP VARIABLES FROM DISK` | sync `disk.global_variables` → `main.global_variables` (mcp-* slice), then implicit reload |
-| `LOAD MCP VARIABLES FROM CONFIG` | re-read `mcp` block from `proxysql.cnf` |
+| `LOAD MCP VARIABLES FROM DISK` / `TO MEMORY` | sync `disk.global_variables` → `main.global_variables` (mcp-* slice); runtime remains unchanged until `TO RUNTIME` |
+| `LOAD MCP VARIABLES FROM CONFIG` | re-read the `mcp` block from `proxysql.cnf`, apply it, and reevaluate the listener |
 | `SAVE MCP VARIABLES TO MEMORY` / `... TO DISK` | reverse direction |
-| `LOAD MCP PROFILES TO RUNTIME` | atomic install of `main.mcp_auth_profiles` + `main.mcp_target_profiles` into the in-memory snapshot, rebuilds joined `target_auth_map`. The only verb that applies profiles, and the only one that may start the listener |
+| `LOAD MCP PROFILES TO RUNTIME` | atomic install of `main.mcp_auth_profiles` + `main.mcp_target_profiles` into the in-memory snapshot, rebuilds joined `target_auth_map`; within the profile-command family, this is the only verb that applies profiles or may start the listener |
 | `LOAD MCP PROFILES FROM DISK` / `TO MEMORY` | `disk.` → `main.` only; the runtime is untouched until `TO RUNTIME` |
 | `SAVE MCP PROFILES TO MEMORY` | atomic dump of in-memory snapshot back to both editable tables in one transaction |
 | `LOAD MCP QUERY RULES TO RUNTIME` | install `main.mcp_query_rules` snapshot, attach to `Discovery_Schema` if listener up |

--- a/plugins/genai/README.md
+++ b/plugins/genai/README.md
@@ -95,7 +95,8 @@ dispatcher routes by canonical name + alias.
 | `LOAD MCP VARIABLES FROM DISK` | sync `disk.global_variables` → `main.global_variables` (mcp-* slice), then implicit reload |
 | `LOAD MCP VARIABLES FROM CONFIG` | re-read `mcp` block from `proxysql.cnf` |
 | `SAVE MCP VARIABLES TO MEMORY` / `... TO DISK` | reverse direction |
-| `LOAD MCP PROFILES TO RUNTIME` | atomic install of `main.mcp_auth_profiles` + `main.mcp_target_profiles` into the in-memory snapshot, rebuilds joined `target_auth_map` |
+| `LOAD MCP PROFILES TO RUNTIME` | atomic install of `main.mcp_auth_profiles` + `main.mcp_target_profiles` into the in-memory snapshot, rebuilds joined `target_auth_map`. The only verb that applies profiles, and the only one that may start the listener |
+| `LOAD MCP PROFILES FROM DISK` / `TO MEMORY` | `disk.` → `main.` only; the runtime is untouched until `TO RUNTIME` |
 | `SAVE MCP PROFILES TO MEMORY` | atomic dump of in-memory snapshot back to both editable tables in one transaction |
 | `LOAD MCP QUERY RULES TO RUNTIME` | install `main.mcp_query_rules` snapshot, attach to `Discovery_Schema` if listener up |
 | `SAVE MCP QUERY RULES TO MEMORY` | dump in-memory snapshot back to `main.mcp_query_rules` |

--- a/plugins/genai/src/plugin_commands.cpp
+++ b/plugins/genai/src/plugin_commands.cpp
@@ -264,8 +264,18 @@ ProxySQL_PluginCommandResult save_mcp_variables_to_memory(
 /**
  * `LOAD MCP VARIABLES FROM DISK` / `TO MEMORY`.
  *
- * Copies `mcp-*` variables from disk.global_variables into main and
- * then refreshes the running MCP listener from the in-memory copy.
+ * Copies `mcp-*` variables from disk.global_variables into main.  That is
+ * ALL it does: per the admin verb contract that core and the mysqlx plugin
+ * both obey, FROM DISK / TO MEMORY moves disk -> memory and nothing else.
+ * Applying the staged values to the running module -- and starting or
+ * restarting the listener -- is exclusively
+ * `LOAD MCP VARIABLES TO RUNTIME`.
+ *
+ * Until issue #6171 this callback also ran the runtime install and called
+ * mcp_start_listener_if_enabled(), which meant `LOAD MCP VARIABLES TO
+ * MEMORY` -- the one verb whose entire purpose is "stage this without
+ * applying it" -- could reopen the MCP port on a node where the listener
+ * had been deliberately stopped.
  */
 ProxySQL_PluginCommandResult load_mcp_variables_from_disk(
 	const ProxySQL_PluginCommandContext& cmd_ctx,
@@ -281,14 +291,9 @@ ProxySQL_PluginCommandResult load_mcp_variables_from_disk(
 		rollback_tx(db);
 		return err_result("LOAD MCP VARIABLES FROM DISK: failed to copy variables");
 	}
-	GenAIPluginContext& ctx = genai_context();
-	if (!mcp_load_variables_from_admindb(ctx)) {
-		return err_result("LOAD MCP VARIABLES FROM DISK: failed to refresh runtime");
-	}
-	AdminMutexHandoff handoff(cmd_ctx);
-	handoff.release();
-	mcp_start_listener_if_enabled(ctx);
-	return ok_result("MCP variables loaded from disk");
+	return ok_result(
+		"MCP variables loaded from disk to memory."
+		" Run 'LOAD MCP VARIABLES TO RUNTIME' to apply them");
 }
 
 /**
@@ -478,15 +483,13 @@ ProxySQL_PluginCommandResult load_mcp_profiles_from_disk(
 		rollback_tx(db);
 		return err_result("LOAD MCP PROFILES FROM DISK: failed to copy tables");
 	}
-	GenAIPluginContext& ctx = genai_context();
-	if (!mcp_load_target_auth_map_from_admindb(ctx)) {
-		return err_result("LOAD MCP PROFILES FROM DISK: failed to refresh runtime");
-	}
-	const std::string summary = format_profile_install_summary("MCP profiles loaded from disk");
-	AdminMutexHandoff handoff(cmd_ctx);
-	handoff.release();
-	mcp_start_listener_if_enabled(ctx);
-	return ok_result(summary.c_str());
+	// disk -> main only. See the note on load_mcp_variables_from_disk and
+	// issue #6171: applying the staged profiles to the runtime is
+	// `LOAD MCP PROFILES TO RUNTIME`, which is also the only verb allowed
+	// to start the listener.
+	return ok_result(
+		"MCP profiles loaded from disk to memory."
+		" Run 'LOAD MCP PROFILES TO RUNTIME' to apply them");
 }
 
 ProxySQL_PluginCommandResult save_mcp_profiles_to_disk(
@@ -522,11 +525,10 @@ ProxySQL_PluginCommandResult load_mcp_query_rules_from_disk(
 		rollback_tx(db);
 		return err_result("LOAD MCP QUERY RULES FROM DISK: failed to copy tables");
 	}
-	GenAIPluginContext& ctx = genai_context();
-	if (!mcp_load_query_rules_to_runtime(ctx)) {
-		return err_result("LOAD MCP QUERY RULES FROM DISK: failed to refresh runtime");
-	}
-	return ok_result("MCP query rules loaded from disk");
+	// disk -> main only; see issue #6171.
+	return ok_result(
+		"MCP query rules loaded from disk to memory."
+		" Run 'LOAD MCP QUERY RULES TO RUNTIME' to apply them");
 }
 
 ProxySQL_PluginCommandResult save_mcp_query_rules_to_disk(

--- a/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
@@ -299,8 +299,13 @@ void restore_mcp_runtime(MYSQL* admin) {
 	}
 	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
 	// actually restores the running listener.
-	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	if (run_q(admin, "LOAD MCP VARIABLES FROM DISK") != 0) {
+		diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+		return;
+	}
+	if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+		diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+	}
 }
 
 /**

--- a/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mixed_mysql_pgsql_concurrency_stress-t.cpp
@@ -297,7 +297,10 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
+	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
+	// actually restores the running listener.
 	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 }
 
 /**

--- a/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
@@ -213,7 +213,10 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
+	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
+	// actually restores the running listener.
 	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 }
 
 /**

--- a/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_mysql_concurrency_stress-t.cpp
@@ -215,8 +215,13 @@ void restore_mcp_runtime(MYSQL* admin) {
 	}
 	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
 	// actually restores the running listener.
-	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	if (run_q(admin, "LOAD MCP VARIABLES FROM DISK") != 0) {
+		diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+		return;
+	}
+	if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+		diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+	}
 }
 
 /**

--- a/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
@@ -209,7 +209,10 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
+	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
+	// actually restores the running listener.
 	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 }
 
 /**

--- a/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
+++ b/test/tap/tests/mcp_pgsql_concurrency_stress-t.cpp
@@ -211,8 +211,13 @@ void restore_mcp_runtime(MYSQL* admin) {
 	}
 	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
 	// actually restores the running listener.
-	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	if (run_q(admin, "LOAD MCP VARIABLES FROM DISK") != 0) {
+		diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+		return;
+	}
+	if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+		diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+	}
 }
 
 /**

--- a/test/tap/tests/mcp_query_rules-t.cpp
+++ b/test/tap/tests/mcp_query_rules-t.cpp
@@ -230,9 +230,14 @@ int main(int argc, char** argv) {
 	diag("Final cleanup");
 	run_q(admin, "DELETE FROM mcp_query_rules WHERE rule_id >= 1000");
 	run_q(admin, "LOAD MCP QUERY RULES TO RUNTIME");
-	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
-	ok(true, "Cleanup completed");
+	bool variables_restored = run_q(admin, "LOAD MCP VARIABLES FROM DISK") == 0;
+	if (!variables_restored) {
+		diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+	} else if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+		diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+		variables_restored = false;
+	}
+	ok(variables_restored, "Cleanup completed");
 
 	mysql_close(admin);
 	return exit_status();

--- a/test/tap/tests/mcp_query_rules-t.cpp
+++ b/test/tap/tests/mcp_query_rules-t.cpp
@@ -231,6 +231,7 @@ int main(int argc, char** argv) {
 	run_q(admin, "DELETE FROM mcp_query_rules WHERE rule_id >= 1000");
 	run_q(admin, "LOAD MCP QUERY RULES TO RUNTIME");
 	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 	ok(true, "Cleanup completed");
 
 	mysql_close(admin);

--- a/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
@@ -223,8 +223,11 @@ cleanup:
 		mysql_close(mysql);
 	}
 	if (admin) {
-		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+		if (run_q(admin, "LOAD MCP VARIABLES FROM DISK") != 0) {
+			diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+		} else if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+			diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+		}
 		run_q(admin, ("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());

--- a/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly-t.cpp
@@ -224,6 +224,7 @@ cleanup:
 	}
 	if (admin) {
 		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 		run_q(admin, ("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());

--- a/test/tap/tests/mcp_query_run_sql_readonly_bypass-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly_bypass-t.cpp
@@ -322,6 +322,7 @@ cleanup:
 		run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());
 		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 		run_q(admin, "LOAD MCP PROFILES TO RUNTIME");
 		run_q(admin, "LOAD MYSQL SERVERS TO RUNTIME");
 		mysql_close(admin);

--- a/test/tap/tests/mcp_query_run_sql_readonly_bypass-t.cpp
+++ b/test/tap/tests/mcp_query_run_sql_readonly_bypass-t.cpp
@@ -321,8 +321,11 @@ cleanup:
 		run_q(admin, ("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mcp_auth_profiles WHERE auth_profile_id='" + std::string(k_auth_profile_id) + "'").c_str());
 		run_q(admin, ("DELETE FROM mysql_servers WHERE hostgroup_id=" + std::to_string(k_hostgroup_id)).c_str());
-		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+		if (run_q(admin, "LOAD MCP VARIABLES FROM DISK") != 0) {
+			diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+		} else if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+			diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+		}
 		run_q(admin, "LOAD MCP PROFILES TO RUNTIME");
 		run_q(admin, "LOAD MYSQL SERVERS TO RUNTIME");
 		mysql_close(admin);

--- a/test/tap/tests/mcp_rules_testing/mcp_test_helpers.sh
+++ b/test/tap/tests/mcp_rules_testing/mcp_test_helpers.sh
@@ -236,8 +236,12 @@ get_rule_hits() {
 }
 
 restore_mcp_group_baseline() {
+    # LOAD ... FROM DISK is disk->memory only (issue #6171), so each one needs
+    # its TO RUNTIME counterpart to actually restore the running module.
     exec_admin_silent \
-        "LOAD MCP VARIABLES FROM DISK; LOAD MCP PROFILES FROM DISK; LOAD MCP QUERY RULES FROM DISK;" \
+        "LOAD MCP VARIABLES FROM DISK; LOAD MCP VARIABLES TO RUNTIME;
+         LOAD MCP PROFILES FROM DISK; LOAD MCP PROFILES TO RUNTIME;
+         LOAD MCP QUERY RULES FROM DISK; LOAD MCP QUERY RULES TO RUNTIME;" \
         >/dev/null
 }
 

--- a/test/tap/tests/mcp_show_connections_commands_inmemory-t.cpp
+++ b/test/tap/tests/mcp_show_connections_commands_inmemory-t.cpp
@@ -115,8 +115,13 @@ void restore_mcp_runtime(MYSQL* admin) {
 	}
 	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
 	// actually restores the running listener.
-	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+	if (run_q(admin, "LOAD MCP VARIABLES FROM DISK") != 0) {
+		diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+		return;
+	}
+	if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+		diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+	}
 }
 
 /**

--- a/test/tap/tests/mcp_show_connections_commands_inmemory-t.cpp
+++ b/test/tap/tests/mcp_show_connections_commands_inmemory-t.cpp
@@ -113,7 +113,10 @@ void restore_mcp_runtime(MYSQL* admin) {
 	if (!admin) {
 		return;
 	}
+	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME is what
+	// actually restores the running listener.
 	run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+	run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 }
 
 /**

--- a/test/tap/tests/mcp_show_queries_topk-t.cpp
+++ b/test/tap/tests/mcp_show_queries_topk-t.cpp
@@ -404,6 +404,7 @@ int main(int argc, char** argv) {
 	if (admin) {
 		run_q(admin, "PROXYSQLTEST 4");
 		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 		mysql_close(admin);
 	}
 	if (mcp) {

--- a/test/tap/tests/mcp_show_queries_topk-t.cpp
+++ b/test/tap/tests/mcp_show_queries_topk-t.cpp
@@ -403,8 +403,11 @@ int main(int argc, char** argv) {
 
 	if (admin) {
 		run_q(admin, "PROXYSQLTEST 4");
-		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+		if (run_q(admin, "LOAD MCP VARIABLES FROM DISK") != 0) {
+			diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+		} else if (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") != 0) {
+			diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+		}
 		mysql_close(admin);
 	}
 	if (mcp) {

--- a/test/tap/tests/mcp_stats_refresh-t.cpp
+++ b/test/tap/tests/mcp_stats_refresh-t.cpp
@@ -355,6 +355,7 @@ int main(int argc, char** argv) {
 
 	if (admin) {
 		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
+		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
 		mysql_close(admin);
 	}
 

--- a/test/tap/tests/mcp_stats_refresh-t.cpp
+++ b/test/tap/tests/mcp_stats_refresh-t.cpp
@@ -354,8 +354,9 @@ int main(int argc, char** argv) {
 	}
 
 	if (admin) {
-		run_q(admin, "LOAD MCP VARIABLES FROM DISK");
-		run_q(admin, "LOAD MCP VARIABLES TO RUNTIME");
+		if (run_admin_stmt(admin, "LOAD MCP VARIABLES FROM DISK", "Restore MCP variables from disk")) {
+			run_admin_stmt(admin, "LOAD MCP VARIABLES TO RUNTIME", "Apply restored MCP variables");
+		}
 		mysql_close(admin);
 	}
 

--- a/test/tap/tests/test_stats_mcp_tables-t.cpp
+++ b/test/tap/tests/test_stats_mcp_tables-t.cpp
@@ -183,7 +183,9 @@ int main() {
 	ok(counters_after_reset == 0, "stats_mcp_query_tools_counters is empty after _reset (got %d)", counters_after_reset);
 
 	bool cleanup_ok = true;
+	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME applies it.
 	cleanup_ok = (run_q(admin, "LOAD MCP VARIABLES FROM DISK") == 0) && cleanup_ok;
+	cleanup_ok = (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") == 0) && cleanup_ok;
 	cleanup_ok = (run_q(admin,
 		("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str()) == 0)
 		&& cleanup_ok;

--- a/test/tap/tests/test_stats_mcp_tables-t.cpp
+++ b/test/tap/tests/test_stats_mcp_tables-t.cpp
@@ -184,8 +184,18 @@ int main() {
 
 	bool cleanup_ok = true;
 	// FROM DISK is disk->memory only (issue #6171); TO RUNTIME applies it.
-	cleanup_ok = (run_q(admin, "LOAD MCP VARIABLES FROM DISK") == 0) && cleanup_ok;
-	cleanup_ok = (run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") == 0) && cleanup_ok;
+	const bool variables_restored = run_q(admin, "LOAD MCP VARIABLES FROM DISK") == 0;
+	if (!variables_restored) {
+		diag("Failed to restore MCP variables from disk: %s", mysql_error(admin));
+	}
+	cleanup_ok = variables_restored && cleanup_ok;
+	if (variables_restored) {
+		const bool variables_applied = run_q(admin, "LOAD MCP VARIABLES TO RUNTIME") == 0;
+		if (!variables_applied) {
+			diag("Failed to apply restored MCP variables: %s", mysql_error(admin));
+		}
+		cleanup_ok = variables_applied && cleanup_ok;
+	}
 	cleanup_ok = (run_q(admin,
 		("DELETE FROM mcp_target_profiles WHERE target_id='" + std::string(k_target_id) + "'").c_str()) == 0)
 		&& cleanup_ok;

--- a/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+++ b/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
@@ -126,7 +126,7 @@ SQLite3DB* proxysql_plugin_get_configdb() { return g_configdb; }
 SQLite3DB* proxysql_plugin_get_statsdb()  { return g_statsdb; }
 
 int main() {
-	plan(129);
+	plan(136);
 
 	g_admindb  = new SQLite3DB();
 	g_configdb = new SQLite3DB();
@@ -581,11 +581,23 @@ int main() {
 			" VALUES('d_target','mysql',1,'d_auth','',200,2000,1,1,1,'')"),
 		   "seeded a distinct configuration on disk");
 
+		// Serialized dispatch contributes one R/A pair. The old callback added
+		// a second pair before mcp_start_listener_if_enabled(), so this also
+		// detects a staging command regaining that listener-start path.
+		AdminMutexHandoffProbe profile_disk_handoff;
+		ProxySQL_PluginCommandContext profile_disk_ctx {
+			g_admindb, g_configdb, g_statsdb,
+			&profile_disk_handoff,
+			&record_admin_mutex_release,
+			&record_admin_mutex_acquire
+		};
 		ProxySQL_PluginCommandResult from_disk_result;
-		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP PROFILES FROM DISK", from_disk_result) &&
+		ok(mgr.dispatch_admin_command(profile_disk_ctx, "LOAD MCP PROFILES FROM DISK", from_disk_result) &&
 		       from_disk_result.error_code == 0,
 		   "LOAD MCP PROFILES FROM DISK dispatches (rc=%d, msg=%s)",
 		   from_disk_result.error_code, from_disk_result.message.c_str());
+		ok(profile_disk_handoff.events == std::vector<char>({'R', 'A'}),
+		   "FROM DISK performs only the serialized-command Admin handoff");
 
 		// main. is replaced by the disk contents ...
 		ok(g_admindb->return_one_int(
@@ -621,10 +633,19 @@ int main() {
 		// dangerous.
 		ok(g_admindb->execute("DELETE FROM disk.mcp_target_profiles WHERE target_id='d_target'"),
 		   "removed the target from disk");
+		AdminMutexHandoffProbe profile_memory_handoff;
+		ProxySQL_PluginCommandContext profile_memory_ctx {
+			g_admindb, g_configdb, g_statsdb,
+			&profile_memory_handoff,
+			&record_admin_mutex_release,
+			&record_admin_mutex_acquire
+		};
 		ProxySQL_PluginCommandResult to_mem_result;
-		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP PROFILES TO MEMORY", to_mem_result) &&
+		ok(mgr.dispatch_admin_command(profile_memory_ctx, "LOAD MCP PROFILES TO MEMORY", to_mem_result) &&
 		       to_mem_result.error_code == 0,
 		   "LOAD MCP PROFILES TO MEMORY dispatches (rc=%d)", to_mem_result.error_code);
+		ok(profile_memory_handoff.events == std::vector<char>({'R', 'A'}),
+		   "TO MEMORY performs only the serialized-command Admin handoff");
 		ok(g_admindb->return_one_int(
 			"SELECT COUNT(*) FROM mcp_target_profiles WHERE target_id='d_target'") == 0,
 		   "TO MEMORY updated main. from disk");
@@ -659,11 +680,20 @@ int main() {
 			" WHERE variable_name='mcp-timeout_ms' AND variable_value='54321'");
 		ok(runtime_had == 0, "runtime does not have the disk value yet (got %d)", runtime_had);
 
+		AdminMutexHandoffProbe variables_disk_handoff;
+		ProxySQL_PluginCommandContext variables_disk_ctx {
+			g_admindb, g_configdb, g_statsdb,
+			&variables_disk_handoff,
+			&record_admin_mutex_release,
+			&record_admin_mutex_acquire
+		};
 		ProxySQL_PluginCommandResult var_disk_result;
-		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP VARIABLES FROM DISK", var_disk_result) &&
+		ok(mgr.dispatch_admin_command(variables_disk_ctx, "LOAD MCP VARIABLES FROM DISK", var_disk_result) &&
 		       var_disk_result.error_code == 0,
 		   "LOAD MCP VARIABLES FROM DISK dispatches (rc=%d, msg=%s)",
 		   var_disk_result.error_code, var_disk_result.message.c_str());
+		ok(variables_disk_handoff.events == std::vector<char>({'R', 'A'}),
+		   "variables FROM DISK does not enter the listener-start handoff");
 		ok(g_admindb->return_one_int(
 			"SELECT COUNT(*) FROM main.global_variables"
 			" WHERE variable_name='mcp-timeout_ms' AND variable_value='54321'") == 1,
@@ -685,6 +715,28 @@ int main() {
 
 	{
 		diag(">>> LOAD MCP QUERY RULES FROM DISK stages into main without touching runtime");
+
+		ok(g_admindb->execute(
+			"DELETE FROM mcp_query_rules") &&
+		   g_admindb->execute(
+			"INSERT INTO mcp_query_rules"
+			" (rule_id, active, username, target_id, schemaname, tool_name,"
+			"  match_pattern, negate_match_pattern, re_modifiers, flagIN, flagOUT,"
+			"  replace_pattern, timeout_ms, error_msg, OK_msg, log, apply, comment)"
+			" VALUES(3131,1,'','','','run_sql_readonly','^SELECT 1$',0,'',0,NULL,"
+			"        '',NULL,'','',NULL,1,'')"),
+		   "seeded the pre-existing live query rule in main");
+		ProxySQL_PluginCommandResult rules_initial_apply_result;
+		ok(mgr.dispatch_admin_command(
+			cmd_ctx, "LOAD MCP QUERY RULES TO RUNTIME", rules_initial_apply_result) &&
+		       rules_initial_apply_result.error_code == 0,
+		   "installed the pre-existing query rule before staging (rc=%d)",
+		   rules_initial_apply_result.error_code);
+		mgr.refresh_runtime_views_for_query(
+			"SELECT * FROM runtime_mcp_query_rules", g_admindb, nullptr, nullptr);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=3131") == 1,
+		   "runtime begins with the pre-existing query rule");
 
 		ok(g_admindb->execute(
 			"INSERT INTO disk.mcp_query_rules"
@@ -709,6 +761,9 @@ int main() {
 		ok(g_admindb->return_one_int(
 			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=4242") == 0,
 		   "the staged rule is NOT live before LOAD MCP QUERY RULES TO RUNTIME");
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=3131") == 1,
+		   "FROM DISK preserved the pre-existing live query rule");
 
 		ProxySQL_PluginCommandResult rules_apply_result;
 		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP QUERY RULES TO RUNTIME", rules_apply_result) &&
@@ -717,8 +772,10 @@ int main() {
 		mgr.refresh_runtime_views_for_query(
 			"SELECT * FROM runtime_mcp_query_rules", g_admindb, nullptr, nullptr);
 		ok(g_admindb->return_one_int(
-			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=4242") == 1,
-		   "the staged rule goes live only after TO RUNTIME");
+			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=4242") == 1 &&
+		   g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=3131") == 0,
+		   "TO RUNTIME replaces the old rule with the staged rule");
 	}
 
 	ok(mgr.stop_all(),     "stop_all succeeds");

--- a/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
+++ b/test/tap/tests/unit/genai_plugin_load_unit-t.cpp
@@ -93,6 +93,32 @@ void setup_admindb_schema(SQLite3DB* db) {
 	            " SELECT * FROM mcp_query_rules WHERE 0");
 }
 
+// Mirror of the persisted (non-runtime) tables into the attached `disk`
+// schema, so the FROM DISK callbacks have something to copy from.
+void setup_admindb_schema_on_disk(SQLite3DB* db) {
+	db->execute("CREATE TABLE IF NOT EXISTS disk.global_variables ("
+	            " variable_name TEXT PRIMARY KEY, variable_value TEXT)");
+	db->execute("CREATE TABLE IF NOT EXISTS disk.mcp_auth_profiles ("
+	            " auth_profile_id TEXT PRIMARY KEY, db_username TEXT,"
+	            " db_password TEXT, default_schema TEXT DEFAULT '',"
+	            " use_ssl INTEGER NOT NULL DEFAULT 0,"
+	            " ssl_mode TEXT DEFAULT '',"
+	            " comment TEXT DEFAULT '')");
+	db->execute("CREATE TABLE IF NOT EXISTS disk.mcp_target_profiles ("
+	            " target_id TEXT PRIMARY KEY, protocol TEXT, hostgroup_id INTEGER,"
+	            " auth_profile_id TEXT, description TEXT DEFAULT '',"
+	            " max_rows INTEGER DEFAULT 200, timeout_ms INTEGER DEFAULT 2000,"
+	            " allow_explain INTEGER DEFAULT 1, allow_discovery INTEGER DEFAULT 1,"
+	            " active INTEGER DEFAULT 1, comment TEXT DEFAULT '')");
+	db->execute("CREATE TABLE IF NOT EXISTS disk.mcp_query_rules ("
+	            " rule_id INTEGER PRIMARY KEY, active INTEGER NOT NULL DEFAULT 0,"
+	            " username TEXT, target_id TEXT, schemaname TEXT, tool_name TEXT,"
+	            " match_pattern TEXT, negate_match_pattern INTEGER NOT NULL DEFAULT 0,"
+	            " re_modifiers TEXT, flagIN INTEGER NOT NULL DEFAULT 0, flagOUT INTEGER,"
+	            " replace_pattern TEXT, timeout_ms INTEGER, error_msg TEXT, OK_msg TEXT,"
+	            " log INTEGER, apply INTEGER NOT NULL DEFAULT 1, comment TEXT)");
+}
+
 } // namespace
 
 SQLite3DB* proxysql_plugin_get_admindb()  { return g_admindb; }
@@ -100,7 +126,7 @@ SQLite3DB* proxysql_plugin_get_configdb() { return g_configdb; }
 SQLite3DB* proxysql_plugin_get_statsdb()  { return g_statsdb; }
 
 int main() {
-	plan(104);
+	plan(129);
 
 	g_admindb  = new SQLite3DB();
 	g_configdb = new SQLite3DB();
@@ -110,6 +136,13 @@ int main() {
 	g_statsdb->open((char*)":memory:", SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 	setup_admindb_schema(g_admindb);
 	setup_global_variables_schema(g_configdb);
+
+	// Real Admin attaches configdb to admindb as `disk` (see __attach_db in
+	// Admin_Bootstrap). The plugin's "LOAD MCP <X> FROM DISK" callbacks issue
+	// `SELECT * FROM disk.<table>` against admindb, so the staging tests below
+	// need the same shape. A separate in-memory database is enough here.
+	g_admindb->execute("ATTACH DATABASE ':memory:' AS disk");
+	setup_admindb_schema_on_disk(g_admindb);
 
 	// Exercise a genuinely fresh installation before setting up the partial
 	// installation used by the rest of this regression. Both stores begin with
@@ -515,6 +548,178 @@ int main() {
 		" WHERE target_id='t_inactive' AND effective=0"
 		" AND skip_reason='inactive'") == 1,
 	   "inactive target: effective=0 with matching skip_reason");
+
+	// Issue #6171: LOAD MCP <X> FROM DISK (and its TO MEMORY alias) must move
+	// disk -> memory and NOTHING else. It previously also installed into the
+	// runtime and called mcp_start_listener_if_enabled(), which made the one
+	// verb that means "stage this without applying it" apply it -- and, for
+	// variables, able to reopen the MCP port on a node where the listener had
+	// been deliberately stopped. These assertions pin the staged workflow:
+	// FROM DISK repopulates main. while the runtime keeps its previous state,
+	// and only TO RUNTIME applies it.
+	{
+		diag(">>> LOAD MCP PROFILES FROM DISK stages into main without touching runtime");
+
+		// Runtime currently holds the three targets from the block above.
+		mgr.refresh_runtime_views_for_query(
+			"SELECT * FROM runtime_mcp_target_profiles", g_admindb, nullptr, nullptr);
+		const int runtime_before = g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_target_profiles");
+		ok(runtime_before == 3,
+		   "runtime holds the 3 previously installed targets (got %d)", runtime_before);
+
+		// Disk holds a completely different, single-target configuration.
+		ok(g_admindb->execute(
+			"INSERT INTO disk.mcp_auth_profiles"
+			" (auth_profile_id, db_username, db_password, default_schema,"
+			"  use_ssl, ssl_mode, comment)"
+			" VALUES('d_auth','du','dp','',0,'','')") &&
+		   g_admindb->execute(
+			"INSERT INTO disk.mcp_target_profiles"
+			" (target_id, protocol, hostgroup_id, auth_profile_id, description,"
+			"  max_rows, timeout_ms, allow_explain, allow_discovery, active, comment)"
+			" VALUES('d_target','mysql',1,'d_auth','',200,2000,1,1,1,'')"),
+		   "seeded a distinct configuration on disk");
+
+		ProxySQL_PluginCommandResult from_disk_result;
+		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP PROFILES FROM DISK", from_disk_result) &&
+		       from_disk_result.error_code == 0,
+		   "LOAD MCP PROFILES FROM DISK dispatches (rc=%d, msg=%s)",
+		   from_disk_result.error_code, from_disk_result.message.c_str());
+
+		// main. is replaced by the disk contents ...
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM mcp_target_profiles") == 1 &&
+		   g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM mcp_target_profiles WHERE target_id='d_target'") == 1,
+		   "FROM DISK replaced main.mcp_target_profiles with the disk copy");
+
+		// ... and the runtime is untouched.
+		mgr.refresh_runtime_views_for_query(
+			"SELECT * FROM runtime_mcp_target_profiles", g_admindb, nullptr, nullptr);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_target_profiles") == 3,
+		   "FROM DISK left the runtime target set unchanged");
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_target_profiles WHERE target_id='d_target'") == 0,
+		   "the staged target is NOT live before LOAD MCP PROFILES TO RUNTIME");
+
+		// TO RUNTIME is what applies it.
+		ProxySQL_PluginCommandResult apply_result;
+		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP PROFILES TO RUNTIME", apply_result) &&
+		       apply_result.error_code == 0,
+		   "LOAD MCP PROFILES TO RUNTIME dispatches (rc=%d)", apply_result.error_code);
+		mgr.refresh_runtime_views_for_query(
+			"SELECT * FROM runtime_mcp_target_profiles", g_admindb, nullptr, nullptr);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_target_profiles WHERE target_id='d_target'"
+			" AND effective=1") == 1,
+		   "the staged target goes live only after TO RUNTIME");
+
+		// The TO MEMORY alias must behave identically -- it resolves to the
+		// same callback, and that is exactly why the old behaviour was
+		// dangerous.
+		ok(g_admindb->execute("DELETE FROM disk.mcp_target_profiles WHERE target_id='d_target'"),
+		   "removed the target from disk");
+		ProxySQL_PluginCommandResult to_mem_result;
+		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP PROFILES TO MEMORY", to_mem_result) &&
+		       to_mem_result.error_code == 0,
+		   "LOAD MCP PROFILES TO MEMORY dispatches (rc=%d)", to_mem_result.error_code);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM mcp_target_profiles WHERE target_id='d_target'") == 0,
+		   "TO MEMORY updated main. from disk");
+		mgr.refresh_runtime_views_for_query(
+			"SELECT * FROM runtime_mcp_target_profiles", g_admindb, nullptr, nullptr);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_target_profiles WHERE target_id='d_target'") == 1,
+		   "TO MEMORY did NOT remove the still-live target from the runtime");
+	}
+
+	{
+		diag(">>> LOAD MCP VARIABLES FROM DISK stages into main without touching runtime");
+
+		// Disk must hold a COMPLETE mcp-* set, the way SAVE MCP VARIABLES TO
+		// DISK writes it: LOAD MCP VARIABLES TO RUNTIME refuses a partial set
+		// (see the desired.size() != previous.size() guard in
+		// mcp_load_variables_from_admindb), so seeding a single row here would
+		// test the guard rather than the staging contract. Mirror main, then
+		// change exactly one value on disk.
+		ok(g_admindb->execute(
+			"INSERT OR REPLACE INTO disk.global_variables"
+			" SELECT * FROM main.global_variables WHERE variable_name LIKE 'mcp-%'") &&
+		   g_admindb->execute(
+			"UPDATE disk.global_variables SET variable_value='54321'"
+			" WHERE variable_name='mcp-timeout_ms'") &&
+		   g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM disk.global_variables"
+			" WHERE variable_name='mcp-timeout_ms' AND variable_value='54321'") == 1,
+		   "seeded a full mcp-* set on disk with mcp-timeout_ms=54321");
+		const int runtime_had = g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM main.runtime_global_variables"
+			" WHERE variable_name='mcp-timeout_ms' AND variable_value='54321'");
+		ok(runtime_had == 0, "runtime does not have the disk value yet (got %d)", runtime_had);
+
+		ProxySQL_PluginCommandResult var_disk_result;
+		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP VARIABLES FROM DISK", var_disk_result) &&
+		       var_disk_result.error_code == 0,
+		   "LOAD MCP VARIABLES FROM DISK dispatches (rc=%d, msg=%s)",
+		   var_disk_result.error_code, var_disk_result.message.c_str());
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM main.global_variables"
+			" WHERE variable_name='mcp-timeout_ms' AND variable_value='54321'") == 1,
+		   "FROM DISK staged mcp-timeout_ms into main.global_variables");
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM main.runtime_global_variables"
+			" WHERE variable_name='mcp-timeout_ms' AND variable_value='54321'") == 0,
+		   "FROM DISK did NOT publish the staged value to the runtime");
+
+		ProxySQL_PluginCommandResult var_apply_result;
+		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP VARIABLES TO RUNTIME", var_apply_result) &&
+		       var_apply_result.error_code == 0,
+		   "LOAD MCP VARIABLES TO RUNTIME dispatches (rc=%d)", var_apply_result.error_code);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM main.runtime_global_variables"
+			" WHERE variable_name='mcp-timeout_ms' AND variable_value='54321'") == 1,
+		   "the staged variable reaches the runtime only after TO RUNTIME");
+	}
+
+	{
+		diag(">>> LOAD MCP QUERY RULES FROM DISK stages into main without touching runtime");
+
+		ok(g_admindb->execute(
+			"INSERT INTO disk.mcp_query_rules"
+			" (rule_id, active, username, target_id, schemaname, tool_name,"
+			"  match_pattern, negate_match_pattern, re_modifiers, flagIN, flagOUT,"
+			"  replace_pattern, timeout_ms, error_msg, OK_msg, log, apply, comment)"
+			" VALUES(4242,1,'','','','run_sql_readonly','^SELECT',0,'',0,NULL,"
+			"        '',NULL,'','',NULL,1,'')"),
+		   "seeded a query rule on disk only");
+
+		ProxySQL_PluginCommandResult rules_disk_result;
+		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP QUERY RULES FROM DISK", rules_disk_result) &&
+		       rules_disk_result.error_code == 0,
+		   "LOAD MCP QUERY RULES FROM DISK dispatches (rc=%d, msg=%s)",
+		   rules_disk_result.error_code, rules_disk_result.message.c_str());
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM mcp_query_rules WHERE rule_id=4242") == 1,
+		   "FROM DISK staged the rule into main.mcp_query_rules");
+
+		mgr.refresh_runtime_views_for_query(
+			"SELECT * FROM runtime_mcp_query_rules", g_admindb, nullptr, nullptr);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=4242") == 0,
+		   "the staged rule is NOT live before LOAD MCP QUERY RULES TO RUNTIME");
+
+		ProxySQL_PluginCommandResult rules_apply_result;
+		ok(mgr.dispatch_admin_command(cmd_ctx, "LOAD MCP QUERY RULES TO RUNTIME", rules_apply_result) &&
+		       rules_apply_result.error_code == 0,
+		   "LOAD MCP QUERY RULES TO RUNTIME dispatches (rc=%d)", rules_apply_result.error_code);
+		mgr.refresh_runtime_views_for_query(
+			"SELECT * FROM runtime_mcp_query_rules", g_admindb, nullptr, nullptr);
+		ok(g_admindb->return_one_int(
+			"SELECT COUNT(*) FROM runtime_mcp_query_rules WHERE rule_id=4242") == 1,
+		   "the staged rule goes live only after TO RUNTIME");
+	}
 
 	ok(mgr.stop_all(),     "stop_all succeeds");
 


### PR DESCRIPTION
Fixes #6171.

> **Stacked on #6170** — based on `fix/6167-6168-mcp-persistence-and-profile-diagnostics`, so the base retargets to `v3.0` automatically once that merges. Review only the commit on this branch.

## The bug

All three genai `FROM DISK` verbs copied `disk.` → `main.` **and then installed into the runtime**; two of them also called `mcp_start_listener_if_enabled()`.

Because `LOAD MCP <X> TO MEMORY` is registered as an **alias** of `FROM DISK`, the verb whose entire purpose is *stage this without applying it* applied it — and for variables, could reopen the MCP port on a node where the listener had been deliberately stopped. The MCP endpoints expose backend query execution, so that isn't cosmetic.

This broke the contract the rest of ProxySQL obeys:

| Verb family | Contract |
|---|---|
| `LOAD <X> FROM DISK` / `TO MEMORY` | disk → memory |
| `LOAD <X> TO RUNTIME` / `FROM MEMORY` | memory → runtime |
| `SAVE <X> TO DISK` / `FROM MEMORY` | memory → disk |
| `SAVE <X> TO MEMORY` / `FROM RUNTIME` | runtime → memory |

genai was the outlier. Core's `FlushCommandWrapper(..., "disk_to_memory")` (`Admin_Handler.cpp:571`) is a pure table copy, and mysqlx's `load_*_from_disk` callbacks call `disk_to_memory()` and nothing else (`mysqlx_admin_schema.cpp:323`).

## The change

All three are now pure `disk.` → `main.` copies, and their replies name the verb that applies the staged config:

```
admin> LOAD MCP PROFILES FROM DISK;
MCP profiles loaded from disk to memory. Run 'LOAD MCP PROFILES TO RUNTIME' to apply them
```

`LOAD MCP <X> TO RUNTIME` remains the only verb that touches the runtime, and the only one that may start or restart the listener. The staged workflow now works as it does everywhere else in ProxySQL:

```sql
LOAD MCP PROFILES FROM DISK;        -- stage: disk -> main, runtime untouched
SELECT * FROM mcp_target_profiles;  -- review / edit
LOAD MCP PROFILES TO RUNTIME;       -- apply
```

## The test suite depended on the old behaviour

Eleven call sites used `LOAD MCP VARIABLES FROM DISK` as a restore-the-runtime idiom — four of them inside helpers literally named `restore_mcp_runtime()`. Each now issues the explicit `TO RUNTIME` counterpart:

`mcp_show_connections_commands_inmemory-t` · `mcp_mysql_concurrency_stress-t` · `mcp_pgsql_concurrency_stress-t` · `mcp_mixed_mysql_pgsql_concurrency_stress-t` · `mcp_query_rules-t` · `mcp_query_run_sql_readonly-t` · `mcp_query_run_sql_readonly_bypass-t` · `mcp_show_queries_topk-t` · `mcp_stats_refresh-t` · `test_stats_mcp_tables-t` · `mcp_rules_testing/mcp_test_helpers.sh` (`restore_mcp_group_baseline`)

That every one of those reads as "restore the runtime" is itself evidence the old semantics were surprising: the suite adopted the shortcut precisely because the verb did more than its name said.

`mcp_module-t`'s two call sites are deliberately left alone — both assert on *memory* values (`SELECT @@mcp-<var>` reads `main.global_variables`), so they keep testing what they were written to test, and now do so without a runtime side effect.

## Interaction with #6167

This removes the shortcut that made the #6167 workaround appear to work. On a build without the startup restore, the correct sequence is now:

```sql
LOAD MCP PROFILES FROM DISK;
LOAD MCP PROFILES TO RUNTIME;
LOAD MCP QUERY RULES FROM DISK;
LOAD MCP QUERY RULES TO RUNTIME;
```

Once #6170 lands, none of this is needed at startup at all.

## Testing

Verified on a full `PROXYSQL40=1 make debug` build (linux/arm64, `proxysql/packaging:build-debian13-v4.0.0`):

| Test | Result |
|---|---|
| `genai_plugin_load_unit-t` | **129/129 pass** (was 104; +25 for this issue) |
| `plugin_runtime_views_unit-t` | 42/42 pass |
| 11 edited TAP tests | compile clean (`-fsyntax-only`) |

New coverage in `genai_plugin_load_unit-t`, for all three verb families:

- `FROM DISK` replaces `main.` with the disk copy while the runtime keeps its previous contents;
- the staged config is **not** live before `TO RUNTIME`, and **is** after it;
- the `TO MEMORY` alias behaves identically (it resolves to the same callback — which is exactly why the old behaviour was dangerous);
- `LOAD MCP VARIABLES FROM DISK` does not publish to `runtime_global_variables`.

The fixture attaches an in-memory `disk` schema to the test admindb, mirroring `__attach_db(admindb, configdb, "disk")` in real Admin bootstrap, since the `FROM DISK` callbacks issue `SELECT * FROM disk.<table>`.

One fixture subtlety worth knowing: the variables case seeds a **complete** `mcp-*` set on disk. `LOAD MCP VARIABLES TO RUNTIME` rejects a partial set (`desired.size() != previous.size()` in `mcp_load_variables_from_admindb`), so a single-row disk fixture tests that guard rather than the staging contract. Real disk state is always a full `SAVE MCP VARIABLES TO DISK` snapshot.

https://claude.ai/code/session_018Jx9yffNfnSZDvC6WvGxgw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6171 by making all `LOAD MCP <X> FROM DISK` commands stage `disk` into `main` without changing the runtime. Previously, these commands also installed the configuration and could restart the MCP listener; callers that need the configuration live must now run the matching `TO RUNTIME` command.

**Changes**

- Applies the disk-to-memory-only contract to MCP variables, profiles, and query rules, including the `TO MEMORY` aliases.
- Updates command responses and MCP documentation with the staged workflow.
- Updates test cleanup and restore helpers to use explicit `TO RUNTIME` commands.
- Adds unit coverage proving staged values remain inactive until they are applied.

<sup>Written for commit 1e96ea06f8b6209afaf4ec865639fd0b68c0e43d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - `LOAD MCP ... FROM DISK` and `TO MEMORY` now stage variables, profiles, and query rules without changing the running MCP runtime.
  - Use `LOAD MCP ... TO RUNTIME` to apply staged configuration and start or restart the MCP listener when required.
  - Configuration-file loading applies variables and reevaluates the listener.
  - Command responses now direct administrators to apply staged configuration explicitly.

- **Documentation**
  - Updated MCP command documentation with the staging and runtime-application workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->