### PR TITLE
fix(ci): run MySQLX dbdeployer sandbox on Ubuntu 24

### DIFF
--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -23,7 +23,11 @@ jobs:
   # reach 127.0.0.1:$mysqlx_port. mysqlx-e2e/env.sh documents this
   # arrangement.
   e2e-tests:
-    runs-on: ubuntu-24.04
+    # The dbdeployer MySQL 8.4 minimal archive is linked against the
+    # legacy libaio.so.1, libncurses.so.5, and libtinfo.so.5 SONAMEs.
+    # Keep the host-side sandbox on Jammy; the test binaries themselves
+    # still run in the Ubuntu 24 build container below.
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
 
     permissions:
@@ -136,8 +140,8 @@ jobs:
 
       - name: Install MySQL 8.4 runtime libs
         # dbdeployer ships pre-built mysqld binaries that DT_NEEDED
-        # libaio1t64/libnuma1 (server) and libncurses6/libtinfo6 (client).
-        # ubuntu-24.04 runner image includes most but not all of these
+        # libaio1/libnuma1 (server) and libncurses5/libtinfo5 (client).
+        # ubuntu-22.04 runner image includes most but not all of these
         # by default; install explicitly so we never silently depend on
         # whatever the runner happens to ship.
         run: |
@@ -148,7 +152,7 @@ jobs:
           # currently-published version.
           sudo apt-get update -y
           sudo apt-get install -y -qq --no-install-recommends \
-            libaio1t64 libnuma1 libncurses6 libtinfo6
+            libaio1 libnuma1 libncurses5 libtinfo5
 
       - name: Checkout GH-Actions dbdeployer guard
         # The control test and ci-mysqlx.yml live on GH-Actions. The job

--- a/.github/workflows/ci-mysqlx.yml
+++ b/.github/workflows/ci-mysqlx.yml
@@ -23,11 +23,7 @@ jobs:
   # reach 127.0.0.1:$mysqlx_port. mysqlx-e2e/env.sh documents this
   # arrangement.
   e2e-tests:
-    # The dbdeployer MySQL 8.4 minimal archive is linked against the
-    # legacy libaio.so.1, libncurses.so.5, and libtinfo.so.5 SONAMEs.
-    # Keep the host-side sandbox on Jammy; the test binaries themselves
-    # still run in the Ubuntu 24 build container below.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
 
     permissions:
@@ -139,11 +135,12 @@ jobs:
           ls -la plugins/mysqlx/ plugins/genai/ 2>/dev/null || true
 
       - name: Install MySQL 8.4 runtime libs
-        # dbdeployer ships pre-built mysqld binaries that DT_NEEDED
-        # libaio1/libnuma1 (server) and libncurses5/libtinfo5 (client).
-        # ubuntu-22.04 runner image includes most but not all of these
-        # by default; install explicitly so we never silently depend on
-        # whatever the runner happens to ship.
+        # The glibc 2.28 MySQL archive uses Noble's ncurses/tinfo 6 ABI.
+        # Oracle's generic mysqld still requests libaio.so.1 while Noble's
+        # time64 package exposes the same x86_64 ABI as libaio.so.1t64
+        # (MySQL bug #119954). Provide that name in a job-private directory
+        # so dbdeployer's library validation and the sandbox see it without
+        # modifying the runner's system library directories.
         run: |
           # The runner image ships a pre-baked apt index that pins point-
           # releases which get superseded and pulled from the mirror, so a
@@ -152,7 +149,13 @@ jobs:
           # currently-published version.
           sudo apt-get update -y
           sudo apt-get install -y -qq --no-install-recommends \
-            libaio1 libnuma1 libncurses5 libtinfo5
+            libaio1t64 libnuma1 libncurses6 libtinfo6
+          MYSQLX_COMPAT_LIB_DIR="${RUNNER_TEMP}/mysqlx-compat-libs"
+          mkdir -p "${MYSQLX_COMPAT_LIB_DIR}"
+          LIBAIO_T64=$(ldconfig -p | awk '$1 == "libaio.so.1t64" { print $NF; exit }')
+          test -n "${LIBAIO_T64}"
+          ln -s "${LIBAIO_T64}" "${MYSQLX_COMPAT_LIB_DIR}/libaio.so.1"
+          echo "LD_LIBRARY_PATH=${MYSQLX_COMPAT_LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
 
       - name: Checkout GH-Actions dbdeployer guard
         # The control test and ci-mysqlx.yml live on GH-Actions. The job
@@ -194,10 +197,23 @@ jobs:
           dbdeployer --version
 
       - name: Download and unpack MySQL 8.4
+        # dbdeployer 2.1's download catalog only records the glibc 2.17
+        # x86_64 archive. Keep dbdeployer's catalog-driven 8.4 version
+        # selection, but request the matching official glibc 2.28 minimal
+        # archive by URL so its clients use libncurses.so.6/libtinfo.so.6.
         run: |
           mkdir -p "$HOME/opt/mysql"
-          dbdeployer downloads get-by-version 8.4 --newest --minimal
-          TARBALL=$(ls -t mysql-8.4.*.tar.xz 2>/dev/null | head -1)
+          CATALOG_URL=$(dbdeployer downloads get-by-version 8.4 --newest --minimal --dry-run \
+            | awk '/^would download:/ { print $3; exit }')
+          test -n "${CATALOG_URL}"
+          MYSQL_URL=${CATALOG_URL/linux-glibc2.17-x86_64-minimal.tar.xz/linux-glibc2.28-x86_64-minimal.tar.xz}
+          case "${MYSQL_URL}" in
+            https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.*-linux-glibc2.28-x86_64-minimal.tar.xz) ;;
+            *) echo "ERROR: unexpected MySQL download URL: ${MYSQL_URL}" >&2; exit 1 ;;
+          esac
+          dbdeployer downloads get "${MYSQL_URL}" --retries-on-failure 3
+          TARBALL=$(ls -t mysql-8.4.*-linux-glibc2.28-x86_64-minimal.tar.xz 2>/dev/null | head -1)
+          test -n "${TARBALL}"
           dbdeployer unpack "$TARBALL"
 
       - name: Deploy MySQL 8.4 sandbox

--- a/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+++ b/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
@@ -4,6 +4,25 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 workflow="${root}/.github/workflows/ci-mysqlx.yml"
 
+e2e_job="$(awk '
+  /^  e2e-tests:$/ { capture = 1 }
+  capture { print }
+  capture && /^  [[:alnum:]_-]+:$/ && $0 !~ /^  e2e-tests:$/ { exit }
+' "${workflow}")"
+
+printf '%s\n' "${e2e_job}" | grep -Fq 'runs-on: ubuntu-22.04' || {
+	echo 'MySQL dbdeployer sandbox must run on ubuntu-22.04' >&2
+	exit 1
+}
+printf '%s\n' "${e2e_job}" | grep -Fq 'libaio1 libnuma1 libncurses5 libtinfo5' || {
+	echo 'MySQL dbdeployer sandbox must install its legacy runtime libraries' >&2
+	exit 1
+}
+if printf '%s\n' "${e2e_job}" | grep -Fq -- '--skip-library-check'; then
+	echo 'dbdeployer library validation must remain enabled' >&2
+	exit 1
+fi
+
 step="$(awk '
   /^      - name: Install dbdeployer$/ { capture = 1 }
   capture { print }

--- a/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
+++ b/test/infra/control/test-ci-mysqlx-dbdeployer-install.bash
@@ -10,14 +10,48 @@ e2e_job="$(awk '
   capture && /^  [[:alnum:]_-]+:$/ && $0 !~ /^  e2e-tests:$/ { exit }
 ' "${workflow}")"
 
-printf '%s\n' "${e2e_job}" | grep -Fq 'runs-on: ubuntu-22.04' || {
-	echo 'MySQL dbdeployer sandbox must run on ubuntu-22.04' >&2
+printf '%s\n' "${e2e_job}" | grep -Eq '^    runs-on: ubuntu-24\.04$' || {
+	echo 'MySQL dbdeployer sandbox must run on ubuntu-24.04' >&2
 	exit 1
 }
-printf '%s\n' "${e2e_job}" | grep -Fq 'libaio1 libnuma1 libncurses5 libtinfo5' || {
-	echo 'MySQL dbdeployer sandbox must install its legacy runtime libraries' >&2
+
+runtime_step="$(printf '%s\n' "${e2e_job}" | awk '
+  /^      - name: Install MySQL 8\.4 runtime libs$/ { capture = 1 }
+  capture && /^      - name:/ && $0 !~ /Install MySQL 8\.4 runtime libs/ { exit }
+  capture { print }
+')"
+
+printf '%s\n' "${runtime_step}" | grep -Eq '^[[:space:]]+libaio1t64 libnuma1 libncurses6 libtinfo6$' || {
+	echo 'MySQL dbdeployer sandbox must install the Ubuntu 24 runtime libraries' >&2
 	exit 1
 }
+printf '%s\n' "${runtime_step}" | grep -Eq '^[[:space:]]+LIBAIO_T64=.*libaio\.so\.1t64' || {
+	echo 'MySQL dbdeployer sandbox must locate Noble libaio by SONAME' >&2
+	exit 1
+}
+printf '%s\n' "${runtime_step}" | grep -Fq 'ln -s "${LIBAIO_T64}" "${MYSQLX_COMPAT_LIB_DIR}/libaio.so.1"' || {
+	echo 'MySQL dbdeployer sandbox must provide the Noble libaio compatibility link' >&2
+	exit 1
+}
+
+download_step="$(printf '%s\n' "${e2e_job}" | awk '
+  /^      - name: Download and unpack MySQL 8\.4$/ { capture = 1 }
+  capture && /^      - name:/ && $0 !~ /Download and unpack MySQL 8\.4/ { exit }
+  capture { print }
+')"
+
+printf '%s\n' "${download_step}" | grep -Eq '^[[:space:]]+MYSQL_URL=.*linux-glibc2\.28-x86_64-minimal\.tar\.xz' || {
+	echo 'MySQL dbdeployer sandbox must use the glibc 2.28 minimal archive' >&2
+	exit 1
+}
+printf '%s\n' "${download_step}" | grep -Fq 'dbdeployer downloads get "${MYSQL_URL}"' || {
+	echo 'MySQL archive must be downloaded through dbdeployer' >&2
+	exit 1
+}
+if printf '%s\n' "${e2e_job}" | grep -Fq 'mysql:8.4'; then
+	echo 'MySQL e2e infrastructure must remain dbdeployer-based' >&2
+	exit 1
+fi
 if printf '%s\n' "${e2e_job}" | grep -Fq -- '--skip-library-check'; then
 	echo 'dbdeployer library validation must remain enabled' >&2
 	exit 1


### PR DESCRIPTION
## Summary

- keep the MySQLX e2e host and dbdeployer sandbox on Ubuntu 24.04
- use dbdeployer's catalog to select the current MySQL 8.4 version, then download the matching official glibc 2.28 minimal archive through dbdeployer
- install Noble's native `libaio1t64`, `libncurses6`, and `libtinfo6` packages
- expose a job-private `libaio.so.1` compatibility name for Oracle's generic `mysqld`, without modifying system library directories or disabling dbdeployer's library validation
- strengthen the workflow guard so it validates the actual runner field and relevant install/download steps

## Root cause

The previous workflow used dbdeployer's catalogued `mysql-8.4.8-linux-glibc2.17-x86_64-minimal.tar.xz`. On Ubuntu 24, that archive requests the legacy `libncurses.so.5` and `libtinfo.so.5` client ABI names. MySQL also has an open Ubuntu 24 generic-tarball issue because `mysqld` requests `libaio.so.1` while Noble packages it as `libaio.so.1t64`: https://bugs.mysql.com/bug.php?id=119954

MySQL publishes a matching glibc 2.28 x86_64 minimal archive. It uses Noble's ncurses/tinfo 6 ABI, leaving only the libaio packaging-name mismatch handled by the private compatibility directory.

## Validation

- regression guard passes
- guard script passes `bash -n`
- workflow parses as YAML and asserts `e2e-tests.runs-on == ubuntu-24.04`
- derived official glibc 2.28 download URL returns successfully
- clean Ubuntu 24 container validation deployed MySQL 8.4.8 with dbdeployer and queried `8.4.8/18408`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated MySQL 8.4 end-to-end test environments to run on Ubuntu 24.04.
  - Improved runtime library setup and compatibility handling for MySQL 8.4 test execution.
  - Updated MySQL downloads to use validated dbdeployer catalog versions and compatible archives.

- **Tests**
  - Added checks confirming the expected operating system, runtime libraries, download process, and dbdeployer-based configuration are used in CI testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->