### PR TITLE
fix(tsan): run all unit tests and dedup mysqlx disk fixture

### DIFF
--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -19,7 +19,11 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 #
 #   The test phase runs the resulting *-t binaries through
 #   `test/infra/control/run-tests-isolated.bash` driving TAP_GROUP
-#   `mysqlx-tsan-g1`. The harness is the same one used locally.
+#   `mysqlx-tsan-g1` first, then the full `unit-tests-g1` group.
+#   The second phase is free: `make ubuntu24-tap` already built every
+#   UNIT_TESTS binary, and both groups are standalone (SKIP_PROXYSQL=1,
+#   same TSAN_OPTIONS) — so the ~50 min TSAN build is amortized over
+#   all 113 unit tests instead of just the 26 mysqlx/plugin ones.
 #
 # Why this PR doesn't restore the CI-builds cache:
 #
@@ -66,7 +70,7 @@ jobs:
     # 'cache write denied: token has no writable scopes'.
     permissions: write-all
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
 
@@ -121,7 +125,7 @@ jobs:
       run: |
         make ubuntu24-tap
 
-    - name: Run mysqlx-tsan-g1 TAP group inside Docker
+    - name: Run mysqlx-tsan-g1 + unit-tests-g1 TAP groups inside Docker
       # Run the TSAN-instrumented unit tests INSIDE the same Docker
       # image used for the build — same source mount at /opt/proxysql,
       # same toolchain, same libstdc++/libgcc that the binaries linked
@@ -156,6 +160,20 @@ jobs:
       # run-tests-isolated.bash, so it just iterates groups.json and
       # execs each *-t binary in turn — no nested docker, no Python
       # tester. TSAN_OPTIONS comes from mysqlx-tsan-g1/env.sh.
+      #
+      # Two phases, one container invocation:
+      #   1. TAP_GROUP=mysqlx-tsan-g1 — the 26 TSAN-targeted mysqlx +
+      #      plugin-chassis binaries (env.sh supplies SKIP_PROXYSQL=1
+      #      and TSAN_OPTIONS).
+      #   2. TAP_GROUP=unit-tests-g1 — all 113 unit tests, which
+      #      include the 26 above plus the ~87 already-built core /
+      #      duckdb / genai / mcp binaries the build phase produced
+      #      for free. unit-tests-g1 has no env.sh, so SKIP_PROXYSQL=1
+      #      and the same TSAN_OPTIONS are exported inline; every
+      #      *-t binary is standalone and needs no daemon or backend.
+      #      TSAN_OPTIONS keeps halt_on_error=0, so tests never
+      #      TSAN-validated before report races without failing the
+      #      binary — worst case is noisy stderr, not a red build.
       env:
         TAP_GROUP: mysqlx-tsan-g1
         INFRA_ID: ci-unit-tests-tsan
@@ -179,7 +197,8 @@ jobs:
           -lc 'apt-get update -qq \
                && apt-get install -y --no-install-recommends python3-packaging libprotobuf-dev \
                && cd /opt/proxysql \
-               && test/infra/control/run-tests-isolated.bash'
+               && TAP_GROUP=mysqlx-tsan-g1 test/infra/control/run-tests-isolated.bash \
+               && SKIP_PROXYSQL=1 TSAN_OPTIONS="halt_on_error=0:abort_on_error=0:second_deadlock_stack=1:history_size=7" TAP_GROUP=unit-tests-g1 test/infra/control/run-tests-isolated.bash'
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}

--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -19,11 +19,13 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 #
 #   The test phase runs the resulting *-t binaries through
 #   `test/infra/control/run-tests-isolated.bash` driving TAP_GROUP
-#   `mysqlx-tsan-g1` first, then the full `unit-tests-g1` group.
-#   The second phase is free: `make ubuntu24-tap` already built every
-#   UNIT_TESTS binary, and both groups are standalone (SKIP_PROXYSQL=1,
-#   same TSAN_OPTIONS) — so the ~50 min TSAN build is amortized over
-#   all 113 unit tests instead of just the 26 mysqlx/plugin ones.
+#   `mysqlx-tsan-g1` first (the 26 TSAN-targeted mysqlx/plugin
+#   binaries; TSan reports remain fatal via the default exitcode),
+#   then `unit-tests-g1` excluding that overlap. The second phase is
+#   free: `make ubuntu24-tap` already built every UNIT_TESTS binary,
+#   and both groups are standalone (SKIP_PROXYSQL=1) — so the ~50 min
+#   TSAN build is amortized over all 113 unit tests instead of just
+#   the 26 mysqlx/plugin ones.
 #
 # Why this PR doesn't restore the CI-builds cache:
 #
@@ -159,21 +161,21 @@ jobs:
       # SKIP_PROXYSQL=1 short-circuits the daemon + backend checks in
       # run-tests-isolated.bash, so it just iterates groups.json and
       # execs each *-t binary in turn — no nested docker, no Python
-      # tester. TSAN_OPTIONS comes from mysqlx-tsan-g1/env.sh.
-      #
-      # Two phases, one container invocation:
-      #   1. TAP_GROUP=mysqlx-tsan-g1 — the 26 TSAN-targeted mysqlx +
-      #      plugin-chassis binaries (env.sh supplies SKIP_PROXYSQL=1
-      #      and TSAN_OPTIONS).
-      #   2. TAP_GROUP=unit-tests-g1 — all 113 unit tests, which
-      #      include the 26 above plus the ~87 already-built core /
-      #      duckdb / genai / mcp binaries the build phase produced
-      #      for free. unit-tests-g1 has no env.sh, so SKIP_PROXYSQL=1
-      #      and the same TSAN_OPTIONS are exported inline; every
-      #      *-t binary is standalone and needs no daemon or backend.
-      #      TSAN_OPTIONS keeps halt_on_error=0, so tests never
-      #      TSAN-validated before report races without failing the
-      #      binary — worst case is noisy stderr, not a red build.
+       # tester. TSAN_OPTIONS comes from mysqlx-tsan-g1/env.sh.
+       #
+       # Two phases, one container invocation. Both always run; the
+       # combined status fails if either phase fails.
+       #   1. TAP_GROUP=mysqlx-tsan-g1 — the 26 TSAN-targeted mysqlx +
+       #      plugin-chassis binaries (env.sh supplies SKIP_PROXYSQL=1
+       #      and TSAN_OPTIONS). TSan reports still fail the binary
+       #      (default exitcode 66).
+       #   2. TAP_GROUP=unit-tests-g1 — the remaining already-built
+       #      core / duckdb / genai / mcp binaries. unit-tests-g1 has
+       #      no env.sh, so SKIP_PROXYSQL=1 and TSAN_OPTIONS are
+       #      exported inline. TEST_PY_TAP_EXCL drops the phase-1
+       #      overlap. halt_on_error=0:exitcode=0 keeps never-TSAN-
+       #      validated tests from red-ing the build on a race
+       #      report (TAP assertion failures still fail).
       env:
         TAP_GROUP: mysqlx-tsan-g1
         INFRA_ID: ci-unit-tests-tsan
@@ -194,11 +196,13 @@ jobs:
           -e TAP_GROUP="${TAP_GROUP}" \
           --entrypoint bash \
           ubuntu24_dbg_build \
-          -lc 'apt-get update -qq \
-               && apt-get install -y --no-install-recommends python3-packaging libprotobuf-dev \
-               && cd /opt/proxysql \
-               && TAP_GROUP=mysqlx-tsan-g1 test/infra/control/run-tests-isolated.bash \
-               && SKIP_PROXYSQL=1 TSAN_OPTIONS="halt_on_error=0:abort_on_error=0:second_deadlock_stack=1:history_size=7" TAP_GROUP=unit-tests-g1 test/infra/control/run-tests-isolated.bash'
+           -lc 'apt-get update -qq \
+                && apt-get install -y --no-install-recommends python3-packaging libprotobuf-dev \
+                && cd /opt/proxysql \
+                && { TAP_GROUP=mysqlx-tsan-g1 test/infra/control/run-tests-isolated.bash; mysqlx_status=$?
+                     tsan_excl=$(python3 -c "import json; g=json.load(open('\''test/tap/groups/groups.json'\'')); print('\''|'\''.join(n for n,m in g.items() if '\''mysqlx-tsan-g1'\'' in m))")
+                     SKIP_PROXYSQL=1 TSAN_OPTIONS="halt_on_error=0:abort_on_error=0:exitcode=0:second_deadlock_stack=1:history_size=7" TAP_GROUP=unit-tests-g1 TEST_PY_TAP_EXCL="${tsan_excl}" test/infra/control/run-tests-isolated.bash; unit_status=$?
+                     test "${mysqlx_status}" -eq 0 && test "${unit_status}" -eq 0; }'
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}

--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -208,9 +208,10 @@ if [ "${SKIP_PROXYSQL}" = "1" ]; then
 
     # Extract test names belonging to this group, filtering by @proxysql_min_version
     TEST_NAMES=$(python3 -c "
-import json, sys
+import json, sys, os, re
 from packaging import version
 proxysql_ver = '${PROXYSQL_VERSION}'
+excl = os.environ.get('TEST_PY_TAP_EXCL', '')
 with open('${GROUPS_JSON}') as f:
     groups = json.load(f)
 for test_name, test_groups in sorted(groups.items()):
@@ -225,6 +226,8 @@ for test_name, test_groups in sorted(groups.items()):
                         print(f'SKIP ({test_name}): requires ProxySQL >= {min_ver}, have {proxysql_ver}', file=sys.stderr)
                         skip = True
                     break
+        if not skip and excl and re.search(excl, test_name):
+            continue
         if not skip:
             print(test_name)
 ")

--- a/test/tap/Makefile
+++ b/test/tap/Makefile
@@ -75,7 +75,6 @@ unit_tests: tap test_deps
 
 
 .PHONY: ai_genai_unit_tests stage_ai_genai_unit_tests
-.NOTPARALLEL: ai_genai_unit_tests
 ai_genai_unit_tests: tap test_deps
 	cd tests/unit && CC=${CC} CXX=${CXX} ${MAKE} ai_genai_unit_tests
 	$(MAKE) stage_ai_genai_unit_tests

--- a/test/tap/tests/unit/Makefile
+++ b/test/tap/tests/unit/Makefile
@@ -621,7 +621,6 @@ all: $(UNIT_TESTS)
 unit_tests: all
 
 .PHONY: ai_genai_unit_tests
-.NOTPARALLEL: ai_genai_unit_tests
 ai_genai_unit_tests: $(AI_GENAI_UNIT_TESTS)
 
 .PHONY: debug

--- a/test/tap/tests/unit/mysqlx_admin_disk_commands_unit-t.cpp
+++ b/test/tap/tests/unit/mysqlx_admin_disk_commands_unit-t.cpp
@@ -48,18 +48,20 @@ MysqlxPluginContext& mysqlx_context() {
 	return ctx;
 }
 
-static void create_all_tables(SQLite3DB& db) {
+static bool create_tables_by_kind(SQLite3DB& db, ProxySQL_PluginDBKind kind) {
 	for (const auto& t : registered_tables) {
-		if (t.db_kind == ProxySQL_PluginDBKind::admin_db ||
-		    t.db_kind == ProxySQL_PluginDBKind::config_db) {
-			db.execute(t.table_def);
+		if (t.db_kind == kind) {
+			if (!db.execute(t.table_def)) {
+				return false;
+			}
 		}
 	}
+	return true;
 }
 
 int main() {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
-	plan(32);
+	plan(34);
 	diag("=== mysqlx_admin_disk_commands_unit-t starting ===");
 
 	test_init_minimal();
@@ -73,11 +75,21 @@ int main() {
 
 	SQLite3DB admindb;
 	admindb.open(const_cast<char*>("file:mem_admindb?mode=memory&cache=shared"), SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI);  // NOSONAR
-	create_all_tables(admindb);
+	// Mirror production (Admin_Bootstrap.cpp merge_plugin_tables +
+	// check_and_build_standard_tables): admin_db defs materialize in
+	// admindb, config_db defs in configdb, each exactly once. The
+	// plugin intentionally registers the same table name+def in both
+	// namespaces (register_table_pair) so the disk tier persists the
+	// memory tier; executing both namespaces into one handle (as the
+	// old create_all_tables did) double-creates 4 tables and logs
+	// benign "already exists" SQLITE errors that mask real failures.
+	ok(create_tables_by_kind(admindb, ProxySQL_PluginDBKind::admin_db),
+	   "admin fixture tables created in admindb");
 
 	SQLite3DB configdb;
 	configdb.open(const_cast<char*>("file:mem_configdb?mode=memory&cache=shared"), SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI);  // NOSONAR
-	create_all_tables(configdb);
+	ok(create_tables_by_kind(configdb, ProxySQL_PluginDBKind::config_db),
+	   "config fixture tables created in configdb");
 
 	admindb.execute("ATTACH DATABASE 'file:mem_configdb?mode=memory&cache=shared' AS disk");
 


### PR DESCRIPTION
CI-unit-tests-tsan paid a ~50 min TSAN build but ran only the 26 mysqlx-tsan-g1 binaries. This runs the full unit-tests-g1 group (~113 tests) in the same container invocation: every UNIT_TESTS binary is already built, all are standalone (SKIP_PROXYSQL=1, same TSAN_OPTIONS), and halt_on_error=0 keeps never-TSAN-validated tests from red-ing the build. Timeout 90 -> 120.

Also fixes the mysqlx_admin_disk_commands_unit-t fixture: create_all_tables() executed both admin_db and config_db defs into each handle, so the 4 intentionally pair-registered tables were double-created and logged benign 'already exists' SQLITE errors that masked real failures. Each namespace is now created once in its own DB handle (mirroring Admin_Bootstrap merge per db_kind) with the result asserted (plan 32 -> 34).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the full unit-tests-g1 group (~113 tests) in TSAN CI, fixes the `mysqlx_admin_disk_commands` fixture, and drops `.NOTPARALLEL` so unit tests build in parallel.

- The CI job now runs both `mysqlx-tsan-g1` and `unit-tests-g1` groups in one container invocation, reusing the built binaries and raising the timeout to 120 minutes; both phases always run, with phase 2 excluding the 26 mysqlx binaries and treating TSan reports as diagnostic (`exitcode=0`).
- The fixture now creates admin_db and config_db tables in separate handles, mirroring production's per-kind merge so the 4 pair-registered tables aren't double-created and no longer log benign 'already exists' errors.
- Removed `.NOTPARALLEL` from the TAP Makefiles; GNU Make 4.3 serialized the whole makefile on any mention, so unit tests compiled one-by-one under `-j`.

<sup>Written for commit 1196d24ffaa393c4c746d6f9ee418e0e7baa53d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded unit test coverage for administrative and configuration database table handling.
  - Updated test expectations to reflect clearer separation between database types.
  - Improved ThreadSanitizer validation by running test groups independently while still reporting failures accurately.
  - Added support for excluding matching tests from isolated test runs.

- **Chores**
  - Enabled eligible unit test targets to build in parallel.
  - Preserved the existing 120-minute CI time limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->