### PR TITLE
ci: use one Ubuntu 24 build for regular tests

### DIFF
--- a/.github/workflows/ci-ai-gcov.yml
+++ b/.github/workflows/ci-ai-gcov.yml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         infradb: [ 'mysql84' ]
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_src
       MATRIX: '(${{ matrix.infradb }},genai-gcov)'
 
     steps:

--- a/.github/workflows/ci-ai-gcov.yml
+++ b/.github/workflows/ci-ai-gcov.yml
@@ -76,7 +76,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -91,7 +91,6 @@ jobs:
     env:
       TESTDIST: ${{ matrix.testdist }}
       INFRADB:  ${{ matrix.infradb }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_src
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:

--- a/.github/workflows/ci-basictests.yml
+++ b/.github/workflows/ci-basictests.yml
@@ -135,7 +135,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ${{ matrix.testdist }}
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -115,32 +115,9 @@ jobs:
       matrix:
         include:
 
-          # debian12 is needed for 3p testing
-          - dist: 'debian12'
-            type: '-dbg'
-#          - dist: 'opensuse15'
-#            type: '-clang'
-
-          # ubuntu22 is needed for TAP testing
-          - dist: 'ubuntu22'
-            type: '-tap'
-
           # ubuntu24 GenAI build with code coverage
           - dist: 'ubuntu24'
             type: '-tap-genai-gcov'
-
-          # ubuntu22 chassis build for the mysqlx plugin. Injects
-          # PROXYSQL40=1 into docker-compose (see the Build step). The
-          # chassis cascade in Makefile sets PROXYSQL31 / PROXYSQLFFTO /
-          # PROXYSQLTSDB automatically, and entrypoint.bash descends into
-          # plugins/mysqlx so the .so lands at
-          # proxysql/plugins/mysqlx/ProxySQL_MySQLX_Plugin.so. CI-mysqlx's
-          # callee on this branch (ci-mysqlx.yml) restores this matrix's
-          # _src and _test caches and runs the tests without compiling
-          # anything on the bare runner -- mirroring how every other
-          # CI-* test workflow consumes the CI-builds caches.
-          - dist: 'ubuntu22'
-            type: '-tap-mysqlx'
 
           # Additive full regular producer. It enables the v4.0 chassis and
           # retains every TAP/unit binary plus every in-tree plugin in one
@@ -195,7 +172,7 @@ jobs:
     # matrix legs serially, so the stale writer can belong to a different
     # distribution than the new leg. The previous project-name-filtered cleanup
     # never matched, because the Makefile names each project
-    # <BLD_NAME>-<GITVERSION> (e.g. ubuntu22-tap-3.0.11-502-gd8bdd5a), not the
+    # <BLD_NAME>-<GITVERSION> (e.g. ubuntu24-tap-full-3.0.11-502-gd8bdd5a), not the
     # bare distribution name. Nuke ALL docker state on the runner instead: every
     # container, every volume, every network. Nothing dockerized may survive
     # into the next job.
@@ -428,8 +405,8 @@ jobs:
           # Cache size control: prune artifacts the _test cache doesn't
           # need before it gets saved. Without this pruning, the _test
           # cache grows to ~4 GB compressed (~16 GB uncompressed), and
-          # two concurrent cascades (each saving one ubuntu22-tap cache
-          # and one ubuntu24-tap-genai-gcov cache) exceed GitHub's 10 GB
+          # two concurrent cascades (each saving a regular and a gcov cache)
+          # exceed GitHub's 10 GB
           # per-repo cache quota. LRU eviction then deletes caches
           # between when CI-builds saves them and when downstream test
           # workflows try to restore them, causing "Cache restore test"
@@ -772,7 +749,7 @@ jobs:
     # computes), NOT the workflow_run default-branch SHA, so names line up
     # without any run-id correlation.
     - name: Pack src + matrix for handoff (zstd-15)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       run: |
         command -v zstd >/dev/null || sudo apt-get install -y zstd
         cd proxysql/
@@ -783,14 +760,14 @@ jobs:
         gcno=(lib/obj/*.gcno)
         tar -cf - src/ "${gcno[@]}" | zstd -15 -T0 -o ../cache_src.tar.zst
         # _matrix payload (tap-matrix* json) -- only the taptests* groups consume
-        # it, and only ubuntu22-tap generates it; skip when absent.
+        # it; skip it when absent.
         mtx=(tap-matrix*)
         if [ ${#mtx[@]} -gt 0 ]; then
           tar -cf - "${mtx[@]}" | zstd -15 -T0 -o ../cache_matrix.tar.zst
         fi
 
     - name: Upload handoff (src)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-src
@@ -800,7 +777,7 @@ jobs:
         path: cache_src.tar.zst
 
     - name: Upload handoff (test)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-test
@@ -811,13 +788,13 @@ jobs:
         path: cache_test.tar.zst
 
     - name: Upload handoff (matrix)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-matrix
         retention-days: 1
         compression-level: 0
-        # Only ubuntu22-tap generates tap-matrix*; ignore on variants without it.
+        # Only variants that generate tap-matrix* upload this payload.
         if-no-files-found: ignore
         path: cache_matrix.tar.zst
 
@@ -836,30 +813,18 @@ jobs:
           exit 1
         fi
         tar -cf - src/ test/ "${gcno[@]}" "${matrix_files[@]}" "${plugin_files[@]}" \
-          | zstd -15 -T0 -o ../full-handoff.tar.zst
+          | zstd -15 -T0 -o ../cache_full.tar.zst
 
     - name: Upload complete regular handoff
       if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-full') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: ci-builds-handoff-${{ env.SHA }}-ubuntu24-tap-full
+        name: ci-builds-handoff-${{ env.SHA }}-ubuntu24-tap-full-full
         retention-days: 1
         compression-level: 0
         if-no-files-found: error
-        path: full-handoff.tar.zst
+        path: cache_full.tar.zst
 
-    - name: Upload handoff (bin)
-      # Only the debian12-dbg build feeds the 3p suites, and they consume bin
-      # only. bin is large (.git/ + binaries/), so don't ship it for -tap.
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-dbg') }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-bin
-        retention-days: 1
-        compression-level: 0
-        if-no-files-found: error
-        # cache_bin.tar.zst is produced by the "Pack bin cache" step above.
-        path: cache_bin.tar.zst
 
     # Nuke ALL docker state before leaving the runner clean for its next job.
     # This prevents a failed or cancelled build from continuing to write

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -141,6 +141,13 @@ jobs:
           # CI-* test workflow consumes the CI-builds caches.
           - dist: 'ubuntu22'
             type: '-tap-mysqlx'
+
+          # Additive full regular producer. It enables the v4.0 chassis and
+          # retains every TAP/unit binary plus every in-tree plugin in one
+          # handoff. Consumers select TAP groups; this matrix leg must never
+          # learn plugin-specific filename patterns.
+          - dist: 'ubuntu24'
+            type: '-tap-full'
           # ubuntu22 is needed for ASAN TAP testing
           # disabled to save cache space
           #- dist: 'ubuntu22'
@@ -374,6 +381,12 @@ jobs:
           # at this matrix entry. CI-mysqlx never runs genai_*_unit-t.
           sed -i "/command/i \      - SKIP_GENAI_UNIT_TESTS=1" docker-compose.yml
         fi
+        if [[ "${{ matrix.type }}" =~ "-full" ]]; then
+          # The full regular handoff uses the chassis tier so the core and all
+          # in-tree plugins share one build. Deliberately do not inject
+          # SKIP_GENAI_UNIT_TESTS: this leg retains every test binary.
+          sed -i "/command/i \      - PROXYSQL40=1" docker-compose.yml
+        fi
         if [[ "${{ matrix.type }}" =~ "-gcov" ]]; then
           sed -i "/command/i \      - WITHGCOV=1" docker-compose.yml
         fi
@@ -437,8 +450,8 @@ jobs:
             echo "       This typically means the TAP build did not run or failed."
             exit 1
           fi
-          if [[ "${{ matrix.type }}" =~ "-mysqlx" ]] && [ "${UNIT_COUNT}" -lt 1 ]; then
-            echo "ERROR: no unit test binaries found at test/tap/tests/unit/*-t for the mysqlx cache"
+          if [[ "${{ matrix.type }}" =~ "-full" ]] && [ "${UNIT_COUNT}" -lt 1 ]; then
+            echo "ERROR: no unit test binaries found for the complete regular handoff"
             exit 1
           fi
 
@@ -459,7 +472,9 @@ jobs:
           # this cache, so preserve those and delete only the rest. Spot-
           # checks (readelf) confirm the kept binaries do not dyn-link to
           # test/deps -- the test/deps deletion below still applies.
-          if [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
+          if [[ "${{ matrix.type }}" =~ "-full" ]]; then
+            echo ">>> Retaining all ${UNIT_COUNT} unit test binaries for the complete regular handoff"
+          elif [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
             sudo find test/tap/tests/unit -type f -name '*-t' \
               ! -name 'mysqlx_*_unit-t' ! -name 'plugin_*_unit-t' -delete
             KEPT=$(find test/tap/tests/unit -type f -name '*-t' 2>/dev/null | wc -l)
@@ -639,7 +654,7 @@ jobs:
 
     - name: Pack bin cache with zstd-15
       id: cache-pack-bin
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-full') }}
       # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
       # with zstd -15 to fit more under the 10 GB repo quota. Level 15
       # captures most of the size win (~80% of what --ultra -22 gives
@@ -657,7 +672,7 @@ jobs:
 
     - name: Cache save bin
       id: cache-save-bin
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-full') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_bin
@@ -666,7 +681,7 @@ jobs:
 
     - name: Cache save src
       id: cache-save-src
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_src
@@ -706,7 +721,7 @@ jobs:
 
     - name: Pack test cache with zstd-15
       id: cache-pack-test
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
       # with zstd -15 to fit more under the 10 GB repo quota. See the
       # bin-cache pack step above for the rationale on dropping from
@@ -722,7 +737,7 @@ jobs:
 
     - name: Cache save test
       id: cache-save-test
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_test
@@ -731,7 +746,7 @@ jobs:
 
     - name: Cache save matrix
       id: cache-save-matrix
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_matrix
@@ -805,6 +820,33 @@ jobs:
         # Only ubuntu22-tap generates tap-matrix*; ignore on variants without it.
         if-no-files-found: ignore
         path: cache_matrix.tar.zst
+
+    - name: Pack complete regular handoff (zstd-15)
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-full') }}
+      run: |
+        set -euo pipefail
+        command -v zstd >/dev/null || sudo apt-get install -y zstd
+        cd proxysql/
+        shopt -s nullglob
+        gcno=(lib/obj/*.gcno)
+        matrix_files=(tap-matrix*)
+        plugin_files=(plugins/*/*.so)
+        if [ "${#plugin_files[@]}" -lt 1 ]; then
+          echo "ERROR: no plugin shared libraries were built for the complete handoff" >&2
+          exit 1
+        fi
+        tar -cf - src/ test/ "${gcno[@]}" "${matrix_files[@]}" "${plugin_files[@]}" \
+          | zstd -15 -T0 -o ../full-handoff.tar.zst
+
+    - name: Upload complete regular handoff
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-full') }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: ci-builds-handoff-${{ env.SHA }}-ubuntu24-tap-full
+        retention-days: 1
+        compression-level: 0
+        if-no-files-found: error
+        path: full-handoff.tar.zst
 
     - name: Upload handoff (bin)
       # Only the debian12-dbg build feeds the 3p suites, and they consume bin

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -132,7 +132,6 @@ jobs:
 #            type: '-clang-tap-asan'
     env:
       TAP_BUILD_MODE: ${{ needs.resolve-tap-mode.outputs.mode }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.dist }}${{ matrix.type }}${{ needs.resolve-tap-mode.outputs.mode == 'asan' && '_asan' || '' }}
       MATRIX: '(${{ matrix.dist }},${{ matrix.type }},${{ needs.resolve-tap-mode.outputs.mode }})'
 
     steps:
@@ -149,17 +148,6 @@ jobs:
 #        action_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
     
-    - name: Cache check
-      id: cache-check
-      if: ${{ inputs.trusted && success() }}
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        key: ${{ env.BLDCACHE }}_bin
-        enableCrossOsArchive: true
-        lookup-only: true
-        path: |
-          proxysql/binaries/
-
     # Self-hosted runners reuse the working directory between jobs. A cancelled
     # dockerized build can leave its Compose stack running against the
     # bind-mounted checkout (./:/opt/proxysql), where it continues to create
@@ -172,7 +160,7 @@ jobs:
     # container, every volume, every network. Nothing dockerized may survive
     # into the next job.
     - name: Nuke all docker state (self-hosted)
-      if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && runner.environment == 'self-hosted' }}
       run: |
         set -euo pipefail
         echo ">>> removing all docker containers"
@@ -193,7 +181,7 @@ jobs:
     # user first so checkout can clean. GitHub-hosted runners use an ephemeral
     # workspace and do not need this privileged operation.
     - name: Reclaim workspace ownership (self-hosted contamination guard)
-      if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && runner.environment == 'self-hosted' }}
       run: |
         set -euo pipefail
         runner_uid="$(id -u)"
@@ -215,7 +203,7 @@ jobs:
     # build container starts. Keep this guard on the self-hosted pool:
     # GitHub-hosted images already provide git-lfs, while ci-vm-1 does not.
     - name: Install Git LFS when absent (self-hosted)
-      if: ${{ inputs.trusted && runner.environment == 'self-hosted' && steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && runner.environment == 'self-hosted' }}
       run: |
         set -euo pipefail
         if command -v git-lfs >/dev/null 2>&1; then
@@ -227,7 +215,7 @@ jobs:
         git-lfs --version
 
     - name: Checkout repository
-      if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ success() }}
       env:
         # The self-hosted workspaces are persistent. Hydrating after the
         # target commit is checked out avoids git-lfs scanning the previous
@@ -277,7 +265,7 @@ jobs:
     # missing verifier expands to no loop iterations rather than a literal
     # non-executable pattern that would fail under `set -e`.
     - name: Hydrate vendored source archives
-      if: ${{ inputs.trusted && steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && success() }}
       working-directory: proxysql
       run: |
         set -euo pipefail
@@ -290,23 +278,12 @@ jobs:
           "$v"
         done
 
-#    - name: Patch TAP-tests
-#      if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
-#      run: |
-#         apply patches
-#        for PATCH in $(cd jenkins-build-scripts/test-scripts/patches && find . -type f); do
-#          if [[ $PATCH =~ \.patch ]]; then
-#            patch --verbose proxysql/${PATCH%.patch} jenkins-build-scripts/test-scripts/patches/${PATCH} || true
-#          elif [[ ! -f jenkins-build-scripts/test-scripts/patches/${PATCH#./}.patch ]]; then
-#            cp -v jenkins-build-scripts/test-scripts/patches/${PATCH#./} proxysql/${PATCH#./} || true
-#          fi
-#        done
 #        ls -l proxysql/test/tap
 
     - name: Build
       timeout-minutes: 90
       id: build
-      if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && success() }}
       run: |
         cd proxysql/
         echo "TAP build mode: ${TAP_BUILD_MODE}"
@@ -520,14 +497,14 @@ jobs:
 
     - name: Check build
       id: check_build
-      if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.trusted && success() }}
       run: |
         for LOG in proxysql/ci_build_log/build*.log ; do
           grep 'exited with code 0' ${LOG} || exit 1
         done
 
     - name: Stage MySQLX runtime libraries in test handoff
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-mysqlx') }}
+      if: ${{ inputs.trusted && success() && contains(matrix.type,'-genai') }}
       run: |
         set -euo pipefail
         cd proxysql/
@@ -580,7 +557,7 @@ jobs:
         ls -la "${runtime_dir}/"
 
     - name: Stage GenAI plugin in test handoff
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-genai') }}
+      if: ${{ inputs.trusted && success() && contains(matrix.type,'-genai') }}
       run: |
         set -euo pipefail
         cd proxysql/
@@ -595,177 +572,8 @@ jobs:
         test -s "${plugin_dest}"
         ls -la "$(dirname "${plugin_dest}")"
 
-    - name: Pack bin cache with zstd-15
-      id: cache-pack-bin
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-gcov') }}
-      # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
-      # with zstd -15 to fit more under the 10 GB repo quota. Level 15
-      # captures most of the size win (~80% of what --ultra -22 gives
-      # over default -3) at roughly 1/10 the time on this codebase --
-      # `--ultra -22` measured 14-16 min just on the test cache step per
-      # ubuntu build job (vs ~17 min for the build itself), pushing
-      # CI-builds wall clock to ~38 min and gating every downstream TAP
-      # workflow on it. Re-compression by actions/cache on the already-
-      # compressed .tar.zst is a near-no-op. Symbols are preserved
-      # bit-for-bit.
-      run: |
-        command -v zstd >/dev/null || sudo apt-get install -y zstd
-        cd proxysql/
-        tar -cf - .git/ binaries/ | zstd -15 -T0 -o ../cache_bin.tar.zst
-
-    - name: Cache save bin
-      id: cache-save-bin
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-gcov') }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        key: ${{ env.BLDCACHE }}_bin
-        enableCrossOsArchive: true
-        path: cache_bin.tar.zst
-
-    - name: Cache save src
-      id: cache-save-src
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        key: ${{ env.BLDCACHE }}_src
-        enableCrossOsArchive: true
-        # For -gcov variants, include lib/obj/*.gcno so the test
-        # workflow's coverage collector can match .gcda (runtime data
-        # written by the proxysql daemon under /gcov) to .gcno
-        # (compile-time data). Without this, fastcov sees .gcda files
-        # with no associated source-file mapping
-        # (`Missing 'current_working_directory'`, `files: []`) and
-        # produces a 0-byte .info report -- the bug that hid coverage
-        # for as long as COVERAGE=1 has existed in run-tests-isolated.bash.
-        # src/obj/*.gcno is already captured by `proxysql/src/`. The
-        # extra entry is a no-op for non-gcov builds (lib/obj/*.gcno
-        # won't exist) and adds only a few MB to the gcov cache.
-        #
-        # The plugins/mysqlx and plugins/genai .so paths are no-ops on
-        # builds without PROXYSQL40=1 (the files don't exist). For the
-        # -tap-mysqlx matrix variant they're the whole point: CI-mysqlx
-        # restores this cache and bind-mounts the .so into the ProxySQL
-        # container at /usr/lib/proxysql/ProxySQL_MySQLX_Plugin.so.
-        #
-        # IMPORTANT: this path list determines the actions/cache "version"
-        # hash. Every downstream test workflow's `Cache restore src`
-        # step on GH-Actions (ci-legacy-g1.yml, ci-mysql84-g3.yml,
-        # every ci-mariadb10-galera-*.yml, etc.) uses exactly the two
-        # paths below. DO NOT add or remove entries here without updating
-        # every downstream callee in lockstep -- adding entries here
-        # changed the cache version hash and broke ~40 downstream
-        # workflows with "Failed to restore cache entry" even though
-        # the cache existed. Plugin .so artefacts and other matrix-
-        # specific extras must ride along inside the test/ tree (where
-        # the _test cache catches them) rather than be added here.
-        path: |
-          proxysql/src/
-          proxysql/lib/obj/*.gcno
-
-    - name: Pack test cache with zstd-15
-      id: cache-pack-test
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
-      # with zstd -15 to fit more under the 10 GB repo quota. See the
-      # bin-cache pack step above for the rationale on dropping from
-      # `--ultra -22` to -15: this step alone was taking 14-16 min per
-      # ubuntu build job at --ultra -22, doubling CI-builds wall clock
-      # and blocking every downstream TAP workflow on it. Re-compression
-      # by actions/cache on the already-compressed .tar.zst is a near-
-      # no-op. Symbols are preserved bit-for-bit.
-      run: |
-        command -v zstd >/dev/null || sudo apt-get install -y zstd
-        cd proxysql/
-        tar -cf - test/ | zstd -15 -T0 -o ../cache_test.tar.zst
-
-    - name: Cache save test
-      id: cache-save-test
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        key: ${{ env.BLDCACHE }}_test
-        enableCrossOsArchive: true
-        path: cache_test.tar.zst
-
-    - name: Cache save matrix
-      id: cache-save-matrix
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        key: ${{ env.BLDCACHE }}_matrix
-        enableCrossOsArchive: true
-        path: |
-          proxysql/tap-matrix*
-
-    # === Build → test handoff via workflow artifacts ===
-    # GitHub made Actions cache WRITES read-only for untrusted / workflow_run
-    # triggers operating in default-branch context (changelog 2026-06-26): the
-    # `Cache save *` steps above get "cache write denied: token has no writable
-    # scopes" on PR/workflow_run runs even with permissions: write-all, so every
-    # downstream test workflow fails at `fail-on-cache-miss`. Workflow ARTIFACTS
-    # are not subject to that policy, so we publish the same payloads the caches
-    # carried as per-type artifacts named `ci-builds-handoff-<sha>-<variant>-<t>`
-    # (t = src|test|matrix|bin). Each test workflow downloads only the types it
-    # used to restore -- a faithful 1:1 replacement of its cache keys. The
-    # `Cache save *` steps above are now dead weight (they warn-and-noop on PRs);
-    # kept for one release to preserve the fast path on trusted `push` builds,
-    # and slated for removal once every consumer is on artifacts.
-    #
-    # env.SHA is the real head SHA (identical to the value each consumer
-    # computes), NOT the workflow_run default-branch SHA, so names line up
-    # without any run-id correlation.
-    - name: Pack src + matrix for handoff (zstd-15)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      run: |
-        command -v zstd >/dev/null || sudo apt-get install -y zstd
-        cd proxysql/
-        shopt -s nullglob
-        # _src payload: src/ (proxysql binary + src gcno) plus the lib gcno the
-        # gcov coverage collector matches against .gcda (gcov build only; the
-        # nullglob array is empty and harmless on non-gcov -tap variants).
-        gcno=(lib/obj/*.gcno)
-        tar -cf - src/ "${gcno[@]}" | zstd -15 -T0 -o ../cache_src.tar.zst
-        # _matrix payload (tap-matrix* json) -- only the taptests* groups consume
-        # it; skip it when absent.
-        mtx=(tap-matrix*)
-        if [ ${#mtx[@]} -gt 0 ]; then
-          tar -cf - "${mtx[@]}" | zstd -15 -T0 -o ../cache_matrix.tar.zst
-        fi
-
-    - name: Upload handoff (src)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-src
-        retention-days: 1
-        compression-level: 0
-        if-no-files-found: error
-        path: cache_src.tar.zst
-
-    - name: Upload handoff (test)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-test
-        retention-days: 1
-        compression-level: 0
-        if-no-files-found: error
-        # cache_test.tar.zst is produced by the "Pack test cache" step above.
-        path: cache_test.tar.zst
-
-    - name: Upload handoff (matrix)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-matrix
-        retention-days: 1
-        compression-level: 0
-        # Only variants that generate tap-matrix* upload this payload.
-        if-no-files-found: ignore
-        path: cache_matrix.tar.zst
-
     - name: Pack complete regular handoff (zstd-15)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-gcov') }}
+      if: ${{ inputs.trusted && success() && contains(matrix.type,'-gcov') }}
       run: |
         set -euo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
@@ -782,7 +590,7 @@ jobs:
           | zstd -15 -T0 -o ../cache_full.tar.zst
 
     - name: Upload complete regular handoff
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-gcov') }}
+      if: ${{ inputs.trusted && success() && contains(matrix.type,'-gcov') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-ubuntu24-tap-genai-gcov-full

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -115,16 +115,11 @@ jobs:
       matrix:
         include:
 
-          # ubuntu24 GenAI build with code coverage
+          # The sole regular producer. It builds the complete chassis with
+          # coverage metadata and retains every TAP/unit binary for every
+          # downstream group.
           - dist: 'ubuntu24'
             type: '-tap-genai-gcov'
-
-          # Additive full regular producer. It enables the v4.0 chassis and
-          # retains every TAP/unit binary plus every in-tree plugin in one
-          # handoff. Consumers select TAP groups; this matrix leg must never
-          # learn plugin-specific filename patterns.
-          - dist: 'ubuntu24'
-            type: '-tap-full'
           # ubuntu22 is needed for ASAN TAP testing
           # disabled to save cache space
           #- dist: 'ubuntu22'
@@ -172,7 +167,7 @@ jobs:
     # matrix legs serially, so the stale writer can belong to a different
     # distribution than the new leg. The previous project-name-filtered cleanup
     # never matched, because the Makefile names each project
-    # <BLD_NAME>-<GITVERSION> (e.g. ubuntu24-tap-full-3.0.11-502-gd8bdd5a), not the
+    # <BLD_NAME>-<GITVERSION> (e.g. ubuntu24-tap-genai-gcov-3.0.11-502-gd8bdd5a), not the
     # bare distribution name. Nuke ALL docker state on the runner instead: every
     # container, every volume, every network. Nothing dockerized may survive
     # into the next job.
@@ -334,35 +329,6 @@ jobs:
           # was exercising a Stable core, with FFTO/TSDB/genai/pass-through
           # #ifdef'd out. Use PROXYSQL40=1 so the core matches the tier.
           sed -i "/command/i \      - PROXYSQL40=1" docker-compose.yml
-          # Skip the ~14 genai_*_unit-t binaries. With PROXYSQL40=1 the unit
-          # Makefile's `ifeq ($(PROXYSQL40),1)` block would otherwise add them
-          # to UNIT_TESTS; they statically link 30+ plugins/genai/.cpp at
-          # -O0 -ggdb (~160 MB each, ~2 GB total, larger still under gcov) and
-          # blow the runner's free disk. This build feeds TAP integration
-          # groups, not unit-test groups (which build separately).
-          sed -i "/command/i \      - SKIP_GENAI_UNIT_TESTS=1" docker-compose.yml
-        fi
-        if [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
-          # Chassis tier flag for plugins/mysqlx build. _build.environment
-          # in docker-compose.yml already lists PROXYSQL40 as a pass-through
-          # var, and entrypoint.bash routes on it (install libprotobuf-dev,
-          # add PROXYSQL40=1 to make EXTRA, build plugins/mysqlx + plugins/
-          # genai). Setting PROXYSQL40=1 alone is enough -- Makefile cascades
-          # it into PROXYSQL31/PROXYSQLFFTO/PROXYSQLTSDB automatically.
-          sed -i "/command/i \      - PROXYSQL40=1" docker-compose.yml
-          # Skip the ~14 genai_*_unit-t binaries. With PROXYSQL40=1 the
-          # unit Makefile's `ifeq ($(PROXYSQL40),1)` block would otherwise
-          # add them to UNIT_TESTS, and they statically link 30+
-          # plugins/genai/.cpp at -O0 -ggdb (~160 MB each, ~2 GB total).
-          # That blew the runner's ~14 GB free disk on the first attempt
-          # at this matrix entry. CI-mysqlx never runs genai_*_unit-t.
-          sed -i "/command/i \      - SKIP_GENAI_UNIT_TESTS=1" docker-compose.yml
-        fi
-        if [[ "${{ matrix.type }}" =~ "-full" ]]; then
-          # The full regular handoff uses the chassis tier so the core and all
-          # in-tree plugins share one build. Deliberately do not inject
-          # SKIP_GENAI_UNIT_TESTS: this leg retains every test binary.
-          sed -i "/command/i \      - PROXYSQL40=1" docker-compose.yml
         fi
         if [[ "${{ matrix.type }}" =~ "-gcov" ]]; then
           sed -i "/command/i \      - WITHGCOV=1" docker-compose.yml
@@ -427,7 +393,7 @@ jobs:
             echo "       This typically means the TAP build did not run or failed."
             exit 1
           fi
-          if [[ "${{ matrix.type }}" =~ "-full" ]] && [ "${UNIT_COUNT}" -lt 1 ]; then
+          if [[ "${{ matrix.type }}" =~ "-gcov" ]] && [ "${UNIT_COUNT}" -lt 1 ]; then
             echo "ERROR: no unit test binaries found for the complete regular handoff"
             exit 1
           fi
@@ -449,7 +415,7 @@ jobs:
           # this cache, so preserve those and delete only the rest. Spot-
           # checks (readelf) confirm the kept binaries do not dyn-link to
           # test/deps -- the test/deps deletion below still applies.
-          if [[ "${{ matrix.type }}" =~ "-full" ]]; then
+          if [[ "${{ matrix.type }}" =~ "-gcov" ]]; then
             echo ">>> Retaining all ${UNIT_COUNT} unit test binaries for the complete regular handoff"
           elif [[ "${{ matrix.type }}" =~ "-mysqlx" ]]; then
             sudo find test/tap/tests/unit -type f -name '*-t' \
@@ -631,7 +597,7 @@ jobs:
 
     - name: Pack bin cache with zstd-15
       id: cache-pack-bin
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-gcov') }}
       # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
       # with zstd -15 to fit more under the 10 GB repo quota. Level 15
       # captures most of the size win (~80% of what --ultra -22 gives
@@ -649,7 +615,7 @@ jobs:
 
     - name: Cache save bin
       id: cache-save-bin
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && !contains(matrix.type,'-gcov') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_bin
@@ -658,7 +624,7 @@ jobs:
 
     - name: Cache save src
       id: cache-save-src
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_src
@@ -698,7 +664,7 @@ jobs:
 
     - name: Pack test cache with zstd-15
       id: cache-pack-test
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       # `actions/cache@v4` compresses with zstd level ~3; we pre-compress
       # with zstd -15 to fit more under the 10 GB repo quota. See the
       # bin-cache pack step above for the rationale on dropping from
@@ -714,7 +680,7 @@ jobs:
 
     - name: Cache save test
       id: cache-save-test
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_test
@@ -723,7 +689,7 @@ jobs:
 
     - name: Cache save matrix
       id: cache-save-matrix
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ env.BLDCACHE }}_matrix
@@ -749,7 +715,7 @@ jobs:
     # computes), NOT the workflow_run default-branch SHA, so names line up
     # without any run-id correlation.
     - name: Pack src + matrix for handoff (zstd-15)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       run: |
         command -v zstd >/dev/null || sudo apt-get install -y zstd
         cd proxysql/
@@ -767,7 +733,7 @@ jobs:
         fi
 
     - name: Upload handoff (src)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-src
@@ -777,7 +743,7 @@ jobs:
         path: cache_src.tar.zst
 
     - name: Upload handoff (test)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-test
@@ -788,7 +754,7 @@ jobs:
         path: cache_test.tar.zst
 
     - name: Upload handoff (matrix)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-tap') && !contains(matrix.type,'-gcov') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ci-builds-handoff-${{ env.SHA }}-${{ matrix.dist }}${{ matrix.type }}-matrix
@@ -799,7 +765,7 @@ jobs:
         path: cache_matrix.tar.zst
 
     - name: Pack complete regular handoff (zstd-15)
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-gcov') }}
       run: |
         set -euo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd
@@ -816,10 +782,10 @@ jobs:
           | zstd -15 -T0 -o ../cache_full.tar.zst
 
     - name: Upload complete regular handoff
-      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-full') }}
+      if: ${{ inputs.trusted && success() && steps.cache-check.outputs.cache-hit != 'true' && contains(matrix.type,'-gcov') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: ci-builds-handoff-${{ env.SHA }}-ubuntu24-tap-full-full
+        name: ci-builds-handoff-${{ env.SHA }}-ubuntu24-tap-genai-gcov-full
         retention-days: 1
         compression-level: 0
         if-no-files-found: error

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -23,13 +23,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu22-tap' ]
+        testdist: [ 'ubuntu24-tap-full' ]
         language: [ 'cpp', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
     env:
       TESTDIST: ${{ matrix.testdist }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_src
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.language }})'
 
     steps:

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu24-tap-full' ]
+        testdist: [ 'ubuntu24-tap-genai-gcov' ]
         language: [ 'cpp', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -29,7 +29,6 @@ jobs:
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
     env:
       TESTDIST: ${{ matrix.testdist }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.language }})'
 
     steps:

--- a/.github/workflows/ci-legacy-clickhouse-g1.yml
+++ b/.github/workflows/ci-legacy-clickhouse-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g1.yml
+++ b/.github/workflows/ci-legacy-g1.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g10.yml
+++ b/.github/workflows/ci-legacy-g10.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g2-genai.yml
+++ b/.github/workflows/ci-legacy-g2-genai.yml
@@ -86,7 +86,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g2.yml
+++ b/.github/workflows/ci-legacy-g2.yml
@@ -132,7 +132,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g3.yml
+++ b/.github/workflows/ci-legacy-g3.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g4.yml
+++ b/.github/workflows/ci-legacy-g4.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g5.yml
+++ b/.github/workflows/ci-legacy-g5.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g6.yml
+++ b/.github/workflows/ci-legacy-g6.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g7.yml
+++ b/.github/workflows/ci-legacy-g7.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g8.yml
+++ b/.github/workflows/ci-legacy-g8.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-legacy-g9.yml
+++ b/.github/workflows/ci-legacy-g9.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g1.yml
+++ b/.github/workflows/ci-mariadb10-galera-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g2.yml
+++ b/.github/workflows/ci-mariadb10-galera-g2.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g3.yml
+++ b/.github/workflows/ci-mariadb10-galera-g3.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g4.yml
+++ b/.github/workflows/ci-mariadb10-galera-g4.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g5.yml
+++ b/.github/workflows/ci-mariadb10-galera-g5.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g6.yml
+++ b/.github/workflows/ci-mariadb10-galera-g6.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g7.yml
+++ b/.github/workflows/ci-mariadb10-galera-g7.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g8.yml
+++ b/.github/workflows/ci-mariadb10-galera-g8.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mariadb10-galera-g9.yml
+++ b/.github/workflows/ci-mariadb10-galera-g9.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql56-single-g1.yml
+++ b/.github/workflows/ci-mysql56-single-g1.yml
@@ -79,7 +79,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-binlog-g1.yml
+++ b/.github/workflows/ci-mysql84-binlog-g1.yml
@@ -56,7 +56,7 @@ jobs:
         SHA: ${{ env.SHA }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -euo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g1.yml
+++ b/.github/workflows/ci-mysql84-g1.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g2.yml
+++ b/.github/workflows/ci-mysql84-g2.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g3.yml
+++ b/.github/workflows/ci-mysql84-g3.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g4.yml
+++ b/.github/workflows/ci-mysql84-g4.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g5.yml
+++ b/.github/workflows/ci-mysql84-g5.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g6.yml
+++ b/.github/workflows/ci-mysql84-g6.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g7.yml
+++ b/.github/workflows/ci-mysql84-g7.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g8.yml
+++ b/.github/workflows/ci-mysql84-g8.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-g9.yml
+++ b/.github/workflows/ci-mysql84-g9.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g1.yml
+++ b/.github/workflows/ci-mysql84-gr-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g2.yml
+++ b/.github/workflows/ci-mysql84-gr-g2.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g3.yml
+++ b/.github/workflows/ci-mysql84-gr-g3.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g4.yml
+++ b/.github/workflows/ci-mysql84-gr-g4.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g5.yml
+++ b/.github/workflows/ci-mysql84-gr-g5.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g6.yml
+++ b/.github/workflows/ci-mysql84-gr-g6.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g7.yml
+++ b/.github/workflows/ci-mysql84-gr-g7.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g8.yml
+++ b/.github/workflows/ci-mysql84-gr-g8.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql84-gr-g9.yml
+++ b/.github/workflows/ci-mysql84-gr-g9.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql90-gr-g1.yml
+++ b/.github/workflows/ci-mysql90-gr-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql93-gr-g1.yml
+++ b/.github/workflows/ci-mysql93-gr-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysql95-gr-g1.yml
+++ b/.github/workflows/ci-mysql95-gr-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -336,19 +336,19 @@ jobs:
 
       - name: Install MySQL 8.4 runtime libs
         # dbdeployer ships pre-built mysqld binaries that DT_NEEDED
-        # libaio1/libnuma1 (server) and libncurses5/libtinfo5 (client).
+        # libaio1t64/libnuma1 (server) and libncurses6/libtinfo6 (client).
         # ubuntu-24.04 runner image includes most but not all of these
         # by default; install explicitly so we never silently depend on
         # whatever the runner happens to ship.
         run: |
           # The runner image ships a pre-baked apt index that pins point-
           # releases which get superseded and pulled from the mirror, so a
-          # bare install 404s (e.g. libtinfo5/libncurses5 6.3-2ubuntu0.1 ->
+          # bare install 404s when a runner's pre-baked index refers to
           # "404 Not Found"). Refresh the index first so we resolve to the
           # currently-published version.
           sudo apt-get update -y
           sudo apt-get install -y -qq --no-install-recommends \
-            libaio1 libnuma1 libncurses5 libtinfo5
+            libaio1t64 libnuma1 libncurses6 libtinfo6
 
       - name: Install dbdeployer
         # Same install flow the OLD bare-runner CI-mysqlx used (the only

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -15,211 +15,6 @@ env:
   SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
 
 jobs:
-  # Run the mysqlx + plugin chassis unit-test binaries that CI-builds
-  # preserved in the test cache (see the matrix-conditional deletion in
-  # ci-builds.yml). The binaries have RUNPATH baked in pointing at
-  # /opt/proxysql/test/tap/tap (the build container's path), so they MUST
-  # execute inside the same image mounted at /opt/proxysql -- otherwise
-  # libtap.so and the bundled libcpp_dotenv.so cannot be located at
-  # runtime. The artifact is built in the Ubuntu 24 image, so its unit/e2e
-  # jobs use that same runtime image rather than relying on runner libraries.
-  unit-tests:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 120
-    permissions:
-      actions: read
-      checks: write
-      contents: read
-      packages: read
-    steps:
-      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
-        id: checks
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: '${{ github.workflow }} / ${{ github.job }}'
-          repo: ${{ github.repository }}
-          sha: ${{ env.SHA }}
-          status: 'in_progress'
-          details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-
-      - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ env.SHA }}
-          path: 'proxysql'
-          # We only need the working tree to mount under /opt/proxysql so
-          # the unit tests can find their data files (test fixtures,
-          # cert bundles, etc.) at the paths their RUNPATH expects. No
-          # sparse-checkout: a few extra MB is much cheaper than
-          # debugging a missing-file failure inside the container.
-
-      - name: Download build handoff
-        # Build payload arrives as workflow artifacts, not an Actions cache:
-        # GitHub made cache writes read-only for workflow_run/untrusted triggers
-        # (changelog 2026-06-26). Download the per-type handoff artifacts and
-        # unpack into proxysql/. The following 'Restore plugin .so' step then
-        # copies the mysqlx/genai .so out of the unpacked test tree as before.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
-          BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-          HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-          HANDOFF_TYPES: full
-        run: |
-          set -uo pipefail
-          command -v zstd >/dev/null || sudo apt-get install -y zstd
-          # Resolve the build-handoff artifact robustly. Self-hosted runners can
-          # pick up this job within ~1 min of CI-builds finishing -- earlier than
-          # GitHub-hosted runners queue -- which lands inside the window where
-          # GitHub's GLOBAL name-filtered artifact index (artifacts?name=) still
-          # lags behind creation, returning empty for an artifact that already
-          # exists. Prefer resolving via the triggering CI-builds run's OWN
-          # artifact list (run-scoped: populated as soon as the artifact is
-          # attached, not subject to the global-index lag); fall back to the
-          # global name query. Retry on a bounded budget and surface the real gh
-          # error, so a genuine build failure is distinguishable from transient lag.
-          : "${HANDOFF_MAX_ATTEMPTS:=20}"   # bounded: 20 x 15s = up to ~5 min
-          ERRLOG="$(mktemp)"
-          resolve_aid() {
-            local name="$1" out=""
-            if [ -n "${BUILD_RUN_ID:-}" ]; then
-              out=$(gh api "repos/${REPO}/actions/runs/${BUILD_RUN_ID}/artifacts?per_page=100" \
-                      --jq "[.artifacts[]|select(.name==\"${name}\" and .expired==false)]|sort_by(.created_at)|last|.id // empty" 2>>"$ERRLOG") || true
-              [ -n "$out" ] && { printf '%s' "$out"; return 0; }
-            fi
-            out=$(gh api "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" \
-                    --jq '[.artifacts[]|select(.expired==false)]|sort_by(.created_at)|last|.id // empty' 2>>"$ERRLOG") || true
-            [ -n "$out" ] && { printf '%s' "$out"; return 0; }
-            return 1
-          }
-          for t in $HANDOFF_TYPES; do
-            name="ci-builds-handoff-${SHA}-${HANDOFF_VARIANT}-${t}"
-            aid=""
-            for attempt in $(seq 1 "$HANDOFF_MAX_ATTEMPTS"); do
-              aid=$(resolve_aid "$name") && [ -n "$aid" ] && break
-              aid=""
-              echo ">>> ${name} not resolvable yet (${attempt}/${HANDOFF_MAX_ATTEMPTS}); sleeping 15s"; sleep 15
-            done
-            if [ -z "$aid" ]; then
-              echo "ERROR: handoff artifact ${name} not found after ${HANDOFF_MAX_ATTEMPTS} attempts (build_run=${BUILD_RUN_ID:-n/a}) -- did CI-builds succeed for ${SHA}?" >&2
-              echo "--- last gh errors ---" >&2; tail -n 20 "$ERRLOG" >&2
-              exit 1
-            fi
-            echo ">>> downloading ${name} (id=${aid})"
-            gh api "repos/${REPO}/actions/artifacts/${aid}/zip" > "handoff-${t}.zip" || { echo "ERROR: download ${name} failed" >&2; exit 1; }
-            unzip -o "handoff-${t}.zip" || { echo "ERROR: unzip ${name} failed" >&2; exit 1; }
-          done
-          mkdir -p proxysql
-          cd proxysql/
-          for tb in ../cache_*.tar.zst; do
-            [ -e "$tb" ] || continue
-            echo ">>> unpacking $(basename "$tb")"
-            zstd -d < "$tb" | tar -xf - || { echo "ERROR: unpack $tb failed" >&2; exit 1; }
-          done
-          rm -f ../cache_*.tar.zst ../handoff-*.zip
-
-      - name: Restore plugin .so files from _runtime_libs
-        # CI-builds stages plugins/mysqlx + plugins/genai .so files
-        # into test/tap/tap/_runtime_libs/. Shared RE2 builds also stage
-        # libre2.so.10. The _src cache path list is shared
-        # infrastructure that CANNOT be extended without invalidating
-        # every other CI workflow's cache restore, so the plugin .so
-        # files ride along inside the _test cache instead. Copy them
-        # back to plugins/mysqlx/ and plugins/genai/ (the paths the
-        # soak harness's setup-infras.bash bind-mounts from).
-        run: |
-          cd proxysql/
-          mkdir -p plugins/mysqlx plugins/genai
-          [ -f test/tap/tap/_runtime_libs/ProxySQL_MySQLX_Plugin.so ] && \
-            cp test/tap/tap/_runtime_libs/ProxySQL_MySQLX_Plugin.so plugins/mysqlx/
-          [ -f test/tap/tap/_runtime_libs/ProxySQL_GenAI_Plugin.so ] && \
-            cp test/tap/tap/_runtime_libs/ProxySQL_GenAI_Plugin.so plugins/genai/
-          ls -la plugins/mysqlx/ plugins/genai/ 2>/dev/null || true
-
-      - name: Log in to GHCR and pull build image
-        env:
-          GHCR_USER: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Pull the same image CI-builds compiled the unit tests in. Mirrors
-        # ci-legacy-g4's GHCR pull pattern (login + pull retry loop). The
-        # image is large (~1 GB) but it's already cached on most runners
-        # because every CI-builds run touches it.
-        run: |
-          set +e
-          attempt=0
-          max_attempts=5
-          while [ $attempt -lt $max_attempts ]; do
-            attempt=$((attempt + 1))
-            echo ">>> GHCR login+pull attempt ${attempt}/${max_attempts}"
-            if echo "$GHCR_TOKEN" | docker login ghcr.io \
-                -u "$GHCR_USER" --password-stdin \
-                && docker pull proxysql/packaging:build-ubuntu24-v4.0.0; then
-              echo ">>> pull OK on attempt ${attempt}"
-              exit 0
-            fi
-            if [ $attempt -lt $max_attempts ]; then
-              sleep_for=$((attempt * 10))
-              echo ">>> attempt ${attempt} failed; sleeping ${sleep_for}s"
-              sleep $sleep_for
-            fi
-          done
-          echo ">>> all ${max_attempts} pull attempts failed"
-          exit 1
-
-      - name: Run mysqlx + plugin unit tests inside build image
-        # Mount the workspace at /opt/proxysql so the binaries' baked-in
-        # RUNPATH resolves. Each binary exits 0 on success / non-zero on
-        # TAP failure; loop exits at the first failure with the
-        # offending binary name in the log. --network none so the unit
-        # tests stay isolated from anything that might be running on the
-        # runner (these are unit tests, not integration tests; nothing
-        # legitimately needs network).
-        run: |
-          docker run --rm \
-            --network none \
-            -v "$(pwd)/proxysql:/opt/proxysql" \
-            -w /opt/proxysql/test/tap/tests/unit \
-            -e LD_LIBRARY_PATH=/opt/proxysql/test/tap/tap/_runtime_libs \
-            proxysql/packaging:build-ubuntu24-v4.0.0 \
-            bash -c '
-              set -e
-              fails=""
-              for t in mysqlx_*_unit-t plugin_*_unit-t; do
-                [ -x "$t" ] || continue
-                echo ">>> ./$t"
-                if ! ./"$t"; then
-                  fails="${fails}${t} "
-                fi
-              done
-              if [ -n "$fails" ]; then
-                echo ">>> FAILED: ${fails}"
-                exit 1
-              fi
-              echo ">>> all unit tests passed"
-            '
-
-      - name: Archive logs on failure
-        if: ${{ failure() && !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: ${{ github.workflow }}-${{ env.SHA }}-${{ github.job }}-run#${{ github.run_number }}
-          path: |
-            proxysql/test/tap/tests/unit/*.log
-          if-no-files-found: ignore
-
-      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          check_id: ${{ steps.checks.outputs.check_id }}
-          repo: ${{ github.repository }}
-          sha: ${{ env.SHA }}
-          conclusion: ${{ job.status }}
-          details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-
   # The handshake-only e2e tests talk to a MySQL 8.4 X-protocol sandbox
   # directly (SKIP_PROXYSQL=1 — they validate that the in-tree client
   # wire code is compatible with upstream, not that ProxySQL proxies
@@ -230,7 +25,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
-    needs: unit-tests
+
     permissions:
       actions: read
       checks: write
@@ -508,7 +303,7 @@ jobs:
   soak-tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
-    needs: unit-tests
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -13,15 +13,9 @@ env:
   # and check_run posts use this so the entire pipeline operates on one
   # SHA consistently.
   SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
-  # CI-builds writes this matrix's caches as <SHA>_ubuntu22-tap-mysqlx_*.
-  # The full chassis tier (PROXYSQL40=1 and the cascaded PROXYSQL31/
-  # PROXYSQLFFTO/PROXYSQLTSDB) is built inside the proxysql/packaging:
-  # build-ubuntu22-v4.0.0 image; this file just restores artefacts and
-  # runs tests. Pre-rewrite, CI-mysqlx was the only test workflow that
-  # compiled proxysql on the bare GitHub runner, which made every failure
-  # mode an infra symptom (OOM, disk-full, missing gnutls, mysql.h
-  # roulette) — see the audit trail on PR #5852.
-  BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap-mysqlx
+  # CI-builds writes one complete regular Ubuntu 24 handoff per SHA. This
+  # workflow restores it and runs MysqlX tests; it never rebuilds ProxySQL.
+  BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-full_full
 
 jobs:
   # Run the mysqlx + plugin chassis unit-test binaries that CI-builds
@@ -72,8 +66,8 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
           BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-          HANDOFF_VARIANT: ubuntu22-tap-mysqlx
-          HANDOFF_TYPES: src test
+          HANDOFF_VARIANT: ubuntu24-tap-full
+          HANDOFF_TYPES: full
         run: |
           set -uo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd
@@ -268,8 +262,8 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
           BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-          HANDOFF_VARIANT: ubuntu22-tap-mysqlx
-          HANDOFF_TYPES: src test
+          HANDOFF_VARIANT: ubuntu24-tap-full
+          HANDOFF_TYPES: full
         run: |
           set -uo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd
@@ -553,8 +547,8 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
           BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-          HANDOFF_VARIANT: ubuntu22-tap-mysqlx
-          HANDOFF_TYPES: src test
+          HANDOFF_VARIANT: ubuntu24-tap-full
+          HANDOFF_TYPES: full
         run: |
           set -uo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -15,7 +15,7 @@ env:
   SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
   # CI-builds writes one complete regular Ubuntu 24 handoff per SHA. This
   # workflow restores it and runs MysqlX tests; it never rebuilds ProxySQL.
-  BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-full_full
+  BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_full
 
 jobs:
   # Run the mysqlx + plugin chassis unit-test binaries that CI-builds
@@ -66,7 +66,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
           BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-          HANDOFF_VARIANT: ubuntu24-tap-full
+          HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
           HANDOFF_TYPES: full
         run: |
           set -uo pipefail
@@ -262,7 +262,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
           BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-          HANDOFF_VARIANT: ubuntu24-tap-full
+          HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
           HANDOFF_TYPES: full
         run: |
           set -uo pipefail
@@ -547,7 +547,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
           BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-          HANDOFF_VARIANT: ubuntu24-tap-full
+          HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
           HANDOFF_TYPES: full
         run: |
           set -uo pipefail

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -24,11 +24,10 @@ jobs:
   # /opt/proxysql/test/tap/tap (the build container's path), so they MUST
   # execute inside the same image mounted at /opt/proxysql -- otherwise
   # libtap.so and the bundled libcpp_dotenv.so cannot be located at
-  # runtime. Trying to run them directly on the ubuntu-22.04 runner with
-  # an LD_LIBRARY_PATH override also misses libprotobuf.so.32 (the build
-  # image ships protobuf 5.x; ubuntu-22.04 packages only protobuf 3.x).
+  # runtime. The artifact is built in the Ubuntu 24 image, so its unit/e2e
+  # jobs use that same runtime image rather than relying on runner libraries.
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions: write-all
     steps:
@@ -156,7 +155,7 @@ jobs:
             echo ">>> GHCR login+pull attempt ${attempt}/${max_attempts}"
             if echo "$GHCR_TOKEN" | docker login ghcr.io \
                 -u "$GHCR_USER" --password-stdin \
-                && docker pull proxysql/packaging:build-ubuntu22-v4.0.0; then
+                && docker pull proxysql/packaging:build-ubuntu24-v4.0.0; then
               echo ">>> pull OK on attempt ${attempt}"
               exit 0
             fi
@@ -183,7 +182,7 @@ jobs:
             -v "$(pwd)/proxysql:/opt/proxysql" \
             -w /opt/proxysql/test/tap/tests/unit \
             -e LD_LIBRARY_PATH=/opt/proxysql/test/tap/tap/_runtime_libs \
-            proxysql/packaging:build-ubuntu22-v4.0.0 \
+            proxysql/packaging:build-ubuntu24-v4.0.0 \
             bash -c '
               set -e
               fails=""
@@ -228,7 +227,7 @@ jobs:
   # reach 127.0.0.1:$mysqlx_port. mysqlx-e2e/env.sh documents this
   # arrangement.
   e2e-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs: unit-tests
     permissions: write-all
@@ -338,7 +337,7 @@ jobs:
       - name: Install MySQL 8.4 runtime libs
         # dbdeployer ships pre-built mysqld binaries that DT_NEEDED
         # libaio1/libnuma1 (server) and libncurses5/libtinfo5 (client).
-        # ubuntu-22.04 runner image includes most but not all of these
+        # ubuntu-24.04 runner image includes most but not all of these
         # by default; install explicitly so we never silently depend on
         # whatever the runner happens to ship.
         run: |
@@ -436,7 +435,7 @@ jobs:
             attempt=$((attempt + 1))
             if echo "$GHCR_TOKEN" | docker login ghcr.io \
                 -u "$GHCR_USER" --password-stdin \
-                && docker pull proxysql/packaging:build-ubuntu22-v4.0.0; then
+                && docker pull proxysql/packaging:build-ubuntu24-v4.0.0; then
               exit 0
             fi
             sleep $((attempt * 10))
@@ -458,7 +457,7 @@ jobs:
             -e "MYSQLX_E2E_PORT=${MYSQLX_E2E_PORT}" \
             -e LD_LIBRARY_PATH=/opt/proxysql/test/tap/tap/_runtime_libs \
             -w /opt/proxysql/test/tap/tests \
-            proxysql/packaging:build-ubuntu22-v4.0.0 \
+            proxysql/packaging:build-ubuntu24-v4.0.0 \
             bash -c '
               set -e
               DISCOVERED="${MYSQLX_E2E_PORT:?missing}"
@@ -502,7 +501,7 @@ jobs:
   # ProxySQL container per PROXYSQL_LOAD_MYSQLX_PLUGIN=1 in
   # mysqlx-soak/env.sh.
   soak-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs: unit-tests
     strategy:

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -13,9 +13,6 @@ env:
   # and check_run posts use this so the entire pipeline operates on one
   # SHA consistently.
   SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
-  # CI-builds writes one complete regular Ubuntu 24 handoff per SHA. This
-  # workflow restores it and runs MysqlX tests; it never rebuilds ProxySQL.
-  BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_full
 
 jobs:
   # Run the mysqlx + plugin chassis unit-test binaries that CI-builds
@@ -29,7 +26,11 @@ jobs:
   unit-tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
-    permissions: write-all
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      packages: read
     steps:
       - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         id: checks
@@ -230,7 +231,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs: unit-tests
-    permissions: write-all
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      packages: read
     steps:
       - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         id: checks
@@ -508,7 +513,11 @@ jobs:
       fail-fast: false
       matrix:
         connector_version: ['9.7.0', '26.7.0']
-    permissions: write-all
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      packages: read
     steps:
       - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         id: checks

--- a/.github/workflows/ci-no-infra-g1.yml
+++ b/.github/workflows/ci-no-infra-g1.yml
@@ -141,7 +141,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-pgsql-socket-g1.yml
+++ b/.github/workflows/ci-pgsql-socket-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -14,6 +14,10 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +27,6 @@ jobs:
     env:
       TESTDIST: ${{ matrix.testdist }}
       INFRADB:  ${{ matrix.infradb }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu24-tap-full' ]
+        testdist: [ 'ubuntu24-tap-genai-gcov' ]
 #        infradb: [ 'mysql57', 'mysql80', 'mysql81', 'mysql82', 'mariadb10', 'mariadb11' ]
         infradb: [ 'mysql57' ]
     env:

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu22-tap' ]
+        testdist: [ 'ubuntu24-tap-full' ]
 #        infradb: [ 'mysql57', 'mysql80', 'mysql81', 'mysql82', 'mariadb10', 'mariadb11' ]
         infradb: [ 'mysql57' ]
     env:
       TESTDIST: ${{ matrix.testdist }}
       INFRADB:  ${{ matrix.infradb }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_src
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:
@@ -86,7 +86,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ${{ matrix.testdist }}
-        HANDOFF_TYPES: src
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-repltests.yml
+++ b/.github/workflows/ci-repltests.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu24-tap-full' ]
+        testdist: [ 'ubuntu24-tap-genai-gcov' ]
 #        infradb: [ 'mysql57', 'mysql80', 'mysql81', 'mysql82', 'mariadb10', 'mariadb11' ]
         infradb: [ 'mysql57' ]
     env:

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu22-tap' ]
+        testdist: [ 'ubuntu24-tap-full' ]
 #        infradb: [ 'mysql57', 'mysql80', 'mysql81', 'mysql82', 'mariadb10', 'mariadb11' ]
         infradb: [ 'mysql57' ]
     env:
       TESTDIST: ${{ matrix.testdist }}
       INFRADB:  ${{ matrix.infradb }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_src
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:
@@ -68,7 +68,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ${{ matrix.testdist }}
-        HANDOFF_TYPES: src
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -14,6 +14,10 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +27,6 @@ jobs:
     env:
       TESTDIST: ${{ matrix.testdist }}
       INFRADB:  ${{ matrix.infradb }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:

--- a/.github/workflows/ci-selftests.yml
+++ b/.github/workflows/ci-selftests.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-set_parser_algorithm_3-g1.yml
+++ b/.github/workflows/ci-set_parser_algorithm_3-g1.yml
@@ -73,7 +73,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -14,6 +14,10 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +27,6 @@ jobs:
     env:
       TESTDIST: ${{ matrix.testdist }}
       INFRADB:  ${{ matrix.infradb }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu24-tap-full' ]
+        testdist: [ 'ubuntu24-tap-genai-gcov' ]
 #        infradb: [ 'mysql57', 'mysql80', 'mysql81', 'mysql82', 'mariadb10', 'mariadb11' ]
         infradb: [ 'mysql57' ]
     env:

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testdist: [ 'ubuntu22-tap' ]
+        testdist: [ 'ubuntu24-tap-full' ]
 #        infradb: [ 'mysql57', 'mysql80', 'mysql81', 'mysql82', 'mariadb10', 'mariadb11' ]
         infradb: [ 'mysql57' ]
     env:
       TESTDIST: ${{ matrix.testdist }}
       INFRADB:  ${{ matrix.infradb }}
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_src
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_${{ matrix.testdist }}_full
       MATRIX: '(${{ matrix.infradb }})'
 
     steps:
@@ -86,7 +86,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ${{ matrix.testdist }}
-        HANDOFF_TYPES: src
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-shuntest.yml
+++ b/.github/workflows/ci-shuntest.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-taptests-pgsql-cluster.yml
+++ b/.github/workflows/ci-taptests-pgsql-cluster.yml
@@ -106,7 +106,7 @@ jobs:
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
         HANDOFF_VARIANT: ${{ matrix.testdist }}
-        HANDOFF_TYPES: src test
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd

--- a/.github/workflows/ci-unit-group.yml
+++ b/.github/workflows/ci-unit-group.yml
@@ -96,7 +96,9 @@ jobs:
               && docker pull proxysql/packaging:build-ubuntu24-v4.0.0; then
               exit 0
             fi
-            sleep "$((attempt * 10))"
+            if [ "${attempt}" -lt 5 ]; then
+              sleep "$((attempt * 10))"
+            fi
           done
           echo "ERROR: failed to pull Ubuntu 24 build image after 5 attempts" >&2
           exit 1

--- a/.github/workflows/ci-unit-group.yml
+++ b/.github/workflows/ci-unit-group.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           set -euo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd
-          artifact_name="ci-builds-handoff-${SHA}-ubuntu24-tap-full-full"
+          artifact_name="ci-builds-handoff-${SHA}-ubuntu24-tap-genai-gcov-full"
           : "${HANDOFF_MAX_ATTEMPTS:=20}"
           error_log="$(mktemp)"
           resolve_artifact_id() {

--- a/.github/workflows/ci-unit-group.yml
+++ b/.github/workflows/ci-unit-group.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           set -euo pipefail
           command -v zstd >/dev/null || sudo apt-get install -y zstd
-          artifact_name="ci-builds-handoff-${SHA}-ubuntu24-tap-full"
+          artifact_name="ci-builds-handoff-${SHA}-ubuntu24-tap-full-full"
           : "${HANDOFF_MAX_ATTEMPTS:=20}"
           error_log="$(mktemp)"
           resolve_artifact_id() {
@@ -80,8 +80,8 @@ jobs:
           fi
           gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > full-handoff.zip
           unzip -o full-handoff.zip
-          zstd -d < full-handoff.tar.zst | tar -xf - -C proxysql
-          rm -f full-handoff.zip full-handoff.tar.zst
+          zstd -d < cache_full.tar.zst | tar -xf - -C proxysql
+          rm -f full-handoff.zip cache_full.tar.zst
           test -x proxysql/src/proxysql
 
       - name: Pull Ubuntu 24 build image

--- a/.github/workflows/ci-unit-group.yml
+++ b/.github/workflows/ci-unit-group.yml
@@ -90,8 +90,16 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
-          docker pull proxysql/packaging:build-ubuntu24-v4.0.0
+          for attempt in 1 2 3 4 5; do
+            echo ">>> GHCR login+pull attempt ${attempt}/5"
+            if echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin \
+              && docker pull proxysql/packaging:build-ubuntu24-v4.0.0; then
+              exit 0
+            fi
+            sleep "$((attempt * 10))"
+          done
+          echo "ERROR: failed to pull Ubuntu 24 build image after 5 attempts" >&2
+          exit 1
 
       - name: Run selected unit group
         env:

--- a/.github/workflows/ci-unit-group.yml
+++ b/.github/workflows/ci-unit-group.yml
@@ -1,0 +1,158 @@
+name: CI unit group
+
+on:
+  workflow_call:
+    inputs:
+      trigger:
+        type: string
+      tap_group:
+        type: string
+        required: true
+
+env:
+  SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      packages: read
+    steps:
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
+        id: check
+        if: always()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: '${{ github.workflow }} / ${{ github.job }} (${{ inputs.tap_group }})'
+          repo: ${{ github.repository }}
+          sha: ${{ env.SHA }}
+          status: in_progress
+          details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ env.SHA }}
+          path: proxysql
+          persist-credentials: false
+
+      - name: Download complete regular handoff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
+        run: |
+          set -euo pipefail
+          command -v zstd >/dev/null || sudo apt-get install -y zstd
+          artifact_name="ci-builds-handoff-${SHA}-ubuntu24-tap-full"
+          : "${HANDOFF_MAX_ATTEMPTS:=20}"
+          error_log="$(mktemp)"
+          resolve_artifact_id() {
+            local artifact_id=""
+            if [ -n "${BUILD_RUN_ID}" ]; then
+              artifact_id="$(gh api "repos/${REPO}/actions/runs/${BUILD_RUN_ID}/artifacts?per_page=100" \
+                --jq ".artifacts[] | select(.name == \"${artifact_name}\" and .expired == false) | .id" \
+                2>>"${error_log}" | tail -n1 || true)"
+            fi
+            if [ -z "${artifact_id}" ]; then
+              artifact_id="$(gh api "repos/${REPO}/actions/artifacts?name=${artifact_name}&per_page=100" \
+                --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .id // empty' \
+                2>>"${error_log}" || true)"
+            fi
+            printf '%s' "${artifact_id}"
+          }
+          artifact_id=""
+          for attempt in $(seq 1 "${HANDOFF_MAX_ATTEMPTS}"); do
+            artifact_id="$(resolve_artifact_id)"
+            [ -n "${artifact_id}" ] && break
+            echo ">>> ${artifact_name} is not available (${attempt}/${HANDOFF_MAX_ATTEMPTS}); retrying in 15s"
+            sleep 15
+          done
+          if [ -z "${artifact_id}" ]; then
+            echo "ERROR: complete regular handoff ${artifact_name} was not found" >&2
+            tail -n 20 "${error_log}" >&2 || true
+            exit 1
+          fi
+          gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > full-handoff.zip
+          unzip -o full-handoff.zip
+          zstd -d < full-handoff.tar.zst | tar -xf - -C proxysql
+          rm -f full-handoff.zip full-handoff.tar.zst
+          test -x proxysql/src/proxysql
+
+      - name: Pull Ubuntu 24 build image
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+          docker pull proxysql/packaging:build-ubuntu24-v4.0.0
+
+      - name: Run selected unit group
+        env:
+          TAP_GROUP: ${{ inputs.tap_group }}
+        run: |
+          set -euo pipefail
+          docker run --rm --network none \
+            -e TAP_GROUP \
+            -v "${PWD}/proxysql:/opt/proxysql" \
+            -w /opt/proxysql \
+            -e LD_LIBRARY_PATH=/opt/proxysql/test/tap/tap:/opt/proxysql/test/tap/tap/_runtime_libs \
+            proxysql/packaging:build-ubuntu24-v4.0.0 \
+            bash -ceu '
+              python3 - <<"PY" > /tmp/unit-tests
+              import json
+              import os
+              import pathlib
+              import sys
+
+              group = os.environ["TAP_GROUP"]
+              with open("test/tap/groups/groups.json", encoding="utf-8") as source:
+                  groups = json.load(source)
+              selected = sorted(name for name, tags in groups.items() if group in tags)
+              if not selected:
+                  raise SystemExit(f"ERROR: no tests are registered for {group}")
+              unit_dir = pathlib.Path("test/tap/tests/unit")
+              for name in selected:
+                  path = unit_dir / name
+                  if not path.is_file() or not os.access(path, os.X_OK):
+                      raise SystemExit(
+                          f"ERROR: {group} selects non-unit or missing executable: {name}"
+                      )
+                  print(path)
+              PY
+              failed=""
+              while IFS= read -r test_binary; do
+                echo ">>> ${test_binary}"
+                if ! "${test_binary}"; then
+                  failed="${failed} ${test_binary}"
+                fi
+              done < /tmp/unit-tests
+              if [ -n "${failed}" ]; then
+                echo ">>> FAILED:${failed}" >&2
+                exit 1
+              fi
+            '
+
+      - name: Archive unit-test logs on failure
+        if: ${{ failure() && !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ github.workflow }}-${{ env.SHA }}-${{ inputs.tap_group }}-logs-run#${{ github.run_number }}
+          path: proxysql/test/tap/tests/unit/*.log
+          if-no-files-found: ignore
+
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
+        if: always()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check_id: ${{ steps.check.outputs.check_id }}
+          repo: ${{ github.repository }}
+          sha: ${{ env.SHA }}
+          conclusion: ${{ job.status }}
+          details_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -14,8 +14,11 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_full
       MATRIX: '(unit-tests-g1)'
 
     steps:

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-full_full
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_full
       MATRIX: '(unit-tests-g1)'
 
     steps:
@@ -54,7 +54,7 @@ jobs:
         REPO: ${{ github.repository }}
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-        HANDOFF_VARIANT: ubuntu24-tap-full
+        HANDOFF_VARIANT: ubuntu24-tap-genai-gcov
         HANDOFF_TYPES: full
       run: |
         set -uo pipefail

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     env:
       BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-genai-gcov_full

--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     env:
-      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu22-tap_src
+      BLDCACHE: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}_ubuntu24-tap-full_full
       MATRIX: '(unit-tests-g1)'
 
     steps:
@@ -54,8 +54,8 @@ jobs:
         REPO: ${{ github.repository }}
         SHA: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.head_sha || github.sha }}
         BUILD_RUN_ID: ${{ inputs.trigger && fromJson(inputs.trigger).event.workflow_run.id || '' }}
-        HANDOFF_VARIANT: ubuntu22-tap
-        HANDOFF_TYPES: src test
+        HANDOFF_VARIANT: ubuntu24-tap-full
+        HANDOFF_TYPES: full
       run: |
         set -uo pipefail
         command -v zstd >/dev/null || sudo apt-get install -y zstd


### PR DESCRIPTION
## Scope

Consolidate regular CI to one build process and one complete handoff.

## Producer

`ubuntu24-tap-genai-gcov` is the **only** regular CI-builds matrix entry. It:

- enables the v4.0 chassis;
- builds every in-tree plugin;
- retains every TAP and unit executable, including GenAI and MysqlX units;
- retains the matching gcov metadata; and
- publishes one SHA-scoped `full` artifact containing `src/`, `test/`, plugin shared objects, coverage metadata, and generated TAP matrices.

There is no `ubuntu24-tap-full`, `ubuntu22-tap`, `ubuntu22-tap-mysqlx`, or `debian12-dbg` producer leg.

## Consumers

All regular TAP consumers now restore `ubuntu24-tap-genai-gcov-full`, unpack it once, and select their own test group. This includes the MysqlX, generic unit-group, standard infrastructure, replication, shunning, and self-test workflows. No consumer recompiles ProxySQL; no producer contains plugin-specific consumer test lists.

## Deliberate boundary

The ten Debian-oriented third-party workflow definitions have no automatic regular-CI caller. They use a different historical binary-package contract and are not misrepresented as consumers of this TAP handoff; that migration is follow-up work.

## Verification

- Parsed every workflow on GH-Actions with Python/PyYAML.
- Static graph contract: one matrix entry, no `SKIP_GENAI_UNIT_TESTS`, no retired Ubuntu 22 producer references, no split `src test` regular handoff requests, and the full producer artifact is present.
- `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reusable CI support for running selected TAP unit-test groups, including build retrieval, test execution, failure-log archiving, and status reporting.

- **CI Improvements**
  - Standardized test workflows on Ubuntu 24 with coverage-enabled builds.
  - Consolidated build handoffs into a single complete artifact across CI test suites.
  - Added retry and fallback handling when retrieving build artifacts.
  - Updated CodeQL, MySQL, self-test, REPL, and legacy test workflows to use the new build handoff.
  - Simplified CI build production and execution paths for more consistent workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->