### PR TITLE
fix(ci): make MySQLX dbdeployer setup idempotent

### DIFF
--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -357,6 +357,9 @@ jobs:
           sudo apt-get install -y -qq --no-install-recommends \
             libaio1 libnuma1 libncurses5 libtinfo5
 
+      - name: Verify dbdeployer install guard
+        run: proxysql/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+
       - name: Install dbdeployer
         # GitHub runner images may already provide dbdeployer. Its upstream
         # installer exits non-zero in that case, so install only when PATH

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -372,7 +372,7 @@ jobs:
             curl --fail --location --proto '=https' --tlsv1.2 \
               https://raw.githubusercontent.com/ProxySQL/dbdeployer/0982f16ad02a20df13caf02838d2722a1e304e4f/scripts/dbdeployer-install.sh \
               -o "${installer}"
-            echo '04ef082fb20dc3e5ad9b164dd96374e6c01034d068ccc891684fabc1be52f6b5  '"${installer}"' | sha256sum --check --status
+            printf '%s  %s\n' '04ef082fb20dc3e5ad9b164dd96374e6c01034d068ccc891684fabc1be52f6b5' "${installer}" | sha256sum --check --status
             bash "${installer}"
             if [ -f dbdeployer ] && ! command -v dbdeployer >/dev/null 2>&1; then
               sudo install -m 0755 dbdeployer /usr/local/bin/dbdeployer

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -358,15 +358,17 @@ jobs:
             libaio1 libnuma1 libncurses5 libtinfo5
 
       - name: Install dbdeployer
-        # Same install flow the OLD bare-runner CI-mysqlx used (the only
-        # thing about the old workflow that wasn't broken). The script
-        # leaves the binary in cwd when run as non-root, so move it
-        # into PATH ourselves before the version check.
+        # GitHub runner images may already provide dbdeployer. Its upstream
+        # installer exits non-zero in that case, so install only when PATH
+        # does not already resolve a usable binary. The installer leaves the
+        # binary in cwd when run as non-root, hence the explicit PATH move.
         run: |
-          curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
-          if [ -f dbdeployer ] && ! command -v dbdeployer >/dev/null 2>&1; then
-            sudo install -m 0755 dbdeployer /usr/local/bin/dbdeployer
-            rm -f dbdeployer
+          if ! command -v dbdeployer >/dev/null 2>&1; then
+            curl -fsSL https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
+            if [ -f dbdeployer ] && ! command -v dbdeployer >/dev/null 2>&1; then
+              sudo install -m 0755 dbdeployer /usr/local/bin/dbdeployer
+              rm -f dbdeployer
+            fi
           fi
           dbdeployer --version
 

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -367,7 +367,13 @@ jobs:
         # binary in cwd when run as non-root, hence the explicit PATH move.
         run: |
           if ! command -v dbdeployer >/dev/null 2>&1; then
-            curl -fsSL https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
+            installer="$(mktemp)"
+            trap 'rm -f "${installer}"' EXIT
+            curl --fail --location --proto '=https' --tlsv1.2 \
+              https://raw.githubusercontent.com/ProxySQL/dbdeployer/0982f16ad02a20df13caf02838d2722a1e304e4f/scripts/dbdeployer-install.sh \
+              -o "${installer}"
+            echo '04ef082fb20dc3e5ad9b164dd96374e6c01034d068ccc891684fabc1be52f6b5  '"${installer}"' | sha256sum --check --status
+            bash "${installer}"
             if [ -f dbdeployer ] && ! command -v dbdeployer >/dev/null 2>&1; then
               sudo install -m 0755 dbdeployer /usr/local/bin/dbdeployer
               rm -f dbdeployer

--- a/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+++ b/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
@@ -11,14 +11,31 @@ step="$(awk '
 ' "${workflow}")"
 
 guard_body="$(printf '%s\n' "${step}" | awk '
-  /if ! command -v dbdeployer >\/dev\/null 2>&1; then/ { capture = 1 }
-  capture { print }
-  capture && /^          fi$/ { exit }
+  /if ! command -v dbdeployer >\/dev\/null 2>&1; then/ {
+    capture = 1
+    depth = 1
+    first_if = 1
+  }
+  capture {
+    print
+    if ($0 ~ /^[[:space:]]*if .*; then[[:space:]]*$/) {
+      if (first_if) {
+        first_if = 0
+      } else {
+        depth++
+      }
+    }
+    if ($0 ~ /^[[:space:]]*fi[[:space:]]*$/) {
+      depth--
+      if (depth == 0) exit
+    }
+  }
 ')"
 
-printf '%s\n' "${guard_body}" | grep -Fqx '          if ! command -v dbdeployer >/dev/null 2>&1; then'
-printf '%s\n' "${guard_body}" | grep -Fqx '            curl --fail --location --proto '\''=https'\'' --tlsv1.2 \\'
+printf '%s\n' "${guard_body}" | grep -Fq 'if ! command -v dbdeployer >/dev/null 2>&1; then'
+printf '%s\n' "${guard_body}" | grep -Fq "curl --fail --location --proto '=https' --tlsv1.2"
 printf '%s\n' "${guard_body}" | grep -Fq 'https://raw.githubusercontent.com/ProxySQL/dbdeployer/0982f16ad02a20df13caf02838d2722a1e304e4f/scripts/dbdeployer-install.sh'
 printf '%s\n' "${guard_body}" | grep -Fq '04ef082fb20dc3e5ad9b164dd96374e6c01034d068ccc891684fabc1be52f6b5'
-printf '%s\n' "${guard_body}" | grep -Fqx '            bash "${installer}"'
-printf '%s\n' "${step}" | grep -Fqx '          dbdeployer --version'
+printf '%s\n' "${guard_body}" | grep -Fq 'sha256sum --check --status'
+printf '%s\n' "${guard_body}" | grep -Fq 'bash "${installer}"'
+printf '%s\n' "${step}" | grep -Fq 'dbdeployer --version'

--- a/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+++ b/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
@@ -17,5 +17,8 @@ guard_body="$(printf '%s\n' "${step}" | awk '
 ')"
 
 printf '%s\n' "${guard_body}" | grep -Fqx '          if ! command -v dbdeployer >/dev/null 2>&1; then'
-printf '%s\n' "${guard_body}" | grep -Fqx '            curl -fsSL https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash'
+printf '%s\n' "${guard_body}" | grep -Fqx '            curl --fail --location --proto '\''=https'\'' --tlsv1.2 \\'
+printf '%s\n' "${guard_body}" | grep -Fq 'https://raw.githubusercontent.com/ProxySQL/dbdeployer/0982f16ad02a20df13caf02838d2722a1e304e4f/scripts/dbdeployer-install.sh'
+printf '%s\n' "${guard_body}" | grep -Fq '04ef082fb20dc3e5ad9b164dd96374e6c01034d068ccc891684fabc1be52f6b5'
+printf '%s\n' "${guard_body}" | grep -Fqx '            bash "${installer}"'
 printf '%s\n' "${step}" | grep -Fqx '          dbdeployer --version'

--- a/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+++ b/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
@@ -10,6 +10,12 @@ step="$(awk '
   capture && /^      - name: Download and unpack MySQL 8\.4$/ { exit }
 ' "${workflow}")"
 
-printf '%s\n' "${step}" | grep -Fq 'if ! command -v dbdeployer >/dev/null 2>&1; then'
-printf '%s\n' "${step}" | grep -Fq 'curl -fsSL https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash'
-printf '%s\n' "${step}" | grep -Fq 'dbdeployer --version'
+guard_body="$(printf '%s\n' "${step}" | awk '
+  /if ! command -v dbdeployer >\/dev\/null 2>&1; then/ { capture = 1 }
+  capture { print }
+  capture && /^          fi$/ { exit }
+')"
+
+printf '%s\n' "${guard_body}" | grep -Fqx '          if ! command -v dbdeployer >/dev/null 2>&1; then'
+printf '%s\n' "${guard_body}" | grep -Fqx '            curl -fsSL https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash'
+printf '%s\n' "${step}" | grep -Fqx '          dbdeployer --version'

--- a/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+++ b/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+workflow="${root}/.github/workflows/ci-mysqlx.yml"
+
+step="$(awk '
+  /^      - name: Install dbdeployer$/ { capture = 1 }
+  capture { print }
+  capture && /^      - name: Download and unpack MySQL 8\.4$/ { exit }
+' "${workflow}")"
+
+printf '%s\n' "${step}" | grep -Fq 'if ! command -v dbdeployer >/dev/null 2>&1; then'
+printf '%s\n' "${step}" | grep -Fq 'curl -fsSL https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash'
+printf '%s\n' "${step}" | grep -Fq 'dbdeployer --version'


### PR DESCRIPTION
## Problem

The MySQLX E2E job invokes dbdeployer’s upstream installer unconditionally. Current GitHub runners can already have `dbdeployer` in `PATH`; the installer deliberately exits non-zero in that condition, so the job fails before any E2E test runs.

## Fix

Use the existing binary when it is available. When it is absent, preserve the current installer and local-binary promotion path, now with fail-fast curl flags.

This reusable workflow belongs to the `GH-Actions` branch, so this is intentionally a separate PR from the v3.0 gcov fix.

## Verification

- `test/infra/control/test-ci-mysqlx-dbdeployer-install.bash`
- YAML parse of `.github/workflows/ci-mysqlx.yml`
- `git diff HEAD^ HEAD --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MySQLX E2E job failing when the runner already provides `dbdeployer`, and hardens the installer path with a pinned, checksum-verified script.

- Checks PATH first and uses the existing binary; only falls back to the installer when missing.
- Pins the installer to a reviewed commit, downloads over HTTPS with fail-fast flags, and verifies its SHA-256 before executing so a corrupted download stops the workflow.
- Adds a workflow-contract test that runs before installation and enforces the guard, installer command, and version check.

<sup>Written for commit b5feed3285ad3b8ef9d4eb11c957c58b3b036bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI setup to reuse an existing usable dbdeployer installation, avoiding unnecessary installation failures.
  * Preserved fallback handling when dbdeployer must be installed, including installed-version validation.
  * Added safeguards to securely retrieve the installer and verify its checksum before execution.
  * Cleaned up temporary installer files after installation.

* **Tests**
  * Expanded automated checks for installation guards, nested conditions, pinned installer retrieval, checksum verification, and version validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->