### PR TITLE
ci: self-hosted sanitizer unit jobs; TSAN runs all units

### DIFF
--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -87,14 +87,22 @@ jobs:
           if [ "${ELIGIBLE:-}" = "true" ]; then
             POOL="${POOL_SIZE:-6}"
             demand=0; err=0
-            ids=$( { gh api --paginate "repos/${REPO}/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id';
-                     gh api --paginate "repos/${REPO}/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id'; } 2>e1 ) || err=1
+            : > e1
+            in_progress_ids=$(gh api --paginate "repos/${REPO}/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id' 2>e1) || err=1
+            queued_ids=$(gh api --paginate "repos/${REPO}/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id' 2>>e1) || err=1
             if [ "$err" = "0" ]; then
-              for rid in ${ids:-}; do
+              ids="${in_progress_ids:-}"$'\n'"${queued_ids:-}"
+              for rid in ${ids}; do
+                [ -n "$rid" ] || continue
                 [ "$demand" -ge "$POOL" ] && break
-                n=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" --jq '[.jobs[]|select((.status=="in_progress" and ((.runner_name//"")|startswith("ci-vm"))) or (.status=="queued" and (([.labels[]]|index("proxysql-ci")) != null)))]|length' 2>/dev/null) || n=0
+                if ! n=$(gh api --paginate --slurp "repos/${REPO}/actions/runs/${rid}/jobs?per_page=100" 2>>e1 | jq '[.[].jobs[]|select((.status=="in_progress" and ((.runner_name//"")|startswith("ci-vm"))) or (.status=="queued" and (([.labels[]]|index("proxysql-ci")) != null)))]|length'); then
+                  err=1
+                  break
+                fi
                 demand=$(( demand + ${n:-0} ))
               done
+            fi
+            if [ "$err" = "0" ]; then
               free=$(( POOL - demand ))
               echo ">>> self-hosted pool: demand=${demand}/${POOL} free=${free} (occupied+queued)"
               if [ "${free}" -ge 1 ]; then
@@ -104,7 +112,7 @@ jobs:
               fi
             else
               echo ">>> WARNING: could not read runs:"; sed 's/^/    /' e1
-              choice='["self-hosted","proxysql-ci"]'; echo ">>> failing SAFE to self-hosted (offload unchanged)"
+              choice='"ubuntu-24.04"'; echo ">>> demand query failed -> spill to GitHub-hosted"
             fi
           else
             echo ">>> not eligible for self-hosted -> GitHub-hosted"

--- a/.github/workflows/CI-unit-tests-asan-coverage.yml
+++ b/.github/workflows/CI-unit-tests-asan-coverage.yml
@@ -65,9 +65,57 @@ env:
   ASAN_OPTIONS: "detect_leaks=0:abort_on_error=1:symbolize=1:print_stacktrace=1:halt_on_error=1"
 
 jobs:
-  unit-tests:
+  pick-runner:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      actions: read
+    outputs:
+      runson: ${{ steps.pick.outputs.runson }}
+    steps:
+      - name: Pick runner pool
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          POOL_SIZE: ${{ vars.SELFHOSTED_POOL_SIZE || '6' }}
+          ELIGIBLE: ${{ (github.actor == 'renecannao' || (github.event.workflow_run && github.event.workflow_run.actor.login == 'renecannao')) && vars.SELFHOSTED_WORKFLOWS && contains(fromJson(vars.SELFHOSTED_WORKFLOWS), github.workflow) }}
+        run: |
+          set -uo pipefail
+          choice='"ubuntu-24.04"'
+          if [ "${ELIGIBLE:-}" = "true" ]; then
+            POOL="${POOL_SIZE:-6}"
+            demand=0; err=0
+            ids=$( { gh api --paginate "repos/${REPO}/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id';
+                     gh api --paginate "repos/${REPO}/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id'; } 2>e1 ) || err=1
+            if [ "$err" = "0" ]; then
+              for rid in ${ids:-}; do
+                [ "$demand" -ge "$POOL" ] && break
+                n=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" --jq '[.jobs[]|select((.status=="in_progress" and ((.runner_name//"")|startswith("ci-vm"))) or (.status=="queued" and (([.labels[]]|index("proxysql-ci")) != null)))]|length' 2>/dev/null) || n=0
+                demand=$(( demand + ${n:-0} ))
+              done
+              free=$(( POOL - demand ))
+              echo ">>> self-hosted pool: demand=${demand}/${POOL} free=${free} (occupied+queued)"
+              if [ "${free}" -ge 1 ]; then
+                choice='["self-hosted","proxysql-ci"]'; echo ">>> capacity available -> self-hosted"
+              else
+                choice='"ubuntu-24.04"'; echo ">>> pool at/over capacity -> spill to GitHub-hosted"
+              fi
+            else
+              echo ">>> WARNING: could not read runs:"; sed 's/^/    /' e1
+              choice='["self-hosted","proxysql-ci"]'; echo ">>> failing SAFE to self-hosted (offload unchanged)"
+            fi
+          else
+            echo ">>> not eligible for self-hosted -> GitHub-hosted"
+          fi
+          echo "runson=${choice}" >> "$GITHUB_OUTPUT"
+          echo ">>> decision: runson=${choice}"
+
+  unit-tests:
+    needs: pick-runner
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
     timeout-minutes: 120
     # codecov/codecov-action@v4 needs `id-token: write` to mint a
     # GitHub OIDC token for tokenless uploads against the Codecov

--- a/.github/workflows/CI-unit-tests-tsan.yml
+++ b/.github/workflows/CI-unit-tests-tsan.yml
@@ -19,7 +19,7 @@ run-name: '${{ github.event.workflow_run && github.event.workflow_run.head_branc
 #
 #   The test phase runs the resulting *-t binaries through
 #   `test/infra/control/run-tests-isolated.bash` driving TAP_GROUP
-#   `mysqlx-tsan-g1`. The harness is the same one used locally.
+#   `mysqlx-tsan-g1` first, then the rest of `unit-tests-g1`.
 #
 # Why this PR doesn't restore the CI-builds cache:
 #
@@ -58,15 +58,63 @@ env:
   SHA: ${{ github.event.workflow_run && github.event.workflow_run.head_sha || github.sha }}
 
 jobs:
+  pick-runner:
+    if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      actions: read
+    outputs:
+      runson: ${{ steps.pick.outputs.runson }}
+    steps:
+      - name: Pick runner pool
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          POOL_SIZE: ${{ vars.SELFHOSTED_POOL_SIZE || '6' }}
+          ELIGIBLE: ${{ (github.actor == 'renecannao' || (github.event.workflow_run && github.event.workflow_run.actor.login == 'renecannao')) && vars.SELFHOSTED_WORKFLOWS && contains(fromJson(vars.SELFHOSTED_WORKFLOWS), github.workflow) }}
+        run: |
+          set -uo pipefail
+          choice='"ubuntu-24.04"'
+          if [ "${ELIGIBLE:-}" = "true" ]; then
+            POOL="${POOL_SIZE:-6}"
+            demand=0; err=0
+            ids=$( { gh api --paginate "repos/${REPO}/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id';
+                     gh api --paginate "repos/${REPO}/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id'; } 2>e1 ) || err=1
+            if [ "$err" = "0" ]; then
+              for rid in ${ids:-}; do
+                [ "$demand" -ge "$POOL" ] && break
+                n=$(gh api "repos/${REPO}/actions/runs/${rid}/jobs" --jq '[.jobs[]|select((.status=="in_progress" and ((.runner_name//"")|startswith("ci-vm"))) or (.status=="queued" and (([.labels[]]|index("proxysql-ci")) != null)))]|length' 2>/dev/null) || n=0
+                demand=$(( demand + ${n:-0} ))
+              done
+              free=$(( POOL - demand ))
+              echo ">>> self-hosted pool: demand=${demand}/${POOL} free=${free} (occupied+queued)"
+              if [ "${free}" -ge 1 ]; then
+                choice='["self-hosted","proxysql-ci"]'; echo ">>> capacity available -> self-hosted"
+              else
+                choice='"ubuntu-24.04"'; echo ">>> pool at/over capacity -> spill to GitHub-hosted"
+              fi
+            else
+              echo ">>> WARNING: could not read runs:"; sed 's/^/    /' e1
+              choice='["self-hosted","proxysql-ci"]'; echo ">>> failing SAFE to self-hosted (offload unchanged)"
+            fi
+          else
+            echo ">>> not eligible for self-hosted -> GitHub-hosted"
+          fi
+          echo "runson=${choice}" >> "$GITHUB_OUTPUT"
+          echo ">>> decision: runson=${choice}"
+
   unit-tests-tsan:
+    needs: pick-runner
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || ! github.event.workflow_run }}
     # `write-all` is required so the workflow_run event's GITHUB_TOKEN has
     # the cache-writable scope (GitHub started enforcing this for workflow_run
     # in early July 2026). Without it actions/cache/save@v4 fails with
     # 'cache write denied: token has no writable scopes'.
     permissions: write-all
-    runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    runs-on: ${{ fromJson(needs.pick-runner.outputs.runson) }}
+    timeout-minutes: 120
 
     steps:
 
@@ -121,7 +169,7 @@ jobs:
       run: |
         make ubuntu24-tap
 
-    - name: Run mysqlx-tsan-g1 TAP group inside Docker
+    - name: Run mysqlx-tsan-g1 + unit-tests-g1 TAP groups inside Docker
       # Run the TSAN-instrumented unit tests INSIDE the same Docker
       # image used for the build — same source mount at /opt/proxysql,
       # same toolchain, same libstdc++/libgcc that the binaries linked
@@ -152,10 +200,22 @@ jobs:
       # consist only of lowercase alphanumeric characters, hyphens,
       # and underscores").
       #
-      # SKIP_PROXYSQL=1 short-circuits the daemon + backend checks in
-      # run-tests-isolated.bash, so it just iterates groups.json and
-      # execs each *-t binary in turn — no nested docker, no Python
-      # tester. TSAN_OPTIONS comes from mysqlx-tsan-g1/env.sh.
+       # SKIP_PROXYSQL=1 short-circuits the daemon + backend checks in
+       # run-tests-isolated.bash, so it just iterates groups.json and
+       # execs each *-t binary in turn — no nested docker, no Python
+       # tester. TSAN_OPTIONS comes from mysqlx-tsan-g1/env.sh.
+       #
+       # Two phases, one container invocation. Both always run; the
+       # combined status fails if either phase fails.
+       #   1. TAP_GROUP=mysqlx-tsan-g1 — the TSAN-targeted mysqlx +
+       #      plugin-chassis binaries (env.sh supplies SKIP_PROXYSQL=1
+       #      and TSAN_OPTIONS). TSan reports still fail the binary
+       #      (default exitcode 66).
+       #   2. TAP_GROUP=unit-tests-g1 — the remaining already-built
+       #      unit binaries. TEST_PY_TAP_EXCL drops the phase-1
+       #      overlap. halt_on_error=0:exitcode=0 keeps never-TSAN-
+       #      validated tests from red-ing the build on a race
+       #      report (TAP assertion failures still fail).
       env:
         TAP_GROUP: mysqlx-tsan-g1
         INFRA_ID: ci-unit-tests-tsan
@@ -176,10 +236,13 @@ jobs:
           -e TAP_GROUP="${TAP_GROUP}" \
           --entrypoint bash \
           ubuntu24_dbg_build \
-          -lc 'apt-get update -qq \
-               && apt-get install -y --no-install-recommends python3-packaging libprotobuf-dev \
-               && cd /opt/proxysql \
-               && test/infra/control/run-tests-isolated.bash'
+           -lc 'apt-get update -qq \
+                && apt-get install -y --no-install-recommends python3-packaging libprotobuf-dev \
+                && cd /opt/proxysql \
+                && { TAP_GROUP=mysqlx-tsan-g1 test/infra/control/run-tests-isolated.bash; mysqlx_status=$?
+                     tsan_excl=$(python3 -c "import json; g=json.load(open('\''test/tap/groups/groups.json'\'')); print('\''|'\''.join(n for n,m in g.items() if '\''mysqlx-tsan-g1'\'' in m))")
+                     SKIP_PROXYSQL=1 TSAN_OPTIONS="halt_on_error=0:abort_on_error=0:exitcode=0:second_deadlock_stack=1:history_size=7" TAP_GROUP=unit-tests-g1 TEST_PY_TAP_EXCL="${tsan_excl}" test/infra/control/run-tests-isolated.bash; unit_status=$?
+                     test "${mysqlx_status}" -eq 0 && test "${unit_status}" -eq 0; }'
 
     - name: Fix artifact permissions
       if: ${{ failure() && !cancelled() }}

--- a/test/infra/control/run-tests-isolated.bash
+++ b/test/infra/control/run-tests-isolated.bash
@@ -208,9 +208,10 @@ if [ "${SKIP_PROXYSQL}" = "1" ]; then
 
     # Extract test names belonging to this group, filtering by @proxysql_min_version
     TEST_NAMES=$(python3 -c "
-import json, sys
+import json, sys, os, re
 from packaging import version
 proxysql_ver = '${PROXYSQL_VERSION}'
+excl = os.environ.get('TEST_PY_TAP_EXCL', '')
 with open('${GROUPS_JSON}') as f:
     groups = json.load(f)
 for test_name, test_groups in sorted(groups.items()):
@@ -225,6 +226,8 @@ for test_name, test_groups in sorted(groups.items()):
                         print(f'SKIP ({test_name}): requires ProxySQL >= {min_ver}, have {proxysql_ver}', file=sys.stderr)
                         skip = True
                     break
+        if not skip and excl and re.search(excl, test_name):
+            continue
         if not skip:
             print(test_name)
 ")


### PR DESCRIPTION
## Summary
- `CI-unit-tests-tsan` and `CI-unit-tests-asan-coverage` use the same availability-aware `pick-runner` as TAP: idle `proxysql-ci` VM → self-hosted, else spill to `ubuntu-24.04`.
- Added both workflow names to `SELFHOSTED_WORKFLOWS`.
- TSAN now runs `mysqlx-tsan-g1` then the rest of `unit-tests-g1` (same shape as #6180).

`CI-unit-tests-asan-coverage` already executes every `test/tap/tests/unit/*-t` binary. Compile time is `make ubuntu24-tap` building the full TAP tree, not a short unit-only target.

Overlaps #6180 on the TSAN two-phase run and `TEST_PY_TAP_EXCL` in `run-tests-isolated.bash`.

## Test plan
- [ ] Confirm pick-runner logs for a `renecannao` dispatch
- [ ] TSAN runs mysqlx-tsan-g1 then unit-tests-g1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the TSAN and ASAN-coverage unit test jobs to the self-hosted `proxysql-ci` pool when capacity is free, spilling to GitHub-hosted `ubuntu-24.04` otherwise. TSAN now runs the full `unit-tests-g1` group after `mysqlx-tsan-g1`.

**Behavior**
- Both workflows add a `pick-runner` job that estimates pool demand from paginated in-progress and queued runs.
- Only dispatches from `renecannao` are eligible for self-hosted runners.
- The picker fails closed: any demand-query failure spills to GitHub-hosted `ubuntu-24.04` instead of queuing on the self-hosted pool.
- TSAN's second phase excludes the `mysqlx-tsan-g1` overlap via `TEST_PY_TAP_EXCL` and treats TSAN race reports as non-fatal, while TAP assertion failures still fail the build.

<sup>Written for commit edf6f829bd8232dc948e1bff090891f2d9160a6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI runner selection to balance workloads between available self-hosted capacity and GitHub-hosted runners.
  * Added safer fallback behavior so tests use GitHub-hosted runners when capacity information cannot be retrieved.
  * Improved workload tracking for queued and in-progress test jobs, including large result sets.
  * Expanded testing guidance for thread-sanitized builds and covered test execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->