### PR TITLE
fix(ci): run mysqlx dbdeployer guard from GH-Actions

### DIFF
--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -150,8 +150,23 @@ jobs:
           sudo apt-get install -y -qq --no-install-recommends \
             libaio1t64 libnuma1 libncurses6 libtinfo6
 
+      - name: Checkout GH-Actions dbdeployer guard
+        # The control test and ci-mysqlx.yml live on GH-Actions. The job
+        # checks out the source SHA into proxysql/, which does not carry
+        # either file (v3.0 only has the uppercase CI-mysqlx.yml caller).
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: ${{ github.repository }}
+          ref: GH-Actions
+          path: gh-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/ci-mysqlx.yml
+            test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+          sparse-checkout-cone-mode: false
+
       - name: Verify dbdeployer install guard
-        run: proxysql/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+        run: gh-actions/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
 
       - name: Install dbdeployer
         # GitHub runner images may already provide dbdeployer. Its upstream


### PR DESCRIPTION
## Summary
`ci-mysqlx.yml` ran `proxysql/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash` from the **source SHA** checkout. That script and `ci-mysqlx.yml` live only on `GH-Actions`, so every v3.0-based run (including PR 6180) failed with `No such file or directory`.

Checkout `GH-Actions` into `gh-actions/` and run the guard from there.

## Test plan
- [ ] `CI-mysqlx` on v3.0 / PR 6180 after this merges

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI-mysqlx workflow so the dbdeployer guard runs from the `GH-Actions` branch instead of the source SHA checkout, which lacked the script and failed every v3.0-based run.

- Checks out `GH-Actions` into `gh-actions/` and runs the guard from there.

<sup>Written for commit 10e9bbe05e58bbd1616c5c16d3b1598136e8bf71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration checks to validate the database deployment installation guard from the dedicated automation branch.
  - Improved workflow checkout behavior by limiting retrieved files and avoiding unnecessary credential persistence.
  - This strengthens automated verification without changing application functionality or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->