### PR TITLE
fix(ci): avoid nested heredoc in unit group runner

### DIFF
--- a/.github/workflows/ci-unit-group.yml
+++ b/.github/workflows/ci-unit-group.yml
@@ -108,34 +108,37 @@ jobs:
           TAP_GROUP: ${{ inputs.tap_group }}
         run: |
           set -euo pipefail
+          unit_list="${RUNNER_TEMP}/unit-tests-${TAP_GROUP}"
+          trap 'rm -f "${unit_list}"' EXIT
+          python3 - <<'PY' > "${unit_list}"
+          import json
+          import os
+          import pathlib
+
+          group = os.environ["TAP_GROUP"]
+          repo_root = pathlib.Path("proxysql")
+          with (repo_root / "test/tap/groups/groups.json").open(encoding="utf-8") as source:
+              groups = json.load(source)
+          selected = sorted(name for name, tags in groups.items() if group in tags)
+          if not selected:
+              raise SystemExit(f"ERROR: no tests are registered for {group}")
+          unit_dir = repo_root / "test/tap/tests/unit"
+          for name in selected:
+              path = unit_dir / name
+              if not path.is_file() or not os.access(path, os.X_OK):
+                  raise SystemExit(
+                      f"ERROR: {group} selects non-unit or missing executable: {name}"
+                  )
+              print(path.relative_to(repo_root))
+          PY
           docker run --rm --network none \
             -e TAP_GROUP \
             -v "${PWD}/proxysql:/opt/proxysql" \
+            -v "${unit_list}:/tmp/unit-tests:ro" \
             -w /opt/proxysql \
             -e LD_LIBRARY_PATH=/opt/proxysql/test/tap/tap:/opt/proxysql/test/tap/tap/_runtime_libs \
             proxysql/packaging:build-ubuntu24-v4.0.0 \
             bash -ceu '
-              python3 - <<"PY" > /tmp/unit-tests
-              import json
-              import os
-              import pathlib
-              import sys
-
-              group = os.environ["TAP_GROUP"]
-              with open("test/tap/groups/groups.json", encoding="utf-8") as source:
-                  groups = json.load(source)
-              selected = sorted(name for name, tags in groups.items() if group in tags)
-              if not selected:
-                  raise SystemExit(f"ERROR: no tests are registered for {group}")
-              unit_dir = pathlib.Path("test/tap/tests/unit")
-              for name in selected:
-                  path = unit_dir / name
-                  if not path.is_file() or not os.access(path, os.X_OK):
-                      raise SystemExit(
-                          f"ERROR: {group} selects non-unit or missing executable: {name}"
-                      )
-                  print(path)
-              PY
               failed=""
               while IFS= read -r test_binary; do
                 echo ">>> ${test_binary}"

--- a/.github/workflows/ci-unit-group.yml
+++ b/.github/workflows/ci-unit-group.yml
@@ -108,7 +108,7 @@ jobs:
           TAP_GROUP: ${{ inputs.tap_group }}
         run: |
           set -euo pipefail
-          unit_list="${RUNNER_TEMP}/unit-tests-${TAP_GROUP}"
+          unit_list="$(mktemp "${RUNNER_TEMP}/unit-tests.XXXXXX")"
           trap 'rm -f "${unit_list}"' EXIT
           python3 - <<'PY' > "${unit_list}"
           import json
@@ -116,15 +116,21 @@ jobs:
           import pathlib
 
           group = os.environ["TAP_GROUP"]
-          repo_root = pathlib.Path("proxysql")
+          repo_root = pathlib.Path("proxysql").resolve(strict=True)
           with (repo_root / "test/tap/groups/groups.json").open(encoding="utf-8") as source:
               groups = json.load(source)
           selected = sorted(name for name, tags in groups.items() if group in tags)
           if not selected:
               raise SystemExit(f"ERROR: no tests are registered for {group}")
-          unit_dir = repo_root / "test/tap/tests/unit"
+          unit_dir = (repo_root / "test/tap/tests/unit").resolve(strict=True)
           for name in selected:
-              path = unit_dir / name
+              try:
+                  path = (unit_dir / name).resolve(strict=True)
+                  path.relative_to(unit_dir)
+              except (OSError, RuntimeError, ValueError):
+                  raise SystemExit(
+                      f"ERROR: {group} selects non-unit or missing executable: {name}"
+                  )
               if not path.is_file() or not os.access(path, os.X_OK):
                   raise SystemExit(
                       f"ERROR: {group} selects non-unit or missing executable: {name}"


### PR DESCRIPTION
The reusable unit-group workflow embeds a Python heredoc inside a quoted `docker run ... bash -ceu` script. YAML indentation leaves the heredoc terminator indented, so the container shell consumes the rest of the script and Python fails with `IndentationError`.

Generate and validate the selected unit-test list on the Ubuntu 24 runner, then bind-mount it read-only into the existing Ubuntu 24 build container. This preserves the current container/runtime setup while removing the nested-heredoc parsing ambiguity.

Validation:
- PyYAML parses `ci-unit-group.yml`
- extracted `Run selected unit group` script passes `bash -n`
- extracted script passes `shellcheck -s bash`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI unit-group runner by generating the test list on the runner and bind-mounting it read-only into the container, avoiding the nested heredoc that caused Python `IndentationError`. Selections are now resolved and validated as executable files inside `test/tap/tests/unit`.

**Validation**
- Extracted `Run selected unit group` script passes `bash -n` and `shellcheck -s bash`.
- PyYAML parses `ci-unit-group.yml` and `git diff --check` is clean.

<sup>Written for commit 818d315158e1cb881ace54e1d5e2917594bd90aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysown/proxysql/pull/6188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved unit-test selection and validation before containerized test execution.
  - Added safeguards to reject invalid or out-of-scope test selections.
  - Test selections are now passed into the test environment through a temporary, read-only list.
  - Temporary test data is automatically cleaned up after execution.
  - These changes make automated test runs more reliable and help prevent unintended files from being executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->