### PR TITLE
fix(coverage): make gcov counters thread-safe

### DIFF
--- a/include/makefiles_vars.mk
+++ b/include/makefiles_vars.mk
@@ -44,7 +44,7 @@ STDCPP := -std=c++$(shell echo $(CPLUSPLUS) | cut -c3-4) -DCXX$(shell echo $(CPL
 
 WGCOV :=
 ifeq ($(WITHGCOV),1)
-	WGCOV := -DWITHGCOV -lgcov --coverage
+	WGCOV := -DWITHGCOV -lgcov --coverage -fprofile-update=atomic
 endif
 
 WASAN :=

--- a/test/infra/control/test-gcov-atomic-profile-update.bash
+++ b/test/infra/control/test-gcov-atomic-profile-update.bash
@@ -3,11 +3,17 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-actual="$(make -s -f - -C "${root}" WITHGCOV=1 <<'MAKE'
+actual="$(make -s -f - -C "${root}" WITHGCOV=1 GIT_VERSION=control CPLUSPLUS=201703L <<'MAKE'
 include include/makefiles_vars.mk
 print:
 	@printf '%s\n' "$(WGCOV)"
 MAKE
 )"
 
-test "${actual}" = '-DWITHGCOV -lgcov --coverage -fprofile-update=atomic'
+case " ${actual} " in
+  *' -fprofile-update=atomic '*) ;;
+  *)
+    echo "missing -fprofile-update=atomic from WGCOV: ${actual}" >&2
+    exit 1
+    ;;
+esac

--- a/test/infra/control/test-gcov-atomic-profile-update.bash
+++ b/test/infra/control/test-gcov-atomic-profile-update.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+actual="$(make -s -f - -C "${root}" WITHGCOV=1 <<'MAKE'
+include include/makefiles_vars.mk
+print:
+	@printf '%s\n' "$(WGCOV)"
+MAKE
+)"
+
+test "${actual}" = '-DWITHGCOV -lgcov --coverage -fprofile-update=atomic'

--- a/test/infra/control/validate-coverage-gcov-toolchain.bash
+++ b/test/infra/control/validate-coverage-gcov-toolchain.bash
@@ -37,3 +37,4 @@ awk '
 ' "${lint_runner}"
 
 "${root}/test/infra/control/test-final-gcov-dump.bash"
+"${root}/test/infra/control/test-gcov-atomic-profile-update.bash"


### PR DESCRIPTION
## Problem

`CI-unit-tests-asan-coverage` can run every unit test successfully and then fail during `geninfo` with a negative gcov counter. The coverage-instrumented daemon is threaded, but its profile counters were built with GCC’s default non-atomic updates.

## Fix

Enable `-fprofile-update=atomic` for every `WITHGCOV=1` build. This preserves valid `.gcda` counters under concurrent updates.

A focused Makefile-contract test is now executed by the existing coverage-toolchain validator, so the required flag cannot be removed unnoticed.

## Verification

- `test/infra/control/test-gcov-atomic-profile-update.bash`
- `test/infra/control/validate-coverage-gcov-toolchain.bash`
- `git diff HEAD^ HEAD --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes gcov profile counters thread-safe by enabling atomic updates for all `WITHGCOV` builds, preventing negative counter errors in the ASAN coverage suite.

- Adds a Makefile contract test so the flag cannot be removed without detection.
- The test stubs unrelated makefile probes and checks the flag by membership, so it does not depend on flag ordering or toolchain availability.

<sup>Written for commit da302d778d597d70928a130bab736166a7c87f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage builds to safely update profiling data during parallel or concurrent test execution.

* **Tests**
  * Added validation to confirm the coverage configuration includes atomic profile updates.
  * Included the new check in the coverage toolchain validation sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->